### PR TITLE
Add stop button to cancel active chat turns

### DIFF
--- a/app/api/conversations/[conversationId]/chat/route.ts
+++ b/app/api/conversations/[conversationId]/chat/route.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import { resolveAssistantTurn } from "@/lib/assistant-runtime";
+import { ChatTurnStoppedError, registerChatTurn, clearChatTurn } from "@/lib/chat-turn-control";
 import { requireUser } from "@/lib/auth";
 import {
   bindAttachmentsToMessage,
@@ -117,6 +118,7 @@ export async function POST(
       });
 
       setConversationActive(conversation.id, true);
+      const control = registerChatTurn(conversation.id);
 
       try {
         const compacted = await ensureCompactedContext(conversation.id, settings, {
@@ -142,6 +144,9 @@ export async function POST(
         }
 
         let timelineSortOrder = 0;
+        let latestAnswer = "";
+        let latestThinking = "";
+        const runningActionHandles = new Set<string>();
 
         const providerResult = await resolveAssistantTurn({
           settings,
@@ -150,7 +155,16 @@ export async function POST(
           mcpServers,
           mcpToolSets,
           mcpTimeout: appSettings.mcpTimeout,
-          onEvent: write,
+          abortSignal: control.abortController.signal,
+          throwIfStopped: control.throwIfStopped,
+          onEvent(event: ChatStreamEvent) {
+            write(event);
+            if (event.type === "answer_delta") {
+              latestAnswer += event.text;
+            } else if (event.type === "thinking_delta") {
+              latestThinking += event.text;
+            }
+          },
           onAnswerSegment(segment) {
             createMessageTextSegment({
               messageId: assistantMessage.id,
@@ -171,6 +185,8 @@ export async function POST(
               sortOrder: timelineSortOrder++
             });
 
+            runningActionHandles.add(persisted.id);
+
             write({
               type: "action_start",
               action: persisted
@@ -182,6 +198,8 @@ export async function POST(
             if (!handle) {
               return;
             }
+
+            runningActionHandles.delete(handle);
 
             const updated = updateMessageAction(handle, {
               status: "completed",
@@ -202,6 +220,7 @@ export async function POST(
               return;
             }
 
+            runningActionHandles.delete(handle);
             const updated = updateMessageAction(handle, {
               status: "error",
               detail: patch.detail,
@@ -235,18 +254,41 @@ export async function POST(
         setConversationActive(conversation.id, false);
         controller.close();
       } catch (error) {
-        updateMessage(assistantMessage.id, {
-          content: "",
-          thinkingContent: "",
-          status: "error"
-        });
+        if (error instanceof ChatTurnStoppedError) {
+          updateMessage(assistantMessage.id, {
+            content: latestAnswer,
+            thinkingContent: latestThinking,
+            status: "stopped",
+            estimatedTokens: estimateTextTokens(latestAnswer)
+          });
 
-        write({
-          type: "error",
-          message: error instanceof Error ? error.message : "Chat stream failed"
-        });
+          for (const handle of runningActionHandles) {
+            updateMessageAction(handle, {
+              status: "stopped",
+              completedAt: new Date().toISOString()
+            });
+          }
+
+          write({
+            type: "done",
+            messageId: assistantMessage.id
+          });
+        } else {
+          updateMessage(assistantMessage.id, {
+            content: "",
+            thinkingContent: "",
+            status: "error"
+          });
+
+          write({
+            type: "error",
+            message: error instanceof Error ? error.message : "Chat stream failed"
+          });
+        }
         setConversationActive(conversation.id, false);
         controller.close();
+      } finally {
+        clearChatTurn(conversation.id);
       }
     }
   });

--- a/app/api/conversations/[conversationId]/chat/route.ts
+++ b/app/api/conversations/[conversationId]/chat/route.ts
@@ -119,6 +119,9 @@ export async function POST(
 
       setConversationActive(conversation.id, true);
       const control = registerChatTurn(conversation.id);
+      let latestAnswer = "";
+      let latestThinking = "";
+      const runningActionHandles = new Set<string>();
 
       try {
         const compacted = await ensureCompactedContext(conversation.id, settings, {
@@ -144,9 +147,6 @@ export async function POST(
         }
 
         let timelineSortOrder = 0;
-        let latestAnswer = "";
-        let latestThinking = "";
-        const runningActionHandles = new Set<string>();
 
         const providerResult = await resolveAssistantTurn({
           settings,

--- a/components/chat-composer.tsx
+++ b/components/chat-composer.tsx
@@ -9,6 +9,7 @@ import {
   FileText,
   LoaderCircle,
   Paperclip,
+  Square,
   Users,
   X
 } from "lucide-react";
@@ -43,6 +44,9 @@ type ChatComposerProps = {
   modelContextLimit: number;
   compactionThreshold: number;
   hasMessages: boolean;
+  canStop: boolean;
+  isStopPending: boolean;
+  onStop: () => void | Promise<void>;
 };
 
 export function ChatComposer({
@@ -66,11 +70,15 @@ export function ChatComposer({
   usedTokens,
   modelContextLimit,
   compactionThreshold,
-  hasMessages
+  hasMessages,
+  canStop,
+  isStopPending,
+  onStop
 }: ChatComposerProps) {
   const fileInputRef = React.useRef<HTMLInputElement | null>(null);
   const isSubmitDisabled =
     isSending || isUploadingAttachments || (!input.trim() && pendingAttachments.length === 0);
+  const showStopButton = canStop && !isUploadingAttachments;
 
   return (
     <div
@@ -152,16 +160,20 @@ export function ChatComposer({
         </div>
 
         <button
-          onClick={() => void onSubmit()}
-          disabled={isSubmitDisabled}
+          onClick={() => void (showStopButton ? onStop() : onSubmit())}
+          disabled={showStopButton ? isStopPending : isSubmitDisabled}
           className={`mb-0.5 mr-0.5 flex h-8 w-8 items-center justify-center rounded-xl transition-all duration-300 shrink-0 ${
-            !isSubmitDisabled
-              ? "bg-[var(--accent)] text-white shadow-[0_0_12px_var(--accent-glow)] hover:shadow-[0_0_20px_var(--accent-glow)] active:scale-95"
-              : "bg-white/6 text-white/25"
+            showStopButton
+              ? isStopPending
+                ? "bg-white/6 text-white/25"
+                : "bg-amber-500 text-white shadow-[0_0_12px_rgba(245,158,11,0.3)] hover:shadow-[0_0_20px_rgba(245,158,11,0.4)] active:scale-95"
+              : !isSubmitDisabled
+                ? "bg-[var(--accent)] text-white shadow-[0_0_12px_var(--accent-glow)] hover:shadow-[0_0_20px_var(--accent-glow)] active:scale-95"
+                : "bg-white/6 text-white/25"
           }`}
-          aria-label="Send message"
+          aria-label={showStopButton ? "Stop response" : "Send message"}
         >
-          {isSending || isUploadingAttachments ? (
+          {showStopButton ? <Square className="h-3.5 w-3.5 fill-current" /> : isSending || isUploadingAttachments ? (
             <LoaderCircle className="h-4 w-4 animate-spin" />
           ) : (
             <ArrowUp className="h-4 w-4" />

--- a/components/chat-composer.tsx
+++ b/components/chat-composer.tsx
@@ -166,7 +166,7 @@ export function ChatComposer({
             showStopButton
               ? isStopPending
                 ? "bg-white/6 text-white/25"
-                : "bg-amber-500 text-white shadow-[0_0_12px_rgba(245,158,11,0.3)] hover:shadow-[0_0_20px_rgba(245,158,11,0.4)] active:scale-95"
+                : "bg-red-500 text-white shadow-[0_0_12px_rgba(239,68,68,0.3)] hover:shadow-[0_0_20px_rgba(239,68,68,0.4)] active:scale-95"
               : !isSubmitDisabled
                 ? "bg-[var(--accent)] text-white shadow-[0_0_12px_var(--accent-glow)] hover:shadow-[0_0_20px_var(--accent-glow)] active:scale-95"
                 : "bg-white/6 text-white/25"
@@ -182,7 +182,7 @@ export function ChatComposer({
       </div>
 
       {showVisionWarning ? (
-        <div className="mt-2 flex items-center gap-2 rounded-xl border border-amber-400/10 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
+        <div className="mt-2 flex items-center gap-2 rounded-xl border border-red-400/10 bg-red-500/10 px-3 py-2 text-xs text-red-200">
           <AlertCircle className="h-4 w-4 shrink-0" />
           <span>
             This model may not support image input. Eidon will still send the attachment and surface any provider error.

--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -237,6 +237,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
   const [input, setInput] = useState("");
   const [error, setError] = useState("");
   const [isSending, setIsSending] = useState(false);
+  const [isStopPending, setIsStopPending] = useState(false);
   const [streamThinkingTarget, setStreamThinkingTarget] = useState("");
   const [streamThinkingDisplay, setStreamThinkingDisplay] = useState("");
   const [streamAnswerTarget, setStreamAnswerTarget] = useState("");
@@ -508,6 +509,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
 
     if (event.type === "done") {
       clearCompactionIndicator();
+      setIsStopPending(false);
       const finalAnswer = streamAnswerTargetRef.current;
       const finalThinking = streamThinkingTargetRef.current;
       const finalTimeline = streamTimelineRef.current;
@@ -542,6 +544,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
 
     if (event.type === "error") {
       clearCompactionIndicator();
+      setIsStopPending(false);
       const activeStreamMessageId = streamMessageIdRef.current;
       dispatchConversationActivityUpdated({
         conversationId: payload.conversation.id,
@@ -1176,6 +1179,18 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
     }
   }
 
+  function stopActiveTurn() {
+    if (!streamMessageIdRef.current || isStopPending) {
+      return;
+    }
+
+    setIsStopPending(true);
+    wsSend({
+      type: "stop",
+      conversationId: payload.conversation.id
+    });
+  }
+
   submitRef.current = submit;
 
   return (
@@ -1309,6 +1324,9 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
             modelContextLimit={selectedProfile?.modelContextLimit ?? 128000}
             compactionThreshold={selectedProfile?.compactionThreshold ?? 0.78}
             hasMessages={messages.length > 0}
+            canStop={!!streamMessageId && !isStopPending}
+            isStopPending={isStopPending}
+            onStop={stopActiveTurn}
           />
         </div>
       </div>

--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -509,6 +509,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
 
     if (event.type === "done") {
       clearCompactionIndicator();
+      const wasStopped = isStopPending;
       setIsStopPending(false);
       const finalAnswer = streamAnswerTargetRef.current;
       const finalThinking = streamThinkingTargetRef.current;
@@ -525,7 +526,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
                 ...m,
                 content: finalAnswer,
                 thinkingContent: finalThinking,
-                status: "completed" as const,
+                status: wasStopped ? ("stopped" as const) : ("completed" as const),
                 timeline: finalTimeline
               }
             : m

--- a/components/home-view.tsx
+++ b/components/home-view.tsx
@@ -334,6 +334,9 @@ export function HomeView({
           modelContextLimit={selectedProfile?.modelContextLimit ?? 128000}
           compactionThreshold={selectedProfile?.compactionThreshold ?? 0.78}
           hasMessages={false}
+          canStop={false}
+          isStopPending={false}
+          onStop={() => {}}
         />
 
         {error ? (

--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -52,7 +52,7 @@ function CollapsibleActionRow({
     : action.status === "completed"
       ? <Check className="h-2.5 w-2.5 text-emerald-400" />
       : action.status === "stopped"
-        ? <Square className="h-2.5 w-2.5 text-amber-300 fill-current" />
+        ? <Square className="h-2.5 w-2.5 text-red-400 fill-current" />
         : <X className="h-2.5 w-2.5 text-red-400" />;
 
   if (action.status === "running") {
@@ -619,7 +619,7 @@ export function MessageBubble({
                     );
                   })}
                   {message.status === "stopped" ? (
-                    <div className="inline-flex items-center gap-1.5 rounded-md border border-amber-300/12 bg-amber-300/8 px-2 py-1 text-[11px] text-amber-100/85">
+                    <div className="inline-flex items-center gap-1.5 rounded-md border border-red-400/12 bg-red-400/8 px-2 py-1 text-[11px] text-red-200/85">
                       <Square className="h-2.5 w-2.5 fill-current" />
                       <span>Stopped</span>
                     </div>

--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useEffect, useRef, useState } from "react";
-import { Brain, Check, ChevronDown, ChevronRight, Copy, FileText, LoaderCircle, Pencil, X } from "lucide-react";
+import { Brain, Check, ChevronDown, ChevronRight, Copy, FileText, LoaderCircle, Pencil, Square, X } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
@@ -51,7 +51,9 @@ function CollapsibleActionRow({
     ? <LoaderCircle className="h-2.5 w-2.5 animate-spin text-white/55" />
     : action.status === "completed"
       ? <Check className="h-2.5 w-2.5 text-emerald-400" />
-      : <X className="h-2.5 w-2.5 text-red-400" />;
+      : action.status === "stopped"
+        ? <Square className="h-2.5 w-2.5 text-amber-300 fill-current" />
+        : <X className="h-2.5 w-2.5 text-red-400" />;
 
   if (action.status === "running") {
     return (
@@ -616,6 +618,12 @@ export function MessageBubble({
                       </div>
                     );
                   })}
+                  {message.status === "stopped" ? (
+                    <div className="inline-flex items-center gap-1.5 rounded-md border border-amber-300/12 bg-amber-300/8 px-2 py-1 text-[11px] text-amber-100/85">
+                      <Square className="h-2.5 w-2.5 fill-current" />
+                      <span>Stopped</span>
+                    </div>
+                  ) : null}
                 </div>
 
                 {showAssistantBubbleActions ? (

--- a/docs/superpowers/plans/2026-04-08-stop-stream-button.md
+++ b/docs/superpowers/plans/2026-04-08-stop-stream-button.md
@@ -1,0 +1,640 @@
+# Stop Button for Active Chat Turns Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the composer spinner with a stop button that cancels the entire active turn while preserving the partial assistant reply and marking it as stopped in the transcript.
+
+**Architecture:** Add explicit `stopped` terminal states to the chat model and websocket protocol, then introduce a shared turn-control registry that both websocket and HTTP chat flows use to cancel active work cooperatively. The client stops sending new work once cancellation is requested, keeps the partial assistant bubble on screen, and renders a compact stopped indicator plus interrupted action rows after the server finalizes the turn.
+
+**Tech Stack:** TypeScript, Next.js 15 App Router, React 19, `ws`, Vitest, Testing Library, Playwright
+
+**Spec:** `docs/superpowers/specs/2026-04-08-stop-stream-button-design.md`
+
+---
+
+## File Structure
+
+### New files
+
+| File | Responsibility |
+|------|---------------|
+| `lib/chat-turn-control.ts` | Active turn registry, per-conversation abort controller, `ChatTurnStoppedError`, and stop/register/clear helpers |
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `lib/types.ts` | Add `stopped` to `MessageStatus` and `MessageActionStatus`; add any stop-related stream event types if needed |
+| `lib/ws-protocol.ts` | Add client `stop` message parsing/serialization support |
+| `lib/provider.ts` | Accept external abort signal so provider streaming can be cancelled from the turn registry |
+| `lib/assistant-runtime.ts` | Accept cancellation hooks, stop between tool phases, and propagate `ChatTurnStoppedError` cleanly |
+| `lib/chat-turn.ts` | Register/clear turn controls, persist partial assistant data on stop, mark active actions/messages as `stopped` |
+| `app/api/conversations/[conversationId]/chat/route.ts` | Reuse the shared cancellation-aware turn flow for HTTP streaming |
+| `lib/ws-handler.ts` | Handle websocket `stop` messages and resolve them through the turn registry |
+| `components/chat-composer.tsx` | Render stop button state instead of spinner when a turn is active |
+| `components/chat-view.tsx` | Send stop requests, keep partial streamed content during cancellation, and reconcile stopped messages |
+| `components/message-bubble.tsx` | Render stopped assistant indicator and stopped action rows |
+| `tests/unit/ws-protocol.test.ts` | Add stop message coverage |
+| `tests/unit/assistant-runtime.test.ts` | Verify runtime exits cleanly when cancellation is requested |
+| `tests/unit/chat-turn.test.ts` | Verify partial content is persisted and statuses become `stopped` |
+| `tests/unit/ws-handler.test.ts` | Verify websocket stop messages hit the turn registry |
+| `tests/unit/chat-view.test.ts` | Verify composer sends stop and keeps the partial assistant row visible |
+| `tests/unit/message-bubble.test.ts` | Verify stopped indicator and stopped action styling |
+
+---
+
+### Task 1: Add typed stop and stopped-state support
+
+**Files:**
+- Modify: `lib/types.ts`
+- Modify: `lib/ws-protocol.ts`
+- Test: `tests/unit/ws-protocol.test.ts`
+
+- [ ] **Step 1: Write the failing protocol test**
+
+Update `tests/unit/ws-protocol.test.ts` with a stop-message assertion:
+
+```typescript
+it("serializes and parses a client stop message", async () => {
+  const { serializeClientMessage, parseClientMessage } = await import("@/lib/ws-protocol");
+  const msg = { type: "stop", conversationId: "conv-1" };
+  const raw = serializeClientMessage(msg);
+  const parsed = parseClientMessage(raw);
+  expect(parsed).toEqual(msg);
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run tests/unit/ws-protocol.test.ts`
+Expected: FAIL with the stop message parsing to `null` or TypeScript rejecting the new client message type.
+
+- [ ] **Step 3: Implement the type and protocol changes**
+
+Update `lib/types.ts`:
+
+```typescript
+export type MessageStatus = "idle" | "streaming" | "completed" | "error" | "stopped";
+
+export type MessageActionStatus = "running" | "completed" | "error" | "stopped";
+```
+
+Update `lib/ws-protocol.ts`:
+
+```typescript
+export type ClientMessage =
+  | { type: "subscribe"; conversationId: string }
+  | { type: "unsubscribe"; conversationId: string }
+  | { type: "message"; conversationId: string; content: string; attachmentIds?: string[]; personaId?: string }
+  | { type: "stop"; conversationId: string }
+  | { type: "edit"; messageId: string; content: string };
+
+const CLIENT_MESSAGE_TYPES = new Set(["subscribe", "unsubscribe", "message", "stop", "edit"]);
+```
+
+- [ ] **Step 4: Run the protocol test again**
+
+Run: `npx vitest run tests/unit/ws-protocol.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/types.ts lib/ws-protocol.ts tests/unit/ws-protocol.test.ts
+git commit -m "feat: add stopped chat statuses and ws stop message"
+```
+
+---
+
+### Task 2: Introduce shared turn cancellation primitives
+
+**Files:**
+- Create: `lib/chat-turn-control.ts`
+- Modify: `lib/provider.ts`
+- Modify: `lib/assistant-runtime.ts`
+- Test: `tests/unit/assistant-runtime.test.ts`
+
+- [ ] **Step 1: Write the failing runtime cancellation test**
+
+Add this case to `tests/unit/assistant-runtime.test.ts`:
+
+```typescript
+it("stops before executing a tool call when cancellation is requested", async () => {
+  const abortController = new AbortController();
+
+  streamProviderResponse.mockReturnValueOnce(
+    createProviderStream([], {
+      answer: "",
+      thinking: "",
+      toolCalls: [{ id: "call_1", name: "mcp_mcp_docs_search_docs", arguments: JSON.stringify({ query: "MCP" }) }],
+      usage: { inputTokens: 9 }
+    })
+  );
+
+  const { ChatTurnStoppedError, createChatTurnControl } = await import("@/lib/chat-turn-control");
+  const { resolveAssistantTurn } = await import("@/lib/assistant-runtime");
+  const control = createChatTurnControl("conv_1", abortController);
+  control.requestStop();
+
+  await expect(resolveAssistantTurn({
+    settings: createSettings(),
+    promptMessages: [{ role: "user", content: "Find MCP docs" }],
+    skills: [],
+    mcpToolSets: [],
+    abortSignal: abortController.signal,
+    throwIfStopped: control.throwIfStopped
+  })).rejects.toBeInstanceOf(ChatTurnStoppedError);
+
+  expect(callMcpTool).not.toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 2: Run the runtime test to verify it fails**
+
+Run: `npx vitest run tests/unit/assistant-runtime.test.ts`
+Expected: FAIL because `resolveAssistantTurn` does not yet accept cancellation input or stop before tool execution.
+
+- [ ] **Step 3: Implement the shared control object and thread it into provider/runtime**
+
+Create `lib/chat-turn-control.ts`:
+
+```typescript
+export class ChatTurnStoppedError extends Error {
+  constructor() {
+    super("Chat turn stopped by user");
+    this.name = "ChatTurnStoppedError";
+  }
+}
+
+const activeTurns = new Map<string, ReturnType<typeof createChatTurnControl>>();
+
+export function createChatTurnControl(conversationId: string, abortController = new AbortController()) {
+  let stopped = false;
+
+  return {
+    conversationId,
+    abortController,
+    get stopped() {
+      return stopped;
+    },
+    requestStop() {
+      stopped = true;
+      if (!abortController.signal.aborted) {
+        abortController.abort();
+      }
+    },
+    throwIfStopped() {
+      if (stopped || abortController.signal.aborted) {
+        throw new ChatTurnStoppedError();
+      }
+    }
+  };
+}
+
+export function registerChatTurn(conversationId: string) {
+  const control = createChatTurnControl(conversationId);
+  activeTurns.set(conversationId, control);
+  return control;
+}
+
+export function requestStop(conversationId: string) {
+  activeTurns.get(conversationId)?.requestStop();
+}
+
+export function clearChatTurn(conversationId: string) {
+  activeTurns.delete(conversationId);
+}
+```
+
+Update `lib/provider.ts` so the input accepts an external signal and reuses it:
+
+```typescript
+export async function* streamProviderResponse(input: {
+  settings: ProviderProfileWithApiKey;
+  promptMessages: PromptMessage[];
+  tools?: ToolDefinition[];
+  abortSignal?: AbortSignal;
+}) { /* ... */ }
+
+const abortController = new AbortController();
+const signal = input.abortSignal ?? abortController.signal;
+```
+
+Update `lib/assistant-runtime.ts` so the resolver checks cancellation before each provider loop, before each tool execution, and after answer commits:
+
+```typescript
+export async function resolveAssistantTurn(input: {
+  /* existing fields */
+  abortSignal?: AbortSignal;
+  throwIfStopped?: () => void;
+}) {
+  const assertRunning = () => {
+    input.throwIfStopped?.();
+    if (input.abortSignal?.aborted) {
+      throw new ChatTurnStoppedError();
+    }
+  };
+
+  for (let step = 0; step < MAX_ASSISTANT_CONTROL_STEPS; step += 1) {
+    assertRunning();
+    const providerStream = streamProviderResponse({
+      settings: input.settings,
+      promptMessages,
+      tools: tools.length ? tools : undefined,
+      abortSignal: input.abortSignal
+    });
+    /* ... */
+    assertRunning();
+    for (const toolCall of toolCalls) {
+      assertRunning();
+      const result = await executeToolCall(toolCall, /* ... */);
+      /* ... */
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run the runtime tests again**
+
+Run: `npx vitest run tests/unit/assistant-runtime.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/chat-turn-control.ts lib/provider.ts lib/assistant-runtime.ts tests/unit/assistant-runtime.test.ts
+git commit -m "feat: add cancellable chat turn runtime"
+```
+
+---
+
+### Task 3: Persist partial stopped turns on the server
+
+**Files:**
+- Modify: `lib/chat-turn.ts`
+- Modify: `lib/ws-handler.ts`
+- Modify: `app/api/conversations/[conversationId]/chat/route.ts`
+- Test: `tests/unit/chat-turn.test.ts`
+- Test: `tests/unit/ws-handler.test.ts`
+
+- [ ] **Step 1: Write the failing server-side tests**
+
+Add this case to `tests/unit/chat-turn.test.ts`:
+
+```typescript
+it("persists a partial assistant message as stopped when the turn is cancelled", async () => {
+  vi.useFakeTimers();
+  const { streamProviderResponse } = await import("@/lib/provider");
+  const { createConversationManager } = await import("@/lib/conversation-manager");
+  const { updateSettings } = await import("@/lib/settings");
+  const { requestStop } = await import("@/lib/chat-turn-control");
+
+  const manager = createConversationManager();
+  const { profileId, profile } = setupProviderProfile();
+  updateSettings({ defaultProviderProfileId: profileId, skillsEnabled: false, providerProfiles: [profile] });
+  const conv = (await import("@/lib/conversations")).createConversation(undefined, undefined, { providerProfileId: null });
+
+  let release = () => {};
+  const gate = new Promise<void>((resolve) => { release = resolve; });
+  streamProviderResponse.mockReturnValueOnce((async function* () {
+    yield { type: "answer_delta", text: "Partial" };
+    await gate;
+    return { answer: "Partial answer", thinking: "", usage: { outputTokens: 2 } };
+  })());
+
+  const { startChatTurn } = await import("@/lib/chat-turn");
+  const run = startChatTurn(manager, conv.id, "Hi", []);
+
+  await vi.advanceTimersByTimeAsync(120);
+  requestStop(conv.id);
+  release();
+  await run;
+
+  const { listVisibleMessages } = await import("@/lib/conversations");
+  const assistant = listVisibleMessages(conv.id).find((message) => message.role === "assistant");
+  expect(assistant?.status).toBe("stopped");
+  expect(assistant?.content).toContain("Partial");
+  vi.useRealTimers();
+});
+```
+
+Add this case to `tests/unit/ws-handler.test.ts`:
+
+```typescript
+it("routes client stop messages to the turn registry", async () => {
+  const requestStop = vi.fn();
+  vi.doMock("@/lib/chat-turn-control", () => ({ requestStop }));
+  const { verifySessionToken } = await import("@/lib/auth");
+  (verifySessionToken as ReturnType<typeof vi.fn>).mockResolvedValue({ userId: "user-1" });
+
+  const { handleConnection } = await import("@/lib/ws-handler");
+  const messageHandlers: Array<(data: string) => void> = [];
+  const ws = {
+    readyState: 1,
+    send: vi.fn(),
+    close: vi.fn(),
+    on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      if (event === "message") messageHandlers.push((d: string) => handler(d));
+    })
+  } as unknown as WebSocket;
+
+  await handleConnection(ws, "session=valid-token");
+  messageHandlers.forEach((handler) => handler(JSON.stringify({ type: "stop", conversationId: "conv-1" })));
+
+  expect(requestStop).toHaveBeenCalledWith("conv-1");
+});
+```
+
+- [ ] **Step 2: Run the server tests to verify they fail**
+
+Run: `npx vitest run tests/unit/chat-turn.test.ts tests/unit/ws-handler.test.ts`
+Expected: FAIL because there is no registry-backed stop path and stopped turns are still finalized as `completed` or `error`.
+
+- [ ] **Step 3: Implement the registry-backed stop flow in the shared server paths**
+
+Update `lib/chat-turn.ts` to register a control, flush partial buffers, and finalize stopped messages:
+
+```typescript
+const control = registerChatTurn(conversationId);
+let latestThinking = "";
+let latestAnswer = "";
+const runningActionHandles = new Set<string>();
+
+try {
+  const providerResult = await resolveAssistantTurn({
+    /* existing args */
+    abortSignal: control.abortController.signal,
+    throwIfStopped: control.throwIfStopped,
+    onEvent(event) {
+      if (event.type === "thinking_delta") latestThinking += event.text;
+      if (event.type === "answer_delta") latestAnswer += event.text;
+      /* existing broadcast logic */
+    },
+    onActionStart(action) {
+      const persisted = createMessageAction(/* existing fields */);
+      runningActionHandles.add(persisted.id);
+      return persisted.id;
+    },
+    onActionComplete(handle, patch) {
+      if (handle) runningActionHandles.delete(handle);
+      /* existing update logic */
+    },
+    onActionError(handle, patch) {
+      if (handle) runningActionHandles.delete(handle);
+      /* existing update logic */
+    },
+  });
+
+  updateMessage(assistantMessage.id, {
+    content: providerResult.answer,
+    thinkingContent: providerResult.thinking,
+    status: "completed"
+  });
+} catch (error) {
+  if (error instanceof ChatTurnStoppedError) {
+    if (flushTimer) clearTimeout(flushTimer);
+    flushAnswerBuffer();
+    updateMessage(assistantMessage.id, {
+      content: latestAnswer,
+      thinkingContent: latestThinking,
+      status: "stopped"
+    });
+    for (const handle of runningActionHandles) {
+      updateMessageAction(handle, {
+        status: "stopped",
+        resultSummary: "Stopped by user",
+        completedAt: new Date().toISOString()
+      });
+    }
+    manager.broadcast(conversationId, {
+      type: "delta",
+      conversationId,
+      event: { type: "done", messageId: assistantMessage.id }
+    });
+  } else {
+    updateMessage(assistantMessage.id, { content: "", thinkingContent: "", status: "error" });
+  }
+} finally {
+  clearChatTurn(conversationId);
+  setConversationActive(conversation.id, false);
+}
+```
+
+Update `lib/ws-handler.ts`:
+
+```typescript
+case "stop": {
+  requestStop(msg.conversationId);
+  break;
+}
+```
+
+Update `app/api/conversations/[conversationId]/chat/route.ts` so it uses the same control object and stopped finalization branch instead of treating an abort as a generic stream error.
+
+- [ ] **Step 4: Run the server tests again**
+
+Run: `npx vitest run tests/unit/chat-turn.test.ts tests/unit/ws-handler.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/chat-turn.ts lib/ws-handler.ts app/api/conversations/[conversationId]/chat/route.ts tests/unit/chat-turn.test.ts tests/unit/ws-handler.test.ts
+git commit -m "feat: persist stopped chat turns and ws cancel flow"
+```
+
+---
+
+### Task 4: Switch the composer to stop mode and render stopped transcript state
+
+**Files:**
+- Modify: `components/chat-composer.tsx`
+- Modify: `components/chat-view.tsx`
+- Modify: `components/message-bubble.tsx`
+- Test: `tests/unit/chat-view.test.ts`
+- Test: `tests/unit/message-bubble.test.ts`
+
+- [ ] **Step 1: Write the failing UI tests**
+
+Add this case to `tests/unit/chat-view.test.ts`:
+
+```typescript
+it("sends a websocket stop message when the active-turn button is clicked", async () => {
+  renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
+
+  await act(async () => {
+    wsMock.onMessage?.({
+      type: "delta",
+      conversationId: "conv_1",
+      event: { type: "message_start", messageId: "msg_assistant_1" }
+    });
+  });
+
+  fireEvent.click(screen.getByRole("button", { name: "Stop response" }));
+
+  expect(wsMock.send).toHaveBeenCalledWith({
+    type: "stop",
+    conversationId: "conv_1"
+  });
+});
+```
+
+Add this case to `tests/unit/message-bubble.test.ts`:
+
+```typescript
+it("renders a stopped badge for interrupted assistant messages", () => {
+  render(
+    React.createElement(MessageBubble, {
+      message: {
+        ...createAssistantMessage(),
+        status: "stopped",
+        content: "Partial answer"
+      }
+    })
+  );
+
+  expect(screen.getByText("Stopped")).toBeInTheDocument();
+  expect(screen.getByText("Partial answer")).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run the UI tests to verify they fail**
+
+Run: `npx vitest run tests/unit/chat-view.test.ts tests/unit/message-bubble.test.ts`
+Expected: FAIL because the composer still renders a spinner-only active state and assistant bubbles do not show a stopped indicator.
+
+- [ ] **Step 3: Implement the client stop UX**
+
+Update `components/chat-composer.tsx` to accept stop props and render a stop button:
+
+```typescript
+type ChatComposerProps = {
+  /* existing props */
+  canStop: boolean;
+  isStopPending: boolean;
+  onStop: () => void | Promise<void>;
+};
+
+const showStopButton = canStop && !isUploadingAttachments;
+
+<button
+  onClick={() => void (showStopButton ? onStop() : onSubmit())}
+  disabled={showStopButton ? isStopPending : isSubmitDisabled}
+  aria-label={showStopButton ? "Stop response" : "Send message"}
+>
+  {showStopButton ? <Square className="h-3.5 w-3.5 fill-current" /> : isUploadingAttachments ? <LoaderCircle className="h-4 w-4 animate-spin" /> : <ArrowUp className="h-4 w-4" />}
+</button>
+```
+
+Update `components/chat-view.tsx` to track `isStopPending`, send `{ type: "stop" }`, and only clear the live stream state when the server snapshot or delta finalizes the message as `stopped`:
+
+```typescript
+const [isStopPending, setIsStopPending] = useState(false);
+
+async function stopActiveTurn() {
+  if (!streamMessageIdRef.current || isStopPending) return;
+  setIsStopPending(true);
+  wsSend({ type: "stop", conversationId: payload.conversation.id });
+}
+
+if (event.type === "done") {
+  setIsStopPending(false);
+  /* existing finalize/reset path */
+}
+
+if (event.type === "error") {
+  setIsStopPending(false);
+  /* existing error path */
+}
+```
+
+Update `components/message-bubble.tsx` so stopped assistant messages show a compact badge and stopped action rows use a neutral interrupted label instead of the red error state:
+
+```typescript
+const statusIcon = action.status === "running"
+  ? <LoaderCircle className="h-2.5 w-2.5 animate-spin text-white/55" />
+  : action.status === "completed"
+    ? <Check className="h-2.5 w-2.5 text-emerald-400" />
+    : action.status === "stopped"
+      ? <Square className="h-2.5 w-2.5 text-amber-300 fill-current" />
+      : <X className="h-2.5 w-2.5 text-red-400" />;
+
+{message.status === "stopped" ? (
+  <div className="inline-flex items-center gap-1.5 rounded-md border border-amber-300/12 bg-amber-300/8 px-2 py-1 text-[11px] text-amber-100/85">
+    <Square className="h-2.5 w-2.5 fill-current" />
+    <span>Stopped</span>
+  </div>
+) : null}
+```
+
+- [ ] **Step 4: Run the UI tests again**
+
+Run: `npx vitest run tests/unit/chat-view.test.ts tests/unit/message-bubble.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add components/chat-composer.tsx components/chat-view.tsx components/message-bubble.tsx tests/unit/chat-view.test.ts tests/unit/message-bubble.test.ts
+git commit -m "feat: add stop button and stopped transcript state"
+```
+
+---
+
+### Task 5: Verify the full stop flow end-to-end
+
+**Files:**
+- Modify: `tests/e2e/features.spec.ts`
+- Verify: browser at the dev server URL from `.dev-server`
+
+- [ ] **Step 1: Add an end-to-end regression test**
+
+Append a targeted stop-flow scenario to `tests/e2e/features.spec.ts`:
+
+```typescript
+test("user can stop an active response and keep the partial assistant message", async ({ page }) => {
+  await page.goto("/");
+  await page.getByPlaceholder("Ask, create, or start a task. Press ⌘ ⏎ to insert a line break...").fill("Explain quantum physics in detail");
+  await page.getByRole("button", { name: "Send message" }).click();
+
+  await expect(page.getByRole("button", { name: "Stop response" })).toBeVisible();
+  await page.getByRole("button", { name: "Stop response" }).click();
+
+  await expect(page.getByText("Stopped")).toBeVisible();
+  await expect(page.locator('[data-testid="assistant-message-bubble"]')).toHaveCount(1);
+});
+```
+
+- [ ] **Step 2: Run the focused automated checks**
+
+Run: `npx vitest run tests/unit/ws-protocol.test.ts tests/unit/assistant-runtime.test.ts tests/unit/chat-turn.test.ts tests/unit/ws-handler.test.ts tests/unit/chat-view.test.ts tests/unit/message-bubble.test.ts`
+Expected: PASS
+
+Run: `npx playwright test tests/e2e/features.spec.ts --grep "stop"`
+Expected: PASS
+
+- [ ] **Step 3: Run manual browser validation**
+
+1. Read `.dev-server`; if missing or stale, start `npm run dev` and wait for `.dev-server`.
+2. Open the app URL with the `agent-browser` skill.
+3. Send a prompt that streams long enough to stop mid-turn.
+4. Click the stop button and verify:
+   - the button is actionable, not a spinner
+   - the partial assistant content stays visible
+   - the assistant message shows `Stopped`
+   - a follow-up prompt continues the same conversation normally
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/e2e/features.spec.ts
+git commit -m "test: cover stop-turn flow"
+```
+
+---
+
+## Self-Review
+
+- Spec coverage: Task 1 covers typed stop/stopped states; Task 2 covers shared cancellation control; Task 3 covers persistence, websocket routing, and partial-turn preservation; Task 4 covers composer/transcript UX; Task 5 covers verification.
+- Placeholder scan: No `TODO`, `TBD`, or “handle appropriately” placeholders remain.
+- Type consistency: The plan consistently uses `stopped` for both `MessageStatus` and `MessageActionStatus`, and `stop` for the client websocket message.

--- a/docs/superpowers/specs/2026-04-08-stop-stream-button-design.md
+++ b/docs/superpowers/specs/2026-04-08-stop-stream-button-design.md
@@ -1,0 +1,171 @@
+# Stop Button for Active Chat Turns
+
+## Overview
+
+When a conversation is actively streaming or running tool work, the composer action button should show a stop control instead of a spinner. Clicking stop cancels the entire in-flight turn, including model streaming and any downstream skill, MCP, or shell work that has not already finished. Any assistant text, thinking text, and timeline items already produced remain persisted in the conversation so they are still part of future prompt context. The interrupted assistant turn is visibly marked as stopped in the transcript.
+
+---
+
+## UI Changes
+
+### ChatComposer (`components/chat-composer.tsx`)
+
+Replace the current passive spinner state in the composer action button with an actionable stop button whenever a turn is active.
+
+**States:**
+
+| State | Icon | Behavior |
+|-------|------|----------|
+| idle | `ArrowUp` | Sends a new message |
+| uploading only | `LoaderCircle` | Shows upload progress, no stop action |
+| active turn | stop-square icon | Cancels the active turn |
+| stop requested | stop-square icon disabled | Prevents duplicate stop requests until the turn resolves |
+
+**Behavior:**
+- A running assistant turn takes precedence over the normal send affordance
+- Clicking stop immediately issues a cancel request for the active conversation
+- The control should stay in place while the cancellation is being processed so the UI does not flicker back to send prematurely
+
+### Message Bubble (`components/message-bubble.tsx`)
+
+Stopped assistant turns remain visible as ordinary assistant messages, but with a compact interrupted-state indicator near the assistant metadata area.
+
+**Transcript requirements:**
+- Partial answer text remains readable as normal assistant content
+- Partial thinking text remains available using the existing thinking UI
+- Timeline rows remain in chronological order
+- Any action still running at the moment of cancellation resolves to an interrupted terminal state instead of looking completed
+- The stopped indicator should read as an intentional user action, not as a generic system failure
+
+---
+
+## Runtime Contract
+
+### Turn Cancellation Registry
+
+Each active conversation turn should register a server-owned cancellation handle when the turn starts and clear it when the turn finishes. The cancel handle is keyed by conversation id and is shared by both the websocket chat path and the HTTP streaming chat path.
+
+**Responsibilities of the handle:**
+- Abort provider streaming
+- Prevent new tool, skill, or shell actions from starting after cancellation
+- Surface cancellation checks at boundaries between compaction, provider streaming, tool execution, and final persistence
+- Mark the active turn as resolved once cleanup completes
+
+### Stop Semantics
+
+Stopping a turn is a hard cancel for the entire active turn, not just for text rendering.
+
+**On stop:**
+1. Mark the turn as cancellation-requested
+2. Abort in-flight provider requests
+3. Stop scheduling any remaining tool, skill, MCP, or shell work
+4. Finalize any running action rows as interrupted
+5. Persist the current assistant text/thinking/timeline state
+6. Finalize the assistant message with a `stopped` status
+7. Clear the conversation active state and notify subscribers
+
+The turn should never roll back already-persisted content. Whatever has been streamed or saved before the stop request remains part of the stored conversation.
+
+---
+
+## Data Model
+
+### Message Status
+
+Extend `MessageStatus` with a `stopped` terminal state for assistant messages that were intentionally cancelled by the user.
+
+```ts
+type MessageStatus = "idle" | "streaming" | "completed" | "error" | "stopped";
+```
+
+### Message Action Status
+
+Add an interrupted-style terminal state for actions that were active when the user stopped the turn.
+
+```ts
+type MessageActionStatus = "running" | "completed" | "error" | "stopped";
+```
+
+This allows the timeline to distinguish:
+- completed work
+- execution failures
+- user-requested interruption
+
+### Stream Protocol
+
+Add explicit stop support to the transport contract:
+
+- Client websocket message for stop requests
+- Shared turn-finalization event path that allows subscribed clients to reconcile a stopped turn
+- If needed, a dedicated stop acknowledgement event so the initiating client can hold the stop control disabled until the server resolves the turn
+
+---
+
+## State Flow
+
+1. User sends a message
+2. Client inserts optimistic user message and shows assistant streaming shell
+3. Server registers the active turn cancellation handle and marks the conversation active
+4. Assistant turn streams normally through provider and action events
+5. User clicks stop
+6. Client sends a stop request for the active conversation and disables repeat stop clicks
+7. Server resolves the request against the active cancellation handle
+8. Provider streaming aborts and no new actions start
+9. Running actions are finalized as stopped
+10. Assistant message is persisted with the partial text/thinking/timeline already produced and status `stopped`
+11. Conversation active state clears and all subscribed clients reconcile to the stopped message state
+
+---
+
+## Persistence And Context
+
+Stopped assistant messages stay in the same conversation history as completed messages. Prompt reconstruction should not exclude them. This ensures that if the user stops a reply midway and asks a follow-up question, the model still receives the interrupted assistant turn as part of the stored transcript.
+
+No special rollback or deletion path should run for stopped turns. The only distinction is terminal metadata and UI presentation.
+
+---
+
+## File Changes
+
+| File | Change |
+|------|--------|
+| `components/chat-composer.tsx` | Replace active-turn spinner state with stop button support |
+| `components/chat-view.tsx` | Send stop requests, track stop-pending UI state, reconcile stopped turns without clearing partial content |
+| `components/message-bubble.tsx` | Render stopped assistant indicator and interrupted action states |
+| `lib/types.ts` | Add `stopped` message and action statuses plus any new protocol types |
+| `lib/ws-protocol.ts` | Add websocket client/server stop message shapes |
+| `lib/ws-client.ts` | Expose stop-send support if needed |
+| `lib/ws-handler.ts` | Handle client stop requests |
+| `lib/chat-turn.ts` | Register active turn handles, honor cancellation, persist partial stopped turns |
+| `app/api/conversations/[conversationId]/chat/route.ts` | Reuse the shared cancellation-aware turn runner for HTTP chat streaming |
+| `lib/assistant-runtime.ts` | Check cancellation between provider/tool/action phases |
+| `lib/provider.ts` | Accept external abort/cancel input so streaming can be interrupted cleanly |
+| `lib/conversations.ts` | Persist stopped statuses and any interrupted action updates |
+
+---
+
+## Testing
+
+### Automated Coverage
+
+1. Stopping during answer streaming persists the partial assistant message and marks it `stopped`
+2. Stopping before any answer text still leaves a stopped assistant shell in the transcript
+3. Stopping during tool or shell execution prevents later actions from starting and finalizes active actions as `stopped`
+4. Snapshot reconciliation preserves partial text after reconnect or refresh
+5. The active conversation flag clears after a stopped turn
+
+### Manual Validation
+
+1. Send a message and verify the composer button changes from send to stop while the turn is active
+2. Click stop mid-stream and verify the partial assistant reply remains visible
+3. Confirm the assistant row shows a stopped indicator instead of an error banner
+4. Ask a follow-up question and verify the conversation continues normally with the stopped message still present in history
+5. Stop a turn during tool activity and verify the timeline shows interruption rather than completion
+
+---
+
+## Notes
+
+- The stop affordance should only appear for an active assistant turn, not for attachment uploads alone
+- Cancellation should be cooperative at execution boundaries, but the user-facing contract is a hard stop for the active turn
+- The implementation should use one shared turn runner/cancellation model so websocket and HTTP chat behavior do not diverge

--- a/lib/assistant-runtime.ts
+++ b/lib/assistant-runtime.ts
@@ -1,4 +1,5 @@
 import { resolveAttachmentPath } from "@/lib/attachments";
+import { ChatTurnStoppedError } from "@/lib/chat-turn-control";
 import { getMemory as getMemoryRecord, createMemory, updateMemory as updateMemoryRecord, deleteMemory as deleteMemoryRecord, getMemoryCount } from "@/lib/memories";
 import { getSettings } from "@/lib/settings";
 import { parseSkillContentMetadata } from "@/lib/skill-metadata";
@@ -849,6 +850,8 @@ export async function resolveAssistantTurn(input: {
   visionMcpServer?: McpServer | null;
   memoriesEnabled?: boolean;
   mcpTimeout?: number;
+  abortSignal?: AbortSignal;
+  throwIfStopped?: () => void;
   onEvent?: (event: ChatStreamEvent) => void;
   onAnswerSegment?: (segment: string) => Promise<void> | void;
   onActionStart?: (action: RuntimeAction) => Promise<string | void> | string | void;
@@ -862,6 +865,13 @@ export async function resolveAssistantTurn(input: {
   ) => Promise<void> | void;
 }) {
   const mcpServers = input.mcpServers ?? input.mcpToolSets.map((e) => e.server);
+
+  const assertRunning = () => {
+    input.throwIfStopped?.();
+    if (input.abortSignal?.aborted) {
+      throw new ChatTurnStoppedError();
+    }
+  };
 
   // Handle vision MCP mode - strip images and inject directive
   let promptMessages = input.promptMessages;
@@ -898,6 +908,8 @@ export async function resolveAssistantTurn(input: {
   };
 
   for (let step = 0; step < MAX_ASSISTANT_CONTROL_STEPS; step += 1) {
+    assertRunning();
+
     const tools = buildToolDefinitions({
       mcpToolSets: input.mcpToolSets,
       skills: turnSkills,
@@ -909,7 +921,8 @@ export async function resolveAssistantTurn(input: {
     const providerStream = streamProviderResponse({
       settings: input.settings,
       promptMessages,
-      tools: tools.length ? tools : undefined
+      tools: tools.length ? tools : undefined,
+      abortSignal: input.abortSignal
     });
 
     let answer = "";
@@ -929,6 +942,8 @@ export async function resolveAssistantTurn(input: {
       }
       input.onEvent?.(next.value);
     }
+
+    assertRunning();
 
     if (!toolCalls.length) {
       if (!answer.trim() && step > 0) {
@@ -956,6 +971,8 @@ export async function resolveAssistantTurn(input: {
     }
 
     for (const toolCall of toolCalls) {
+      assertRunning();
+
       const result = await executeToolCall(toolCall, {
         input: toolRuntimeInput,
         mcpServers,

--- a/lib/chat-turn-control.ts
+++ b/lib/chat-turn-control.ts
@@ -1,0 +1,45 @@
+export class ChatTurnStoppedError extends Error {
+  constructor() {
+    super("Chat turn stopped by user");
+    this.name = "ChatTurnStoppedError";
+  }
+}
+
+const activeTurns = new Map<string, ReturnType<typeof createChatTurnControl>>();
+
+export function createChatTurnControl(conversationId: string, abortController = new AbortController()) {
+  let stopped = false;
+
+  return {
+    conversationId,
+    abortController,
+    get stopped() {
+      return stopped;
+    },
+    requestStop() {
+      stopped = true;
+      if (!abortController.signal.aborted) {
+        abortController.abort();
+      }
+    },
+    throwIfStopped() {
+      if (stopped || abortController.signal.aborted) {
+        throw new ChatTurnStoppedError();
+      }
+    }
+  };
+}
+
+export function registerChatTurn(conversationId: string) {
+  const control = createChatTurnControl(conversationId);
+  activeTurns.set(conversationId, control);
+  return control;
+}
+
+export function requestStop(conversationId: string) {
+  activeTurns.get(conversationId)?.requestStop();
+}
+
+export function clearChatTurn(conversationId: string) {
+  activeTurns.delete(conversationId);
+}

--- a/lib/chat-turn.ts
+++ b/lib/chat-turn.ts
@@ -1,4 +1,5 @@
 import { resolveAssistantTurn } from "@/lib/assistant-runtime";
+import { ChatTurnStoppedError, registerChatTurn, clearChatTurn } from "@/lib/chat-turn-control";
 import {
   bindAttachmentsToMessage,
   createMessage,
@@ -91,6 +92,36 @@ export async function startChatTurn(
   setConversationActive(conversation.id, true);
   manager.broadcastAll({ type: "conversation_activity", conversationId, isActive: true });
 
+  const control = registerChatTurn(conversationId);
+
+  let timelineSortOrder = 0;
+  let answerBuffer = "";
+  let latestAnswer = "";
+  let latestThinking = "";
+  let sawStreamedAnswerSinceLastSegment = false;
+  let lastFlush = Date.now();
+  let flushTimer: ReturnType<typeof setTimeout> | null = null;
+  const runningActionHandles = new Set<string>();
+
+  function flushAnswerBuffer() {
+    if (!answerBuffer) return;
+    createMessageTextSegment({
+      messageId: assistantMessage.id,
+      content: answerBuffer,
+      sortOrder: timelineSortOrder++
+    });
+    answerBuffer = "";
+    lastFlush = Date.now();
+  }
+
+  function scheduleFlush() {
+    if (flushTimer) return;
+    flushTimer = setTimeout(() => {
+      flushTimer = null;
+      flushAnswerBuffer();
+    }, 100);
+  }
+
   try {
     const compacted = await ensureCompactedContext(conversation.id, settings, {
       onCompactionStart() {
@@ -130,31 +161,6 @@ export async function startChatTurn(
       }
     }
 
-    let timelineSortOrder = 0;
-    let answerBuffer = "";
-    let sawStreamedAnswerSinceLastSegment = false;
-    let lastFlush = Date.now();
-    let flushTimer: ReturnType<typeof setTimeout> | null = null;
-
-    function flushAnswerBuffer() {
-      if (!answerBuffer) return;
-      createMessageTextSegment({
-        messageId: assistantMessage.id,
-        content: answerBuffer,
-        sortOrder: timelineSortOrder++
-      });
-      answerBuffer = "";
-      lastFlush = Date.now();
-    }
-
-    function scheduleFlush() {
-      if (flushTimer) return;
-      flushTimer = setTimeout(() => {
-        flushTimer = null;
-        flushAnswerBuffer();
-      }, 100);
-    }
-
     const providerResult = await resolveAssistantTurn({
       settings,
       promptMessages,
@@ -164,6 +170,8 @@ export async function startChatTurn(
       visionMcpServer,
       memoriesEnabled: appSettings.memoriesEnabled,
       mcpTimeout: appSettings.mcpTimeout,
+      abortSignal: control.abortController.signal,
+      throwIfStopped: control.throwIfStopped,
       onEvent(event: ChatStreamEvent) {
         manager.broadcast(conversationId, {
           type: "delta",
@@ -175,6 +183,7 @@ export async function startChatTurn(
         if (event.type === "answer_delta") {
           sawStreamedAnswerSinceLastSegment = true;
           answerBuffer += event.text;
+          latestAnswer += event.text;
           if (answerBuffer.length >= 500 || Date.now() - lastFlush >= 100) {
             flushAnswerBuffer();
           } else {
@@ -205,6 +214,7 @@ export async function startChatTurn(
           arguments: action.arguments,
           sortOrder: timelineSortOrder++
         });
+        runningActionHandles.add(persisted.id);
         manager.broadcast(conversationId, {
           type: "delta",
           conversationId,
@@ -215,6 +225,7 @@ export async function startChatTurn(
       },
       onActionComplete(handle, patch) {
         if (!handle) return;
+        runningActionHandles.delete(handle);
         const updated = updateMessageAction(handle, {
           status: "completed",
           detail: patch.detail,
@@ -232,6 +243,7 @@ export async function startChatTurn(
       },
       onActionError(handle, patch) {
         if (!handle) return;
+        runningActionHandles.delete(handle);
         const updated = updateMessageAction(handle, {
           status: "error",
           detail: patch.detail,
@@ -268,20 +280,46 @@ export async function startChatTurn(
       event: { type: "done", messageId: assistantMessage.id }
     });
   } catch (error) {
-    updateMessage(assistantMessage.id, {
-      content: "",
-      thinkingContent: "",
-      status: "error"
-    });
-    manager.broadcast(conversationId, {
-      type: "delta",
-      conversationId,
-      event: {
-        type: "error",
-        message: error instanceof Error ? error.message : "Chat stream failed"
+    if (error instanceof ChatTurnStoppedError) {
+      if (flushTimer) clearTimeout(flushTimer);
+      flushAnswerBuffer();
+
+      updateMessage(assistantMessage.id, {
+        content: latestAnswer,
+        thinkingContent: latestThinking,
+        status: "stopped",
+        estimatedTokens: estimateTextTokens(latestAnswer)
+      });
+
+      for (const handle of runningActionHandles) {
+        updateMessageAction(handle, {
+          status: "stopped",
+          completedAt: new Date().toISOString()
+        });
       }
-    });
+
+      manager.broadcast(conversationId, {
+        type: "delta",
+        conversationId,
+        event: { type: "done", messageId: assistantMessage.id }
+      });
+    } else {
+      updateMessage(assistantMessage.id, {
+        content: "",
+        thinkingContent: "",
+        status: "error"
+      });
+      manager.broadcast(conversationId, {
+        type: "delta",
+        conversationId,
+        event: {
+          type: "error",
+          message: error instanceof Error ? error.message : "Chat stream failed"
+        }
+      });
+    }
   } finally {
+    clearChatTurn(conversationId);
     setConversationActive(conversation.id, false);
     manager.setActive(conversationId, false);
     manager.broadcastAll({ type: "conversation_activity", conversationId, isActive: false });

--- a/lib/provider.ts
+++ b/lib/provider.ts
@@ -280,6 +280,7 @@ export async function* streamProviderResponse(input: {
   settings: ProviderProfileWithApiKey;
   promptMessages: PromptMessage[];
   tools?: ToolDefinition[];
+  abortSignal?: AbortSignal;
 }): AsyncGenerator<
   ChatStreamEvent,
   { answer: string; thinking: string; toolCalls?: ProviderToolCall[]; usage: { inputTokens?: number; outputTokens?: number; reasoningTokens?: number } },
@@ -289,6 +290,7 @@ export async function* streamProviderResponse(input: {
   setActiveTokenizer(settings.tokenizerModel ?? "gpt-tokenizer");
   const client = createClient(settings, settings.apiKey);
   const abortController = new AbortController();
+  const signal = input.abortSignal ?? abortController.signal;
   let answer = "";
   let thinking = "";
   let usage: {
@@ -334,7 +336,7 @@ export async function* streamProviderResponse(input: {
       try {
         stream = await client.responses.create(
           responseCreateParams as any,
-          { signal: abortController.signal }
+          { signal }
         ) as unknown as AsyncIterable<any>;
       } catch (createError) {
         const isSchemaError =
@@ -348,7 +350,7 @@ export async function* streamProviderResponse(input: {
           responseCreateParams.tools = toolsWithoutStrict;
           stream = await client.responses.create(
             responseCreateParams as any,
-            { signal: abortController.signal }
+            { signal }
           ) as unknown as AsyncIterable<any>;
         } else {
           throw createError;
@@ -439,7 +441,7 @@ export async function* streamProviderResponse(input: {
 
     const stream = await client.responses.create(
       responseCreateParams as any,
-      { signal: abortController.signal }
+      { signal }
     ) as unknown as AsyncIterable<any>;
 
     const pendingToolCalls = new Map<string, { name: string; arguments: string }>();
@@ -539,7 +541,7 @@ export async function* streamProviderResponse(input: {
 
   const stream = await client.chat.completions.create(
     chatCreateParams as any,
-    { signal: abortController.signal }
+    { signal }
   ) as unknown as AsyncIterable<any>;
 
   const toolCallChunks = new Map<string, { name: string; arguments: string }>();

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -8,7 +8,7 @@ export type VisionMode = "none" | "native" | "mcp";
 
 export type MessageRole = "user" | "assistant" | "system";
 
-export type MessageStatus = "idle" | "streaming" | "completed" | "error";
+export type MessageStatus = "idle" | "streaming" | "completed" | "error" | "stopped";
 
 export type ConversationTitleGenerationStatus =
   | "pending"
@@ -18,7 +18,7 @@ export type ConversationTitleGenerationStatus =
 
 export type MessageActionKind = "skill_load" | "mcp_tool_call" | "shell_command" | "create_memory" | "update_memory" | "delete_memory";
 
-export type MessageActionStatus = "running" | "completed" | "error";
+export type MessageActionStatus = "running" | "completed" | "error" | "stopped";
 
 export type AttachmentKind = "image" | "text";
 

--- a/lib/ws-handler.ts
+++ b/lib/ws-handler.ts
@@ -6,6 +6,7 @@ import { SESSION_COOKIE_NAME } from "@/lib/constants";
 import { getConversationSnapshot, listActiveConversations } from "@/lib/conversations";
 import { type ConversationManager } from "@/lib/conversation-manager";
 import { isPasswordLoginEnabled } from "@/lib/env";
+import { requestStop } from "@/lib/chat-turn-control";
 import { parseClientMessage, serializeServerMessage } from "@/lib/ws-protocol";
 import type { ClientMessage } from "@/lib/ws-protocol";
 import { initializeMcpServers, shutdownAllProcesses } from "@/lib/mcp-client";
@@ -107,6 +108,10 @@ function handleMessage(
       break;
     }
     case "edit": {
+      break;
+    }
+    case "stop": {
+      requestStop(msg.conversationId);
       break;
     }
   }

--- a/lib/ws-protocol.ts
+++ b/lib/ws-protocol.ts
@@ -4,6 +4,7 @@ export type ClientMessage =
   | { type: "subscribe"; conversationId: string }
   | { type: "unsubscribe"; conversationId: string }
   | { type: "message"; conversationId: string; content: string; attachmentIds?: string[]; personaId?: string }
+  | { type: "stop"; conversationId: string }
   | { type: "edit"; messageId: string; content: string };
 
 export type ServerMessage =
@@ -25,7 +26,7 @@ export function serializeServerMessage(msg: ServerMessage): string {
   return JSON.stringify(msg);
 }
 
-const CLIENT_MESSAGE_TYPES = new Set(["subscribe", "unsubscribe", "message", "edit"]);
+const CLIENT_MESSAGE_TYPES = new Set(["subscribe", "unsubscribe", "message", "stop", "edit"]);
 
 export function parseClientMessage(raw: string): ClientMessage | null {
   try {

--- a/tests/unit/assistant-runtime.test.ts
+++ b/tests/unit/assistant-runtime.test.ts
@@ -978,4 +978,33 @@ Run browser commands.`
       expect(result.answer).toBe("Try updating instead");
     });
   });
+
+  it("stops before executing a tool call when cancellation is requested", async () => {
+    const abortController = new AbortController();
+
+    streamProviderResponse.mockReturnValueOnce(
+      createProviderStream([], {
+        answer: "",
+        thinking: "",
+        toolCalls: [{ id: "call_1", name: "mcp_mcp_docs_search_docs", arguments: JSON.stringify({ query: "MCP" }) }],
+        usage: { inputTokens: 9 }
+      })
+    );
+
+    const { ChatTurnStoppedError, createChatTurnControl } = await import("@/lib/chat-turn-control");
+    const { resolveAssistantTurn } = await import("@/lib/assistant-runtime");
+    const control = createChatTurnControl("conv_1", abortController);
+    control.requestStop();
+
+    await expect(resolveAssistantTurn({
+      settings: createSettings(),
+      promptMessages: [{ role: "user", content: "Find MCP docs" }],
+      skills: [],
+      mcpToolSets: [],
+      abortSignal: abortController.signal,
+      throwIfStopped: control.throwIfStopped
+    })).rejects.toBeInstanceOf(ChatTurnStoppedError);
+
+    expect(callMcpTool).not.toHaveBeenCalled();
+  });
 });

--- a/tests/unit/chat-turn.test.ts
+++ b/tests/unit/chat-turn.test.ts
@@ -183,6 +183,41 @@ describe("chat-turn", () => {
     expect(errorMsg).toBeDefined();
   });
 
+  it("persists a partial assistant message as stopped when the turn is cancelled", async () => {
+    vi.useFakeTimers();
+    const { streamProviderResponse } = await import("@/lib/provider");
+    const { createConversationManager } = await import("@/lib/conversation-manager");
+    const { updateSettings } = await import("@/lib/settings");
+    const { requestStop } = await import("@/lib/chat-turn-control");
+
+    const manager = createConversationManager();
+    const { profileId, profile } = setupProviderProfile();
+    updateSettings({ defaultProviderProfileId: profileId, skillsEnabled: false, providerProfiles: [profile] });
+    const conv = (await import("@/lib/conversations")).createConversation(undefined, undefined, { providerProfileId: null });
+
+    let release = () => {};
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    streamProviderResponse.mockReturnValueOnce((async function* () {
+      yield { type: "answer_delta", text: "Partial" };
+      await gate;
+      return { answer: "Partial answer", thinking: "", usage: { outputTokens: 2 } };
+    })());
+
+    const { startChatTurn } = await import("@/lib/chat-turn");
+    const run = startChatTurn(manager, conv.id, "Hi", []);
+
+    await vi.advanceTimersByTimeAsync(120);
+    requestStop(conv.id);
+    release();
+    await run;
+
+    const { listVisibleMessages } = await import("@/lib/conversations");
+    const assistant = listVisibleMessages(conv.id).find((message) => message.role === "assistant");
+    expect(assistant?.status).toBe("stopped");
+    expect(assistant?.content).toContain("Partial");
+    vi.useRealTimers();
+  });
+
   it("flushes answer text to DB periodically during streaming", async () => {
     vi.useFakeTimers();
     const { streamProviderResponse } = await import("@/lib/provider");

--- a/tests/unit/chat-view.test.ts
+++ b/tests/unit/chat-view.test.ts
@@ -1062,6 +1062,25 @@ describe("chat view", () => {
     expect(screen.getByText("Hello")).toBeInTheDocument();
   });
 
+  it("sends a websocket stop message when the active-turn button is clicked", async () => {
+    renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
+
+    await act(async () => {
+      wsMock.onMessage?.({
+        type: "delta",
+        conversationId: "conv_1",
+        event: { type: "message_start", messageId: "msg_assistant_1" }
+      });
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Stop response" }));
+
+    expect(wsMock.send).toHaveBeenCalledWith({
+      type: "stop",
+      conversationId: "conv_1"
+    });
+  });
+
   it("updates token usage gauge when usage event arrives", async () => {
     renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
 

--- a/tests/unit/message-bubble.test.ts
+++ b/tests/unit/message-bubble.test.ts
@@ -554,6 +554,21 @@ describe("message bubble", () => {
     expect(screen.getByText("Here are the results.")).toBeInTheDocument();
   });
 
+  it("renders a stopped badge for interrupted assistant messages", () => {
+    render(
+      React.createElement(MessageBubble, {
+        message: {
+          ...createAssistantMessage(),
+          status: "stopped",
+          content: "Partial answer"
+        }
+      })
+    );
+
+    expect(screen.getByText("Stopped")).toBeInTheDocument();
+    expect(screen.getByText("Partial answer")).toBeInTheDocument();
+  });
+
   it("renders a compaction separator instead of typing dots while compaction is active", () => {
     const { container } = render(
       React.createElement(StreamingPlaceholder, {

--- a/tests/unit/ws-handler.test.ts
+++ b/tests/unit/ws-handler.test.ts
@@ -73,6 +73,29 @@ describe("ws-handler", () => {
     expect(getConversationSnapshot).toHaveBeenCalledWith("conv-1");
   });
 
+  it("routes client stop messages to the turn registry", async () => {
+    const requestStop = vi.fn();
+    vi.doMock("@/lib/chat-turn-control", () => ({ requestStop }));
+    const { verifySessionToken } = await import("@/lib/auth");
+    (verifySessionToken as ReturnType<typeof vi.fn>).mockResolvedValue({ userId: "user-1" });
+
+    const { handleConnection } = await import("@/lib/ws-handler");
+    const messageHandlers: Array<(data: string) => void> = [];
+    const ws = {
+      readyState: 1,
+      send: vi.fn(),
+      close: vi.fn(),
+      on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+        if (event === "message") messageHandlers.push((d: string) => handler(d));
+      })
+    } as unknown as WebSocket;
+
+    await handleConnection(ws, "session=valid-token");
+    messageHandlers.forEach((handler) => handler(JSON.stringify({ type: "stop", conversationId: "conv-1" })));
+
+    expect(requestStop).toHaveBeenCalledWith("conv-1");
+  });
+
   it("sends error and closes when no token provided", async () => {
     const { handleConnection } = await import("@/lib/ws-handler");
     const sent: string[] = [];

--- a/tests/unit/ws-protocol.test.ts
+++ b/tests/unit/ws-protocol.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect } from "vitest";
 describe("ws-protocol", () => {
   it("serializes and parses a client subscribe message", async () => {
     const { serializeClientMessage, parseClientMessage } = await import("@/lib/ws-protocol");
-    const msg = { type: "subscribe", conversationId: "conv-1" };
+    const msg = { type: "subscribe" as const, conversationId: "conv-1" };
     const raw = serializeClientMessage(msg);
     const parsed = parseClientMessage(raw);
     expect(parsed).toEqual(msg);
@@ -11,7 +11,7 @@ describe("ws-protocol", () => {
 
   it("serializes and parses a client message message", async () => {
     const { serializeClientMessage, parseClientMessage } = await import("@/lib/ws-protocol");
-    const msg = { type: "message", conversationId: "conv-1", content: "hello", attachmentIds: ["att-1"] };
+    const msg = { type: "message" as const, conversationId: "conv-1", content: "hello", attachmentIds: ["att-1"] };
     const raw = serializeClientMessage(msg);
     const parsed = parseClientMessage(raw);
     expect(parsed).toEqual(msg);
@@ -19,7 +19,7 @@ describe("ws-protocol", () => {
 
   it("serializes a server ready message", async () => {
     const { serializeServerMessage } = await import("@/lib/ws-protocol");
-    const msg = { type: "ready", activeConversations: [{ id: "conv-1", title: "Test", status: "streaming" as const }] };
+    const msg = { type: "ready" as const, activeConversations: [{ id: "conv-1", title: "Test", status: "streaming" as const }] };
     const raw = serializeServerMessage(msg);
     const parsed = JSON.parse(raw);
     expect(parsed.type).toBe("ready");
@@ -28,7 +28,7 @@ describe("ws-protocol", () => {
 
   it("serializes a server delta message", async () => {
     const { serializeServerMessage } = await import("@/lib/ws-protocol");
-    const msg = { type: "delta", conversationId: "conv-1", event: { type: "answer_delta", text: "hello" } };
+    const msg = { type: "delta" as const, conversationId: "conv-1", event: { type: "answer_delta" as const, text: "hello" } };
     const raw = serializeServerMessage(msg);
     const parsed = JSON.parse(raw);
     expect(parsed.type).toBe("delta");
@@ -43,5 +43,13 @@ describe("ws-protocol", () => {
   it("returns null for unknown client message type", async () => {
     const { parseClientMessage } = await import("@/lib/ws-protocol");
     expect(parseClientMessage(JSON.stringify({ type: "unknown" }))).toBeNull();
+  });
+
+  it("serializes and parses a client stop message", async () => {
+    const { serializeClientMessage, parseClientMessage } = await import("@/lib/ws-protocol");
+    const msg = { type: "stop" as const, conversationId: "conv-1" };
+    const raw = serializeClientMessage(msg);
+    const parsed = parseClientMessage(raw);
+    expect(parsed).toEqual(msg);
   });
 });


### PR DESCRIPTION
Adds a stop button to the chat composer that cancels the active streaming turn while preserving partial assistant content. The composer shows a red stop button during streaming, and stopped messages display a "Stopped" badge in the transcript.

Key changes: shared turn cancellation registry (`lib/chat-turn-control.ts`), abort signal threading through provider/runtime, server-side persistence of partial stopped turns, and client-side stop UX with immediate status update. Both WebSocket and HTTP chat paths use the same cancellation flow. 310 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)