### PR TITLE
fix: correct argument order in sidebar navigation

### DIFF
--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -180,7 +180,7 @@ function ConversationItem({
     }
 
     event.preventDefault();
-    void onNavigate(conversation.id, `/chat/${conversation.id}`);
+    void onNavigate(`/chat/${conversation.id}`, conversation.id);
   }
 
   useEffect(() => {


### PR DESCRIPTION
Fixes a bug where clicking on conversations in the sidebar resulted in 404 errors.

The `onNavigate` callback was receiving arguments in the wrong order - passing `conversation.id` as the `href` parameter and the full path as `nextConversationId`. This caused `router.push()` to navigate to `/conv_...` instead of `/chat/conv_...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)