### PR TITLE
feat: add stdio transport support for local MCP servers (uvx/npx)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,10 @@ FROM base AS runner
 ENV NODE_ENV=production
 ENV PORT=3000
 ENV HERMES_DATA_DIR=/app/data
+
+# Install uv for uvx (Python-based MCP servers)
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+
 RUN groupadd --system hermes && useradd --system --gid hermes hermes
 COPY --from=builder /app/.next/standalone ./
 COPY --from=builder /app/.next/static ./.next/static

--- a/app/api/mcp-servers/[serverId]/route.ts
+++ b/app/api/mcp-servers/[serverId]/route.ts
@@ -18,6 +18,10 @@ export async function PATCH(
     name?: string;
     url?: string;
     headers?: Record<string, string>;
+    transport?: "streamable_http" | "stdio";
+    command?: string | null;
+    args?: string[] | null;
+    env?: Record<string, string> | null;
     enabled?: boolean;
   };
 

--- a/app/api/mcp-servers/route.ts
+++ b/app/api/mcp-servers/route.ts
@@ -9,11 +9,23 @@ export async function GET() {
   return ok({ servers: listMcpServers() });
 }
 
-const createSchema = z.object({
-  name: z.string().min(1).max(100),
-  url: z.string().url(),
-  headers: z.record(z.string()).optional()
-});
+const createSchema = z.discriminatedUnion("transport", [
+  z.object({
+    transport: z.literal("streamable_http"),
+    name: z.string().min(1).max(100),
+    url: z.string().url(),
+    headers: z.record(z.string()).optional()
+  }),
+  z.object({
+    transport: z.literal("stdio"),
+    name: z.string().min(1).max(100),
+    command: z.string().min(1),
+    args: z.array(z.string()).optional(),
+    env: z.record(z.string()).optional(),
+    url: z.string().optional(),
+    headers: z.record(z.string()).optional()
+  })
+]);
 
 export async function POST(request: Request) {
   await requireUser();

--- a/components/settings-form.tsx
+++ b/components/settings-form.tsx
@@ -9,7 +9,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { supportsVisibleReasoning } from "@/lib/model-capabilities";
-import type { AppSettings, AuthUser, McpServer, Skill } from "@/lib/types";
+import type { AppSettings, AuthUser, McpServer, McpTransport, Skill } from "@/lib/types";
 
 type SettingsPayload = Omit<AppSettings, "apiKeyEncrypted"> & {
   hasApiKey: boolean;
@@ -35,9 +35,13 @@ export function SettingsForm({
   // MCP Servers state
   const [mcpServers, setMcpServers] = useState<McpServer[]>([]);
   const [showMcpForm, setShowMcpForm] = useState(false);
+  const [mcpTransport, setMcpTransport] = useState<McpTransport>("streamable_http");
   const [mcpName, setMcpName] = useState("");
   const [mcpUrl, setMcpUrl] = useState("");
   const [mcpHeaders, setMcpHeaders] = useState("");
+  const [mcpCommand, setMcpCommand] = useState("");
+  const [mcpArgs, setMcpArgs] = useState("");
+  const [mcpEnv, setMcpEnv] = useState("");
   const [editingMcpId, setEditingMcpId] = useState<string | null>(null);
 
   // Skills state
@@ -130,23 +134,55 @@ export function SettingsForm({
 
   // MCP Server handlers
   async function saveMcpServer() {
-    if (!mcpName.trim() || !mcpUrl.trim()) return;
+    if (!mcpName.trim()) return;
+    if (mcpTransport === "streamable_http" && !mcpUrl.trim()) return;
+    if (mcpTransport === "stdio" && !mcpCommand.trim()) return;
+
     let headersObj: Record<string, string> = {};
-    if (mcpHeaders.trim()) {
+    if (mcpTransport === "streamable_http" && mcpHeaders.trim()) {
       try { headersObj = JSON.parse(mcpHeaders); } catch { headersObj = {}; }
+    }
+
+    let argsArr: string[] | undefined;
+    if (mcpTransport === "stdio" && mcpArgs.trim()) {
+      try {
+        const parsed = JSON.parse(mcpArgs);
+        argsArr = Array.isArray(parsed) ? parsed : mcpArgs.split(/\s+/).filter(Boolean);
+      } catch {
+        argsArr = mcpArgs.split(/\s+/).filter(Boolean);
+      }
+    }
+
+    let envObj: Record<string, string> | undefined;
+    if (mcpTransport === "stdio" && mcpEnv.trim()) {
+      try { envObj = JSON.parse(mcpEnv); } catch { envObj = undefined; }
+    }
+
+    const payload: Record<string, unknown> = {
+      name: mcpName,
+      transport: mcpTransport
+    };
+
+    if (mcpTransport === "streamable_http") {
+      payload.url = mcpUrl;
+      payload.headers = headersObj;
+    } else {
+      payload.command = mcpCommand;
+      if (argsArr) payload.args = argsArr;
+      if (envObj) payload.env = envObj;
     }
 
     if (editingMcpId) {
       await fetch(`/api/mcp-servers/${editingMcpId}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name: mcpName, url: mcpUrl, headers: headersObj })
+        body: JSON.stringify(payload)
       });
     } else {
       await fetch("/api/mcp-servers", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name: mcpName, url: mcpUrl, headers: headersObj })
+        body: JSON.stringify(payload)
       });
     }
 
@@ -173,16 +209,24 @@ export function SettingsForm({
   function editMcpServer(server: McpServer) {
     setEditingMcpId(server.id);
     setMcpName(server.name);
+    setMcpTransport(server.transport ?? "streamable_http");
     setMcpUrl(server.url);
     setMcpHeaders(JSON.stringify(server.headers, null, 2));
+    setMcpCommand(server.command ?? "");
+    setMcpArgs(server.args ? JSON.stringify(server.args) : "");
+    setMcpEnv(server.env ? JSON.stringify(server.env, null, 2) : "");
     setShowMcpForm(true);
   }
 
   function resetMcpForm() {
     setShowMcpForm(false);
+    setMcpTransport("streamable_http");
     setMcpName("");
     setMcpUrl("");
     setMcpHeaders("");
+    setMcpCommand("");
+    setMcpArgs("");
+    setMcpEnv("");
     setEditingMcpId(null);
   }
 
@@ -403,7 +447,7 @@ export function SettingsForm({
             </div>
           </div>
           <p className="mt-3 text-sm text-[color:var(--muted)]">
-            Add HTTP streamable MCP servers to make external tools available in chat.
+            Add HTTP streamable or local stdio MCP servers to make external tools available in chat.
           </p>
 
           <div className="mt-4 space-y-3">
@@ -412,7 +456,20 @@ export function SettingsForm({
                 <div className="min-w-0 flex-1">
                   <div className="flex items-center gap-2">
                     <span className="text-sm font-medium text-[var(--text)]">{server.name}</span>
-                    <span className="text-xs text-white/30">{server.url}</span>
+                    {server.transport === "stdio" ? (
+                      <span className="inline-flex items-center rounded-md bg-emerald-900/40 px-1.5 py-0.5 text-[0.65rem] font-medium text-emerald-300">
+                        stdio
+                      </span>
+                    ) : (
+                      <span className="inline-flex items-center rounded-md bg-sky-900/40 px-1.5 py-0.5 text-[0.65rem] font-medium text-sky-300">
+                        http
+                      </span>
+                    )}
+                    <span className="text-xs text-white/30">
+                      {server.transport === "stdio"
+                        ? `${server.command}${server.args?.length ? " " + server.args.join(" ") : ""}`
+                        : server.url}
+                    </span>
                   </div>
                 </div>
                 <div className="flex items-center gap-2 ml-2">
@@ -442,18 +499,60 @@ export function SettingsForm({
                   <Input value={mcpName} onChange={(e) => setMcpName(e.target.value)} placeholder="My MCP Server" />
                 </div>
                 <div>
-                  <Label>URL</Label>
-                  <Input value={mcpUrl} onChange={(e) => setMcpUrl(e.target.value)} placeholder="https://..." />
+                  <Label>Transport</Label>
+                  <select
+                    value={mcpTransport}
+                    onChange={(e) => setMcpTransport(e.target.value as McpTransport)}
+                    className="w-full rounded-2xl border border-white/10 bg-black/20 px-4 py-3 text-sm"
+                  >
+                    <option value="streamable_http">Streamable HTTP</option>
+                    <option value="stdio">Local stdio</option>
+                  </select>
                 </div>
-                <div>
-                  <Label>Headers (JSON)</Label>
-                  <Textarea
-                    value={mcpHeaders}
-                    onChange={(e) => setMcpHeaders(e.target.value)}
-                    placeholder='{"Authorization": "Bearer ..."}'
-                    rows={2}
-                  />
-                </div>
+                {mcpTransport === "streamable_http" ? (
+                  <>
+                    <div>
+                      <Label>URL</Label>
+                      <Input value={mcpUrl} onChange={(e) => setMcpUrl(e.target.value)} placeholder="https://..." />
+                    </div>
+                    <div>
+                      <Label>Headers (JSON)</Label>
+                      <Textarea
+                        value={mcpHeaders}
+                        onChange={(e) => setMcpHeaders(e.target.value)}
+                        placeholder='{"Authorization": "Bearer ..."}'
+                        rows={2}
+                      />
+                    </div>
+                  </>
+                ) : (
+                  <>
+                    <div>
+                      <Label>Command</Label>
+                      <Input value={mcpCommand} onChange={(e) => setMcpCommand(e.target.value)} placeholder="uvx or npx" />
+                      <p className="mt-1 text-xs text-white/30">
+                        Use &quot;uvx&quot; for Python-based servers or &quot;npx&quot; for Node.js-based servers.
+                      </p>
+                    </div>
+                    <div>
+                      <Label>Args (JSON array or space-separated)</Label>
+                      <Input
+                        value={mcpArgs}
+                        onChange={(e) => setMcpArgs(e.target.value)}
+                        placeholder={mcpCommand === "npx" ? "-y @modelcontextprotocol/server-fetch" : "mcp-server-fetch"}
+                      />
+                    </div>
+                    <div>
+                      <Label>Environment variables (JSON, optional)</Label>
+                      <Textarea
+                        value={mcpEnv}
+                        onChange={(e) => setMcpEnv(e.target.value)}
+                        placeholder='{"API_KEY": "..."}'
+                        rows={2}
+                      />
+                    </div>
+                  </>
+                )}
                 <div className="flex gap-2">
                   <Button type="button" onClick={saveMcpServer}>
                     {editingMcpId ? "Update" : "Add server"}

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -130,13 +130,29 @@ function migrate(db: Database.Database) {
   `);
 
   // Migration: add folder_id and sort_order columns to existing conversations table
-  const cols = db.prepare("PRAGMA table_info(conversations)").all() as Array<{ name: string }>;
-  const colNames = cols.map((c) => c.name);
-  if (!colNames.includes("folder_id")) {
+  const convCols = db.prepare("PRAGMA table_info(conversations)").all() as Array<{ name: string }>;
+  const convColNames = convCols.map((c) => c.name);
+  if (!convColNames.includes("folder_id")) {
     db.exec("ALTER TABLE conversations ADD COLUMN folder_id TEXT REFERENCES folders(id) ON DELETE SET NULL");
   }
-  if (!colNames.includes("sort_order")) {
+  if (!convColNames.includes("sort_order")) {
     db.exec("ALTER TABLE conversations ADD COLUMN sort_order INTEGER NOT NULL DEFAULT 0");
+  }
+
+  // Migration: add transport, command, args, env columns to mcp_servers
+  const mcpCols = db.prepare("PRAGMA table_info(mcp_servers)").all() as Array<{ name: string }>;
+  const mcpColNames = mcpCols.map((c) => c.name);
+  if (!mcpColNames.includes("transport")) {
+    db.exec("ALTER TABLE mcp_servers ADD COLUMN transport TEXT NOT NULL DEFAULT 'streamable_http'");
+  }
+  if (!mcpColNames.includes("command")) {
+    db.exec("ALTER TABLE mcp_servers ADD COLUMN command TEXT");
+  }
+  if (!mcpColNames.includes("args")) {
+    db.exec("ALTER TABLE mcp_servers ADD COLUMN args TEXT");
+  }
+  if (!mcpColNames.includes("env")) {
+    db.exec("ALTER TABLE mcp_servers ADD COLUMN env TEXT");
   }
 
   db.prepare(

--- a/lib/mcp-client.ts
+++ b/lib/mcp-client.ts
@@ -1,3 +1,5 @@
+import { ChildProcess, spawn } from "node:child_process";
+
 import type { McpServer } from "@/lib/types";
 
 type McpTool = {
@@ -14,7 +16,162 @@ type McpToolCallResult = {
   content: Array<{ type: string; text?: string }>;
 };
 
-export async function discoverMcpTools(server: McpServer): Promise<McpTool[]> {
+// ─── Stdio transport process registry ────────────────────────────────────
+
+type StdioProcess = {
+  process: ChildProcess;
+  messageId: number;
+  pending: Map<
+    number,
+    {
+      resolve: (value: unknown) => void;
+      reject: (reason: unknown) => void;
+    }
+  >;
+  buffer: string;
+  initialized: boolean;
+  initPromise: Promise<void> | null;
+};
+
+const stdioProcesses = new Map<string, StdioProcess>();
+
+function getOrCreateStdioProcess(server: McpServer): StdioProcess {
+  const existing = stdioProcesses.get(server.id);
+  if (existing && existing.process.exitCode === null) return existing;
+
+  // Clean up old entry if process exited
+  if (existing) {
+    stdioProcesses.delete(server.id);
+  }
+
+  const command = server.command!;
+  const args = server.args ?? [];
+  const envVars = server.env ?? {};
+
+  const child = spawn(command, args, {
+    stdio: ["pipe", "pipe", "pipe"],
+    env: { ...process.env, ...envVars },
+    // Give child processes a PATH that includes common locations
+  });
+
+  const proc: StdioProcess = {
+    process: child,
+    messageId: 1,
+    pending: new Map(),
+    buffer: "",
+    initialized: false,
+    initPromise: null
+  };
+
+  child.stdout?.on("data", (chunk: Buffer) => {
+    proc.buffer += chunk.toString();
+    const lines = proc.buffer.split("\n");
+    proc.buffer = lines.pop() ?? "";
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        const msg = JSON.parse(trimmed) as { id?: number; error?: { message?: string }; result?: unknown };
+        if (msg.id !== undefined && proc.pending.has(msg.id)) {
+          const { resolve, reject } = proc.pending.get(msg.id)!;
+          proc.pending.delete(msg.id);
+          if (msg.error) {
+            reject(new Error(msg.error.message ?? "MCP stdio error"));
+          } else {
+            resolve(msg.result);
+          }
+        }
+      } catch {
+        // Ignore non-JSON lines (server stderr/log output may leak into stdout)
+      }
+    }
+  });
+
+  child.stderr?.on("data", () => {
+    // Silently ignore stderr from child process
+  });
+
+  child.on("exit", () => {
+    // Reject all pending requests
+    for (const [, { reject }] of proc.pending) {
+      reject(new Error("MCP stdio process exited"));
+    }
+    proc.pending.clear();
+  });
+
+  stdioProcesses.set(server.id, proc);
+  return proc;
+}
+
+async function sendStdioRequest<T = unknown>(proc: StdioProcess, method: string, params?: unknown): Promise<T> {
+  const id = proc.messageId++;
+  const message: Record<string, unknown> = {
+    jsonrpc: "2.0",
+    id,
+    method
+  };
+  if (params !== undefined) {
+    message.params = params;
+  }
+
+  return new Promise<T>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      proc.pending.delete(id);
+      reject(new Error(`MCP stdio request timed out: ${method}`));
+    }, 30_000);
+
+    proc.pending.set(id, {
+      resolve: (value: unknown) => {
+        clearTimeout(timeout);
+        resolve(value as T);
+      },
+      reject: (reason: unknown) => {
+        clearTimeout(timeout);
+        reject(reason);
+      }
+    });
+
+    proc.process.stdin?.write(JSON.stringify(message) + "\n");
+  });
+}
+
+async function ensureInitialized(proc: StdioProcess): Promise<void> {
+  if (proc.initialized) return;
+  if (proc.initPromise) return proc.initPromise;
+
+  proc.initPromise = (async () => {
+    await sendStdioRequest(proc, "initialize", {
+      protocolVersion: "2024-11-05",
+      capabilities: {},
+      clientInfo: { name: "hermes", version: "0.1.0" }
+    });
+
+    // Send initialized notification (no id — fire-and-forget)
+    proc.process.stdin?.write(
+      JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" }) + "\n"
+    );
+
+    proc.initialized = true;
+  })();
+
+  return proc.initPromise;
+}
+
+export function shutdownAllProcesses(): void {
+  for (const [id, proc] of stdioProcesses) {
+    try {
+      proc.process.kill();
+    } catch {
+      // Ignore errors during shutdown
+    }
+    stdioProcesses.delete(id);
+  }
+}
+
+// ─── HTTP transport ──────────────────────────────────────────────────────
+
+async function discoverMcpToolsHttp(server: McpServer): Promise<McpTool[]> {
   try {
     const response = await fetch(server.url, {
       method: "POST",
@@ -39,7 +196,7 @@ export async function discoverMcpTools(server: McpServer): Promise<McpTool[]> {
   }
 }
 
-export async function callMcpTool(
+async function callMcpToolHttp(
   server: McpServer,
   toolName: string,
   args: Record<string, unknown>
@@ -86,6 +243,68 @@ export async function callMcpTool(
       content: [{ type: "text", text: "No result from MCP tool" }]
     }
   );
+}
+
+// ─── Stdio transport ─────────────────────────────────────────────────────
+
+async function discoverMcpToolsStdio(server: McpServer): Promise<McpTool[]> {
+  try {
+    const proc = getOrCreateStdioProcess(server);
+    await ensureInitialized(proc);
+    const result = await sendStdioRequest<{ tools?: McpTool[] }>(proc, "tools/list");
+    return result?.tools ?? [];
+  } catch {
+    return [];
+  }
+}
+
+async function callMcpToolStdio(
+  server: McpServer,
+  toolName: string,
+  args: Record<string, unknown>
+): Promise<McpToolCallResult> {
+  try {
+    const proc = getOrCreateStdioProcess(server);
+    await ensureInitialized(proc);
+    const result = await sendStdioRequest<McpToolCallResult>(proc, "tools/call", {
+      name: toolName,
+      arguments: args
+    });
+    return (
+      result ?? {
+        content: [{ type: "text", text: "No result from MCP tool" }]
+      }
+    );
+  } catch (err) {
+    return {
+      content: [
+        {
+          type: "text",
+          text: `MCP stdio error: ${err instanceof Error ? err.message : String(err)}`
+        }
+      ]
+    };
+  }
+}
+
+// ─── Unified API (routes by server.transport) ────────────────────────────
+
+export async function discoverMcpTools(server: McpServer): Promise<McpTool[]> {
+  if (server.transport === "stdio") {
+    return discoverMcpToolsStdio(server);
+  }
+  return discoverMcpToolsHttp(server);
+}
+
+export async function callMcpTool(
+  server: McpServer,
+  toolName: string,
+  args: Record<string, unknown>
+): Promise<McpToolCallResult> {
+  if (server.transport === "stdio") {
+    return callMcpToolStdio(server, toolName, args);
+  }
+  return callMcpToolHttp(server, toolName, args);
 }
 
 export async function gatherAllMcpTools(servers: McpServer[]): Promise<

--- a/lib/mcp-servers.ts
+++ b/lib/mcp-servers.ts
@@ -1,47 +1,51 @@
 import { getDb } from "@/lib/db";
 import { createId } from "@/lib/ids";
-import type { McpServer } from "@/lib/types";
+import type { McpServer, McpTransport } from "@/lib/types";
 
 function nowIso() {
   return new Date().toISOString();
 }
 
-function rowToMcpServer(row: {
+type McpServerRow = {
   id: string;
   name: string;
   url: string;
   headers: string;
+  transport: string;
+  command: string | null;
+  args: string | null;
+  env: string | null;
   enabled: number;
   created_at: string;
   updated_at: string;
-}): McpServer {
+};
+
+function rowToMcpServer(row: McpServerRow): McpServer {
   return {
     id: row.id,
     name: row.name,
     url: row.url,
     headers: JSON.parse(row.headers) as Record<string, string>,
+    transport: (row.transport ?? "streamable_http") as McpTransport,
+    command: row.command,
+    args: row.args ? (JSON.parse(row.args) as string[]) : null,
+    env: row.env ? (JSON.parse(row.env) as Record<string, string>) : null,
     enabled: Boolean(row.enabled),
     createdAt: row.created_at,
     updatedAt: row.updated_at
   };
 }
 
+const SELECT_COLUMNS = `id, name, url, headers, transport, command, args, env, enabled, created_at, updated_at`;
+
 export function listMcpServers() {
   const rows = getDb()
     .prepare(
-      `SELECT id, name, url, headers, enabled, created_at, updated_at
+      `SELECT ${SELECT_COLUMNS}
        FROM mcp_servers
        ORDER BY created_at ASC`
     )
-    .all() as Array<{
-    id: string;
-    name: string;
-    url: string;
-    headers: string;
-    enabled: number;
-    created_at: string;
-    updated_at: string;
-  }>;
+    .all() as Array<McpServerRow>;
 
   return rows.map(rowToMcpServer);
 }
@@ -49,32 +53,37 @@ export function listMcpServers() {
 export function getMcpServer(serverId: string) {
   const row = getDb()
     .prepare(
-      `SELECT id, name, url, headers, enabled, created_at, updated_at
+      `SELECT ${SELECT_COLUMNS}
        FROM mcp_servers
        WHERE id = ?`
     )
-    .get(serverId) as
-    | {
-        id: string;
-        name: string;
-        url: string;
-        headers: string;
-        enabled: number;
-        created_at: string;
-        updated_at: string;
-      }
-    | undefined;
+    .get(serverId) as McpServerRow | undefined;
 
   return row ? rowToMcpServer(row) : null;
 }
 
-export function createMcpServer(input: { name: string; url: string; headers?: Record<string, string> }) {
+type CreateMcpServerInput = {
+  name: string;
+  url?: string;
+  headers?: Record<string, string>;
+  transport?: McpTransport;
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+};
+
+export function createMcpServer(input: CreateMcpServerInput) {
   const timestamp = nowIso();
-  const server = {
+  const transport = input.transport ?? "streamable_http";
+  const server: McpServer = {
     id: createId("mcp"),
     name: input.name,
-    url: input.url,
+    url: input.url ?? "",
     headers: input.headers ?? {},
+    transport,
+    command: input.command ?? null,
+    args: input.args ?? null,
+    env: input.env ?? null,
     enabled: true,
     createdAt: timestamp,
     updatedAt: timestamp
@@ -82,14 +91,18 @@ export function createMcpServer(input: { name: string; url: string; headers?: Re
 
   getDb()
     .prepare(
-      `INSERT INTO mcp_servers (id, name, url, headers, enabled, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?)`
+      `INSERT INTO mcp_servers (id, name, url, headers, transport, command, args, env, enabled, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     )
     .run(
       server.id,
       server.name,
       server.url,
       JSON.stringify(server.headers),
+      server.transport,
+      server.command,
+      server.args ? JSON.stringify(server.args) : null,
+      server.env ? JSON.stringify(server.env) : null,
       server.enabled ? 1 : 0,
       server.createdAt,
       server.updatedAt
@@ -98,9 +111,20 @@ export function createMcpServer(input: { name: string; url: string; headers?: Re
   return server;
 }
 
+type UpdateMcpServerInput = {
+  name?: string;
+  url?: string;
+  headers?: Record<string, string>;
+  transport?: McpTransport;
+  command?: string | null;
+  args?: string[] | null;
+  env?: Record<string, string> | null;
+  enabled?: boolean;
+};
+
 export function updateMcpServer(
   serverId: string,
-  input: { name?: string; url?: string; headers?: Record<string, string>; enabled?: boolean }
+  input: UpdateMcpServerInput
 ) {
   const current = getMcpServer(serverId);
   if (!current) return null;
@@ -109,15 +133,30 @@ export function updateMcpServer(
   const name = input.name ?? current.name;
   const url = input.url ?? current.url;
   const headers = input.headers ?? current.headers;
+  const transport = input.transport ?? current.transport;
+  const command = input.command !== undefined ? input.command : current.command;
+  const args = input.args !== undefined ? input.args : current.args;
+  const env = input.env !== undefined ? input.env : current.env;
   const enabled = input.enabled ?? current.enabled;
 
   getDb()
     .prepare(
       `UPDATE mcp_servers
-       SET name = ?, url = ?, headers = ?, enabled = ?, updated_at = ?
+       SET name = ?, url = ?, headers = ?, transport = ?, command = ?, args = ?, env = ?, enabled = ?, updated_at = ?
        WHERE id = ?`
     )
-    .run(name, url, JSON.stringify(headers), enabled ? 1 : 0, timestamp, serverId);
+    .run(
+      name,
+      url,
+      JSON.stringify(headers),
+      transport,
+      command,
+      args ? JSON.stringify(args) : null,
+      env ? JSON.stringify(env) : null,
+      enabled ? 1 : 0,
+      timestamp,
+      serverId
+    );
 
   return getMcpServer(serverId);
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -43,11 +43,17 @@ export type Folder = {
   updatedAt: string;
 };
 
+export type McpTransport = "streamable_http" | "stdio";
+
 export type McpServer = {
   id: string;
   name: string;
   url: string;
   headers: Record<string, string>;
+  transport: McpTransport;
+  command: string | null;
+  args: string[] | null;
+  env: Record<string, string> | null;
   enabled: boolean;
   createdAt: string;
   updatedAt: string;

--- a/tests/unit/mcp-client.test.ts
+++ b/tests/unit/mcp-client.test.ts
@@ -8,6 +8,10 @@ describe("MCP client utilities", () => {
       name: "Test Server",
       url: "https://mcp.example.com",
       headers: {},
+      transport: "streamable_http",
+      command: null,
+      args: null,
+      env: null,
       enabled: true,
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString()
@@ -42,6 +46,10 @@ describe("MCP client utilities", () => {
       name: "Empty",
       url: "https://mcp.example.com",
       headers: {},
+      transport: "streamable_http",
+      command: null,
+      args: null,
+      env: null,
       enabled: true,
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString()


### PR DESCRIPTION
## Summary
- Add stdio transport for MCP servers running via `uvx`, `npx`, or any local command
- Child process management with JSON-RPC over stdin/stdout, auto-reconnect, and cleanup
- DB migration adds `transport`, `command`, `args`, `env` columns to `mcp_servers`
- Frontend: transport dropdown with conditional fields per type
- Dockerfile: add `uv` for `uvx` support
- Backward compatible — existing HTTP servers continue working unchanged

## Files changed
- `lib/db.ts` — schema migration
- `lib/types.ts` — McpServer type
- `lib/mcp-servers.ts` — CRUD with new fields
- `lib/mcp-client.ts` — stdio transport layer
- `app/api/mcp-servers/` — validation per transport
- `components/settings-form.tsx` — transport UI
- `Dockerfile` — uv install
- `tests/unit/mcp-client.test.ts` — test updates