### PR TITLE
feat: add personas settings and chat integration

### DIFF
--- a/app/api/personas/[personaId]/route.ts
+++ b/app/api/personas/[personaId]/route.ts
@@ -1,0 +1,39 @@
+import { z } from "zod";
+
+import { requireUser } from "@/lib/auth";
+import { updatePersona, deletePersona } from "@/lib/personas";
+import { badRequest, ok } from "@/lib/http";
+
+const paramsSchema = z.object({ personaId: z.string().min(1) });
+
+export async function PATCH(
+  request: Request,
+  context: { params: Promise<{ personaId: string }> }
+) {
+  await requireUser();
+  const params = paramsSchema.safeParse(await context.params);
+  if (!params.success) return badRequest("Invalid persona id");
+
+  const { personaId } = params.data;
+  const body = await request.json() as {
+    name?: string;
+    content?: string;
+  };
+
+  const updated = updatePersona(personaId, body);
+  if (!updated) return badRequest("Persona not found", 404);
+
+  return ok({ persona: updated });
+}
+
+export async function DELETE(
+  _request: Request,
+  context: { params: Promise<{ personaId: string }> }
+) {
+  await requireUser();
+  const params = paramsSchema.safeParse(await context.params);
+  if (!params.success) return badRequest("Invalid persona id");
+
+  deletePersona(params.data.personaId);
+  return ok({ success: true });
+}

--- a/app/api/personas/route.ts
+++ b/app/api/personas/route.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+
+import { requireUser } from "@/lib/auth";
+import { listPersonas, createPersona } from "@/lib/personas";
+import { badRequest, ok } from "@/lib/http";
+
+export async function GET() {
+  await requireUser();
+  return ok({ personas: listPersonas() });
+}
+
+const createSchema = z.object({
+  name: z.string().trim().min(1).max(100),
+  content: z.string().min(1)
+});
+
+export async function POST(request: Request) {
+  await requireUser();
+  const body = createSchema.safeParse(await request.json());
+  if (!body.success) return badRequest("Invalid persona data");
+
+  return ok({ persona: createPersona(body.data) }, { status: 201 });
+}

--- a/app/settings/personas/page.tsx
+++ b/app/settings/personas/page.tsx
@@ -1,0 +1,7 @@
+import { PersonasSection } from "@/components/settings/sections/personas-section";
+import { requireUser } from "@/lib/auth";
+
+export default async function PersonasPage() {
+  await requireUser();
+  return <PersonasSection />;
+}

--- a/components/chat-composer.tsx
+++ b/components/chat-composer.tsx
@@ -12,6 +12,7 @@ import {
   LoaderCircle,
   Paperclip,
   Pen,
+  Users,
   X
 } from "lucide-react";
 
@@ -37,6 +38,9 @@ type ChatComposerProps = {
   providerProfiles: ProviderProfileSummary[];
   providerProfileId: string;
   onProviderProfileChange: (providerProfileId: string) => void | Promise<void>;
+  personas: Array<{ id: string; name: string }>;
+  personaId: string | null;
+  onPersonaChange: (personaId: string | null) => void | Promise<void>;
   toolExecutionMode: ToolExecutionMode;
   onToolExecutionModeChange: (toolExecutionMode: ToolExecutionMode) => void | Promise<void>;
   textareaRef?: React.Ref<HTMLTextAreaElement>;
@@ -60,6 +64,9 @@ export function ChatComposer({
   providerProfiles,
   providerProfileId,
   onProviderProfileChange,
+  personas,
+  personaId,
+  onPersonaChange,
   toolExecutionMode,
   onToolExecutionModeChange,
   textareaRef,
@@ -215,6 +222,34 @@ export function ChatComposer({
               {providerProfiles.map((profile) => (
                 <option key={profile.id} value={profile.id}>
                   {profile.name} · {profile.model}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="relative group">
+            <button
+              className={`p-2 transition-colors duration-200 rounded-lg hover:bg-white/5 shrink-0 flex items-center gap-1 ${
+                personaId ? "text-violet-400/80 hover:text-violet-400" : "text-white/25 hover:text-white/50"
+              }`}
+              aria-label="Select persona"
+              type="button"
+            >
+              <Users className="h-5 w-5" />
+            </button>
+            <select
+              value={personaId ?? ""}
+              onChange={(event) => {
+                const value = event.target.value;
+                void onPersonaChange(value || null);
+              }}
+              className="absolute inset-0 opacity-0 cursor-pointer"
+              disabled={isSending || personas.length === 0}
+            >
+              <option value="">None</option>
+              {personas.map((persona) => (
+                <option key={persona.id} value={persona.id}>
+                  {persona.name}
                 </option>
               ))}
             </select>

--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -115,13 +115,14 @@ function isLegacyCompactionNotice(message: Pick<Message, "role" | "systemKind">)
   return message.role === "system" && message.systemKind === "compaction_notice";
 }
 
-function sanitizeMessages(messages: Message[]) {
+function sanitizeMessages(messages: Message[] | undefined) {
+  if (!messages) return [];
   return messages.filter((message) => !isLegacyCompactionNotice(message));
 }
 
 function reconcileSnapshotMessages(
   current: Message[],
-  snapshot: Message[],
+  snapshot: Message[] | undefined,
   activeStreamMessageId: string | null
 ) {
   const sanitizedSnapshot = sanitizeMessages(snapshot);
@@ -844,12 +845,12 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
   }, [streamAnswerDisplay, streamAnswerTarget]);
 
   const latestCompactionLabel = useMemo(() => {
-    if (!debug.latestCompactionAt) {
+    if (!debug?.latestCompactionAt) {
       return "No compaction yet";
     }
 
     return formatTimestamp(debug.latestCompactionAt);
-  }, [debug.latestCompactionAt]);
+  }, [debug?.latestCompactionAt]);
 
   const selectedProfile = useMemo(
     () => payload.providerProfiles.find((profile) => profile.id === providerProfileId) ?? null,

--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -206,6 +206,8 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
   const [pendingAttachments, setPendingAttachments] = useState<MessageAttachment[]>([]);
   const [isUploadingAttachments, setIsUploadingAttachments] = useState(false);
   const [isDraggingFiles, setIsDraggingFiles] = useState(false);
+  const [personas, setPersonas] = useState<Array<{ id: string; name: string }>>([]);
+  const [personaId, setPersonaId] = useState<string | null>(null);
   const hasEmptyAssistantShell = messages.some(
     (message) =>
       message.role === "assistant" &&
@@ -238,10 +240,11 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
   const bootstrapPayloadRef = useRef<{
     message: string;
     attachments: MessageAttachment[];
+    personaId?: string;
   } | null>(null);
   const bootstrapSubmittedRef = useRef(false);
   const submitRef = useRef<
-    (nextInput?: string, nextPendingAttachments?: MessageAttachment[]) => Promise<void>
+    (nextInput?: string, nextPendingAttachments?: MessageAttachment[], nextPersonaId?: string) => Promise<void>
   >(async () => {});
 
   useEffect(() => {
@@ -289,6 +292,15 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
   useEffect(() => {
     setProviderProfileId(payload.conversation.providerProfileId ?? payload.defaultProviderProfileId);
   }, [payload.conversation.providerProfileId, payload.defaultProviderProfileId]);
+
+  useEffect(() => {
+    fetch("/api/personas")
+      .then((r) => r.json())
+      .then((d) => {
+        if (d.personas) setPersonas(d.personas);
+      })
+      .catch(() => {});
+  }, []);
 
   useEffect(() => {
     if (!queueRef.current) {
@@ -572,7 +584,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
 
     bootstrapSubmittedRef.current = true;
     clearChatBootstrap(payload.conversation.id);
-    void submitRef.current(bootstrapPayload.message, bootstrapPayload.attachments);
+    void submitRef.current(bootstrapPayload.message, bootstrapPayload.attachments, bootstrapPayload.personaId);
   }, [payload.conversation.id, wsConnected]);
 
   useEffect(() => {
@@ -1049,9 +1061,11 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
 
   async function submit(
     nextInput = input,
-    nextPendingAttachments = pendingAttachments
+    nextPendingAttachments = pendingAttachments,
+    nextPersonaId?: string
   ) {
     const value = nextInput.trim();
+    const effectivePersonaId = nextPersonaId ?? personaId;
 
     if ((!value && nextPendingAttachments.length === 0) || isSending || isUploadingAttachments) {
       return;
@@ -1103,7 +1117,8 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
       type: "message",
       conversationId: payload.conversation.id,
       content: value,
-      attachmentIds: nextPendingAttachments.map((attachment) => attachment.id)
+      attachmentIds: nextPendingAttachments.map((attachment) => attachment.id),
+      personaId: effectivePersonaId ?? undefined
     });
 
     if (titleGenerationStatus === "pending") {
@@ -1250,6 +1265,9 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
             providerProfiles={payload.providerProfiles}
             providerProfileId={providerProfileId}
             onProviderProfileChange={updateProviderProfile}
+            personas={personas}
+            personaId={personaId}
+            onPersonaChange={setPersonaId}
             toolExecutionMode={toolExecutionMode}
             onToolExecutionModeChange={updateToolExecutionMode}
             textareaRef={inputRef}

--- a/components/home-view.tsx
+++ b/components/home-view.tsx
@@ -33,6 +33,8 @@ export function HomeView({
   const [isUploadingAttachments, setIsUploadingAttachments] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isDraggingFiles, setIsDraggingFiles] = useState(false);
+  const [personas, setPersonas] = useState<Array<{ id: string; name: string }>>([]);
+  const [personaId, setPersonaId] = useState<string | null>(null);
   const [draftConversationId, setDraftConversationId] = useState<string | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const dragDepthRef = useRef(0);
@@ -49,6 +51,15 @@ export function HomeView({
     });
 
     return () => window.cancelAnimationFrame(handle);
+  }, []);
+
+  useEffect(() => {
+    fetch("/api/personas")
+      .then((r) => r.json())
+      .then((d) => {
+        if (d.personas) setPersonas(d.personas);
+      })
+      .catch(() => {});
   }, []);
 
   const selectedProfile = useMemo(
@@ -252,7 +263,8 @@ export function HomeView({
       }
       storeChatBootstrap(conversationId, {
         message: value,
-        attachments: pendingAttachments
+        attachments: pendingAttachments,
+        personaId: personaId ?? undefined
       });
       router.push(`/chat/${conversationId}`);
     } catch (caughtError) {
@@ -338,6 +350,9 @@ export function HomeView({
           providerProfiles={providerProfiles}
           providerProfileId={providerProfileId}
           onProviderProfileChange={handleProviderProfileChange}
+          personas={personas}
+          personaId={personaId}
+          onPersonaChange={setPersonaId}
           toolExecutionMode={toolExecutionMode}
           onToolExecutionModeChange={handleToolExecutionModeChange}
           textareaRef={textareaRef}

--- a/components/home-view.tsx
+++ b/components/home-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 
 import { ChatComposer } from "@/components/chat-composer";

--- a/components/settings/sections/personas-section.tsx
+++ b/components/settings/sections/personas-section.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Plus, FileText } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import type { Persona } from "@/lib/types";
+
+import { SettingsSplitPane } from "../settings-split-pane";
+import { ProfileCard } from "../profile-card";
+
+export function PersonasSection() {
+  const [personas, setPersonas] = useState<Persona[]>([]);
+  const [personaName, setPersonaName] = useState("");
+  const [personaContent, setPersonaContent] = useState("");
+  const [editingPersonaId, setEditingPersonaId] = useState<string | null>(null);
+  const [selectedPersonaId, setSelectedPersonaId] = useState<string | null>(null);
+  const [mobileDetailVisible, setMobileDetailVisible] = useState(false);
+  const [isAddingNew, setIsAddingNew] = useState(false);
+
+  useEffect(() => {
+    fetch("/api/personas")
+      .then((r) => r.json())
+      .then((d) => {
+        if (d.personas) setPersonas(d.personas);
+      })
+      .catch(() => {});
+  }, []);
+
+  async function savePersona() {
+    if (!personaName.trim() || !personaContent.trim()) return;
+
+    if (editingPersonaId) {
+      await fetch(`/api/personas/${editingPersonaId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: personaName,
+          content: personaContent
+        })
+      });
+    } else {
+      await fetch("/api/personas", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: personaName,
+          content: personaContent
+        })
+      });
+    }
+
+    const res = await fetch("/api/personas");
+    const data = (await res.json()) as { personas: Persona[] };
+    setPersonas(data.personas);
+    resetPersonaForm();
+  }
+
+  async function deletePersona(id: string) {
+    await fetch(`/api/personas/${id}`, { method: "DELETE" });
+    setPersonas((prev) => prev.filter((p) => p.id !== id));
+    if (selectedPersonaId === id) {
+      setSelectedPersonaId(null);
+      setMobileDetailVisible(false);
+    }
+  }
+
+  function handleSelectPersona(persona: Persona) {
+    setEditingPersonaId(persona.id);
+    setPersonaName(persona.name);
+    setPersonaContent(persona.content);
+    setSelectedPersonaId(persona.id);
+    setIsAddingNew(false);
+    setMobileDetailVisible(true);
+  }
+
+  function handleAddNew() {
+    setEditingPersonaId(null);
+    setPersonaName("");
+    setPersonaContent("");
+    setSelectedPersonaId(null);
+    setIsAddingNew(true);
+    setMobileDetailVisible(true);
+  }
+
+  function resetPersonaForm() {
+    setPersonaName("");
+    setPersonaContent("");
+    setEditingPersonaId(null);
+    setSelectedPersonaId(null);
+    setIsAddingNew(false);
+    setMobileDetailVisible(false);
+  }
+
+  const selectedPersona = personas.find((p) => p.id === selectedPersonaId);
+  const showDetail = selectedPersona || isAddingNew;
+
+  const labelClass = "text-[0.68rem] font-semibold uppercase tracking-[0.12em] text-[#71717a]";
+
+  return (
+    <div className="min-h-0 p-4 md:h-full md:p-8">
+      <SettingsSplitPane
+        listHeader={
+          <div className="flex items-center justify-between w-full">
+            <div>
+              <h2 className="text-[0.9rem] font-semibold text-[#f4f4f5]">Personas</h2>
+              <p className="text-[0.68rem] text-[#52525b]">
+                {personas.length} persona{personas.length !== 1 ? "s" : ""}
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={handleAddNew}
+              className="flex h-7 w-7 items-center justify-center rounded-lg border border-white/6 bg-white/[0.03] text-[#71717a] hover:text-[#f4f4f5] hover:bg-white/[0.06] transition-all duration-200"
+            >
+              <Plus className="h-4 w-4" />
+            </button>
+          </div>
+        }
+        listPanel={
+          <>
+            {personas.map((persona) => (
+              <ProfileCard
+                key={persona.id}
+                isActive={persona.id === selectedPersonaId}
+                onClick={() => handleSelectPersona(persona)}
+                title={persona.name}
+              />
+            ))}
+          </>
+        }
+        isDetailVisible={mobileDetailVisible}
+        onBackAction={() => setMobileDetailVisible(false)}
+        detailPanel={
+          <div className="max-w-[560px] space-y-6">
+            {showDetail ? (
+              <>
+                <div className="space-y-4">
+                  <div>
+                    <h3 className="text-[1.1rem] font-semibold text-[#f4f4f5]">
+                      {isAddingNew ? "New Persona" : selectedPersona?.name}
+                    </h3>
+                  </div>
+
+                  {!isAddingNew && selectedPersona ? (
+                    <Button
+                      type="button"
+                      variant="danger"
+                      onClick={() => deletePersona(selectedPersona.id)}
+                      className="gap-1.5 px-3 py-1.5 text-xs"
+                    >
+                      Delete
+                    </Button>
+                  ) : null}
+                </div>
+
+                <div className="space-y-5">
+                  <div>
+                    <label className={labelClass}>Name</label>
+                    <Input
+                      value={personaName}
+                      onChange={(e) => setPersonaName(e.target.value)}
+                      placeholder="Persona name"
+                    />
+                  </div>
+                  <div>
+                    <label className={labelClass}>System Instructions (Markdown)</label>
+                    <Textarea
+                      value={personaContent}
+                      onChange={(e) => setPersonaContent(e.target.value)}
+                      placeholder="Enter the persona instructions in markdown..."
+                      rows={12}
+                    />
+                  </div>
+                </div>
+
+                <div className="flex gap-2 pt-2">
+                  <Button type="button" onClick={savePersona}>
+                    {editingPersonaId ? "Update" : "Add persona"}
+                  </Button>
+                  <Button type="button" variant="secondary" onClick={resetPersonaForm}>
+                    Cancel
+                  </Button>
+                </div>
+              </>
+            ) : (
+              <div className="flex flex-col items-center justify-center py-24 text-center">
+                <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-white/[0.03] border border-white/6 mb-4">
+                  <FileText className="h-5 w-5 text-[#52525b]" />
+                </div>
+                <p className="text-[0.85rem] text-[#71717a]">
+                  Select a persona or add a new one
+                </p>
+              </div>
+            )}
+          </div>
+        }
+      />
+    </div>
+  );
+}

--- a/components/settings/settings-nav.tsx
+++ b/components/settings/settings-nav.tsx
@@ -10,11 +10,13 @@ import {
   Server,
   Zap,
   Shield,
+  Users,
 } from "lucide-react";
 
 const NAV_ITEMS = [
   { href: "/settings/general", label: "General", icon: Settings },
   { href: "/settings/providers", label: "Providers", icon: Sparkles },
+  { href: "/settings/personas", label: "Personas", icon: Users },
   { href: "/settings/mcp-servers", label: "MCP Servers", icon: Server },
   { href: "/settings/skills", label: "Skills", icon: Zap },
   { href: "/settings/account", label: "Account", icon: Shield },

--- a/docs/superpowers/plans/2026-04-07-personas.md
+++ b/docs/superpowers/plans/2026-04-07-personas.md
@@ -1,0 +1,1036 @@
+# Personas Feature Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add user-defined personas (markdown prompts) that append to the system prompt for specialized AI behavior.
+
+**Architecture:** Personas are stored in SQLite, managed via settings page, selected ephemeraly in chat composer, and injected into prompt construction after the system prompt.
+
+**Tech Stack:** Next.js, SQLite (better-sqlite3), React, TypeScript
+
+---
+
+## File Structure
+
+| File | Purpose |
+|------|---------|
+| `lib/personas.ts` | Data layer: CRUD operations for personas |
+| `lib/db.ts` | Modified: Add `personas` table migration |
+| `lib/types.ts` | Modified: Add `Persona` type |
+| `app/api/personas/route.ts` | API: GET (list), PUT (batch upsert) |
+| `app/api/personas/[personaId]/route.ts` | API: DELETE |
+| `app/settings/personas/page.tsx` | Settings page route |
+| `components/settings/sections/personas-section.tsx` | Personas settings section UI |
+| `components/settings/settings-nav.tsx` | Modified: Add Personas nav item |
+| `components/chat-composer.tsx` | Modified: Add persona dropdown |
+| `components/chat-view.tsx` | Modified: Pass persona selection to backend |
+| `lib/chat-turn.ts` | Modified: Pass persona ID to `ensureCompactedContext` |
+| `lib/compaction.ts` | Modified: Accept and append persona content |
+| `tests/unit/personas.test.ts` | Unit tests for personas data layer |
+| `tests/unit/compaction.test.ts` | Modified: Add persona prompt tests |
+
+---
+
+## Task 1: Database Schema and Types
+
+**Files:**
+- Modify: `lib/db.ts:267-276` (add personas table after skills)
+- Modify: `lib/types.ts:158` (add Persona type after Skill)
+
+- [ ] **Step 1: Write failing test for personas table**
+
+Create `tests/unit/personas.test.ts`:
+
+```typescript
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { getDb } from "@/lib/db";
+import { listPersonas, createPersona, getPersona, deletePersona, updatePersona } from "@/lib/personas";
+
+describe("personas", () => {
+  beforeAll(() => {
+    const db = getDb();
+    db.exec("DELETE FROM personas");
+  });
+
+  describe("listPersonas", () => {
+    it("returns empty array when no personas exist", () => {
+      const personas = listPersonas();
+      expect(personas).toEqual([]);
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test tests/unit/personas.test.ts`
+Expected: FAIL - `listPersonas` not defined
+
+- [ ] **Step 3: Add personas table migration in db.ts**
+
+In `lib/db.ts`, after the skills table creation (line 267-275), add:
+
+```typescript
+    CREATE TABLE IF NOT EXISTS personas (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      content TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+```
+
+- [ ] **Step 4: Add Persona type in types.ts**
+
+In `lib/types.ts`, after the `Skill` type (line 158), add:
+
+```typescript
+export type Persona = {
+  id: string;
+  name: string;
+  content: string;
+  createdAt: string;
+  updatedAt: string;
+};
+```
+
+- [ ] **Step 5: Create personas data layer**
+
+Create `lib/personas.ts`:
+
+```typescript
+import { getDb } from "@/lib/db";
+import { createId } from "@/lib/ids";
+import type { Persona } from "@/lib/types";
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function rowToPersona(row: {
+  id: string;
+  name: string;
+  content: string;
+  created_at: string;
+  updated_at: string;
+}): Persona {
+  return {
+    id: row.id,
+    name: row.name,
+    content: row.content,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at
+  };
+}
+
+export function listPersonas(): Persona[] {
+  const rows = getDb()
+    .prepare(
+      `SELECT id, name, content, created_at, updated_at
+       FROM personas
+       ORDER BY created_at ASC`
+    )
+    .all() as Array<{
+    id: string;
+    name: string;
+    content: string;
+    created_at: string;
+    updated_at: string;
+  }>;
+
+  return rows.map(rowToPersona);
+}
+
+export function getPersona(personaId: string): Persona | null {
+  const row = getDb()
+    .prepare(
+      `SELECT id, name, content, created_at, updated_at
+       FROM personas
+       WHERE id = ?`
+    )
+    .get(personaId) as {
+    id: string;
+    name: string;
+    content: string;
+    created_at: string;
+    updated_at: string;
+  } | undefined;
+
+  return row ? rowToPersona(row) : null;
+}
+
+export function createPersona(input: { name: string; content: string }): Persona {
+  const timestamp = nowIso();
+  const persona: Persona = {
+    id: createId("persona"),
+    name: input.name.trim(),
+    content: input.content,
+    createdAt: timestamp,
+    updatedAt: timestamp
+  };
+
+  getDb()
+    .prepare(
+      `INSERT INTO personas (id, name, content, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?)`
+    )
+    .run(persona.id, persona.name, persona.content, persona.createdAt, persona.updatedAt);
+
+  return persona;
+}
+
+export function updatePersona(
+  personaId: string,
+  input: { name?: string; content?: string }
+): Persona | null {
+  const current = getPersona(personaId);
+  if (!current) return null;
+
+  const timestamp = nowIso();
+  const name = input.name?.trim() ?? current.name;
+  const content = input.content ?? current.content;
+
+  getDb()
+    .prepare(
+      `UPDATE personas SET name = ?, content = ?, updated_at = ? WHERE id = ?`
+    )
+    .run(name, content, timestamp, personaId);
+
+  return getPersona(personaId);
+}
+
+export function deletePersona(personaId: string): void {
+  getDb().prepare("DELETE FROM personas WHERE id = ?").run(personaId);
+}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `npm test tests/unit/personas.test.ts`
+Expected: PASS
+
+- [ ] **Step 7: Commit database and types changes**
+
+```bash
+git add lib/db.ts lib/types.ts lib/personas.ts tests/unit/personas.test.ts
+git commit -m "feat: add personas database schema and data layer"
+```
+
+---
+
+## Task 2: Personas API Endpoints
+
+**Files:**
+- Create: `app/api/personas/route.ts`
+- Create: `app/api/personas/[personaId]/route.ts`
+- Modify: `tests/unit/personas.test.ts` (add API-level tests)
+
+- [ ] **Step 1: Write failing test for API endpoints**
+
+Add to `tests/unit/personas.test.ts`:
+
+```typescript
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { getDb } from "@/lib/db";
+import { listPersonas, createPersona, getPersona, deletePersona, updatePersona } from "@/lib/personas";
+
+describe("personas", () => {
+  beforeAll(() => {
+    const db = getDb();
+    db.exec("DELETE FROM personas");
+  });
+
+  describe("listPersonas", () => {
+    it("returns empty array when no personas exist", () => {
+      const personas = listPersonas();
+      expect(personas).toEqual([]);
+    });
+  });
+
+  describe("createPersona", () => {
+    it("creates a persona with name and content", () => {
+      const persona = createPersona({
+        name: "Finance Expert",
+        content: "You are a financial advisor specializing in tax optimization."
+      });
+      expect(persona.id).toBeDefined();
+      expect(persona.name).toBe("Finance Expert");
+      expect(persona.content).toBe("You are a financial advisor specializing in tax optimization.");
+      expect(persona.createdAt).toBeDefined();
+      expect(persona.updatedAt).toBeDefined();
+    });
+  });
+
+  describe("updatePersona", () => {
+    it("updates persona name and content", () => {
+      const created = createPersona({ name: "Test", content: "Initial" });
+      const updated = updatePersona(created.id, { name: "Updated", content: "New content" });
+      expect(updated?.name).toBe("Updated");
+      expect(updated?.content).toBe("New content");
+    });
+  });
+
+  describe("deletePersona", () => {
+    it("deletes a persona", () => {
+      const created = createPersona({ name: "To Delete", content: "Delete me" });
+      deletePersona(created.id);
+      expect(getPersona(created.id)).toBeNull();
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test tests/unit/personas.test.ts`
+Expected: PASS (tests should pass since we created the data layer)
+
+- [ ] **Step 3: Create GET/PUT API route**
+
+Create `app/api/personas/route.ts`:
+
+```typescript
+import { z } from "zod";
+import { requireUser } from "@/lib/auth";
+import { listPersonas, createPersona } from "@/lib/personas";
+import { badRequest, ok } from "@/lib/http";
+
+export async function GET() {
+  await requireUser();
+  return ok({ personas: listPersonas() });
+}
+
+const createSchema = z.object({
+  name: z.string().trim().min(1).max(100),
+  content: z.string().min(1)
+});
+
+export async function POST(request: Request) {
+  await requireUser();
+  const body = createSchema.safeParse(await request.json());
+  if (!body.success) return badRequest("Invalid persona data");
+
+  return ok({ persona: createPersona(body.data) }, { status: 201 });
+}
+```
+
+- [ ] **Step 4: Create DELETE API route**
+
+Create `app/api/personas/[personaId]/route.ts`:
+
+```typescript
+import { z } from "zod";
+import { requireUser } from "@/lib/auth";
+import { getPersona, updatePersona, deletePersona } from "@/lib/personas";
+import { badRequest, ok } from "@/lib/http";
+
+const paramsSchema = z.object({ personaId: z.string().min(1) });
+
+export async function PATCH(
+  request: Request,
+  context: { params: Promise<{ personaId: string }> }
+) {
+  await requireUser();
+  const params = paramsSchema.safeParse(await context.params);
+  if (!params.success) return badRequest("Invalid persona id");
+
+  const { personaId } = params.data;
+  const body = await request.json() as {
+    name?: string;
+    content?: string;
+  };
+
+  const updated = updatePersona(personaId, body);
+  if (!updated) return badRequest("Persona not found", 404);
+
+  return ok({ persona: updated });
+}
+
+export async function DELETE(
+  _request: Request,
+  context: { params: Promise<{ personaId: string }> }
+) {
+  await requireUser();
+  const params = paramsSchema.safeParse(await context.params);
+  if (!params.success) return badRequest("Invalid persona id");
+
+  deletePersona(params.data.personaId);
+  return ok({ success: true });
+}
+```
+
+- [ ] **Step 5: Commit API endpoints**
+
+```bash
+git add app/api/personas/route.ts app/api/personas/[personaId]/route.ts
+git commit -m "feat: add personas API endpoints"
+```
+
+---
+
+## Task 3: Personas Settings Page
+
+**Files:**
+- Create: `app/settings/personas/page.tsx`
+- Create: `components/settings/sections/personas-section.tsx`
+
+- [ ] **Step 1: Create settings page route**
+
+Create `app/settings/personas/page.tsx`:
+
+```typescript
+import { PersonasSection } from "@/components/settings/sections/personas-section";
+import { requireUser } from "@/lib/auth";
+
+export default async function PersonasPage() {
+  await requireUser();
+  return <PersonasSection />;
+}
+```
+
+- [ ] **Step 2: Create personas section component**
+
+Create `components/settings/sections/personas-section.tsx`:
+
+```typescript
+"use client";
+
+import { useEffect, useState } from "react";
+import { Plus, Users, Check } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import type { Persona } from "@/lib/types";
+
+import { SettingsSplitPane } from "../settings-split-pane";
+import { ProfileCard } from "../profile-card";
+
+export function PersonasSection() {
+  const [personas, setPersonas] = useState<Persona[]>([]);
+  const [personaName, setPersonaName] = useState("");
+  const [personaContent, setPersonaContent] = useState("");
+  const [editingPersonaId, setEditingPersonaId] = useState<string | null>(null);
+  const [selectedPersonaId, setSelectedPersonaId] = useState<string | null>(null);
+  const [mobileDetailVisible, setMobileDetailVisible] = useState(false);
+  const [isAddingNew, setIsAddingNew] = useState(false);
+  const [success, setSuccess] = useState("");
+
+  useEffect(() => {
+    fetch("/api/personas")
+      .then((r) => r.json())
+      .then((d) => {
+        if (d.personas) setPersonas(d.personas);
+      })
+      .catch(() => {});
+  }, []);
+
+  async function savePersona() {
+    if (!personaName.trim() || !personaContent.trim()) return;
+    setSuccess("");
+
+    if (editingPersonaId) {
+      await fetch(`/api/personas/${editingPersonaId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: personaName,
+          content: personaContent
+        })
+      });
+    } else {
+      await fetch("/api/personas", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: personaName,
+          content: personaContent
+        })
+      });
+    }
+
+    const res = await fetch("/api/personas");
+    const data = await res.json();
+    setPersonas(data.personas || []);
+    resetPersonaForm();
+    setSuccess("Persona saved.");
+    setTimeout(() => setSuccess(""), 2000);
+  }
+
+  async function deletePersona(id: string) {
+    await fetch(`/api/personas/${id}`, { method: "DELETE" });
+    setPersonas((prev) => prev.filter((p) => p.id !== id));
+    if (selectedPersonaId === id) {
+      setSelectedPersonaId(null);
+      setMobileDetailVisible(false);
+    }
+  }
+
+  function handleSelectPersona(persona: Persona) {
+    setEditingPersonaId(persona.id);
+    setPersonaName(persona.name);
+    setPersonaContent(persona.content);
+    setSelectedPersonaId(persona.id);
+    setIsAddingNew(false);
+    setMobileDetailVisible(true);
+  }
+
+  function handleAddNew() {
+    setEditingPersonaId(null);
+    setPersonaName("");
+    setPersonaContent("");
+    setSelectedPersonaId(null);
+    setIsAddingNew(true);
+    setMobileDetailVisible(true);
+  }
+
+  function resetPersonaForm() {
+    setPersonaName("");
+    setPersonaContent("");
+    setEditingPersonaId(null);
+    setSelectedPersonaId(null);
+    setIsAddingNew(false);
+    setMobileDetailVisible(false);
+  }
+
+  const selectedPersona = personas.find((p) => p.id === selectedPersonaId);
+  const showDetail = selectedPersona || isAddingNew;
+
+  const labelClass = "text-[0.68rem] font-semibold uppercase tracking-[0.12em] text-[#71717a]";
+
+  return (
+    <div className="min-h-0 p-4 md:h-full md:p-8">
+      <SettingsSplitPane
+        listHeader={
+          <div className="flex items-center justify-between w-full">
+            <div>
+              <h2 className="text-[0.9rem] font-semibold text-[#f4f4f5]">Personas</h2>
+              <p className="text-[0.68rem] text-[#52525b]">
+                {personas.length} persona{personas.length !== 1 ? "s" : ""}
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={handleAddNew}
+              className="flex h-7 w-7 items-center justify-center rounded-lg border border-white/6 bg-white/[0.03] text-[#71717a] hover:text-[#f4f4f5] hover:bg-white/[0.06] transition-all duration-200"
+            >
+              <Plus className="h-4 w-4" />
+            </button>
+          </div>
+        }
+        listPanel={
+          <>
+            {personas.map((persona) => (
+              <ProfileCard
+                key={persona.id}
+                isActive={persona.id === selectedPersonaId}
+                onClick={() => handleSelectPersona(persona)}
+                title={persona.name}
+                subtitle={persona.content.slice(0, 50) + (persona.content.length > 50 ? "..." : "")}
+              />
+            ))}
+          </>
+        }
+        isDetailVisible={mobileDetailVisible}
+        onBackAction={() => setMobileDetailVisible(false)}
+        detailPanel={
+          <div className="max-w-[560px] space-y-6">
+            {showDetail ? (
+              <>
+                <div className="space-y-4">
+                  <div>
+                    <h3 className="text-[1.1rem] font-semibold text-[#f4f4f5]">
+                      {isAddingNew ? "New Persona" : selectedPersona?.name}
+                    </h3>
+                    {!isAddingNew && selectedPersona ? (
+                      <p className="mt-0.5 text-[0.75rem] text-[#52525b]">
+                        Created {new Date(selectedPersona.createdAt).toLocaleDateString()}
+                      </p>
+                    ) : null}
+                  </div>
+
+                  {!isAddingNew && selectedPersona ? (
+                    <Button
+                      type="button"
+                      variant="danger"
+                      onClick={() => deletePersona(selectedPersona.id)}
+                      className="gap-1.5 px-3 py-1.5 text-xs"
+                    >
+                      Delete
+                    </Button>
+                  ) : null}
+                </div>
+
+                <div className="space-y-5">
+                  <div>
+                    <label className={labelClass}>Name</label>
+                    <Input
+                      value={personaName}
+                      onChange={(e) => setPersonaName(e.target.value)}
+                      placeholder="e.g., Finance Expert, Senior Developer"
+                    />
+                  </div>
+                  <div>
+                    <label className={labelClass}>Instructions (Markdown)</label>
+                    <Textarea
+                      value={personaContent}
+                      onChange={(e) => setPersonaContent(e.target.value)}
+                      placeholder="Enter persona instructions in markdown..."
+                      rows={8}
+                    />
+                  </div>
+                </div>
+
+                <div className="flex flex-wrap items-center gap-3 pt-2">
+                  <Button type="button" onClick={savePersona}>
+                    {editingPersonaId ? "Update" : "Add persona"}
+                  </Button>
+                  <Button type="button" variant="secondary" onClick={resetPersonaForm}>
+                    Cancel
+                  </Button>
+                  {success ? (
+                    <div className="flex items-center gap-1.5 text-sm text-emerald-400">
+                      <Check className="h-3.5 w-3.5" />
+                      {success}
+                    </div>
+                  ) : null}
+                </div>
+              </>
+            ) : (
+              <div className="flex flex-col items-center justify-center py-24 text-center">
+                <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-white/[0.03] border border-white/6 mb-4">
+                  <Users className="h-5 w-5 text-[#52525b]" />
+                </div>
+                <p className="text-[0.85rem] text-[#71717a]">
+                  Select a persona or add a new one
+                </p>
+                <p className="text-[0.75rem] text-[#52525b] mt-1">
+                  Personas are prompts that specialize AI behavior
+                </p>
+              </div>
+            )}
+          </div>
+        }
+      />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Add Personas to settings navigation**
+
+Modify `components/settings/settings-nav.tsx`. In the `NAV_ITEMS` array (line 15-21), add after "Providers":
+
+```typescript
+const NAV_ITEMS = [
+  { href: "/settings/general", label: "General", icon: Settings },
+  { href: "/settings/providers", label: "Providers", icon: Sparkles },
+  { href: "/settings/personas", label: "Personas", icon: Users },
+  { href: "/settings/mcp-servers", label: "MCP Servers", icon: Server },
+  { href: "/settings/skills", label: "Skills", icon: Zap },
+  { href: "/settings/account", label: "Account", icon: Shield },
+] as const;
+```
+
+Also add the import at the top:
+```typescript
+import {
+  ArrowLeft,
+  Settings,
+  Sparkles,
+  Server,
+  Zap,
+  Shield,
+  Users,
+} from "lucide-react";
+```
+
+- [ ] **Step 4: Commit settings page**
+
+```bash
+git add app/settings/personas/page.tsx components/settings/sections/personas-section.tsx components/settings/settings-nav.tsx
+git commit -m "feat: add personas settings page"
+```
+
+---
+
+## Task 4: Integrate Persona into Prompt Construction
+
+**Files:**
+- Modify: `lib/compaction.ts` (buildPromptMessages function)
+- Modify: `lib/chat-turn.ts` (pass personaId to ensureCompactedContext)
+- Modify: `tests/unit/compaction.test.ts` (add persona tests)
+
+- [ ] **Step 1: Write failing test for persona in buildPromptMessages**
+
+Add to `tests/unit/compaction.test.ts`:
+
+```typescript
+describe("buildPromptMessages with persona", () => {
+  it("appends persona content after system prompt", () => {
+    const messages: Message[] = [
+      { id: "1", conversationId: "c1", role: "user", content: "Hello", status: "completed", estimatedTokens: 10, thinkingContent: "", systemKind: null, compactedAt: null, createdAt: new Date().toISOString() }
+    ];
+    const result = buildPromptMessages({
+      systemPrompt: "You are a helpful assistant.",
+      personaContent: "You are a finance expert. Focus on tax implications.",
+      messages,
+      activeMemoryNodes: []
+    });
+
+    expect(result[0].role).toBe("system");
+    const systemContent = result[0].content as string;
+    expect(systemContent).toContain("You are a helpful assistant.");
+    expect(systemContent).toContain("You are a finance expert. Focus on tax implications.");
+  });
+
+  it("works without persona content", () => {
+    const messages: Message[] = [
+      { id: "1", conversationId: "c1", role: "user", content: "Hello", status: "completed", estimatedTokens: 10, thinkingContent: "", systemKind: null, compactedAt: null, createdAt: new Date().toISOString() }
+    ];
+    const result = buildPromptMessages({
+      systemPrompt: "You are a helpful assistant.",
+      messages,
+      activeMemoryNodes: []
+    });
+
+    expect(result[0].role).toBe("system");
+    const systemContent = result[0].content as string;
+    expect(systemContent).toBe("You are a helpful assistant.");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test tests/unit/compaction.test.ts`
+Expected: FAIL - personaContent not accepted in buildPromptMessages
+
+- [ ] **Step 3: Modify buildPromptMessages to accept persona content**
+
+In `lib/compaction.ts`, modify the `buildPromptMessages` function signature and implementation (around line 567):
+
+```typescript
+export function buildPromptMessages(input: {
+  systemPrompt: string;
+  personaContent?: string;
+  messages: Message[];
+  activeMemoryNodes: MemoryNode[];
+  userInput?: string;
+  maxAttachmentTextTokens?: number;
+}): PromptMessage[] {
+  const remainingAttachmentTextTokens = {
+    value: input.maxAttachmentTextTokens ?? Number.POSITIVE_INFINITY
+  };
+
+  // Build single merged system message
+  const systemParts: string[] = [input.systemPrompt];
+
+  // Append persona content if provided
+  if (input.personaContent?.trim()) {
+    systemParts.push(input.personaContent.trim());
+  }
+
+  if (input.activeMemoryNodes.length) {
+    systemParts.push(
+      "## Compacted Memory\n" + input.activeMemoryNodes
+        .map((node) => renderMemoryNode(node.content))
+        .join("\n\n")
+    );
+  }
+
+  // ... rest of the function unchanged
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test tests/unit/compaction.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit prompt construction changes**
+
+```bash
+git add lib/compaction.ts tests/unit/compaction.test.ts
+git commit -m "feat: append persona content to system prompt in buildPromptMessages"
+```
+
+---
+
+## Task 5: Pass Persona ID Through Chat Turn
+
+**Files:**
+- Modify: `lib/chat-turn.ts`
+- Modify: `lib/compaction.ts` (ensureCompactedContext)
+
+- [ ] **Step 1: Modify ensureCompactedContext to accept personaId**
+
+In `lib/compaction.ts`, modify the `ensureCompactedContext` function signature (around line 634):
+
+```typescript
+export async function ensureCompactedContext(
+  conversationId: string,
+  settings: ProviderProfileWithApiKey,
+  hooks: CompactionLifecycleHooks = {},
+  personaId?: string
+): Promise<EnsureCompactedContextResult> {
+```
+
+Then modify the `buildPromptMessages` call inside this function (around line 672 and other call sites):
+
+First, add import at top of file:
+```typescript
+import { getPersona } from "@/lib/personas";
+```
+
+Then modify the calls to `buildPromptMessages`:
+
+```typescript
+const persona = personaId ? getPersona(personaId) : null;
+const personaContent = persona?.content;
+
+// In the buildPromptMessages call:
+const promptMessages = buildPromptMessages({
+  systemPrompt: settings.systemPrompt,
+  personaContent,
+  messages,
+  activeMemoryNodes,
+  // ... other params
+});
+```
+
+There are multiple calls to `buildPromptMessages` in this file. Find all of them and add `personaContent` parameter.
+
+- [ ] **Step 2: Modify startChatTurn to accept personaId**
+
+In `lib/chat-turn.ts`, modify the function signature (line 40):
+
+```typescript
+export async function startChatTurn(
+  manager: ConversationManager,
+  conversationId: string,
+  content: string,
+  attachmentIds: string[],
+  personaId?: string
+) {
+```
+
+Then pass `personaId` to `ensureCompactedContext` (line 93):
+
+```typescript
+const compacted = await ensureCompactedContext(conversation.id, settings, {
+  onCompactionStart() {
+    // ...
+  },
+  onCompactionEnd() {
+    // ...
+  }
+}, personaId);
+```
+
+- [ ] **Step 3: Commit chat turn changes**
+
+```bash
+git add lib/chat-turn.ts lib/compaction.ts
+git commit -m "feat: pass persona ID through chat turn to prompt construction"
+```
+
+---
+
+## Task 6: Add Persona Dropdown in Chat Composer
+
+**Files:**
+- Modify: `components/chat-composer.tsx`
+- Modify: `components/chat-view.tsx`
+
+- [ ] **Step 1: Add persona state and dropdown in ChatComposer**
+
+In `components/chat-composer.tsx`, add props and state for persona selection:
+
+First, update the props interface (around line 27):
+
+```typescript
+type ChatComposerProps = {
+  input: string;
+  onInputChange: (value: string) => void;
+  onSubmit: () => void | Promise<void>;
+  isSending: boolean;
+  pendingAttachments: MessageAttachment[];
+  isUploadingAttachments: boolean;
+  onUploadFiles: (files: File[]) => Promise<void>;
+  onRemovePendingAttachment: (attachmentId: string) => Promise<void>;
+  showVisionWarning: boolean;
+  providerProfiles: ProviderProfileSummary[];
+  providerProfileId: string;
+  onProviderProfileChange: (providerProfileId: string) => void | Promise<void>;
+  personas: Array<{ id: string; name: string }>;
+  personaId: string | null;
+  onPersonaChange: (personaId: string | null) => void | Promise<void>;
+  toolExecutionMode: ToolExecutionMode;
+  onToolExecutionModeChange: (toolExecutionMode: ToolExecutionMode) => void | Promise<void>;
+  textareaRef?: React.Ref<HTMLTextAreaElement>;
+  className?: string;
+  usedTokens: number | null;
+  modelContextLimit: number;
+  compactionThreshold: number;
+  hasMessages: boolean;
+};
+```
+
+Then in the component function, destructure the new props:
+
+```typescript
+export function ChatComposer({
+  input,
+  onInputChange,
+  onSubmit,
+  isSending,
+  pendingAttachments,
+  isUploadingAttachments,
+  onUploadFiles,
+  onRemovePendingAttachment,
+  showVisionWarning,
+  providerProfiles,
+  providerProfileId,
+  onProviderProfileChange,
+  personas,
+  personaId,
+  onPersonaChange,
+  toolExecutionMode,
+  onToolExecutionModeChange,
+  textareaRef,
+  className,
+  usedTokens,
+  modelContextLimit,
+  compactionThreshold,
+  hasMessages
+}: ChatComposerProps) {
+```
+
+Then add the persona dropdown in the UI (after the model selector, around line 220):
+
+```typescript
+          <div className="relative group">
+            <button
+              className={`p-2 transition-colors duration-200 rounded-lg hover:bg-white/5 shrink-0 flex items-center gap-1 ${
+                personaId ? "text-violet-400/80 hover:text-violet-400" : "text-white/25 hover:text-white/50"
+              }`}
+              aria-label="Select persona"
+              type="button"
+            >
+              <Users className="h-5 w-5" />
+            </button>
+            <select
+              value={personaId ?? ""}
+              onChange={(event) => {
+                const value = event.target.value;
+                void onPersonaChange(value || null);
+              }}
+              className="absolute inset-0 opacity-0 cursor-pointer"
+              disabled={isSending || personas.length === 0}
+            >
+              <option value="">None</option>
+              {personas.map((persona) => (
+                <option key={persona.id} value={persona.id}>
+                  {persona.name}
+                </option>
+              ))}
+            </select>
+          </div>
+```
+
+Also add `Users` to the lucide-react imports at the top of the file.
+
+- [ ] **Step 2: Update ChatView to fetch personas and pass to ChatComposer**
+
+In `components/chat-view.tsx`, add state for personas and persona selection:
+
+First, add imports:
+```typescript
+import { useState, useEffect } from "react"; // add useEffect if not already
+```
+
+Then add state for personas:
+```typescript
+const [personas, setPersonas] = useState<Array<{ id: string; name: string }>>([]);
+const [personaId, setPersonaId] = useState<string | null>(null);
+```
+
+Add useEffect to fetch personas:
+```typescript
+useEffect(() => {
+  fetch("/api/personas")
+    .then((r) => r.json())
+    .then((d) => {
+      if (d.personas) setPersonas(d.personas);
+    })
+    .catch(() => {});
+}, []);
+```
+
+Pass these to ChatComposer in the JSX:
+```typescript
+<ChatComposer
+  // ... existing props
+  personas={personas}
+  personaId={personaId}
+  onPersonaChange={setPersonaId}
+/>
+```
+
+- [ ] **Step 3: Pass personaId to startChatTurn**
+
+In the chat submission handler, pass `personaId` to `startChatTurn`. Find where `startChatTurn` is called and add the parameter:
+
+```typescript
+await startChatTurn(manager, conversation.id, content, attachmentIds, personaId);
+```
+
+- [ ] **Step 4: Commit chat composer changes**
+
+```bash
+git add components/chat-composer.tsx components/chat-view.tsx
+git commit -m "feat: add persona dropdown to chat composer"
+```
+
+---
+
+## Task 7: Integration Testing
+
+**Files:**
+- Modify: `tests/unit/chat-view.test.tsx` (add persona dropdown tests)
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `npm test`
+Expected: All tests pass
+
+- [ ] **Step 2: Manual testing checklist**
+
+1. Start dev server: `npm run dev`
+2. Navigate to Settings > Personas
+3. Create a persona with name "Finance Expert" and markdown content
+4. Navigate to chat
+5. Verify persona dropdown shows "None" and "Finance Expert"
+6. Select "Finance Expert" and send a message
+7. Verify the persona is applied (check backend logs or prompt construction)
+
+- [ ] **Step 3: Final commit**
+
+```bash
+git add -A
+git commit -m "feat: complete personas feature with settings page and chat integration"
+```
+
+---
+
+## Summary
+
+This implementation adds:
+
+1. **Database layer**: Personas table and CRUD operations
+2. **API layer**: GET, POST, PATCH, DELETE endpoints
+3. **Settings page**: Full personas management UI
+4. **Chat integration**: Persona dropdown and prompt injection
+5. **Tests**: Unit tests for data layer and prompt construction
+
+The persona content is appended after the system prompt but before compacted memory, following the established prompt construction pattern.

--- a/docs/superpowers/specs/2026-04-07-personas-design.md
+++ b/docs/superpowers/specs/2026-04-07-personas-design.md
@@ -1,0 +1,144 @@
+---
+name: Personas Feature
+description: User-defined markdown prompts appended to system prompt for specialized AI behavior
+type: design
+---
+
+# Personas Feature Design
+
+## Overview
+
+Personas allow users to define markdown prompts that get appended after the system prompt, enabling specialized AI behavior without modifying the base provider settings. Examples: "Finance Expert", "Senior Python Developer", "Technical Writer".
+
+## Requirements
+
+- Users can create, edit, and delete personas in settings
+- Personas contain a name and markdown content
+- Persona selection is ephemeral (session-scoped, resets on reload/new conversation)
+- "None" is the default selection (no persona applied)
+- Selected persona content is appended after system prompt in prompt construction
+- Personas are global (shared across all provider profiles)
+
+## Data Model
+
+### Database Schema
+
+```sql
+CREATE TABLE personas (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  content TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+```
+
+### TypeScript Types
+
+```typescript
+type Persona = {
+  id: string;
+  name: string;
+  content: string;
+  createdAt: string;
+  updatedAt: string;
+};
+```
+
+## API Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/personas` | List all personas |
+| PUT | `/api/personas` | Upsert personas (create/update batch) |
+| DELETE | `/api/personas/:id` | Delete a persona |
+
+## Components
+
+### 1. Personas Settings Page
+
+**Route:** `/settings/personas`
+
+**Layout:** Follows `providers-section.tsx` pattern with `SettingsSplitPane`
+
+**Left Panel:**
+- List of persona cards showing name
+- Add button (+) in header
+- Empty state: "No personas. Create one to specialize AI behavior."
+
+**Right Panel:**
+- Name input field
+- Markdown textarea for content (same component as system prompt field)
+- Save button
+- Delete button (disabled if only one persona exists)
+- Preview section showing rendered markdown (optional enhancement)
+
+### 2. Settings Navigation
+
+**File:** `components/settings/settings-nav.tsx`
+
+**Add nav item:**
+```typescript
+{ href: "/settings/personas", label: "Personas", icon: Users }
+```
+
+Position: After "Providers", before "MCP Servers"
+
+### 3. Persona Dropdown in Chat Composer
+
+**File:** `components/chat-composer.tsx`
+
+**Location:** Next to model selector (Bot icon)
+
+**Behavior:**
+- Shows "None" by default
+- Lists all persona names when expanded
+- Selection stored in React state (not persisted to database)
+- Resets to "None" on page reload or new conversation
+
+## Prompt Construction Flow
+
+**File:** `lib/compaction.ts` — `buildPromptMessages()`
+
+```
+buildPromptMessages(input) called
+    ↓
+systemParts = [input.systemPrompt]
+    ↓
+If personaId provided in input → fetch persona → systemParts.push(persona.content)
+    ↓
+Append compacted memory nodes
+    ↓
+Append visible system messages
+    ↓
+Return [{ role: "system", content: systemParts.join("\n\n") }, ...]
+```
+
+## Files to Create
+
+| File | Purpose |
+|------|---------|
+| `lib/personas.ts` | Data layer: CRUD operations for personas |
+| `app/settings/personas/page.tsx` | Settings page route |
+| `components/settings/sections/personas-section.tsx` | Personas settings section |
+| `app/api/personas/route.ts` | API routes (GET, PUT) |
+| `app/api/personas/[id]/route.ts` | API route (DELETE) |
+
+## Files to Modify
+
+| File | Changes |
+|------|---------|
+| `lib/db.ts` | Add `personas` table migration |
+| `lib/types.ts` | Add `Persona` type |
+| `components/settings/settings-nav.tsx` | Add Personas nav item |
+| `components/chat-composer.tsx` | Add persona dropdown |
+| `components/chat-view.tsx` | Pass persona selection to backend |
+| `lib/chat-turn.ts` | Pass persona ID to `ensureCompactedContext` |
+| `lib/compaction.ts` | Accept and append persona content in `buildPromptMessages` |
+
+## UX Considerations
+
+- Persona content is markdown — users can format instructions with headers, lists, code blocks
+- No character limit enforced (let users decide)
+- Empty content validation on save
+- Name required (minimum 1 character)

--- a/lib/chat-bootstrap.ts
+++ b/lib/chat-bootstrap.ts
@@ -3,6 +3,7 @@ import type { MessageAttachment } from "@/lib/types";
 export type ChatBootstrapPayload = {
   message: string;
   attachments: MessageAttachment[];
+  personaId?: string;
 };
 
 function getChatBootstrapStorageKey(conversationId: string) {

--- a/lib/chat-turn.ts
+++ b/lib/chat-turn.ts
@@ -41,7 +41,8 @@ export async function startChatTurn(
   manager: ConversationManager,
   conversationId: string,
   content: string,
-  attachmentIds: string[]
+  attachmentIds: string[],
+  personaId?: string
 ) {
   const conversation = getConversation(conversationId);
   if (!conversation) return;
@@ -105,7 +106,7 @@ export async function startChatTurn(
           event: { type: "compaction_end" }
         });
       }
-    });
+    }, personaId);
     let promptMessages = compacted.promptMessages;
     const skills = appSettings.skillsEnabled ? listEnabledSkills() : [];
     const mcpServers = listEnabledMcpServers();

--- a/lib/compaction.ts
+++ b/lib/compaction.ts
@@ -566,6 +566,7 @@ async function scoreMemoryNodes(input: {
 
 export function buildPromptMessages(input: {
   systemPrompt: string;
+  personaContent?: string;
   messages: Message[];
   activeMemoryNodes: MemoryNode[];
   userInput?: string;
@@ -577,6 +578,11 @@ export function buildPromptMessages(input: {
 
   // Build single merged system message
   const systemParts: string[] = [input.systemPrompt];
+
+  // Append persona content if provided
+  if (input.personaContent?.trim()) {
+    systemParts.push(input.personaContent.trim());
+  }
 
   if (input.activeMemoryNodes.length) {
     systemParts.push(

--- a/lib/compaction.ts
+++ b/lib/compaction.ts
@@ -8,6 +8,7 @@ import {
 } from "@/lib/conversations";
 import { getDb } from "@/lib/db";
 import { createId } from "@/lib/ids";
+import { getPersona } from "@/lib/personas";
 import { callProviderText } from "@/lib/provider";
 import { estimateMessageTokens, estimatePromptTokens, estimateTextTokens, estimatePromptContentTokens } from "@/lib/tokenization";
 import type {
@@ -640,13 +641,17 @@ export function buildPromptMessages(input: {
 export async function ensureCompactedContext(
   conversationId: string,
   settings: ProviderProfileWithApiKey,
-  hooks: CompactionLifecycleHooks = {}
+  hooks: CompactionLifecycleHooks = {},
+  personaId?: string
 ): Promise<EnsureCompactedContextResult> {
   const conversation = getConversation(conversationId);
 
   if (!conversation) {
     throw new Error("Conversation not found");
   }
+
+  const persona = personaId ? getPersona(personaId) : null;
+  const personaContent = persona?.content;
 
   const allowedPromptTokens =
     settings.modelContextLimit - settings.maxOutputTokens - settings.safetyMarginTokens;
@@ -676,6 +681,7 @@ export async function ensureCompactedContext(
       const visibleMessages = messages.filter((message) => !message.compactedAt);
       const promptMessages = buildPromptMessages({
         systemPrompt: settings.systemPrompt,
+        personaContent,
         messages: visibleMessages,
         activeMemoryNodes,
         maxAttachmentTextTokens: Math.floor(settings.modelContextLimit * MAX_ATTACHMENT_TEXT_RATIO)
@@ -706,6 +712,7 @@ export async function ensureCompactedContext(
             selectedNodes = [...scored];
             const scoredTokens = buildPromptMessages({
               systemPrompt: settings.systemPrompt,
+              personaContent,
               messages: visibleMessages,
               activeMemoryNodes: scored,
               maxAttachmentTextTokens: Math.floor(settings.modelContextLimit * MAX_ATTACHMENT_TEXT_RATIO)
@@ -726,6 +733,7 @@ export async function ensureCompactedContext(
 
         const finalPromptMessages = buildPromptMessages({
           systemPrompt: settings.systemPrompt,
+          personaContent,
           messages: visibleMessages,
           activeMemoryNodes: selectedNodes,
           maxAttachmentTextTokens: Math.floor(settings.modelContextLimit * MAX_ATTACHMENT_TEXT_RATIO)
@@ -769,6 +777,7 @@ export async function ensureCompactedContext(
       if (lastUserMessage) {
         const promptMessages = buildPromptMessages({
           systemPrompt: settings.systemPrompt,
+          personaContent,
           messages: [lastUserMessage],
           activeMemoryNodes: remainingNodes
         });

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -273,6 +273,13 @@ function migrate(db: Database.Database) {
       created_at TEXT NOT NULL,
       updated_at TEXT NOT NULL
     );
+    CREATE TABLE IF NOT EXISTS personas (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      content TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
   `);
 
   const convCols = db.prepare("PRAGMA table_info(conversations)").all() as Array<{ name: string }>;

--- a/lib/personas.ts
+++ b/lib/personas.ts
@@ -1,0 +1,103 @@
+import { getDb } from "@/lib/db";
+import { createId } from "@/lib/ids";
+import type { Persona } from "@/lib/types";
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function rowToPersona(row: {
+  id: string;
+  name: string;
+  content: string;
+  created_at: string;
+  updated_at: string;
+}): Persona {
+  return {
+    id: row.id,
+    name: row.name,
+    content: row.content,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at
+  };
+}
+
+export function listPersonas(): Persona[] {
+  const rows = getDb()
+    .prepare(
+      `SELECT id, name, content, created_at, updated_at
+       FROM personas
+       ORDER BY created_at ASC`
+    )
+    .all() as Array<{
+    id: string;
+    name: string;
+    content: string;
+    created_at: string;
+    updated_at: string;
+  }>;
+
+  return rows.map(rowToPersona);
+}
+
+export function getPersona(personaId: string): Persona | null {
+  const row = getDb()
+    .prepare(
+      `SELECT id, name, content, created_at, updated_at
+       FROM personas
+       WHERE id = ?`
+    )
+    .get(personaId) as {
+    id: string;
+    name: string;
+    content: string;
+    created_at: string;
+    updated_at: string;
+  } | undefined;
+
+  return row ? rowToPersona(row) : null;
+}
+
+export function createPersona(input: { name: string; content: string }): Persona {
+  const timestamp = nowIso();
+  const persona: Persona = {
+    id: createId("persona"),
+    name: input.name.trim(),
+    content: input.content,
+    createdAt: timestamp,
+    updatedAt: timestamp
+  };
+
+  getDb()
+    .prepare(
+      `INSERT INTO personas (id, name, content, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?)`
+    )
+    .run(persona.id, persona.name, persona.content, persona.createdAt, persona.updatedAt);
+
+  return persona;
+}
+
+export function updatePersona(
+  personaId: string,
+  input: { name?: string; content?: string }
+): Persona | null {
+  const current = getPersona(personaId);
+  if (!current) return null;
+
+  const timestamp = nowIso();
+  const name = input.name?.trim() ?? current.name;
+  const content = input.content ?? current.content;
+
+  getDb()
+    .prepare(
+      `UPDATE personas SET name = ?, content = ?, updated_at = ? WHERE id = ?`
+    )
+    .run(name, content, timestamp, personaId);
+
+  return getPersona(personaId);
+}
+
+export function deletePersona(personaId: string): void {
+  getDb().prepare("DELETE FROM personas WHERE id = ?").run(personaId);
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -157,6 +157,14 @@ export type Skill = {
   updatedAt: string;
 };
 
+export type Persona = {
+  id: string;
+  name: string;
+  content: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
 export type Message = {
   id: string;
   conversationId: string;

--- a/lib/ws-handler.ts
+++ b/lib/ws-handler.ts
@@ -120,10 +120,10 @@ function handleMessage(
 async function handleUserMessage(
   mgr: ConversationManager,
   ws: WebSocket,
-  msg: { type: "message"; conversationId: string; content: string; attachmentIds?: string[] }
+  msg: { type: "message"; conversationId: string; content: string; attachmentIds?: string[]; personaId?: string }
 ) {
   if (!mgr.hasSubscribers(msg.conversationId)) {
     mgr.subscribe(msg.conversationId, ws);
   }
-  await startChatTurn(mgr, msg.conversationId, msg.content, msg.attachmentIds ?? []);
+  await startChatTurn(mgr, msg.conversationId, msg.content, msg.attachmentIds ?? [], msg.personaId);
 }

--- a/lib/ws-protocol.ts
+++ b/lib/ws-protocol.ts
@@ -3,7 +3,7 @@ import type { ChatStreamEvent } from "@/lib/types";
 export type ClientMessage =
   | { type: "subscribe"; conversationId: string }
   | { type: "unsubscribe"; conversationId: string }
-  | { type: "message"; conversationId: string; content: string; attachmentIds?: string[] }
+  | { type: "message"; conversationId: string; content: string; attachmentIds?: string[]; personaId?: string }
   | { type: "edit"; messageId: string; content: string };
 
 export type ServerMessage =

--- a/tests/unit/chat-view.test.ts
+++ b/tests/unit/chat-view.test.ts
@@ -145,7 +145,10 @@ describe("chat view", () => {
     conversationEventMock.dispatchConversationActivityUpdated.mockReset();
     conversationEventMock.dispatchConversationTitleUpdated.mockReset();
     vi.clearAllMocks();
-    global.fetch = vi.fn();
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ personas: [] })
+    } as Response);
     window.history.pushState({}, "", "/chat/conv_1");
   });
 
@@ -163,14 +166,19 @@ describe("chat view", () => {
 
   it("uploads an attachment from the file input and removes it from the pending list", async () => {
     const attachment = createAttachment();
-    vi.mocked(global.fetch).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ attachments: [attachment] })
-    } as Response);
-    vi.mocked(global.fetch).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ success: true })
-    } as Response);
+    vi.mocked(global.fetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ personas: [] })
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ attachments: [attachment] })
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true })
+      } as Response);
 
     const { container } = render(React.createElement(ChatView, { payload: createPayload() }));
     const input = container.querySelector('input[type="file"]') as HTMLInputElement;
@@ -228,10 +236,15 @@ describe("chat view", () => {
       kind: "text",
       extractedText: "hello"
     });
-    vi.mocked(global.fetch).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ attachments: [attachment] })
-    } as Response);
+    vi.mocked(global.fetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ personas: [] })
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ attachments: [attachment] })
+      } as Response);
 
     const { container } = render(React.createElement(ChatView, { payload: createPayload() }));
     const root = container.querySelector(".contents") as HTMLElement;

--- a/tests/unit/compaction.test.ts
+++ b/tests/unit/compaction.test.ts
@@ -327,3 +327,59 @@ describe("lossless compaction", () => {
     expect(result.promptMessages.some(m => m.role === "user")).toBe(true);
   });
 });
+
+describe("buildPromptMessages with persona", () => {
+  it("appends persona content after system prompt", () => {
+    const messages: import("@/lib/types").Message[] = [
+      {
+        id: "1",
+        conversationId: "c1",
+        role: "user",
+        content: "Hello",
+        status: "completed",
+        estimatedTokens: 10,
+        thinkingContent: "",
+        systemKind: null,
+        compactedAt: null,
+        createdAt: new Date().toISOString()
+      }
+    ];
+    const result = buildPromptMessages({
+      systemPrompt: "You are a helpful assistant.",
+      personaContent: "You are a finance expert. Focus on tax implications.",
+      messages,
+      activeMemoryNodes: []
+    });
+
+    expect(result[0].role).toBe("system");
+    const systemContent = result[0].content as string;
+    expect(systemContent).toContain("You are a helpful assistant.");
+    expect(systemContent).toContain("You are a finance expert. Focus on tax implications.");
+  });
+
+  it("works without persona content", () => {
+    const messages: import("@/lib/types").Message[] = [
+      {
+        id: "1",
+        conversationId: "c1",
+        role: "user",
+        content: "Hello",
+        status: "completed",
+        estimatedTokens: 10,
+        thinkingContent: "",
+        systemKind: null,
+        compactedAt: null,
+        createdAt: new Date().toISOString()
+      }
+    ];
+    const result = buildPromptMessages({
+      systemPrompt: "You are a helpful assistant.",
+      messages,
+      activeMemoryNodes: []
+    });
+
+    expect(result[0].role).toBe("system");
+    const systemContent = result[0].content as string;
+    expect(systemContent).toBe("You are a helpful assistant.");
+  });
+});

--- a/tests/unit/home-view.test.tsx
+++ b/tests/unit/home-view.test.tsx
@@ -40,7 +40,10 @@ describe("home view", () => {
   beforeEach(() => {
     push.mockReset();
     sessionStorage.clear();
-    global.fetch = vi.fn();
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ personas: [] })
+    } as Response);
   });
 
   afterEach(() => {
@@ -56,14 +59,19 @@ describe("home view", () => {
   });
 
   it("uses the shared composer and removes the old suggestion cards", async () => {
-    vi.mocked(global.fetch).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        conversation: {
-          id: "conv_new"
-        }
-      })
-    } as Response);
+    vi.mocked(global.fetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ personas: [] })
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          conversation: {
+            id: "conv_new"
+          }
+        })
+      } as Response);
 
     render(
       React.createElement(HomeView, {

--- a/tests/unit/personas.test.ts
+++ b/tests/unit/personas.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { listPersonas, createPersona, getPersona, deletePersona, updatePersona } from "@/lib/personas";
+
+describe("personas", () => {
+  describe("listPersonas", () => {
+    it("returns empty array when no personas exist", () => {
+      const personas = listPersonas();
+      expect(personas).toEqual([]);
+    });
+  });
+
+  describe("createPersona", () => {
+    it("creates a persona with name and content", () => {
+      const persona = createPersona({
+        name: "Finance Expert",
+        content: "You are a financial advisor specializing in tax optimization."
+      });
+      expect(persona.id).toBeDefined();
+      expect(persona.name).toBe("Finance Expert");
+      expect(persona.content).toBe("You are a financial advisor specializing in tax optimization.");
+      expect(persona.createdAt).toBeDefined();
+      expect(persona.updatedAt).toBeDefined();
+    });
+  });
+
+  describe("updatePersona", () => {
+    it("updates persona name and content", () => {
+      const created = createPersona({ name: "Test", content: "Initial" });
+      const updated = updatePersona(created.id, { name: "Updated", content: "New content" });
+      expect(updated?.name).toBe("Updated");
+      expect(updated?.content).toBe("New content");
+    });
+  });
+
+  describe("deletePersona", () => {
+    it("deletes a persona", () => {
+      const created = createPersona({ name: "To Delete", content: "Delete me" });
+      deletePersona(created.id);
+      expect(getPersona(created.id)).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a Personas settings page where users can create, edit, and delete markdown prompt personas that specialize AI behavior (e.g., "Finance Expert", "Senior Developer")
- Adds a persona dropdown in the chat composer (next to the model selector) for ephemeral per-session persona selection
- Appends selected persona content to the system prompt in prompt construction, invisible to the user

## Test Plan
- [ ] Navigate to Settings > Personas and verify CRUD operations work
- [ ] Verify persona dropdown appears in chat composer next to model selector
- [ ] Select a persona and send a message to verify prompt injection