### PR TITLE
fix: prevent mobile scroll triggering drag-and-drop in sidebar

### DIFF
--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -25,7 +25,7 @@ import {
   DragOverlay,
   closestCenter,
   pointerWithin,
-  PointerSensor,
+  MouseSensor,
   useDroppable,
   useSensor,
   useSensors,
@@ -232,6 +232,7 @@ function ConversationItem({
     <div
       ref={setNodeRef}
       style={style}
+      className="relative"
       {...(dragEnabled ? attributes : {})}
       {...(dragEnabled ? listeners : {})}
     >
@@ -638,7 +639,7 @@ export function Sidebar({
   }, []);
 
   const sensors = useSensors(
-    useSensor(PointerSensor, {
+    useSensor(MouseSensor, {
       activationConstraint: {
         distance: 8
       }


### PR DESCRIPTION
Replace `PointerSensor` with `MouseSensor` so touch events no longer activate drag-and-drop, fixing scroll interference on mobile. On touch devices, users organize conversations via the existing triple-dot → Move menu instead. Also adds `relative` positioning to the conversation item wrapper so the triple-dot dropdown menu anchors correctly next to the conversation instead of appearing at the bottom of the page.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>