### PR TITLE
fix: use hex colors for SVG stroke in ContextGauge

### DIFF
--- a/components/context-gauge.tsx
+++ b/components/context-gauge.tsx
@@ -20,9 +20,9 @@ function formatTokens(tokens: number): string {
 }
 
 function getGaugeColor(percentage: number): string {
-  if (percentage >= 70) return "var(--gauge-red)";
-  if (percentage >= 50) return "var(--gauge-yellow)";
-  return "var(--gauge-green)";
+  if (percentage >= 70) return "#ef4444"; // red-500
+  if (percentage >= 50) return "#eab308"; // yellow-500
+  return "#22c55e"; // green-500
 }
 
 export function ContextGauge({ usedTokens, usableLimit, maxLimit }: ContextGaugeProps) {
@@ -97,7 +97,7 @@ export function ContextGauge({ usedTokens, usableLimit, maxLimit }: ContextGauge
             strokeLinecap="round"
             strokeDasharray={circumference}
             strokeDashoffset={dashOffset}
-            style={{ transition: "stroke-dashoffset 0.3s ease-out" }}
+            style={{ transition: "stroke-dashoffset 0.3s ease-out", stroke: color }}
           />
         </svg>
       </button>

--- a/tests/unit/context-gauge.test.tsx
+++ b/tests/unit/context-gauge.test.tsx
@@ -27,7 +27,7 @@ describe("ContextGauge", () => {
     const gauge = screen.getByRole("progressbar");
     expect(gauge).toHaveAttribute("aria-valuenow", "38");
 
-    const progressCircle = gauge.querySelector('circle[stroke="var(--gauge-green)"]');
+    const progressCircle = gauge.querySelector('circle[stroke="#22c55e"]');
     expect(progressCircle).toBeInTheDocument();
   });
 
@@ -37,7 +37,7 @@ describe("ContextGauge", () => {
     const gauge = screen.getByRole("progressbar");
     expect(gauge).toHaveAttribute("aria-valuenow", "69");
 
-    const progressCircle = gauge.querySelector('circle[stroke="var(--gauge-yellow)"]');
+    const progressCircle = gauge.querySelector('circle[stroke="#eab308"]');
     expect(progressCircle).toBeInTheDocument();
   });
 
@@ -47,7 +47,7 @@ describe("ContextGauge", () => {
     const gauge = screen.getByRole("progressbar");
     expect(gauge).toHaveAttribute("aria-valuenow", "75");
 
-    const progressCircle = gauge.querySelector('circle[stroke="var(--gauge-red)"]');
+    const progressCircle = gauge.querySelector('circle[stroke="#ef4444"]');
     expect(progressCircle).toBeInTheDocument();
   });
 


### PR DESCRIPTION
CSS variables don't work directly in SVG stroke attributes. Reverted to hex values for gauge colors to ensure visibility.