### PR TITLE
feat: add import button to skills settings page

### DIFF
--- a/components/settings/sections/skills-section.tsx
+++ b/components/settings/sections/skills-section.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { Plus, FileText } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { Plus, FileText, Upload } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import { parseSkillContentMetadata } from "@/lib/skill-metadata";
 import type { Skill } from "@/lib/types";
 
 import { SettingsSplitPane } from "../settings-split-pane";
@@ -20,6 +21,7 @@ export function SkillsSection() {
   const [selectedSkillId, setSelectedSkillId] = useState<string | null>(null);
   const [mobileDetailVisible, setMobileDetailVisible] = useState(false);
   const [isAddingNew, setIsAddingNew] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     fetch("/api/skills")
@@ -99,6 +101,26 @@ export function SkillsSection() {
     setMobileDetailVisible(true);
   }
 
+  function handleImportFile(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onload = () => {
+      const text = reader.result as string;
+      const metadata = parseSkillContentMetadata(text);
+      const filenameStem = file.name.replace(/\.md$/i, "");
+
+      handleAddNew();
+      setSkillName(metadata.name || filenameStem);
+      setSkillDescription(metadata.description || "");
+      setSkillContent(text);
+    };
+    reader.readAsText(file);
+
+    e.target.value = "";
+  }
+
   function resetSkillForm() {
     setSkillName("");
     setSkillDescription("");
@@ -126,13 +148,30 @@ export function SkillsSection() {
                 {skills.length} skill{skills.length !== 1 ? "s" : ""}
               </p>
             </div>
-            <button
-              type="button"
-              onClick={handleAddNew}
-              className="flex h-7 w-7 items-center justify-center rounded-lg border border-white/6 bg-white/[0.03] text-[#71717a] hover:text-[#f4f4f5] hover:bg-white/[0.06] transition-all duration-200"
-            >
-              <Plus className="h-4 w-4" />
-            </button>
+            <div className="flex gap-1">
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept=".md"
+                className="hidden"
+                onChange={handleImportFile}
+              />
+              <button
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                className="flex h-7 w-7 items-center justify-center rounded-lg border border-white/6 bg-white/[0.03] text-[#71717a] hover:text-[#f4f4f5] hover:bg-white/[0.06] transition-all duration-200"
+                title="Import skill from .md file"
+              >
+                <Upload className="h-4 w-4" />
+              </button>
+              <button
+                type="button"
+                onClick={handleAddNew}
+                className="flex h-7 w-7 items-center justify-center rounded-lg border border-white/6 bg-white/[0.03] text-[#71717a] hover:text-[#f4f4f5] hover:bg-white/[0.06] transition-all duration-200"
+              >
+                <Plus className="h-4 w-4" />
+              </button>
+            </div>
           </div>
         }
         listPanel={

--- a/docs/superpowers/plans/2026-04-07-import-skill-button.md
+++ b/docs/superpowers/plans/2026-04-07-import-skill-button.md
@@ -1,0 +1,118 @@
+# Import Skill Button Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an Import button to the skills settings page that lets users upload a `.md` file and pre-fill the Add skill form.
+
+**Architecture:** Client-side only. A hidden `<input type="file">` reads the `.md` file via `FileReader`. The existing `parseSkillContentMetadata` parser extracts `name`/`description` from frontmatter. The parsed values populate the same form state that `handleAddNew()` initializes.
+
+**Tech Stack:** React, `lucide-react` (Upload icon), existing `parseSkillContentMetadata` from `lib/skill-metadata.ts`.
+
+---
+
+### Task 1: Add import button and file handling
+
+**Files:**
+- Modify: `components/settings/sections/skills-section.tsx`
+
+- [ ] **Step 1: Add the import button and hidden file input**
+
+In `skills-section.tsx`:
+
+1. Add `useRef` to the React import (line 3):
+```tsx
+import { useEffect, useRef, useState } from "react";
+```
+
+2. Add `Upload` to the lucide-react import (line 4):
+```tsx
+import { Plus, FileText, Upload } from "lucide-react";
+```
+
+3. Add `parseSkillContentMetadata` import (after line 9):
+```tsx
+import { parseSkillContentMetadata } from "@/lib/skill-metadata";
+```
+
+4. Add a file input ref inside the component, after the existing state declarations (after line 22):
+```tsx
+const fileInputRef = useRef<HTMLInputElement>(null);
+```
+
+5. Add a `handleImportFile` function after `handleAddNew` (after line 100):
+```tsx
+function handleImportFile(e: React.ChangeEvent<HTMLInputElement>) {
+  const file = e.target.files?.[0];
+  if (!file) return;
+
+  const reader = new FileReader();
+  reader.onload = () => {
+    const text = reader.result as string;
+    const metadata = parseSkillContentMetadata(text);
+    const filenameStem = file.name.replace(/\.md$/i, "");
+
+    handleAddNew();
+    setSkillName(metadata.name || filenameStem);
+    setSkillDescription(metadata.description || "");
+    setSkillContent(text);
+  };
+  reader.readAsText(file);
+
+  e.target.value = "";
+}
+```
+
+6. Add the hidden file input right before the closing `</div>` of the `listHeader` (before the `</div>` on line 136), and add the Upload button next to the Plus button. Replace the `listHeader` prop (lines 121-137) with:
+```tsx
+listHeader={
+  <div className="flex items-center justify-between w-full">
+    <div>
+      <h2 className="text-[0.9rem] font-semibold text-[#f4f4f5]">Skills</h2>
+      <p className="text-[0.68rem] text-[#52525b]">
+        {skills.length} skill{skills.length !== 1 ? "s" : ""}
+      </p>
+    </div>
+    <div className="flex gap-1">
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".md"
+        className="hidden"
+        onChange={handleImportFile}
+      />
+      <button
+        type="button"
+        onClick={() => fileInputRef.current?.click()}
+        className="flex h-7 w-7 items-center justify-center rounded-lg border border-white/6 bg-white/[0.03] text-[#71717a] hover:text-[#f4f4f5] hover:bg-white/[0.06] transition-all duration-200"
+        title="Import skill from .md file"
+      >
+        <Upload className="h-4 w-4" />
+      </button>
+      <button
+        type="button"
+        onClick={handleAddNew}
+        className="flex h-7 w-7 items-center justify-center rounded-lg border border-white/6 bg-white/[0.03] text-[#71717a] hover:text-[#f4f4f5] hover:bg-white/[0.06] transition-all duration-200"
+      >
+        <Plus className="h-4 w-4" />
+      </button>
+    </div>
+  </div>
+}
+```
+
+- [ ] **Step 2: Verify the dev server and test in browser**
+
+Run `npm run dev` (or use existing `.dev-server` URL). Open the settings/skills page. Verify:
+- Upload button appears next to the `+` button
+- Clicking it opens a file picker filtered to `.md`
+- Selecting a `.md` file with frontmatter pre-fills name, description, and content
+- Selecting a `.md` file without frontmatter uses filename as name
+- The form is editable — user can modify values before clicking "Add skill"
+- "Add skill" creates the skill successfully
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add components/settings/sections/skills-section.tsx
+git commit -m "feat: add import button to skills settings page"
+```

--- a/docs/superpowers/specs/2026-04-07-import-skill-button-design.md
+++ b/docs/superpowers/specs/2026-04-07-import-skill-button-design.md
@@ -1,0 +1,41 @@
+# Import Skill Button
+
+## Summary
+
+Add an "Import" button to the skills settings page that lets users upload a `.md` file. The file's content is parsed for YAML frontmatter metadata and used to pre-fill the existing "Add skill" form. The user can modify any values before saving.
+
+## Scope
+
+Client-side only. No backend changes, no new dependencies.
+
+## Changes
+
+### `components/settings/sections/skills-section.tsx`
+
+1. Add a hidden `<input type="file" accept=".md">` ref.
+2. Add an `Upload` icon button (from `lucide-react`) next to the existing `+` button in the `listHeader`.
+3. On button click, trigger the hidden file input.
+4. On file selection:
+   - Read the file with `FileReader.readAsText()`.
+   - Parse the content with `parseSkillContentMetadata()` (from `lib/skill-metadata.ts`).
+   - Call `handleAddNew()` to enter the new-skill form state.
+   - Set form values:
+     - `skillName` = frontmatter `name` or fallback to filename stem (without `.md` extension).
+     - `skillDescription` = frontmatter `description` or `""`.
+     - `skillContent` = full file text.
+
+### Edge Cases
+
+| Scenario | Behavior |
+|----------|----------|
+| File has no frontmatter | Name = filename stem, description empty, content = full file |
+| Frontmatter has only `name` | Name from frontmatter, description empty |
+| Frontmatter has only `description` | Name = filename stem, description from frontmatter |
+| User picks non-`.md` file | OS file picker prevents this via `accept=".md"` |
+
+## What Stays the Same
+
+- The "Add skill" form, its validation, and the POST `/api/skills` endpoint.
+- The existing `parseSkillContentMetadata` parser in `lib/skill-metadata.ts`.
+- The `+` button behavior (manual empty form).
+- Built-in skill read-only handling.


### PR DESCRIPTION
Add an Upload button next to the existing + button on the skills settings page. Clicking it opens a native file picker filtered to .md files. The selected file is parsed for YAML frontmatter metadata (name, description) and used to pre-fill the Add skill form, with the filename as a fallback when frontmatter is absent. Users can edit any pre-filled values before saving. No backend changes — reads files client-side via FileReader and reuses the existing `parseSkillContentMetadata` parser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)