### PR TITLE
ci: add test and docker build workflows for PR gates

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,23 @@
+name: Docker Build
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: Test
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm test


### PR DESCRIPTION
## Summary
Adds two GitHub Actions workflows that run on pull requests targeting main:
- **Test workflow**: Runs `npm test` with Node 22 and npm caching
- **Docker workflow**: Validates the Docker build succeeds using Buildx with GitHub Actions cache

These serve as required status checks before merging to main.

## Test plan
- [ ] Merge this PR
- [ ] Enable branch protection for main requiring these status checks