### PR TITLE
feat: use full Eidon logo in sidebar, login, and mobile header

### DIFF
--- a/components/login-form.tsx
+++ b/components/login-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { FormEvent, useState } from "react";
+import Image from "next/image";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { ArrowRight, LoaderCircle } from "lucide-react";
@@ -42,17 +43,14 @@ export function LoginForm() {
       className="relative z-10 mx-auto flex w-full max-w-[420px] flex-col gap-7 rounded-2xl border border-white/6 bg-white/[0.03] backdrop-blur-xl px-8 py-10 shadow-[var(--shadow)] animate-slide-up"
     >
       <div className="space-y-3">
-        <div className="flex items-center gap-3">
-          <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-[var(--accent)] text-white text-sm font-bold shadow-[0_0_16px_var(--accent-glow)]">
-            E
-          </div>
-          <span
-            className="text-3xl text-[var(--text)]"
-            style={{ fontFamily: "var(--font-display)" }}
-          >
-            Eidon
-          </span>
-        </div>
+        <Image
+          src="/logo.png"
+          alt="Eidon"
+          height={80}
+          width={110}
+          priority
+          className="mx-auto"
+        />
         <p className="text-sm leading-relaxed text-[var(--muted)]">
           A private conversational workspace with streaming, visible thinking, and long-memory compaction.
         </p>

--- a/components/shell.tsx
+++ b/components/shell.tsx
@@ -3,6 +3,7 @@
 import { useState, type PropsWithChildren } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import { Menu, Plus } from "lucide-react";
+import Image from "next/image";
 import { motion, AnimatePresence } from "framer-motion";
 import { Sidebar } from "@/components/sidebar";
 import { SettingsNav } from "@/components/settings/settings-nav";
@@ -62,7 +63,14 @@ export function Shell({
             <Menu className="h-5 w-5" />
           </button>
 
-          <div className="font-semibold text-[var(--text)] text-sm tracking-wide">Eidon</div>
+          <Image
+            src="/logo.png"
+            alt="Eidon"
+            height={24}
+            width={34}
+            priority
+            className="mx-auto"
+          />
 
           <button
             type="button"

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef, useEffect, useCallback, type MouseEvent as ReactMouseEvent } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import Link from "next/link";
+import Image from "next/image";
 import {
   Plus,
   Search,
@@ -1035,12 +1036,15 @@ export function Sidebar({
               event.preventDefault();
               void navigateToHref("/");
             }}
-            className="flex items-center gap-2.5 rounded-lg px-2 py-1.5 hover:bg-white/[0.04] transition-colors duration-200"
+            className="flex items-center rounded-lg px-2 py-1.5 hover:bg-white/[0.04] transition-colors duration-200"
           >
-            <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-[var(--accent)] text-white text-xs font-bold shadow-[0_0_12px_var(--accent-glow)]">
-              E
-            </div>
-            <span className="font-semibold text-white/90 text-sm tracking-wide">Eidon</span>
+            <Image
+              src="/logo.png"
+              alt="Eidon"
+              height={55}
+              width={75}
+              priority
+            />
           </Link>
         </div>
 

--- a/docs/superpowers/plans/2026-04-07-full-logo-sidebar.md
+++ b/docs/superpowers/plans/2026-04-07-full-logo-sidebar.md
@@ -1,0 +1,167 @@
+# Full Logo in Sidebar, Login, and Mobile Header — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the hardcoded purple "E" icon + "Eidon" text with the full `logo.png` image in the sidebar, login card, and mobile header.
+
+**Architecture:** Three independent edits to replace inline JSX branding markup with `next/image` `<Image>` components pointing to the existing `/logo.png`. No new files, no new dependencies.
+
+**Tech Stack:** Next.js Image component, existing `public/logo.png`
+
+---
+
+### Task 1: Replace sidebar logo
+
+**Files:**
+- Modify: `components/sidebar.tsx:5` (add import)
+- Modify: `components/sidebar.tsx:1020-1044` (replace markup)
+
+- [ ] **Step 1: Add `next/image` import to sidebar.tsx**
+
+At line 5 (after the `Link` import), add:
+
+```tsx
+import Image from "next/image";
+```
+
+- [ ] **Step 2: Replace the E + "Eidon" markup with the logo image**
+
+Replace lines 1020-1044 (the `<div className="mb-4 px-1">` block) with:
+
+```tsx
+        <div className="mb-4 px-1">
+          <Link
+            href="/"
+            onClick={(event) => {
+              if (
+                event.defaultPrevented ||
+                event.button !== 0 ||
+                event.metaKey ||
+                event.ctrlKey ||
+                event.shiftKey ||
+                event.altKey
+              ) {
+                return;
+              }
+
+              event.preventDefault();
+              void navigateToHref("/");
+            }}
+            className="flex items-center rounded-lg px-2 py-1.5 hover:bg-white/[0.04] transition-colors duration-200"
+          >
+            <Image
+              src="/logo.png"
+              alt="Eidon"
+              height={36}
+              width={50}
+              priority
+            />
+          </Link>
+        </div>
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add components/sidebar.tsx
+git commit -m "feat: use full logo image in sidebar"
+```
+
+---
+
+### Task 2: Replace login card logo
+
+**Files:**
+- Modify: `components/login-form.tsx:3` (add import)
+- Modify: `components/login-form.tsx:45-55` (replace markup)
+
+- [ ] **Step 1: Add `next/image` import to login-form.tsx**
+
+At line 3 (after the `useState` import), add:
+
+```tsx
+import Image from "next/image";
+```
+
+- [ ] **Step 2: Replace the E + "Eidon" markup with the logo image**
+
+Replace lines 44-55 (the `<div className="space-y-3">` inner content — the flex row with E + Eidon text) with:
+
+```tsx
+      <div className="space-y-3">
+        <Image
+          src="/logo.png"
+          alt="Eidon"
+          height={80}
+          width={110}
+          priority
+          className="mx-auto"
+        />
+```
+
+Note: the closing `</div>` and `<p>` description that follow remain unchanged.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add components/login-form.tsx
+git commit -m "feat: use full logo image in login card"
+```
+
+---
+
+### Task 3: Replace mobile header text with logo
+
+**Files:**
+- Modify: `components/shell.tsx:4` (add import)
+- Modify: `components/shell.tsx:65` (replace markup)
+
+- [ ] **Step 1: Add `next/image` import to shell.tsx**
+
+At line 4 (after the `Menu` import), add:
+
+```tsx
+import Image from "next/image";
+```
+
+- [ ] **Step 2: Replace the "Eidon" text with the logo image**
+
+Replace line 65:
+
+```tsx
+          <div className="font-semibold text-[var(--text)] text-sm tracking-wide">Eidon</div>
+```
+
+With:
+
+```tsx
+          <Image
+            src="/logo.png"
+            alt="Eidon"
+            height={24}
+            width={34}
+            priority
+            className="mx-auto"
+          />
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add components/shell.tsx
+git commit -m "feat: use full logo image in mobile header"
+```
+
+---
+
+### Task 4: Visual validation
+
+**Files:** None (testing only)
+
+- [ ] **Step 1: Start dev server and validate all three locations**
+
+Start the dev server, then use the browser agent to:
+1. Open the app — verify the sidebar shows the full logo image at a comfortable size
+2. Navigate to the login page — verify the logo appears above the form fields
+3. Resize to mobile viewport — verify the logo appears in the top header bar
+4. Confirm the logo looks good on the dark background and doesn't have visual artifacts

--- a/docs/superpowers/specs/2026-04-07-full-logo-sidebar-design.md
+++ b/docs/superpowers/specs/2026-04-07-full-logo-sidebar-design.md
@@ -1,0 +1,36 @@
+# Full Logo in Sidebar, Login, and Mobile Header
+
+## Summary
+
+Replace the hardcoded purple "E" icon + "Eidon" text with the existing full logo image (`public/logo.png`) in three locations: sidebar, login page, and mobile header.
+
+## Current State
+
+Three files have duplicated hardcoded branding using a purple `<div>` containing the letter "E" and a `<span>` with "Eidon":
+
+- `components/sidebar.tsx` lines 1020-1044 — sidebar top-left
+- `components/login-form.tsx` lines 45-55 — top of login card
+- `components/shell.tsx` line 65 — mobile header (text only, no icon)
+
+`public/logo.png` (1022x743px, aspect ratio ~1.37:1) exists but is unused.
+
+## Changes
+
+### All three locations
+
+Replace the hardcoded E + "Eidon" markup with `next/image` `<Image>` pointing to `/logo.png` with `alt="Eidon"`.
+
+| Location | File | Image Size |
+|---|---|---|
+| Sidebar | `components/sidebar.tsx` | `height={36} width={50}` |
+| Login card | `components/login-form.tsx` | `height={80} width={110}` |
+| Mobile header | `components/shell.tsx` | `height={24} width={34}` |
+
+Sidebar and login versions use `priority` (above the fold). The existing Link wrapper, hover effects, and surrounding layout stay unchanged.
+
+## What Doesn't Change
+
+- Layout structure, spacing, link behavior
+- Mobile hamburger button, login form fields
+- The logo file itself
+- Any other UI components


### PR DESCRIPTION
Replace the hardcoded purple "E" icon + "Eidon" text with the existing `public/logo.png` image using `next/image` in three locations: sidebar top-left, login card, and mobile header bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)