### PR TITLE
fix: add sharp dependency for Docker image optimization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "react-markdown": "^10.1.0",
         "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.1",
+        "sharp": "^0.34.5",
         "tailwind-merge": "^2.5.5",
         "ws": "^8.20.0",
         "zod": "^3.24.2"
@@ -1046,7 +1047,6 @@
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
       "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=18"
       }
@@ -10448,7 +10448,6 @@
       "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "@img/colour": "^1.0.0",
         "detect-libc": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "react-markdown": "^10.1.0",
     "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
+    "sharp": "^0.34.5",
     "tailwind-merge": "^2.5.5",
     "ws": "^8.20.0",
     "zod": "^3.24.2"


### PR DESCRIPTION
## Summary
- Adds `sharp` as a direct production dependency so Next.js image optimization works in Docker standalone deployments
- Without `sharp`, `/_next/image` returns 400 for all images in production

## Test plan
- [ ] Rebuild Docker image and verify images load correctly
- [ ] Confirm no 400 errors from `/_next/image` endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)