### PR TITLE
add worktree setup script for env and data symlinks

### DIFF
--- a/scripts/setup-worktree.sh
+++ b/scripts/setup-worktree.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -euo pipefail
+
+WORKTREE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+MAIN_WT="$(git -C "$WORKTREE_DIR" worktree list | head -1 | awk '{print $1}')"
+
+link_file() {
+    local src="$1"
+    local dest="$2"
+    if [ ! -e "$src" ]; then
+        echo "warning: $src does not exist, skipping"
+        return 1
+    fi
+    if [ -L "$dest" ] || [ -e "$dest" ]; then
+        echo "already exists: $dest"
+        return 0
+    fi
+    ln -s "$src" "$dest"
+    echo "linked: $dest -> $src"
+}
+
+echo "Setting up worktree from main: $MAIN_WT"
+
+link_file "$MAIN_WT/.env" "$WORKTREE_DIR/.env"
+link_file "$MAIN_WT/.data" "$WORKTREE_DIR/.data"


### PR DESCRIPTION
## Summary
- Adds `scripts/setup-worktree.sh` that auto-links `.env` and `.data` from the main worktree into new git worktrees, solving the common issue of missing database and environment files after worktree creation

## Test plan
- [ ] Run the script in a new worktree and verify `.env` and `.data` are symlinked correctly
- [ ] Confirm script is idempotent (safe to run multiple times)

🤖 Generated with [Claude Code](https://claude.com/claude-code)