### PR TITLE
feat: GitHub Copilot provider with OAuth and streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Eidon gives you a local-first assistant workspace with:
 
 - Streaming chat with support for visible reasoning and tool call timelines
 - OpenAI-compatible provider profiles, including custom API base URLs
+- GitHub Copilot provider — chat through your own Copilot subscription via OAuth
 - Long-memory compaction to preserve context in lengthy conversations
 - MCP server support for external tools and services
 - Reusable skills, including a built-in browser automation skill in the Docker image
@@ -88,7 +89,7 @@ npm install
 
 ### 2. Create a local env file
 
-Create `.env.local` in the repo root:
+Create `.env` in the repo root:
 
 ```bash
 EIDON_PASSWORD_LOGIN_ENABLED=false
@@ -189,6 +190,9 @@ docker run -d \
   -e EIDON_ADMIN_PASSWORD='replace-this-with-a-long-random-password' \
   -e EIDON_SESSION_SECRET='replace-this-with-a-long-random-session-secret' \
   -e EIDON_ENCRYPTION_SECRET='replace-this-with-a-long-random-encryption-secret' \
+  -e EIDON_GITHUB_APP_CLIENT_ID='Iv1.xxxxxxxx' \
+  -e EIDON_GITHUB_APP_CLIENT_SECRET='xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx' \
+  -e EIDON_GITHUB_APP_CALLBACK_URL='https://your-host/api/providers/github/callback' \
   eidon:latest
 ```
 
@@ -210,6 +214,9 @@ services:
       EIDON_ADMIN_PASSWORD: "replace-this-with-a-long-random-password"
       EIDON_SESSION_SECRET: "replace-this-with-a-long-random-session-secret"
       EIDON_ENCRYPTION_SECRET: "replace-this-with-a-long-random-encryption-secret"
+      EIDON_GITHUB_APP_CLIENT_ID: "Iv1.xxxxxxxx"
+      EIDON_GITHUB_APP_CLIENT_SECRET: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+      EIDON_GITHUB_APP_CALLBACK_URL: "https://your-host/api/providers/github/callback"
     volumes:
       - eidon-data:/app/data
 
@@ -231,6 +238,44 @@ docker compose up -d --build
 4. Rotate the username/password if needed
 5. Open **Settings → Providers** and set your provider API key
 
+## GitHub Copilot Provider
+
+Eidon can route chat through your GitHub Copilot subscription instead of a direct API key. This requires registering a GitHub App so Eidon can perform the OAuth flow on your behalf.
+
+### Create the GitHub App
+
+1. Go to **[github.com/settings/developers](https://github.com/settings/developers)** and click **New GitHub App**
+2. Fill in the form:
+   - **GitHub App name** — anything you like (e.g. `Eidon Dev`)
+   - **Homepage URL** — your Eidon instance URL
+   - **Callback URL** — `http://localhost:3000/api/providers/github/callback` for local dev, or `https://<your-host>/api/providers/github/callback` in production
+   - Under **Identifying and authorizing users**, check **Request user authorization (OAuth) during installation**
+   - **Where can this GitHub App be installed?** — choose *Only on this account*
+3. Click **Create GitHub App**
+4. On the app's general settings page, copy the **Client ID** — this is `EIDON_GITHUB_APP_CLIENT_ID`
+5. Click **Generate a new client secret** and copy it — this is `EIDON_GITHUB_APP_CLIENT_SECRET`
+6. The callback URL you set in step 2 is `EIDON_GITHUB_APP_CALLBACK_URL`
+
+### Configure the environment
+
+Add the three variables to `.env` (dev) or your container environment (production):
+
+```bash
+EIDON_GITHUB_APP_CLIENT_ID=Iv1.xxxxxxxx
+EIDON_GITHUB_APP_CLIENT_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+EIDON_GITHUB_APP_CALLBACK_URL=http://localhost:3000/api/providers/github/callback
+```
+
+All three are optional — if they are not set, the GitHub Copilot provider type is still visible in settings but the connection flow is disabled.
+
+### Connect a profile
+
+1. Open **Settings → Providers**
+2. Create a new profile (or edit an existing one) and set **Provider type** to *GitHub Copilot*
+3. Click **Connect GitHub** — you will be redirected to GitHub to authorize
+4. After approving, you'll be returned to settings and the profile will show your GitHub username
+5. Pick a model from the dropdown and start chatting
+
 ## Configuration
 
 | Variable | Purpose | Required in production |
@@ -241,6 +286,9 @@ docker compose up -d --build
 | `EIDON_SESSION_SECRET` | Session signing secret | Yes |
 | `EIDON_ENCRYPTION_SECRET` | Encryption seed for stored provider credentials | Yes |
 | `EIDON_DATA_DIR` | Directory for SQLite and runtime data | No |
+| `EIDON_GITHUB_APP_CLIENT_ID` | GitHub App OAuth client ID for the Copilot provider | No |
+| `EIDON_GITHUB_APP_CLIENT_SECRET` | GitHub App OAuth client secret for the Copilot provider | No |
+| `EIDON_GITHUB_APP_CALLBACK_URL` | GitHub App OAuth callback URL (must match the app settings on GitHub) | No |
 
 Runtime defaults:
 

--- a/agent-memory/infrastructure/config.md
+++ b/agent-memory/infrastructure/config.md
@@ -8,6 +8,9 @@
 | `EIDON_ADMIN_PASSWORD` | Initial admin password | Yes |
 | `EIDON_SESSION_SECRET` | Session signing secret | Yes |
 | `EIDON_ENCRYPTION_SECRET` | Encryption key seed for stored provider credentials | Yes |
+| `EIDON_GITHUB_APP_CLIENT_ID` | GitHub App OAuth client ID for Copilot provider | No |
+| `EIDON_GITHUB_APP_CLIENT_SECRET` | GitHub App OAuth client secret for Copilot provider | No |
+| `EIDON_GITHUB_APP_CALLBACK_URL` | GitHub App OAuth callback redirect URL | No |
 | `EIDON_DATA_DIR` | Directory containing the SQLite database | No |
 
 ## By Environment

--- a/agent-memory/integrations/external.md
+++ b/agent-memory/integrations/external.md
@@ -4,6 +4,7 @@
 | Service | Purpose | Config |
 |---------|---------|--------|
 | OpenAI-compatible API | Chat inference, streaming, and compaction summarization | Stored in `app_settings` from `/settings` |
+| GitHub Copilot | Chat inference via user's Copilot subscription | Per-profile OAuth tokens in `provider_profiles` |
 | Model Context Protocol (MCP) servers | External tool discovery and tool execution from chat | Stored in `mcp_servers` from `/settings` |
 
 ## OpenAI-compatible API
@@ -14,6 +15,16 @@
 - **Reasoning Visibility:** Eidon requests visible reasoning for supported models; OpenAI reasoning models use Responses API summaries, while Z.AI `glm-5`/`glm-4.7` style models can surface thinking through `chat.completions` reasoning deltas
 - **Text Normalization:** Provider deltas and final text normalize escaped newline sequences like `\\n` and `\\r\\n` into real line breaks before persistence and rendering
 - **Error Handling:** Bubble provider failures back to the UI with explicit error messages; no silent fallback provider
+
+## GitHub Copilot
+- **SDK:** `@github/copilot-sdk` (`CopilotClient`) for model listing and chat
+- **Auth Flow:** Per-profile GitHub OAuth via `lib/github-copilot.ts` — user authorizes a GitHub App, Eidon stores encrypted user access/refresh tokens in `provider_profiles`
+- **Token Lifecycle:** Tokens auto-refresh within a 2-minute window before expiry (`ensureFreshGithubAccessToken`); connection status is computed as `disconnected`/`connected`/`expired`
+- **OAuth State:** JWT signed with `EIDON_SESSION_SECRET` (10-minute expiry) via `jose` library
+- **Model Selection:** Connected Copilot profiles list available models dynamically from `CopilotClient.listModels()`, shown in settings as a dropdown
+- **Settings UI:** Provider type selector (`openai_compatible` / `github_copilot`), Connect/Reconnect/Disconnect GitHub buttons, model picker for connected accounts
+- **API Routes:** `/api/providers/github/connect`, `/api/providers/github/callback`, `/api/providers/github/disconnect`, `/api/providers/github/models`
+- **Usage:** `lib/provider.ts` branches on `providerKind === "github_copilot"` to route chat through the Copilot SDK instead of the OpenAI-compatible path
 
 ## Model Context Protocol (MCP)
 - **Client Implementation:** Eidon uses the official `@modelcontextprotocol/sdk` client for both `stdio` and `streamable_http` transports

--- a/app/api/conversations/[conversationId]/chat/route.ts
+++ b/app/api/conversations/[conversationId]/chat/route.ts
@@ -73,8 +73,16 @@ export async function POST(
       : null) ?? getDefaultProviderProfileWithApiKey();
   const appSettings = getSettings();
 
-  if (!settings?.apiKey) {
+  if (!settings) {
+    return badRequest("No provider profile configured");
+  }
+
+  if (settings.providerKind !== "github_copilot" && !settings.apiKey) {
     return badRequest("Set an API key in settings before starting a chat");
+  }
+
+  if (settings.providerKind === "github_copilot" && !settings.githubUserAccessTokenEncrypted) {
+    return badRequest("Connect a GitHub account in settings before starting a chat");
   }
 
   const userMessage = createMessage({

--- a/app/api/providers/github/callback/route.ts
+++ b/app/api/providers/github/callback/route.ts
@@ -1,0 +1,47 @@
+import { redirect } from "next/navigation";
+
+import { requireUser } from "@/lib/auth";
+import { badRequest } from "@/lib/http";
+import { exchangeGithubCodeForTokens, verifyGithubOauthState } from "@/lib/github-copilot";
+import { updateGithubCopilotCredentials } from "@/lib/settings";
+
+export async function GET(request: Request) {
+  const user = await requireUser();
+  const url = new URL(request.url);
+  const code = url.searchParams.get("code");
+  const state = url.searchParams.get("state");
+
+  if (!code || !state) {
+    return badRequest("Missing code or state parameter");
+  }
+
+  let claims: { profileId: string; userId: string };
+  try {
+    claims = await verifyGithubOauthState(state);
+  } catch {
+    return badRequest("Invalid or expired OAuth state");
+  }
+
+  if (claims.userId !== user.id) {
+    return badRequest("OAuth state user mismatch");
+  }
+
+  try {
+    const tokens = await exchangeGithubCodeForTokens(code);
+
+    updateGithubCopilotCredentials(claims.profileId, {
+      githubUserAccessToken: tokens.access_token,
+      githubRefreshToken: tokens.refresh_token ?? "",
+      githubTokenExpiresAt: tokens.expires_in
+        ? new Date(Date.now() + tokens.expires_in * 1000).toISOString()
+        : null,
+      githubRefreshTokenExpiresAt: null,
+      githubAccountLogin: null,
+      githubAccountName: null
+    });
+  } catch (error) {
+    return badRequest(`Token exchange failed: ${error instanceof Error ? error.message : "Unknown error"}`);
+  }
+
+  redirect("/settings?tab=providers");
+}

--- a/app/api/providers/github/callback/route.ts
+++ b/app/api/providers/github/callback/route.ts
@@ -29,8 +29,16 @@ export async function GET(request: Request) {
   try {
     const tokens = await exchangeGithubCodeForTokens(code);
 
+    if (tokens.error) {
+      return badRequest(`GitHub OAuth error: ${tokens.error_description ?? tokens.error}`);
+    }
+
+    if (!tokens.access_token) {
+      return badRequest("GitHub OAuth did not return an access token");
+    }
+
     updateGithubCopilotCredentials(claims.profileId, {
-      githubUserAccessToken: tokens.access_token,
+      githubUserAccessToken: tokens.access_token!,
       githubRefreshToken: tokens.refresh_token ?? "",
       githubTokenExpiresAt: tokens.expires_in
         ? new Date(Date.now() + tokens.expires_in * 1000).toISOString()
@@ -43,5 +51,5 @@ export async function GET(request: Request) {
     return badRequest(`Token exchange failed: ${error instanceof Error ? error.message : "Unknown error"}`);
   }
 
-  redirect("/settings?tab=providers");
+  redirect("/settings/providers");
 }

--- a/app/api/providers/github/connect/route.ts
+++ b/app/api/providers/github/connect/route.ts
@@ -1,0 +1,25 @@
+import { redirect } from "next/navigation";
+
+import { requireUser } from "@/lib/auth";
+import { badRequest } from "@/lib/http";
+import { createGithubOauthState, getGithubAuthorizeUrl } from "@/lib/github-copilot";
+import { getProviderProfile } from "@/lib/settings";
+
+export async function GET(request: Request) {
+  const user = await requireUser();
+  const url = new URL(request.url);
+  const providerProfileId = url.searchParams.get("providerProfileId");
+
+  if (!providerProfileId) {
+    return badRequest("Provider profile is required");
+  }
+
+  const profile = getProviderProfile(providerProfileId);
+
+  if (!profile || profile.providerKind !== "github_copilot") {
+    return badRequest("GitHub Copilot is only available for Copilot profiles");
+  }
+
+  const state = await createGithubOauthState(profile.id, user.id);
+  redirect(getGithubAuthorizeUrl(state));
+}

--- a/app/api/providers/github/disconnect/route.ts
+++ b/app/api/providers/github/disconnect/route.ts
@@ -1,0 +1,15 @@
+import { badRequest, ok } from "@/lib/http";
+import { clearGithubCopilotCredentials } from "@/lib/settings";
+
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => ({}));
+  const { providerProfileId } = body as { providerProfileId?: string };
+
+  if (!providerProfileId) {
+    return badRequest("Provider profile is required");
+  }
+
+  clearGithubCopilotCredentials(providerProfileId);
+
+  return ok({ success: true });
+}

--- a/app/api/providers/github/models/route.ts
+++ b/app/api/providers/github/models/route.ts
@@ -1,0 +1,26 @@
+import { badRequest, ok } from "@/lib/http";
+import { getGithubConnectionStatus, listGithubCopilotModels } from "@/lib/github-copilot";
+import { getProviderProfileWithApiKey } from "@/lib/settings";
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const providerProfileId = url.searchParams.get("providerProfileId");
+
+  if (!providerProfileId) {
+    return badRequest("Provider profile is required");
+  }
+
+  const profile = getProviderProfileWithApiKey(providerProfileId);
+
+  if (!profile || profile.providerKind !== "github_copilot") {
+    return badRequest("Profile not found or not a Copilot profile");
+  }
+
+  if (getGithubConnectionStatus(profile) !== "connected") {
+    return badRequest("GitHub account not connected");
+  }
+
+  const modelList = await listGithubCopilotModels(profile);
+
+  return ok({ models: modelList });
+}

--- a/app/api/providers/github/models/route.ts
+++ b/app/api/providers/github/models/route.ts
@@ -20,7 +20,18 @@ export async function GET(request: Request) {
     return badRequest("GitHub account not connected");
   }
 
-  const modelList = await listGithubCopilotModels(profile);
+  try {
+    const modelList = await listGithubCopilotModels(profile);
 
-  return ok({ models: modelList });
+    return ok({
+      models: modelList.map((model) => ({
+        id: model.id,
+        name: model.name,
+        maxContextWindowTokens: model.capabilities?.limits?.max_context_window_tokens ?? null
+      }))
+    });
+  } catch (error) {
+    console.error("[copilot/models] Failed to list models:", error instanceof Error ? error.message : error);
+    return ok({ models: [] });
+  }
 }

--- a/app/api/settings/test/route.ts
+++ b/app/api/settings/test/route.ts
@@ -17,8 +17,19 @@ export async function POST(request: Request) {
       (body.providerProfileId ? getProviderProfileWithApiKey(body.providerProfileId) : null) ??
       getDefaultProviderProfileWithApiKey();
 
-    if (!settings?.apiKey) {
+    if (!settings) {
+      return badRequest("Provider profile not found");
+    }
+
+    if (settings.providerKind === "openai_compatible" && !settings.apiKey) {
       return badRequest("Set an API key before running a connection test");
+    }
+
+    if (
+      settings.providerKind === "github_copilot" &&
+      !settings.githubUserAccessTokenEncrypted
+    ) {
+      return badRequest("Connect a GitHub account before running a Copilot connection test");
     }
 
     const text = await callProviderText({

--- a/components/settings/sections/providers-section.tsx
+++ b/components/settings/sections/providers-section.tsx
@@ -36,6 +36,7 @@ type SettingsPayload = {
   providerProfiles: Array<{
     id: string;
     name: string;
+    providerKind: "openai_compatible" | "github_copilot";
     apiBaseUrl: string;
     model: string;
     apiMode: ApiMode;
@@ -55,6 +56,11 @@ type SettingsPayload = {
     mergedTargetTokens: number;
     visionMode: VisionMode;
     visionMcpServerId: string | null;
+    githubAccountLogin: string | null;
+    githubAccountName: string | null;
+    githubTokenExpiresAt: string | null;
+    githubRefreshTokenExpiresAt: string | null;
+    githubConnectionStatus: "disconnected" | "connected" | "expired";
     createdAt: string;
     updatedAt: string;
     hasApiKey: boolean;
@@ -66,6 +72,7 @@ type ProviderProfileDraft = SettingsPayload["providerProfiles"][number] & {
   apiKey: string;
   visionMode: VisionMode;
   visionMcpServerId: string | null;
+  githubConnectionStatus: "disconnected" | "connected" | "expired";
 };
 
 export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
@@ -89,6 +96,7 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
   const [mobileDetailVisible, setMobileDetailVisible] = useState(false);
   const [showApiKey, setShowApiKey] = useState(false);
   const [mcpServers, setMcpServers] = useState<McpServer[]>([]);
+  const [copilotModels, setCopilotModels] = useState<Array<{ id: string; name: string }>>([]);
 
   useEffect(() => {
     fetch("/api/mcp-servers")
@@ -96,6 +104,7 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
       .then((data: { servers: McpServer[] }) => setMcpServers(data.servers))
       .catch(() => setMcpServers([]));
   }, []);
+
   const activeProviderProfile = useMemo(
     () =>
       providerProfiles.find((profile) => profile.id === selectedProviderProfileId) ??
@@ -105,6 +114,20 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
   const activeProviderPresetId = activeProviderProfile
     ? getMatchingProviderPresetId(activeProviderProfile)
     : null;
+
+  useEffect(() => {
+    if (
+      activeProviderProfile?.providerKind === "github_copilot" &&
+      activeProviderProfile.githubConnectionStatus === "connected"
+    ) {
+      fetch(`/api/providers/github/models?providerProfileId=${activeProviderProfile.id}`)
+        .then((res) => (res.ok ? res.json() : { models: [] }))
+        .then((data) => setCopilotModels(data.models ?? []))
+        .catch(() => setCopilotModels([]));
+    } else {
+      setCopilotModels([]);
+    }
+  }, [activeProviderProfile?.id, activeProviderProfile?.providerKind, activeProviderProfile?.githubConnectionStatus]);
 
   function updateActiveProviderProfile(patch: Partial<ProviderProfileDraft>) {
     if (!activeProviderProfile) {
@@ -155,6 +178,11 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
       apiKey: "",
       visionMode: template?.visionMode ?? "native" as VisionMode,
       visionMcpServerId: template?.visionMcpServerId ?? null,
+      githubAccountLogin: null,
+      githubAccountName: null,
+      githubTokenExpiresAt: null,
+      githubRefreshTokenExpiresAt: null,
+      githubConnectionStatus: "disconnected",
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString()
     };
@@ -204,6 +232,7 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
       providerProfiles: providerProfiles.map((profile) => ({
         id: profile.id,
         name: profile.name,
+        providerKind: profile.providerKind ?? "openai_compatible",
         apiBaseUrl: profile.apiBaseUrl,
         apiKey: profile.apiKey,
         model: profile.model,
@@ -223,7 +252,11 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
         mergedMinNodeCount: profile.mergedMinNodeCount,
         mergedTargetTokens: profile.mergedTargetTokens,
         visionMode: profile.visionMode ?? "native",
-        visionMcpServerId: profile.visionMcpServerId ?? null
+        visionMcpServerId: profile.visionMcpServerId ?? null,
+        githubAccountLogin: profile.githubAccountLogin ?? null,
+        githubAccountName: profile.githubAccountName ?? null,
+        githubTokenExpiresAt: profile.githubTokenExpiresAt ?? null,
+        githubRefreshTokenExpiresAt: profile.githubRefreshTokenExpiresAt ?? null
       }))
     };
 
@@ -293,8 +326,11 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
                   ...(profile.id === defaultProviderProfileId
                     ? [{ variant: "default" as const, label: "DEFAULT" }]
                     : []),
-                  ...(!profile.hasApiKey && !profile.apiKey
+                  ...(!profile.hasApiKey && !profile.apiKey && profile.providerKind !== "github_copilot"
                     ? [{ variant: "no-key" as const, label: "NO KEY" }]
+                    : []),
+                  ...(profile.providerKind === "github_copilot" && profile.githubConnectionStatus === "disconnected"
+                    ? [{ variant: "no-key" as const, label: "NOT CONNECTED" }]
                     : [])
                 ]}
               />
@@ -358,28 +394,54 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
 
                 <div className="space-y-5">
                   <div>
-                    <label className={labelClass}>Provider preset</label>
+                    <label className={labelClass}>Provider type</label>
                     <select
-                      value={activeProviderPresetId ?? ""}
-                      onChange={(event) => {
-                        const nextPresetId = event.target.value as ProviderPresetId;
-
-                        if (!nextPresetId) {
-                          return;
-                        }
-
-                        applyPresetToActiveProviderProfile(nextPresetId);
-                      }}
                       className={selectClass}
+                      value={activeProviderProfile.providerKind ?? "openai_compatible"}
+                      onChange={(event) =>
+                        updateActiveProviderProfile({
+                          providerKind: event.target.value as "openai_compatible" | "github_copilot",
+                          apiBaseUrl:
+                            event.target.value === "github_copilot"
+                              ? ""
+                              : activeProviderProfile.apiBaseUrl,
+                          apiKey:
+                            event.target.value === "github_copilot"
+                              ? ""
+                              : activeProviderProfile.apiKey
+                        })
+                      }
                     >
-                      <option value="">Manual configuration</option>
-                      {PROVIDER_PRESETS.map((preset) => (
-                        <option key={preset.id} value={preset.id}>
-                          {preset.label}
-                        </option>
-                      ))}
+                      <option value="openai_compatible">OpenAI compatible</option>
+                      <option value="github_copilot">GitHub Copilot</option>
                     </select>
                   </div>
+
+                  {activeProviderProfile.providerKind !== "github_copilot" && (
+                    <div>
+                      <label className={labelClass}>Provider preset</label>
+                      <select
+                        value={activeProviderPresetId ?? ""}
+                        onChange={(event) => {
+                          const nextPresetId = event.target.value as ProviderPresetId;
+
+                          if (!nextPresetId) {
+                            return;
+                          }
+
+                          applyPresetToActiveProviderProfile(nextPresetId);
+                        }}
+                        className={selectClass}
+                      >
+                        <option value="">Manual configuration</option>
+                        {PROVIDER_PRESETS.map((preset) => (
+                          <option key={preset.id} value={preset.id}>
+                            {preset.label}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                  )}
 
                   <div>
                     <label className={labelClass}>Profile name</label>
@@ -394,69 +456,128 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
                     />
                   </div>
 
-                  <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-                    <div>
-                      <label className={labelClass}>API base URL</label>
-                      <Input
-                        name="provider-api-base-url"
-                        autoComplete="url"
-                        value={activeProviderProfile.apiBaseUrl}
-                        onChange={(event) =>
-                          updateActiveProviderProfile({ apiBaseUrl: event.target.value })
-                        }
-                        required
-                      />
+                  {activeProviderProfile.providerKind === "github_copilot" ? (
+                    <div className="space-y-3">
+                      <p className={labelClass}>GitHub connection</p>
+                      <div className="rounded-xl border border-white/6 bg-white/[0.03] px-4 py-3 text-sm text-[#f4f4f5]">
+                        {activeProviderProfile.githubConnectionStatus === "connected"
+                          ? `Connected as ${activeProviderProfile.githubAccountLogin ?? "GitHub user"}`
+                          : "No GitHub account connected"}
+                      </div>
+                      <div className="flex gap-2">
+                        <Button
+                          type="button"
+                          onClick={() => {
+                            window.location.href = `/api/providers/github/connect?providerProfileId=${activeProviderProfile.id}`;
+                          }}
+                        >
+                          {activeProviderProfile.githubConnectionStatus === "connected"
+                            ? "Reconnect GitHub"
+                            : "Connect GitHub"}
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          onClick={async () => {
+                            await fetch("/api/providers/github/disconnect", {
+                              method: "POST",
+                              headers: { "Content-Type": "application/json" },
+                              body: JSON.stringify({ providerProfileId: activeProviderProfile.id })
+                            });
+                            updateActiveProviderProfile({
+                              githubConnectionStatus: "disconnected",
+                              githubAccountLogin: null,
+                              githubAccountName: null
+                            });
+                          }}
+                          disabled={activeProviderProfile.githubConnectionStatus === "disconnected"}
+                        >
+                          Disconnect
+                        </Button>
+                      </div>
                     </div>
+                  ) : (
+                    <>
+                      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                        <div>
+                          <label className={labelClass}>API base URL</label>
+                          <Input
+                            name="provider-api-base-url"
+                            autoComplete="url"
+                            value={activeProviderProfile.apiBaseUrl}
+                            onChange={(event) =>
+                              updateActiveProviderProfile({ apiBaseUrl: event.target.value })
+                            }
+                            required
+                          />
+                        </div>
+                        <div>
+                          <label className={labelClass}>Model</label>
+                          <Input
+                            name="provider-model"
+                            autoComplete="off"
+                            value={activeProviderProfile.model}
+                            onChange={(event) =>
+                              updateActiveProviderProfile({ model: event.target.value })
+                            }
+                            required
+                          />
+                        </div>
+                      </div>
+
+                      <div>
+                        <label className={labelClass}>API key</label>
+                        <div className="relative">
+                          <Input
+                            name="provider-api-key"
+                            autoComplete="new-password"
+                            spellCheck={false}
+                            type={showApiKey ? "text" : "password"}
+                            value={activeProviderProfile.apiKey}
+                            onChange={(event) =>
+                              updateActiveProviderProfile({
+                                apiKey: event.target.value,
+                                hasApiKey:
+                                  activeProviderProfile.hasApiKey || Boolean(event.target.value)
+                              })
+                            }
+                            placeholder={
+                              activeProviderProfile.hasApiKey
+                                ? "Stored securely. Leave blank to keep."
+                                : "sk-..."
+                            }
+                            className="pr-10"
+                          />
+                          <button
+                            type="button"
+                            onClick={() => setShowApiKey((v) => !v)}
+                            className="absolute right-3 top-1/2 -translate-y-1/2 text-[#52525b] hover:text-[#a1a1aa] transition-colors"
+                          >
+                            {showApiKey ? (
+                              <EyeOff className="h-4 w-4" />
+                            ) : (
+                              <Eye className="h-4 w-4" />
+                            )}
+                          </button>
+                        </div>
+                      </div>
+                    </>
+                  )}
+
+                  {activeProviderProfile.providerKind === "github_copilot" && copilotModels.length > 0 && (
                     <div>
                       <label className={labelClass}>Model</label>
-                      <Input
-                        name="provider-model"
-                        autoComplete="off"
+                      <select
                         value={activeProviderProfile.model}
-                        onChange={(event) =>
-                          updateActiveProviderProfile({ model: event.target.value })
-                        }
-                        required
-                      />
-                    </div>
-                  </div>
-
-                  <div>
-                    <label className={labelClass}>API key</label>
-                    <div className="relative">
-                      <Input
-                        name="provider-api-key"
-                        autoComplete="new-password"
-                        spellCheck={false}
-                        type={showApiKey ? "text" : "password"}
-                        value={activeProviderProfile.apiKey}
-                        onChange={(event) =>
-                          updateActiveProviderProfile({
-                            apiKey: event.target.value,
-                            hasApiKey:
-                              activeProviderProfile.hasApiKey || Boolean(event.target.value)
-                          })
-                        }
-                        placeholder={
-                          activeProviderProfile.hasApiKey
-                            ? "Stored securely. Leave blank to keep."
-                            : "sk-..."
-                        }
-                        className="pr-10"
-                      />
-                      <button
-                        type="button"
-                        onClick={() => setShowApiKey((v) => !v)}
-                        className="absolute right-3 top-1/2 -translate-y-1/2 text-[#52525b] hover:text-[#a1a1aa] transition-colors"
+                        onChange={(event) => updateActiveProviderProfile({ model: event.target.value })}
+                        className={selectClass}
                       >
-                        {showApiKey ? (
-                          <EyeOff className="h-4 w-4" />
-                        ) : (
-                          <Eye className="h-4 w-4" />
-                        )}
-                      </button>
+                        {copilotModels.map((model) => (
+                          <option key={model.id} value={model.id}>{model.name}</option>
+                        ))}
+                      </select>
                     </div>
-                  </div>
+                  )}
                 </div>
 
                 <CollapsibleSection

--- a/components/settings/sections/providers-section.tsx
+++ b/components/settings/sections/providers-section.tsx
@@ -96,7 +96,7 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
   const [mobileDetailVisible, setMobileDetailVisible] = useState(false);
   const [showApiKey, setShowApiKey] = useState(false);
   const [mcpServers, setMcpServers] = useState<McpServer[]>([]);
-  const [copilotModels, setCopilotModels] = useState<Array<{ id: string; name: string }>>([]);
+  const [copilotModels, setCopilotModels] = useState<Array<{ id: string; name: string; maxContextWindowTokens: number | null }>>([]);
 
   useEffect(() => {
     fetch("/api/mcp-servers")
@@ -114,6 +114,7 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
   const activeProviderPresetId = activeProviderProfile
     ? getMatchingProviderPresetId(activeProviderProfile)
     : null;
+  const isCopilot = activeProviderProfile?.providerKind === "github_copilot";
 
   useEffect(() => {
     if (
@@ -221,12 +222,8 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
     }
   }
 
-  async function handleSettings(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    setError("");
-    setSuccess("");
-
-    const payload = {
+  async function buildSettingsPayload() {
+    return {
       defaultProviderProfileId,
       skillsEnabled,
       providerProfiles: providerProfiles.map((profile) => ({
@@ -259,20 +256,32 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
         githubRefreshTokenExpiresAt: profile.githubRefreshTokenExpiresAt ?? null
       }))
     };
+  }
 
+  async function saveSettings() {
     const response = await fetch("/api/settings", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(payload)
+      body: JSON.stringify(await buildSettingsPayload())
     });
 
     const result = (await response.json()) as { error?: string };
     if (!response.ok) {
       setError(result.error ?? "Unable to save settings");
-      return;
+      return false;
     }
-    setSuccess("Settings saved.");
-    router.refresh();
+
+    return true;
+  }
+
+  async function handleSettings(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError("");
+    setSuccess("");
+
+    if (await saveSettings()) {
+      setSuccess("Settings saved.");
+    }
   }
 
   async function runConnectionTest() {
@@ -321,7 +330,11 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
                   setMobileDetailVisible(true);
                 }}
                 title={profile.name}
-                subtitle={`${profile.model} \u00B7 ${profile.apiMode}`}
+                subtitle={
+                  profile.providerKind === "github_copilot"
+                    ? `Copilot${profile.model ? ` · ${profile.model}` : ""}`
+                    : `${profile.model} · ${profile.apiMode}`
+                }
                 badges={[
                   ...(profile.id === defaultProviderProfileId
                     ? [{ variant: "default" as const, label: "DEFAULT" }]
@@ -352,8 +365,9 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
                       {activeProviderProfile.name}
                     </h3>
                     <p className="mt-0.5 text-[0.75rem] text-[#52525b]">
-                      {activeProviderProfile.apiBaseUrl} &middot; {activeProviderProfile.model}{" "}
-                      &middot; {activeProviderProfile.apiMode}
+                      {isCopilot
+                        ? `GitHub Copilot${activeProviderProfile.model ? ` · ${activeProviderProfile.model}` : ""}`
+                        : `${activeProviderProfile.apiBaseUrl} · ${activeProviderProfile.model} · ${activeProviderProfile.apiMode}`}
                     </p>
                   </div>
 
@@ -398,26 +412,35 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
                     <select
                       className={selectClass}
                       value={activeProviderProfile.providerKind ?? "openai_compatible"}
-                      onChange={(event) =>
-                        updateActiveProviderProfile({
-                          providerKind: event.target.value as "openai_compatible" | "github_copilot",
-                          apiBaseUrl:
-                            event.target.value === "github_copilot"
-                              ? ""
-                              : activeProviderProfile.apiBaseUrl,
-                          apiKey:
-                            event.target.value === "github_copilot"
-                              ? ""
-                              : activeProviderProfile.apiKey
-                        })
+                      onChange={(event) => {
+                        const value = event.target.value as "openai_compatible" | "github_copilot";
+
+                        if (value === "github_copilot") {
+                          updateActiveProviderProfile({
+                            providerKind: "github_copilot",
+                            apiBaseUrl: "",
+                            apiKey: "",
+                            model: "",
+                            apiMode: "responses",
+                            systemPrompt: "",
+                            tokenizerModel: "off"
+                          });
+                        } else {
+                          updateActiveProviderProfile({
+                            providerKind: "openai_compatible",
+                            apiBaseUrl: activeProviderProfile.apiBaseUrl || "https://api.openai.com/v1",
+                            apiKey: ""
+                          });
+                        }
                       }
+                    }
                     >
                       <option value="openai_compatible">OpenAI compatible</option>
                       <option value="github_copilot">GitHub Copilot</option>
                     </select>
                   </div>
 
-                  {activeProviderProfile.providerKind !== "github_copilot" && (
+                  {!isCopilot && (
                     <div>
                       <label className={labelClass}>Provider preset</label>
                       <select
@@ -456,7 +479,7 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
                     />
                   </div>
 
-                  {activeProviderProfile.providerKind === "github_copilot" ? (
+                  {isCopilot ? (
                     <div className="space-y-3">
                       <p className={labelClass}>GitHub connection</p>
                       <div className="rounded-xl border border-white/6 bg-white/[0.03] px-4 py-3 text-sm text-[#f4f4f5]">
@@ -467,8 +490,10 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
                       <div className="flex gap-2">
                         <Button
                           type="button"
-                          onClick={() => {
-                            window.location.href = `/api/providers/github/connect?providerProfileId=${activeProviderProfile.id}`;
+                          onClick={async () => {
+                            if (await saveSettings()) {
+                              window.location.href = `/api/providers/github/connect?providerProfileId=${activeProviderProfile.id}`;
+                            }
                           }}
                         >
                           {activeProviderProfile.githubConnectionStatus === "connected"
@@ -564,18 +589,35 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
                     </>
                   )}
 
-                  {activeProviderProfile.providerKind === "github_copilot" && copilotModels.length > 0 && (
+                  {isCopilot && copilotModels.length > 0 && (
                     <div>
                       <label className={labelClass}>Model</label>
                       <select
                         value={activeProviderProfile.model}
-                        onChange={(event) => updateActiveProviderProfile({ model: event.target.value })}
+                        onChange={(event) => {
+                          const selected = copilotModels.find((m) => m.id === event.target.value);
+                          updateActiveProviderProfile({
+                            model: event.target.value,
+                            ...(selected?.maxContextWindowTokens
+                              ? { modelContextLimit: selected.maxContextWindowTokens }
+                              : {})
+                          });
+                        }}
                         className={selectClass}
                       >
                         {copilotModels.map((model) => (
                           <option key={model.id} value={model.id}>{model.name}</option>
                         ))}
                       </select>
+                    </div>
+                  )}
+
+                  {isCopilot && copilotModels.length === 0 && activeProviderProfile.githubConnectionStatus !== "connected" && (
+                    <div>
+                      <label className={labelClass}>Model</label>
+                      <div className="rounded-xl border border-white/6 bg-white/[0.03] px-4 py-3 text-sm text-[#52525b]">
+                        Connect GitHub to browse models
+                      </div>
                     </div>
                   )}
                 </div>
@@ -585,33 +627,37 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
                   icon={<FlaskConical className="h-4 w-4" />}
                 >
                   <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-                    <div>
-                      <label className={labelClass}>Temperature</label>
-                      <Input
-                        name="provider-temperature"
-                        type="number"
-                        step="0.1"
-                        value={activeProviderProfile.temperature}
-                        onChange={(event) =>
-                          updateActiveProviderProfile({
-                            temperature: Number(event.target.value || 0)
-                          })
-                        }
-                      />
-                    </div>
-                    <div>
-                      <label className={labelClass}>Max output tokens</label>
-                      <Input
-                        name="provider-max-output-tokens"
-                        type="number"
-                        value={activeProviderProfile.maxOutputTokens}
-                        onChange={(event) =>
-                          updateActiveProviderProfile({
-                            maxOutputTokens: Number(event.target.value || 0)
-                          })
-                        }
-                      />
-                    </div>
+                    {!isCopilot && (
+                      <>
+                        <div>
+                          <label className={labelClass}>Temperature</label>
+                          <Input
+                            name="provider-temperature"
+                            type="number"
+                            step="0.1"
+                            value={activeProviderProfile.temperature}
+                            onChange={(event) =>
+                              updateActiveProviderProfile({
+                                temperature: Number(event.target.value || 0)
+                              })
+                            }
+                          />
+                        </div>
+                        <div>
+                          <label className={labelClass}>Max output tokens</label>
+                          <Input
+                            name="provider-max-output-tokens"
+                            type="number"
+                            value={activeProviderProfile.maxOutputTokens}
+                            onChange={(event) =>
+                              updateActiveProviderProfile({
+                                maxOutputTokens: Number(event.target.value || 0)
+                              })
+                            }
+                          />
+                        </div>
+                      </>
+                    )}
                     <div>
                       <label className={labelClass}>Reasoning effort</label>
                       <select
@@ -629,34 +675,38 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
                         <option value="xhigh">xhigh</option>
                       </select>
                     </div>
-                    <div>
-                      <label className={labelClass}>Reasoning summary</label>
-                      <label className="flex h-[46px] items-center gap-3 rounded-xl border border-white/6 bg-white/[0.03] px-4 text-[0.82rem] text-[#a1a1aa] cursor-pointer">
-                        <input
-                          type="checkbox"
-                          checked={activeProviderProfile.reasoningSummaryEnabled}
-                          onChange={(event) =>
-                            updateActiveProviderProfile({
-                              reasoningSummaryEnabled: event.target.checked
-                            })
-                          }
-                        />
-                        Show reasoning when supported
-                      </label>
-                    </div>
-                    <div>
-                      <label className={labelClass}>API mode</label>
-                      <select
-                        value={activeProviderProfile.apiMode}
-                        onChange={(event) =>
-                          updateActiveProviderProfile({ apiMode: event.target.value as ApiMode })
-                        }
-                        className={selectClass}
-                      >
-                        <option value="responses">responses</option>
-                        <option value="chat_completions">chat_completions</option>
-                      </select>
-                    </div>
+                    {!isCopilot && (
+                      <>
+                        <div>
+                          <label className={labelClass}>Reasoning summary</label>
+                          <label className="flex h-[46px] items-center gap-3 rounded-xl border border-white/6 bg-white/[0.03] px-4 text-[0.82rem] text-[#a1a1aa] cursor-pointer">
+                            <input
+                              type="checkbox"
+                              checked={activeProviderProfile.reasoningSummaryEnabled}
+                              onChange={(event) =>
+                                updateActiveProviderProfile({
+                                  reasoningSummaryEnabled: event.target.checked
+                                })
+                              }
+                            />
+                            Show reasoning when supported
+                          </label>
+                        </div>
+                        <div>
+                          <label className={labelClass}>API mode</label>
+                          <select
+                            value={activeProviderProfile.apiMode}
+                            onChange={(event) =>
+                              updateActiveProviderProfile({ apiMode: event.target.value as ApiMode })
+                            }
+                            className={selectClass}
+                          >
+                            <option value="responses">responses</option>
+                            <option value="chat_completions">chat_completions</option>
+                          </select>
+                        </div>
+                      </>
+                    )}
                     <div>
                       <label className={labelClass}>Model context limit</label>
                       <Input
@@ -697,74 +747,78 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
                         }
                       />
                     </div>
-                    <div>
-                      <label className={labelClass}>Tokenizer model</label>
-                      <select
-                        value={activeProviderProfile.tokenizerModel}
-                        onChange={(event) =>
-                          updateActiveProviderProfile({ tokenizerModel: event.target.value as "gpt-tokenizer" | "off" })
-                        }
-                        className={selectClass}
-                      >
-                        <option value="gpt-tokenizer">gpt-tokenizer</option>
-                        <option value="off">Off (char / 4)</option>
-                      </select>
-                    </div>
-                    <div>
-                      <label className={labelClass}>Safety margin tokens</label>
-                      <Input
-                        name="provider-safety-margin-tokens"
-                        type="number"
-                        value={activeProviderProfile.safetyMarginTokens}
-                        onChange={(event) =>
-                          updateActiveProviderProfile({ safetyMarginTokens: Number(event.target.value || 0) })
-                        }
-                      />
-                    </div>
-                    <div>
-                      <label className={labelClass}>Leaf source token limit</label>
-                      <Input
-                        name="provider-leaf-source-token-limit"
-                        type="number"
-                        value={activeProviderProfile.leafSourceTokenLimit}
-                        onChange={(event) =>
-                          updateActiveProviderProfile({ leafSourceTokenLimit: Number(event.target.value || 0) })
-                        }
-                      />
-                    </div>
-                    <div>
-                      <label className={labelClass}>Leaf min message count</label>
-                      <Input
-                        name="provider-leaf-min-message-count"
-                        type="number"
-                        value={activeProviderProfile.leafMinMessageCount}
-                        onChange={(event) =>
-                          updateActiveProviderProfile({ leafMinMessageCount: Number(event.target.value || 0) })
-                        }
-                      />
-                    </div>
-                    <div>
-                      <label className={labelClass}>Merged min node count</label>
-                      <Input
-                        name="provider-merged-min-node-count"
-                        type="number"
-                        value={activeProviderProfile.mergedMinNodeCount}
-                        onChange={(event) =>
-                          updateActiveProviderProfile({ mergedMinNodeCount: Number(event.target.value || 0) })
-                        }
-                      />
-                    </div>
-                    <div>
-                      <label className={labelClass}>Merged target tokens</label>
-                      <Input
-                        name="provider-merged-target-tokens"
-                        type="number"
-                        value={activeProviderProfile.mergedTargetTokens}
-                        onChange={(event) =>
-                          updateActiveProviderProfile({ mergedTargetTokens: Number(event.target.value || 0) })
-                        }
-                      />
-                    </div>
+                    {!isCopilot && (
+                      <>
+                        <div>
+                          <label className={labelClass}>Tokenizer model</label>
+                          <select
+                            value={activeProviderProfile.tokenizerModel}
+                            onChange={(event) =>
+                              updateActiveProviderProfile({ tokenizerModel: event.target.value as "gpt-tokenizer" | "off" })
+                            }
+                            className={selectClass}
+                          >
+                            <option value="gpt-tokenizer">gpt-tokenizer</option>
+                            <option value="off">Off (char / 4)</option>
+                          </select>
+                        </div>
+                        <div>
+                          <label className={labelClass}>Safety margin tokens</label>
+                          <Input
+                            name="provider-safety-margin-tokens"
+                            type="number"
+                            value={activeProviderProfile.safetyMarginTokens}
+                            onChange={(event) =>
+                              updateActiveProviderProfile({ safetyMarginTokens: Number(event.target.value || 0) })
+                            }
+                          />
+                        </div>
+                        <div>
+                          <label className={labelClass}>Leaf source token limit</label>
+                          <Input
+                            name="provider-leaf-source-token-limit"
+                            type="number"
+                            value={activeProviderProfile.leafSourceTokenLimit}
+                            onChange={(event) =>
+                              updateActiveProviderProfile({ leafSourceTokenLimit: Number(event.target.value || 0) })
+                            }
+                          />
+                        </div>
+                        <div>
+                          <label className={labelClass}>Leaf min message count</label>
+                          <Input
+                            name="provider-leaf-min-message-count"
+                            type="number"
+                            value={activeProviderProfile.leafMinMessageCount}
+                            onChange={(event) =>
+                              updateActiveProviderProfile({ leafMinMessageCount: Number(event.target.value || 0) })
+                            }
+                          />
+                        </div>
+                        <div>
+                          <label className={labelClass}>Merged min node count</label>
+                          <Input
+                            name="provider-merged-min-node-count"
+                            type="number"
+                            value={activeProviderProfile.mergedMinNodeCount}
+                            onChange={(event) =>
+                              updateActiveProviderProfile({ mergedMinNodeCount: Number(event.target.value || 0) })
+                            }
+                          />
+                        </div>
+                        <div>
+                          <label className={labelClass}>Merged target tokens</label>
+                          <Input
+                            name="provider-merged-target-tokens"
+                            type="number"
+                            value={activeProviderProfile.mergedTargetTokens}
+                            onChange={(event) =>
+                              updateActiveProviderProfile({ mergedTargetTokens: Number(event.target.value || 0) })
+                            }
+                          />
+                        </div>
+                      </>
+                    )}
                     <div>
                       <label className={labelClass}>Vision mode</label>
                       <select

--- a/docs/superpowers/plans/2026-04-08-github-copilot-provider.md
+++ b/docs/superpowers/plans/2026-04-08-github-copilot-provider.md
@@ -1,0 +1,1220 @@
+# GitHub Copilot Provider Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a per-profile GitHub Copilot provider that connects through GitHub OAuth, lazily refreshes tokens on the server, exposes account-scoped models in settings, and lets Eidon chat through the user's own Copilot subscription.
+
+**Architecture:** Extend the existing `provider_profiles` record to support a `providerKind` discriminator plus GitHub OAuth credential metadata, then add a dedicated `lib/github-copilot.ts` module that owns OAuth, lazy refresh, and model discovery. Keep the existing OpenAI-compatible path intact and branch at runtime in `lib/provider.ts` and the settings UI.
+
+**Tech Stack:** Next.js App Router route handlers, React 19, better-sqlite3, zod, Vitest, Testing Library, `@github/copilot-sdk`
+
+---
+
+### Task 1: Add GitHub Copilot dependency and environment plumbing
+
+**Files:**
+- Modify: `package.json`
+- Modify: `package-lock.json`
+- Modify: `lib/env.ts`
+- Test: `tests/unit/env.test.ts`
+
+- [ ] **Step 1: Write the failing environment test**
+
+Add this test block to `tests/unit/env.test.ts`:
+
+```ts
+  it("reads GitHub Copilot OAuth environment variables when provided", () => {
+    const env = parseEnv({
+      NODE_ENV: "production",
+      EIDON_ADMIN_PASSWORD: "production-admin-password-32-chars",
+      EIDON_SESSION_SECRET: "production-session-secret-with-32-chars",
+      EIDON_ENCRYPTION_SECRET: "production-encryption-secret-32-chars",
+      EIDON_GITHUB_APP_CLIENT_ID: "Iv23exampleclientid",
+      EIDON_GITHUB_APP_CLIENT_SECRET: "github-app-client-secret-value",
+      EIDON_GITHUB_APP_CALLBACK_URL: "https://eidon.example.com/api/providers/github/callback"
+    });
+
+    expect(env.EIDON_GITHUB_APP_CLIENT_ID).toBe("Iv23exampleclientid");
+    expect(env.EIDON_GITHUB_APP_CLIENT_SECRET).toBe("github-app-client-secret-value");
+    expect(env.EIDON_GITHUB_APP_CALLBACK_URL).toBe(
+      "https://eidon.example.com/api/providers/github/callback"
+    );
+  });
+```
+
+- [ ] **Step 2: Run the env test to verify it fails**
+
+Run:
+
+```bash
+npm run test -- tests/unit/env.test.ts
+```
+
+Expected: FAIL with `EIDON_GITHUB_APP_CLIENT_ID` or the other GitHub env keys missing from the parsed env object.
+
+- [ ] **Step 3: Add the dependency and env parsing support**
+
+Install the Copilot SDK and keep the resolved version that `npm` writes into `package.json` and `package-lock.json`:
+
+```bash
+npm install @github/copilot-sdk
+```
+
+Extend `lib/env.ts` in both the schema and the proxy return type with:
+
+```ts
+  EIDON_GITHUB_APP_CLIENT_ID: z.string().min(1).optional(),
+  EIDON_GITHUB_APP_CLIENT_SECRET: z.string().min(1).optional(),
+  EIDON_GITHUB_APP_CALLBACK_URL: z.string().url().optional(),
+```
+
+No new production secret-default logic is required for these values because the provider is optional and should be unavailable when unset.
+
+- [ ] **Step 4: Install dependencies and update the lockfile**
+
+Run:
+
+```bash
+npm install
+```
+
+Expected: `package-lock.json` updates and `@github/copilot-sdk` appears in the dependency tree.
+
+- [ ] **Step 5: Run the env test to verify it passes**
+
+Run:
+
+```bash
+npm run test -- tests/unit/env.test.ts
+```
+
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add package.json package-lock.json lib/env.ts tests/unit/env.test.ts
+git commit -m "feat: add copilot oauth env support"
+```
+
+---
+
+### Task 2: Extend provider profile storage for Copilot profiles
+
+**Files:**
+- Modify: `lib/types.ts`
+- Modify: `lib/db.ts`
+- Modify: `lib/settings.ts`
+- Test: `tests/unit/settings.test.ts`
+
+- [ ] **Step 1: Write the failing settings tests**
+
+Add these tests to `tests/unit/settings.test.ts`:
+
+```ts
+  it("stores github copilot profiles without requiring an api key", () => {
+    const copilot = {
+      ...buildProfile({
+        id: "profile_copilot",
+        name: "Copilot"
+      }),
+      providerKind: "github_copilot" as const,
+      apiKey: "",
+      apiBaseUrl: "",
+      githubUserAccessTokenEncrypted: "",
+      githubRefreshTokenEncrypted: "",
+      githubTokenExpiresAt: null,
+      githubRefreshTokenExpiresAt: null,
+      githubAccountLogin: null,
+      githubAccountName: null
+    };
+
+    updateSettings({
+      defaultProviderProfileId: copilot.id,
+      skillsEnabled: true,
+      providerProfiles: [copilot]
+    });
+
+    const stored = getProviderProfile(copilot.id);
+
+    expect(stored?.providerKind).toBe("github_copilot");
+    expect(stored?.apiKeyEncrypted).toBe("");
+  });
+
+  it("keeps duplicated copilot profiles disconnected", () => {
+    const connected = {
+      ...buildProfile({
+        id: "profile_copilot",
+        name: "Copilot"
+      }),
+      providerKind: "github_copilot" as const,
+      apiKey: "",
+      apiBaseUrl: "",
+      githubUserAccessTokenEncrypted: "ciphertext-access",
+      githubRefreshTokenEncrypted: "ciphertext-refresh",
+      githubTokenExpiresAt: "2026-04-08T16:00:00.000Z",
+      githubRefreshTokenExpiresAt: "2026-10-08T16:00:00.000Z",
+      githubAccountLogin: "octocat",
+      githubAccountName: "The Octocat"
+    };
+
+    const duplicate = {
+      ...connected,
+      id: "profile_copilot_copy",
+      name: "Copilot Copy",
+      githubUserAccessTokenEncrypted: "",
+      githubRefreshTokenEncrypted: "",
+      githubTokenExpiresAt: null,
+      githubRefreshTokenExpiresAt: null,
+      githubAccountLogin: null,
+      githubAccountName: null
+    };
+
+    updateSettings({
+      defaultProviderProfileId: connected.id,
+      skillsEnabled: true,
+      providerProfiles: [connected, duplicate]
+    });
+
+    expect(getProviderProfile("profile_copilot_copy")).toMatchObject({
+      providerKind: "github_copilot",
+      githubUserAccessTokenEncrypted: "",
+      githubRefreshTokenEncrypted: "",
+      githubAccountLogin: null
+    });
+  });
+
+  it("does not expose github oauth credentials in sanitized settings", () => {
+    const copilot = {
+      ...buildProfile({
+        id: "profile_copilot",
+        name: "Copilot"
+      }),
+      providerKind: "github_copilot" as const,
+      apiKey: "",
+      apiBaseUrl: "",
+      githubUserAccessTokenEncrypted: "ciphertext-access",
+      githubRefreshTokenEncrypted: "ciphertext-refresh",
+      githubTokenExpiresAt: "2026-04-08T16:00:00.000Z",
+      githubRefreshTokenExpiresAt: "2026-10-08T16:00:00.000Z",
+      githubAccountLogin: "octocat",
+      githubAccountName: "The Octocat"
+    };
+
+    updateSettings({
+      defaultProviderProfileId: copilot.id,
+      skillsEnabled: true,
+      providerProfiles: [copilot]
+    });
+
+    const settings = getSanitizedSettings();
+    const profile = settings.providerProfiles.find((entry) => entry.id === copilot.id);
+
+    expect(profile).toMatchObject({
+      id: "profile_copilot",
+      providerKind: "github_copilot",
+      githubAccountLogin: "octocat",
+      githubConnectionStatus: "connected"
+    });
+    expect("githubUserAccessTokenEncrypted" in (profile ?? {})).toBe(false);
+    expect("githubRefreshTokenEncrypted" in (profile ?? {})).toBe(false);
+  });
+```
+
+- [ ] **Step 2: Run the settings test file to verify it fails**
+
+Run:
+
+```bash
+npm run test -- tests/unit/settings.test.ts
+```
+
+Expected: FAIL because `providerKind` and the GitHub credential fields are not part of the types, schema, or database row mapping yet.
+
+- [ ] **Step 3: Add the new provider fields to the shared types**
+
+Update `lib/types.ts` with these additions:
+
+```ts
+export type ProviderKind = "openai_compatible" | "github_copilot";
+
+export type GithubConnectionStatus = "disconnected" | "connected" | "expired";
+
+export type ProviderProfile = {
+  id: string;
+  providerKind: ProviderKind;
+  name: string;
+  apiBaseUrl: string;
+  apiKeyEncrypted: string;
+  model: string;
+  apiMode: ApiMode;
+  systemPrompt: string;
+  temperature: number;
+  maxOutputTokens: number;
+  reasoningEffort: ReasoningEffort;
+  reasoningSummaryEnabled: boolean;
+  modelContextLimit: number;
+  compactionThreshold: number;
+  freshTailCount: number;
+  tokenizerModel: "gpt-tokenizer" | "off";
+  safetyMarginTokens: number;
+  leafSourceTokenLimit: number;
+  leafMinMessageCount: number;
+  mergedMinNodeCount: number;
+  mergedTargetTokens: number;
+  visionMode: VisionMode;
+  visionMcpServerId: string | null;
+  githubUserAccessTokenEncrypted: string;
+  githubRefreshTokenEncrypted: string;
+  githubTokenExpiresAt: string | null;
+  githubRefreshTokenExpiresAt: string | null;
+  githubAccountLogin: string | null;
+  githubAccountName: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type ProviderProfileSummary = Omit<
+  ProviderProfile,
+  "apiKeyEncrypted" | "githubUserAccessTokenEncrypted" | "githubRefreshTokenEncrypted"
+> & {
+  hasApiKey: boolean;
+  githubConnectionStatus: GithubConnectionStatus;
+};
+```
+
+- [ ] **Step 4: Add the migration and row mapping**
+
+Extend `provider_profiles` in `lib/db.ts` with these columns:
+
+```sql
+      provider_kind TEXT NOT NULL DEFAULT 'openai_compatible',
+      vision_mode TEXT DEFAULT 'native',
+      vision_mcp_server_id TEXT,
+      github_user_access_token_encrypted TEXT NOT NULL DEFAULT '',
+      github_refresh_token_encrypted TEXT NOT NULL DEFAULT '',
+      github_token_expires_at TEXT,
+      github_refresh_token_expires_at TEXT,
+      github_account_login TEXT,
+      github_account_name TEXT,
+```
+
+Add `ALTER TABLE` guards after the main `CREATE TABLE` block so existing databases are upgraded:
+
+```ts
+  const providerColumns = db
+    .prepare("PRAGMA table_info(provider_profiles)")
+    .all() as Array<{ name: string }>;
+
+  const providerColumnNames = new Set(providerColumns.map((column) => column.name));
+
+  if (!providerColumnNames.has("provider_kind")) {
+    db.exec("ALTER TABLE provider_profiles ADD COLUMN provider_kind TEXT NOT NULL DEFAULT 'openai_compatible'");
+  }
+
+  if (!providerColumnNames.has("github_user_access_token_encrypted")) {
+    db.exec("ALTER TABLE provider_profiles ADD COLUMN github_user_access_token_encrypted TEXT NOT NULL DEFAULT ''");
+  }
+
+  if (!providerColumnNames.has("github_refresh_token_encrypted")) {
+    db.exec("ALTER TABLE provider_profiles ADD COLUMN github_refresh_token_encrypted TEXT NOT NULL DEFAULT ''");
+  }
+
+  if (!providerColumnNames.has("github_token_expires_at")) {
+    db.exec("ALTER TABLE provider_profiles ADD COLUMN github_token_expires_at TEXT");
+  }
+
+  if (!providerColumnNames.has("github_refresh_token_expires_at")) {
+    db.exec("ALTER TABLE provider_profiles ADD COLUMN github_refresh_token_expires_at TEXT");
+  }
+
+  if (!providerColumnNames.has("github_account_login")) {
+    db.exec("ALTER TABLE provider_profiles ADD COLUMN github_account_login TEXT");
+  }
+
+  if (!providerColumnNames.has("github_account_name")) {
+    db.exec("ALTER TABLE provider_profiles ADD COLUMN github_account_name TEXT");
+  }
+```
+
+- [ ] **Step 5: Update settings validation and sanitization**
+
+In `lib/settings.ts`, extend the runtime schemas and row mapping:
+
+```ts
+const runtimeSettingsSchema = z.object({
+  providerKind: z.enum(["openai_compatible", "github_copilot"]).default("openai_compatible"),
+  apiBaseUrl: z.string().default(""),
+  apiKey: z.string().optional().default(""),
+  model: z.string().min(1),
+  apiMode: z.enum(["responses", "chat_completions"]),
+  systemPrompt: z.string().min(1),
+  temperature: z.coerce.number().min(0).max(2),
+  maxOutputTokens: z.coerce.number().int().min(128).max(32768),
+  reasoningEffort: z.enum(["low", "medium", "high", "xhigh"]),
+  reasoningSummaryEnabled: z.coerce.boolean(),
+  modelContextLimit: z.coerce.number().int().min(4096).max(2_000_000),
+  compactionThreshold: z.coerce.number().min(0.5).max(0.95),
+  freshTailCount: z.coerce.number().int().min(8).max(128),
+  tokenizerModel: z.enum(["gpt-tokenizer", "off"]).default("gpt-tokenizer"),
+  safetyMarginTokens: z.coerce.number().int().min(128).max(32768).default(1200),
+  leafSourceTokenLimit: z.coerce.number().int().min(1000).max(100000).default(12000),
+  leafMinMessageCount: z.coerce.number().int().min(2).max(50).default(6),
+  mergedMinNodeCount: z.coerce.number().int().min(2).max(20).default(4),
+  mergedTargetTokens: z.coerce.number().int().min(128).max(16000).default(1600),
+  visionMode: z.enum(["none", "native", "mcp"]).default("native"),
+  visionMcpServerId: z.string().nullable().default(null),
+  githubAccountLogin: z.string().nullable().default(null),
+  githubAccountName: z.string().nullable().default(null),
+  githubTokenExpiresAt: z.string().nullable().default(null),
+  githubRefreshTokenExpiresAt: z.string().nullable().default(null)
+}).superRefine((value, context) => {
+  if (value.providerKind === "openai_compatible" && !value.apiBaseUrl) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "API base URL is required for OpenAI-compatible profiles",
+      path: ["apiBaseUrl"]
+    });
+  }
+});
+```
+
+In `getSanitizedSettings()`, compute connection status without exposing encrypted token fields:
+
+```ts
+      githubConnectionStatus:
+        profile.providerKind !== "github_copilot"
+          ? "disconnected"
+          : profile.githubUserAccessTokenEncrypted
+            ? "connected"
+            : "disconnected"
+```
+
+- [ ] **Step 6: Run the settings tests to verify they pass**
+
+Run:
+
+```bash
+npm run test -- tests/unit/settings.test.ts
+```
+
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/types.ts lib/db.ts lib/settings.ts tests/unit/settings.test.ts
+git commit -m "feat: persist github copilot provider profiles"
+```
+
+---
+
+### Task 3: Implement GitHub OAuth, lazy refresh, and model discovery helpers
+
+**Files:**
+- Create: `lib/github-copilot.ts`
+- Create: `tests/unit/github-copilot.test.ts`
+
+- [ ] **Step 1: Write the failing helper tests**
+
+Create `tests/unit/github-copilot.test.ts` with:
+
+```ts
+import { encryptValue } from "@/lib/crypto";
+import {
+  clearGithubCopilotConnection,
+  getGithubConnectionStatus,
+  shouldRefreshGithubToken
+} from "@/lib/github-copilot";
+
+describe("github copilot helpers", () => {
+  it("detects when a token should be refreshed", () => {
+    expect(
+      shouldRefreshGithubToken({
+        githubTokenExpiresAt: new Date(Date.now() + 30_000).toISOString()
+      })
+    ).toBe(true);
+
+    expect(
+      shouldRefreshGithubToken({
+        githubTokenExpiresAt: new Date(Date.now() + 15 * 60_000).toISOString()
+      })
+    ).toBe(false);
+  });
+
+  it("computes connection state from stored credentials", () => {
+    expect(
+      getGithubConnectionStatus({
+        providerKind: "github_copilot",
+        githubUserAccessTokenEncrypted: "",
+        githubTokenExpiresAt: null
+      })
+    ).toBe("disconnected");
+
+    expect(
+      getGithubConnectionStatus({
+        providerKind: "github_copilot",
+        githubUserAccessTokenEncrypted: encryptValue("ghu_123"),
+        githubTokenExpiresAt: new Date(Date.now() + 60_000).toISOString()
+      })
+    ).toBe("connected");
+  });
+
+  it("clears only github oauth fields when disconnecting", () => {
+    expect(
+      clearGithubCopilotConnection({
+        githubUserAccessTokenEncrypted: "ciphertext-access",
+        githubRefreshTokenEncrypted: "ciphertext-refresh",
+        githubTokenExpiresAt: "2026-04-08T16:00:00.000Z",
+        githubRefreshTokenExpiresAt: "2026-10-08T16:00:00.000Z",
+        githubAccountLogin: "octocat",
+        githubAccountName: "The Octocat"
+      })
+    ).toEqual({
+      githubUserAccessTokenEncrypted: "",
+      githubRefreshTokenEncrypted: "",
+      githubTokenExpiresAt: null,
+      githubRefreshTokenExpiresAt: null,
+      githubAccountLogin: null,
+      githubAccountName: null
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run the helper test to verify it fails**
+
+Run:
+
+```bash
+npm run test -- tests/unit/github-copilot.test.ts
+```
+
+Expected: FAIL because `lib/github-copilot.ts` does not exist yet.
+
+- [ ] **Step 3: Create the helper module**
+
+Create `lib/github-copilot.ts` with the foundational helpers and exported interfaces:
+
+```ts
+import { SignJWT, jwtVerify } from "jose";
+
+import { decryptValue, encryptValue } from "@/lib/crypto";
+import { env } from "@/lib/env";
+import type { GithubConnectionStatus, ProviderProfile, ProviderProfileWithApiKey } from "@/lib/types";
+
+const GITHUB_STATE_TTL_SECONDS = 10 * 60;
+const GITHUB_REFRESH_WINDOW_MS = 2 * 60 * 1000;
+
+export function getGithubConnectionStatus(input: {
+  providerKind: ProviderProfile["providerKind"];
+  githubUserAccessTokenEncrypted: string;
+  githubTokenExpiresAt: string | null;
+}): GithubConnectionStatus {
+  if (input.providerKind !== "github_copilot" || !input.githubUserAccessTokenEncrypted) {
+    return "disconnected";
+  }
+
+  if (input.githubTokenExpiresAt && Date.parse(input.githubTokenExpiresAt) <= Date.now()) {
+    return "expired";
+  }
+
+  return "connected";
+}
+
+export function shouldRefreshGithubToken(input: {
+  githubTokenExpiresAt: string | null;
+}) {
+  if (!input.githubTokenExpiresAt) {
+    return false;
+  }
+
+  return Date.parse(input.githubTokenExpiresAt) - Date.now() <= GITHUB_REFRESH_WINDOW_MS;
+}
+
+export function clearGithubCopilotConnection(_input: {
+  githubUserAccessTokenEncrypted: string;
+  githubRefreshTokenEncrypted: string;
+  githubTokenExpiresAt: string | null;
+  githubRefreshTokenExpiresAt: string | null;
+  githubAccountLogin: string | null;
+  githubAccountName: string | null;
+}) {
+  return {
+    githubUserAccessTokenEncrypted: "",
+    githubRefreshTokenEncrypted: "",
+    githubTokenExpiresAt: null,
+    githubRefreshTokenExpiresAt: null,
+    githubAccountLogin: null,
+    githubAccountName: null
+  };
+}
+```
+
+Then continue the same file with:
+- `createGithubOauthState(profileId: string, userId: string)`
+- `verifyGithubOauthState(state: string)`
+- `exchangeGithubCodeForTokens(code: string)`
+- `refreshGithubUserToken(profile: ProviderProfileWithApiKey)`
+- `listGithubCopilotModels(profile: ProviderProfileWithApiKey)`
+- `buildGithubCopilotClient(profile: ProviderProfileWithApiKey)`
+
+Use server-only fetch and encrypt newly returned tokens before persistence boundaries.
+
+- [ ] **Step 4: Run the helper test to verify it passes**
+
+Run:
+
+```bash
+npm run test -- tests/unit/github-copilot.test.ts
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/github-copilot.ts tests/unit/github-copilot.test.ts
+git commit -m "feat: add github copilot oauth helpers"
+```
+
+---
+
+### Task 4: Add profile-scoped GitHub OAuth routes and persistence hooks
+
+**Files:**
+- Create: `app/api/providers/github/connect/route.ts`
+- Create: `app/api/providers/github/callback/route.ts`
+- Create: `app/api/providers/github/disconnect/route.ts`
+- Create: `app/api/providers/github/models/route.ts`
+- Modify: `lib/settings.ts`
+- Test: `tests/unit/github-copilot-routes.test.ts`
+
+- [ ] **Step 1: Write the failing route tests**
+
+Create `tests/unit/github-copilot-routes.test.ts` with:
+
+```ts
+import { GET as connect } from "@/app/api/providers/github/connect/route";
+import { GET as callback } from "@/app/api/providers/github/callback/route";
+import { POST as disconnect } from "@/app/api/providers/github/disconnect/route";
+import { GET as models } from "@/app/api/providers/github/models/route";
+
+describe("github copilot routes", () => {
+  it("rejects connect requests for non-copilot profiles", async () => {
+    const response = await connect(
+      new Request("http://localhost/api/providers/github/connect?providerProfileId=missing")
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("rejects callback requests with an invalid state token", async () => {
+    const response = await callback(
+      new Request(
+        "http://localhost/api/providers/github/callback?code=test-code&state=invalid-state"
+      )
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("clears oauth credentials on disconnect", async () => {
+    const response = await disconnect(
+      new Request("http://localhost/api/providers/github/disconnect", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ providerProfileId: "profile_copilot" })
+      })
+    );
+
+    expect(response.status).toBe(200);
+  });
+
+  it("rejects model discovery for disconnected profiles", async () => {
+    const response = await models(
+      new Request("http://localhost/api/providers/github/models?providerProfileId=profile_copilot")
+    );
+
+    expect(response.status).toBe(400);
+  });
+});
+```
+
+- [ ] **Step 2: Run the route test to verify it fails**
+
+Run:
+
+```bash
+npm run test -- tests/unit/github-copilot-routes.test.ts
+```
+
+Expected: FAIL because the route files do not exist yet.
+
+- [ ] **Step 3: Add persistence helpers to settings**
+
+Add these functions to `lib/settings.ts` before the exported settings readers:
+
+```ts
+export function updateGithubCopilotCredentials(
+  profileId: string,
+  input: {
+    githubUserAccessToken: string;
+    githubRefreshToken: string;
+    githubTokenExpiresAt: string | null;
+    githubRefreshTokenExpiresAt: string | null;
+    githubAccountLogin: string | null;
+    githubAccountName: string | null;
+  }
+) {
+  const timestamp = new Date().toISOString();
+
+  getDb()
+    .prepare(
+      `UPDATE provider_profiles
+       SET github_user_access_token_encrypted = ?,
+           github_refresh_token_encrypted = ?,
+           github_token_expires_at = ?,
+           github_refresh_token_expires_at = ?,
+           github_account_login = ?,
+           github_account_name = ?,
+           updated_at = ?
+       WHERE id = ?`
+    )
+    .run(
+      input.githubUserAccessToken ? encryptValue(input.githubUserAccessToken) : "",
+      input.githubRefreshToken ? encryptValue(input.githubRefreshToken) : "",
+      input.githubTokenExpiresAt,
+      input.githubRefreshTokenExpiresAt,
+      input.githubAccountLogin,
+      input.githubAccountName,
+      timestamp,
+      profileId
+    );
+}
+
+export function clearGithubCopilotCredentials(profileId: string) {
+  const timestamp = new Date().toISOString();
+
+  getDb()
+    .prepare(
+      `UPDATE provider_profiles
+       SET github_user_access_token_encrypted = '',
+           github_refresh_token_encrypted = '',
+           github_token_expires_at = NULL,
+           github_refresh_token_expires_at = NULL,
+           github_account_login = NULL,
+           github_account_name = NULL,
+           updated_at = ?
+       WHERE id = ?`
+    )
+    .run(timestamp, profileId);
+}
+```
+
+- [ ] **Step 4: Create the route handlers**
+
+Implement the connect route around `requireUser()`, `getProviderProfile()`, and `createGithubOauthState()`:
+
+```ts
+import { redirect } from "next/navigation";
+
+import { requireUser } from "@/lib/auth";
+import { badRequest } from "@/lib/http";
+import { createGithubOauthState, getGithubAuthorizeUrl } from "@/lib/github-copilot";
+import { getProviderProfile } from "@/lib/settings";
+
+export async function GET(request: Request) {
+  const user = await requireUser();
+  const url = new URL(request.url);
+  const providerProfileId = url.searchParams.get("providerProfileId");
+
+  if (!providerProfileId) {
+    return badRequest("Provider profile is required");
+  }
+
+  const profile = getProviderProfile(providerProfileId);
+
+  if (!profile || profile.providerKind !== "github_copilot") {
+    return badRequest("GitHub Copilot is only available for Copilot profiles");
+  }
+
+  const state = await createGithubOauthState(profile.id, user.id);
+  redirect(getGithubAuthorizeUrl(state));
+}
+```
+
+Implement the callback, disconnect, and models routes with the same guard pattern:
+- validate `state`
+- exchange code
+- persist encrypted credentials
+- lazily refresh before listing models
+- reject missing or disconnected profiles with `badRequest(...)`
+
+- [ ] **Step 5: Run the route tests to verify they pass**
+
+Run:
+
+```bash
+npm run test -- tests/unit/github-copilot-routes.test.ts
+```
+
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/api/providers/github/connect/route.ts app/api/providers/github/callback/route.ts app/api/providers/github/disconnect/route.ts app/api/providers/github/models/route.ts lib/settings.ts tests/unit/github-copilot-routes.test.ts
+git commit -m "feat: add github copilot oauth routes"
+```
+
+---
+
+### Task 5: Add Copilot runtime branching and connection testing
+
+**Files:**
+- Modify: `lib/provider.ts`
+- Modify: `app/api/settings/test/route.ts`
+- Modify: `tests/unit/provider.test.ts`
+
+- [ ] **Step 1: Write the failing provider tests**
+
+Add these tests to `tests/unit/provider.test.ts`:
+
+```ts
+  it("routes github copilot profiles through the copilot client", async () => {
+    const runGithubCopilotChat = vi.fn().mockResolvedValue("connected");
+
+    vi.doMock("@/lib/github-copilot", () => ({
+      runGithubCopilotChat,
+      ensureFreshGithubAccessToken: vi.fn(async (profile) => profile)
+    }));
+
+    const { callProviderText } = await import("@/lib/provider");
+
+    await expect(
+      callProviderText({
+        settings: createSettings({
+          providerKind: "github_copilot",
+          apiKey: "",
+          apiBaseUrl: ""
+        }) as any,
+        prompt: "Reply with connected",
+        purpose: "test"
+      })
+    ).resolves.toBe("connected");
+
+    expect(runGithubCopilotChat).toHaveBeenCalledOnce();
+    expect(chatCreate).not.toHaveBeenCalled();
+    expect(responsesCreate).not.toHaveBeenCalled();
+  });
+```
+
+Also add a connection-test route assertion in a new block or existing route test file to verify disconnected Copilot profiles return an explicit error message rather than `Set an API key before running a connection test`.
+
+- [ ] **Step 2: Run the provider test file to verify it fails**
+
+Run:
+
+```bash
+npm run test -- tests/unit/provider.test.ts
+```
+
+Expected: FAIL because `callProviderText()` currently assumes every provider is OpenAI-compatible.
+
+- [ ] **Step 3: Branch by provider kind in lib/provider.ts**
+
+At the top of `lib/provider.ts`, add the new import:
+
+```ts
+import { ensureFreshGithubAccessToken, runGithubCopilotChat, streamGithubCopilotChat } from "@/lib/github-copilot";
+```
+
+Then short-circuit both text and stream entry points:
+
+```ts
+  if (settings.providerKind === "github_copilot") {
+    const freshSettings = await ensureFreshGithubAccessToken(settings);
+    return runGithubCopilotChat({
+      settings: freshSettings,
+      prompt: input.prompt,
+      purpose: input.purpose,
+      conversationId: input.conversationId
+    });
+  }
+```
+
+And in the stream function:
+
+```ts
+  if (settings.providerKind === "github_copilot") {
+    return streamGithubCopilotChat({
+      settings: await ensureFreshGithubAccessToken(settings),
+      promptMessages: input.promptMessages,
+      tools: input.tools
+    });
+  }
+```
+
+- [ ] **Step 4: Update the settings connection-test route**
+
+Change `app/api/settings/test/route.ts` to branch on `providerKind`:
+
+```ts
+    if (!settings) {
+      return badRequest("Provider profile not found");
+    }
+
+    if (settings.providerKind === "openai_compatible" && !settings.apiKey) {
+      return badRequest("Set an API key before running a connection test");
+    }
+
+    if (
+      settings.providerKind === "github_copilot" &&
+      !settings.githubUserAccessTokenEncrypted
+    ) {
+      return badRequest("Connect a GitHub account before running a Copilot connection test");
+    }
+```
+
+Leave the actual test call using `callProviderText(...)` so both provider kinds share the same top-level runtime entry point.
+
+- [ ] **Step 5: Run the provider tests to verify they pass**
+
+Run:
+
+```bash
+npm run test -- tests/unit/provider.test.ts
+```
+
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/provider.ts app/api/settings/test/route.ts tests/unit/provider.test.ts
+git commit -m "feat: add github copilot runtime path"
+```
+
+---
+
+### Task 6: Update the providers settings UI for Copilot profiles
+
+**Files:**
+- Modify: `components/settings/sections/providers-section.tsx`
+- Create: `tests/unit/providers-section.test.tsx`
+- Modify: `lib/provider-presets.ts`
+
+- [ ] **Step 1: Write the failing UI test**
+
+Create `tests/unit/providers-section.test.tsx` with:
+
+```tsx
+// @vitest-environment jsdom
+
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import { ProvidersSection } from "@/components/settings/sections/providers-section";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    refresh: vi.fn()
+  })
+}));
+
+describe("providers section", () => {
+  beforeEach(() => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ servers: [], models: [] })
+    } as Response);
+  });
+
+  it("shows github connection controls for copilot profiles", async () => {
+    render(
+      React.createElement(ProvidersSection, {
+        settings: {
+          defaultProviderProfileId: "profile_copilot",
+          skillsEnabled: true,
+          providerProfiles: [
+            {
+              id: "profile_copilot",
+              providerKind: "github_copilot",
+              name: "Copilot",
+              apiBaseUrl: "",
+              model: "openai/gpt-4.1",
+              apiMode: "responses",
+              systemPrompt: "Be exact.",
+              temperature: 0.2,
+              maxOutputTokens: 512,
+              reasoningEffort: "medium",
+              reasoningSummaryEnabled: true,
+              modelContextLimit: 16000,
+              compactionThreshold: 0.8,
+              freshTailCount: 12,
+              tokenizerModel: "gpt-tokenizer",
+              safetyMarginTokens: 1200,
+              leafSourceTokenLimit: 12000,
+              leafMinMessageCount: 6,
+              mergedMinNodeCount: 4,
+              mergedTargetTokens: 1600,
+              visionMode: "native",
+              visionMcpServerId: null,
+              githubAccountLogin: null,
+              githubAccountName: null,
+              githubTokenExpiresAt: null,
+              githubRefreshTokenExpiresAt: null,
+              githubConnectionStatus: "disconnected",
+              createdAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString(),
+              hasApiKey: false
+            }
+          ],
+          updatedAt: new Date().toISOString()
+        }
+      })
+    );
+
+    expect(screen.getByRole("button", { name: "Connect GitHub" })).toBeInTheDocument();
+    expect(screen.queryByLabelText("API key")).toBeNull();
+  });
+
+  it("shows fetched github models for a connected copilot profile", async () => {
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        servers: [],
+        models: [{ id: "openai/gpt-4.1", name: "GPT-4.1" }]
+      })
+    } as Response);
+
+    render(
+      React.createElement(ProvidersSection, {
+        settings: {
+          defaultProviderProfileId: "profile_copilot",
+          skillsEnabled: true,
+          providerProfiles: [
+            {
+              id: "profile_copilot",
+              providerKind: "github_copilot",
+              name: "Copilot",
+              apiBaseUrl: "",
+              model: "openai/gpt-4.1",
+              apiMode: "responses",
+              systemPrompt: "Be exact.",
+              temperature: 0.2,
+              maxOutputTokens: 512,
+              reasoningEffort: "medium",
+              reasoningSummaryEnabled: true,
+              modelContextLimit: 16000,
+              compactionThreshold: 0.8,
+              freshTailCount: 12,
+              tokenizerModel: "gpt-tokenizer",
+              safetyMarginTokens: 1200,
+              leafSourceTokenLimit: 12000,
+              leafMinMessageCount: 6,
+              mergedMinNodeCount: 4,
+              mergedTargetTokens: 1600,
+              visionMode: "native",
+              visionMcpServerId: null,
+              githubAccountLogin: "octocat",
+              githubAccountName: "The Octocat",
+              githubTokenExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+              githubRefreshTokenExpiresAt: new Date(Date.now() + 3600_000).toISOString(),
+              githubConnectionStatus: "connected",
+              createdAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString(),
+              hasApiKey: false
+            }
+          ],
+          updatedAt: new Date().toISOString()
+        }
+      })
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("option", { name: "GPT-4.1" })).toBeInTheDocument();
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run the UI test to verify it fails**
+
+Run:
+
+```bash
+npm run test -- tests/unit/providers-section.test.tsx
+```
+
+Expected: FAIL because the component does not recognize `providerKind` or render Copilot-specific controls.
+
+- [ ] **Step 3: Make provider presets provider-kind aware**
+
+In `lib/provider-presets.ts`, constrain presets to OpenAI-compatible profiles:
+
+```ts
+type PresetCompatibleProfile = {
+  providerKind: "openai_compatible";
+  name: string;
+  apiBaseUrl: string;
+  model: string;
+  apiMode: ApiMode;
+  reasoningEffort: ReasoningEffort;
+  reasoningSummaryEnabled: boolean;
+  modelContextLimit: number;
+};
+```
+
+Then guard the matching and apply paths:
+
+```ts
+  if (profile.providerKind !== "openai_compatible") {
+    return null;
+  }
+```
+
+- [ ] **Step 4: Add the Copilot form mode**
+
+In `components/settings/sections/providers-section.tsx`, extend the payload and draft types with:
+
+```ts
+    providerKind: "openai_compatible" | "github_copilot";
+    githubAccountLogin: string | null;
+    githubAccountName: string | null;
+    githubTokenExpiresAt: string | null;
+    githubRefreshTokenExpiresAt: string | null;
+    githubConnectionStatus: "disconnected" | "connected" | "expired";
+```
+
+Then render the mode-specific UI:
+
+```tsx
+                  <label className={labelClass}>Provider type</label>
+                  <select
+                    className={selectClass}
+                    value={activeProviderProfile.providerKind}
+                    onChange={(event) =>
+                      updateActiveProviderProfile({
+                        providerKind: event.target.value as ProviderProfileDraft["providerKind"],
+                        apiBaseUrl:
+                          event.target.value === "github_copilot"
+                            ? ""
+                            : activeProviderProfile.apiBaseUrl,
+                        apiKey:
+                          event.target.value === "github_copilot"
+                            ? ""
+                            : activeProviderProfile.apiKey
+                      })
+                    }
+                  >
+                    <option value="openai_compatible">OpenAI compatible</option>
+                    <option value="github_copilot">GitHub Copilot</option>
+                  </select>
+```
+
+For the Copilot branch, render:
+
+```tsx
+                  <div className="space-y-3">
+                    <p className={labelClass}>GitHub connection</p>
+                    <div className="rounded-xl border border-white/6 bg-white/[0.03] px-4 py-3 text-sm text-[#f4f4f5]">
+                      {activeProviderProfile.githubConnectionStatus === "connected"
+                        ? `Connected as ${activeProviderProfile.githubAccountLogin ?? "GitHub user"}`
+                        : "No GitHub account connected"}
+                    </div>
+                    <div className="flex gap-2">
+                      <Button type="button" onClick={() => startGithubConnect(activeProviderProfile.id)}>
+                        {activeProviderProfile.githubConnectionStatus === "connected"
+                          ? "Reconnect GitHub"
+                          : "Connect GitHub"}
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        onClick={() => disconnectGithub(activeProviderProfile.id)}
+                        disabled={activeProviderProfile.githubConnectionStatus === "disconnected"}
+                      >
+                        Disconnect
+                      </Button>
+                    </div>
+                  </div>
+```
+
+When a Copilot profile is connected, fetch `/api/providers/github/models?providerProfileId=<id>` in an effect keyed by the selected profile ID and populate the model `<select>` from the returned `models` array.
+
+When duplicating profiles in `addProviderProfile()`, clear all GitHub connection metadata on the cloned draft.
+
+- [ ] **Step 5: Run the UI test to verify it passes**
+
+Run:
+
+```bash
+npm run test -- tests/unit/providers-section.test.tsx
+```
+
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/provider-presets.ts components/settings/sections/providers-section.tsx tests/unit/providers-section.test.tsx
+git commit -m "feat: add github copilot provider settings ui"
+```
+
+---
+
+### Task 7: Verify the feature end-to-end and update project memory
+
+**Files:**
+- Modify: `agent-memory/infrastructure/config.md`
+- Modify: `agent-memory/integrations/external.md`
+
+- [ ] **Step 1: Update the memory files**
+
+Append the new config to `agent-memory/infrastructure/config.md`:
+
+```md
+| `EIDON_GITHUB_APP_CLIENT_ID` | GitHub App OAuth client ID for Copilot provider connections | No |
+| `EIDON_GITHUB_APP_CLIENT_SECRET` | GitHub App OAuth client secret for Copilot provider connections | No |
+| `EIDON_GITHUB_APP_CALLBACK_URL` | Absolute callback URL for GitHub Copilot OAuth | No |
+```
+
+Append the integration notes to `agent-memory/integrations/external.md`:
+
+```md
+## GitHub Copilot
+- **Purpose:** Per-profile LLM provider using each user's own GitHub Copilot subscription
+- **Auth:** GitHub App OAuth stored per provider profile with encrypted access and refresh tokens
+- **Usage:** Settings-level profile connection, account-scoped model discovery, and chat inference through `lib/github-copilot.ts`
+- **Token Management:** Server-side lazy refresh before model discovery and chat execution; no background refresh job
+```
+
+- [ ] **Step 2: Run the focused test suite**
+
+Run:
+
+```bash
+npm run test -- tests/unit/env.test.ts tests/unit/settings.test.ts tests/unit/github-copilot.test.ts tests/unit/github-copilot-routes.test.ts tests/unit/provider.test.ts tests/unit/providers-section.test.tsx
+```
+
+Expected: PASS
+
+- [ ] **Step 3: Run lint and typecheck**
+
+Run:
+
+```bash
+npm run lint
+npm run typecheck
+```
+
+Expected: both commands exit successfully with no new errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add agent-memory/infrastructure/config.md agent-memory/integrations/external.md
+git commit -m "docs: record github copilot provider integration"
+```

--- a/docs/superpowers/specs/2026-04-08-github-copilot-provider-design.md
+++ b/docs/superpowers/specs/2026-04-08-github-copilot-provider-design.md
@@ -1,0 +1,346 @@
+---
+name: GitHub Copilot Provider
+description: Per-profile GitHub OAuth connection that lets users talk to LLMs in Eidon using their own Copilot subscription
+type: design
+---
+
+# GitHub Copilot Provider Design
+
+## Overview
+
+Add GitHub Copilot as a provider type in the existing settings-driven provider profile system. A Copilot profile is connected to one GitHub account through OAuth and uses that account's Copilot entitlement to power chat requests inside Eidon. This does not replace Eidon's existing site authentication.
+
+The integration is profile-scoped:
+- each provider profile can be either `openai_compatible` or `github_copilot`
+- each Copilot profile owns its own GitHub OAuth connection
+- duplicated Copilot profiles start disconnected
+- tokens are stored and refreshed server-side only
+- the available model list is loaded from the connected account and exposed in the profile editor
+
+## Requirements
+
+- GitHub Copilot must appear as a provider option on `/settings/providers`
+- Copilot provider authentication must use OAuth only
+- GitHub sign-in must not become the main site authentication flow
+- OAuth credentials must belong to a single provider profile, not the whole app
+- Duplicating a Copilot profile must not copy GitHub tokens or connection state
+- The server must use lazy token refresh before model discovery or chat execution when a token is near expiry
+- Users must be able to disconnect a Copilot profile without affecting other profiles
+- The settings UI must show the full model list exposed to the connected GitHub account
+- Existing OpenAI-compatible profiles must continue working without behavior changes
+- Provider failures must surface explicit errors instead of silent fallback
+
+## Recommended Approach
+
+Use a GitHub App with the OAuth authorization code web flow and the `@github/copilot-sdk` client for inference.
+
+This is the recommended approach because GitHub documents GitHub App OAuth for web and multi-user applications, recommends GitHub Apps over OAuth Apps for new work, and leaves token lifecycle management to the integrating app.
+
+## External References
+
+- [Authenticating with Copilot SDK](https://docs.github.com/en/copilot/how-tos/copilot-sdk/authenticate-copilot-sdk/authenticate-copilot-sdk)
+- [Using GitHub OAuth with Copilot SDK](https://docs.github.com/en/enterprise-cloud@latest/copilot/how-tos/copilot-sdk/set-up-copilot-sdk/github-oauth)
+- [Best practices for creating an OAuth app](https://docs.github.com/en/enterprise-cloud@latest/apps/oauth-apps/building-oauth-apps/best-practices-for-creating-an-oauth-app)
+- [Refreshing user access tokens](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/refreshing-user-access-tokens)
+- [REST API endpoints for models inference](https://docs.github.com/en/rest/models/inference)
+- [Models catalog](https://docs.github.com/en/rest/models/catalog)
+
+## Data Model
+
+### Provider Profile Kind
+
+Extend provider profiles with a provider kind discriminator.
+
+```typescript
+type ProviderKind = "openai_compatible" | "github_copilot";
+```
+
+### TypeScript Types
+
+```typescript
+type ProviderProfile = {
+  id: string;
+  providerKind: ProviderKind;
+  name: string;
+  apiBaseUrl: string;
+  apiKeyEncrypted: string;
+  model: string;
+  apiMode: ApiMode;
+  systemPrompt: string;
+  temperature: number;
+  maxOutputTokens: number;
+  reasoningEffort: ReasoningEffort;
+  reasoningSummaryEnabled: boolean;
+  modelContextLimit: number;
+  compactionThreshold: number;
+  freshTailCount: number;
+  tokenizerModel: "gpt-tokenizer" | "off";
+  safetyMarginTokens: number;
+  leafSourceTokenLimit: number;
+  leafMinMessageCount: number;
+  mergedMinNodeCount: number;
+  mergedTargetTokens: number;
+  visionMode: VisionMode;
+  visionMcpServerId: string | null;
+  githubUserAccessTokenEncrypted: string;
+  githubRefreshTokenEncrypted: string;
+  githubTokenExpiresAt: string | null;
+  githubRefreshTokenExpiresAt: string | null;
+  githubAccountLogin: string | null;
+  githubAccountName: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type ProviderProfileSummary = Omit<
+  ProviderProfile,
+  "apiKeyEncrypted" | "githubUserAccessTokenEncrypted" | "githubRefreshTokenEncrypted"
+> & {
+  hasApiKey: boolean;
+  githubConnectionStatus: "disconnected" | "connected" | "expired";
+};
+```
+
+### Database Schema
+
+Add nullable Copilot-specific columns to `provider_profiles`.
+
+```sql
+ALTER TABLE provider_profiles ADD COLUMN provider_kind TEXT NOT NULL DEFAULT 'openai_compatible';
+ALTER TABLE provider_profiles ADD COLUMN github_user_access_token_encrypted TEXT NOT NULL DEFAULT '';
+ALTER TABLE provider_profiles ADD COLUMN github_refresh_token_encrypted TEXT NOT NULL DEFAULT '';
+ALTER TABLE provider_profiles ADD COLUMN github_token_expires_at TEXT;
+ALTER TABLE provider_profiles ADD COLUMN github_refresh_token_expires_at TEXT;
+ALTER TABLE provider_profiles ADD COLUMN github_account_login TEXT;
+ALTER TABLE provider_profiles ADD COLUMN github_account_name TEXT;
+```
+
+Existing rows migrate to `provider_kind = 'openai_compatible'`.
+
+## Configuration
+
+Add server-side environment variables for the GitHub App OAuth integration.
+
+| Variable | Purpose |
+|----------|---------|
+| `EIDON_GITHUB_APP_CLIENT_ID` | GitHub App OAuth client ID |
+| `EIDON_GITHUB_APP_CLIENT_SECRET` | GitHub App OAuth client secret |
+| `EIDON_GITHUB_APP_CALLBACK_URL` | Absolute OAuth callback URL |
+
+These values are app-wide integration config and do not belong in the per-profile settings form.
+
+## API Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/providers/github/connect` | Start OAuth for one provider profile |
+| GET | `/api/providers/github/callback` | Complete OAuth and attach tokens to the target profile |
+| POST | `/api/providers/github/disconnect` | Clear Copilot OAuth credentials from one profile |
+| GET | `/api/providers/github/models` | Return models available to the connected account for one profile |
+
+## OAuth Flow
+
+### Connect
+
+1. User clicks `Connect GitHub` on a Copilot profile in settings
+2. Client sends the target `providerProfileId`
+3. Server validates that the profile exists and is `github_copilot`
+4. Server creates a signed, short-lived `state` payload containing:
+   - `providerProfileId`
+   - current local user/session identity
+   - timestamp and nonce
+5. Server redirects the browser to GitHub OAuth authorization
+
+### Callback
+
+1. GitHub redirects to the configured callback URL with `code` and `state`
+2. Server validates the signed `state`
+3. Server exchanges the code for GitHub App user tokens
+4. Server fetches the connected GitHub identity
+5. Server encrypts and stores:
+   - user access token
+   - refresh token
+   - access token expiry
+   - refresh token expiry
+   - GitHub account login and display name
+6. Server redirects back to `/settings/providers` with success or failure status
+
+### Disconnect
+
+Disconnect clears only Copilot-specific credential fields on the targeted profile:
+- `githubUserAccessTokenEncrypted`
+- `githubRefreshTokenEncrypted`
+- `githubTokenExpiresAt`
+- `githubRefreshTokenExpiresAt`
+- `githubAccountLogin`
+- `githubAccountName`
+
+The profile record itself stays intact.
+
+## Runtime Behavior
+
+### Lazy Token Refresh
+
+Token refresh is server-side and demand-driven.
+
+Refresh points:
+- before loading the model list for a Copilot profile
+- before chat execution for a Copilot profile
+
+Refresh policy:
+- if the access token is missing, treat the profile as disconnected
+- if the access token is near expiry, exchange the refresh token and persist the returned credentials
+- if refresh fails, mark the profile unusable until the user reconnects
+
+No background refresh job is included in v1.
+
+### Model Discovery
+
+When a Copilot profile is connected, Eidon loads the model catalog using the connected account's credentials and returns the models available to that account.
+
+Model discovery behavior:
+- fetch models server-side
+- map results to the settings dropdown
+- preserve the saved model only if it still exists in the returned set
+- show an explicit validation error if a previously saved model is no longer available
+
+### Chat Execution
+
+At send time:
+
+1. Resolve the selected provider profile
+2. Branch by `providerKind`
+3. For `openai_compatible`, keep the existing path unchanged
+4. For `github_copilot`:
+   - refresh token if needed
+   - construct the Copilot client using the GitHub user access token
+   - execute the prompt against the selected model
+   - normalize and stream the result into the existing chat event pipeline
+
+## UI Design
+
+### Provider Editor
+
+Update the provider settings editor in `providers-section.tsx` to expose provider type.
+
+For `openai_compatible` profiles, keep the current UI.
+
+For `github_copilot` profiles, show:
+- provider type selector
+- connection status
+- connected GitHub account label
+- `Connect GitHub` button when disconnected
+- `Reconnect GitHub` and `Disconnect` when connected
+- model dropdown sourced from the server
+- non-editable status text for token state or entitlement errors
+
+Hide these fields for Copilot profiles:
+- API base URL
+- API key
+- API mode preset buttons tied only to OpenAI-compatible endpoints
+
+OpenAI-compatible profile duplication keeps current behavior. Copilot profile duplication copies non-secret fields but clears all GitHub credential and account metadata.
+
+### UX States
+
+Required UI states:
+- disconnected
+- connecting
+- connected
+- refresh failed
+- entitlement missing
+- model list unavailable
+
+The settings form should not silently save a Copilot profile as usable if it is disconnected.
+
+## Files to Create
+
+| File | Purpose |
+|------|---------|
+| `app/api/providers/github/connect/route.ts` | Start profile-scoped GitHub OAuth |
+| `app/api/providers/github/callback/route.ts` | Complete OAuth and persist tokens |
+| `app/api/providers/github/disconnect/route.ts` | Disconnect one Copilot profile |
+| `app/api/providers/github/models/route.ts` | Return model list for one Copilot profile |
+| `lib/github-copilot.ts` | OAuth helpers, token refresh, model discovery, Copilot client wiring |
+
+## Files to Modify
+
+| File | Changes |
+|------|---------|
+| `lib/types.ts` | Add provider kind and Copilot credential metadata |
+| `lib/db.ts` | Migrate `provider_profiles` for Copilot fields |
+| `lib/settings.ts` | Validate, persist, sanitize, and duplicate mixed provider kinds |
+| `lib/provider.ts` | Add provider-kind branching and Copilot inference path |
+| `lib/provider-presets.ts` | Limit presets to OpenAI-compatible profiles or make them provider-kind aware |
+| `components/settings/sections/providers-section.tsx` | Add provider-type UI, GitHub connection controls, and model discovery UX |
+| `tests/unit/settings.test.ts` | Cover persistence and duplication rules |
+| `tests/unit/provider.test.ts` | Cover Copilot runtime path and lazy refresh behavior |
+
+## Validation Rules
+
+- `providerKind` is required on every profile
+- `openai_compatible` profiles require existing runtime provider fields
+- `github_copilot` profiles must not require `apiKey`
+- `github_copilot` profiles are allowed to save while disconnected, but they cannot pass connection tests or be used for chat until connected
+- a connected `github_copilot` profile must have:
+  - encrypted user access token
+  - refresh token
+  - access token expiry
+  - connected GitHub account login
+
+## Error Handling
+
+Return explicit, user-visible errors for:
+- invalid or expired OAuth `state`
+- callback profile mismatch
+- token exchange failure
+- refresh failure
+- missing refresh token
+- missing Copilot entitlement
+- failed model discovery
+- selected model no longer available
+- empty provider response
+
+The app must not fall back from Copilot to the default OpenAI-compatible provider.
+
+## Security
+
+- Store GitHub OAuth credentials encrypted at rest using the existing crypto helpers
+- Keep OAuth secrets in environment variables only
+- Sign and validate the OAuth `state` payload server-side
+- Scope each callback to a single provider profile and current session
+- Never expose raw GitHub tokens to the client
+- Clear credential fields completely on disconnect
+
+## Testing
+
+### Unit Tests
+
+- settings parsing for mixed provider kinds
+- sanitization excludes GitHub credential fields from client payloads
+- duplication clears Copilot credentials and account metadata
+- disconnect clears only the targeted profile's GitHub credential fields
+- lazy refresh updates stored credentials before models or chat when expiry is near
+- chat execution uses Copilot path only for `github_copilot`
+- OpenAI-compatible profiles preserve current behavior
+
+### Integration-Level Behavior
+
+- OAuth callback attaches credentials to the intended profile only
+- invalid `state` is rejected
+- model discovery returns account-scoped models
+- disconnected Copilot profile cannot run provider test or chat
+
+## Non-Goals
+
+- replacing site authentication with GitHub sign-in
+- sharing one GitHub connection across multiple provider profiles
+- manual token entry
+- background token refresh jobs
+- organization-wide Copilot connection management
+
+## Rollout Notes
+
+- Existing installs migrate all provider profiles to `openai_compatible`
+- The Copilot provider UI appears only when GitHub App environment variables are configured correctly
+- If integration env vars are missing, the settings page should either hide the Copilot option or present it as unavailable with a clear setup message

--- a/lib/chat-turn.ts
+++ b/lib/chat-turn.ts
@@ -53,10 +53,26 @@ export async function startChatTurn(
       : null) ?? getDefaultProviderProfileWithApiKey();
   const appSettings = getSettings();
 
-  if (!settings?.apiKey) {
+  if (!settings) {
+    manager.broadcast(conversationId, {
+      type: "error",
+      message: "No provider profile configured"
+    });
+    return;
+  }
+
+  if (settings.providerKind !== "github_copilot" && !settings.apiKey) {
     manager.broadcast(conversationId, {
       type: "error",
       message: "Set an API key in settings before starting a chat"
+    });
+    return;
+  }
+
+  if (settings.providerKind === "github_copilot" && !settings.githubUserAccessTokenEncrypted) {
+    manager.broadcast(conversationId, {
+      type: "error",
+      message: "Connect a GitHub account in settings before starting a chat"
     });
     return;
   }

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -152,6 +152,15 @@ function migrate(db: Database.Database) {
       leaf_min_message_count INTEGER DEFAULT 6,
       merged_min_node_count INTEGER DEFAULT 4,
       merged_target_tokens INTEGER DEFAULT 1600,
+      vision_mode TEXT NOT NULL DEFAULT 'native',
+      vision_mcp_server_id TEXT,
+      provider_kind TEXT NOT NULL DEFAULT 'openai_compatible',
+      github_user_access_token_encrypted TEXT NOT NULL DEFAULT '',
+      github_refresh_token_encrypted TEXT NOT NULL DEFAULT '',
+      github_token_expires_at TEXT,
+      github_refresh_token_expires_at TEXT,
+      github_account_login TEXT,
+      github_account_name TEXT,
       created_at TEXT NOT NULL,
       updated_at TEXT NOT NULL
     );
@@ -387,6 +396,23 @@ function migrate(db: Database.Database) {
     }
   }
 
+  const githubCols = {
+    provider_kind: "TEXT NOT NULL DEFAULT 'openai_compatible'",
+    github_user_access_token_encrypted: "TEXT NOT NULL DEFAULT ''",
+    github_refresh_token_encrypted: "TEXT NOT NULL DEFAULT ''",
+    github_token_expires_at: "TEXT",
+    github_refresh_token_expires_at: "TEXT",
+    github_account_login: "TEXT",
+    github_account_name: "TEXT"
+  };
+  const githubProfileCols = db.prepare("PRAGMA table_info(provider_profiles)").all() as Array<{ name: string }>;
+  const githubProfileColNames = githubProfileCols.map((c) => c.name);
+  for (const [colName, colDef] of Object.entries(githubCols)) {
+    if (!githubProfileColNames.includes(colName)) {
+      db.exec(`ALTER TABLE provider_profiles ADD COLUMN ${colName} ${colDef}`);
+    }
+  }
+
   try {
     db.exec(`ALTER TABLE compaction_events RENAME TO compaction_events_old`);
     db.exec(`
@@ -551,6 +577,7 @@ function migrate(db: Database.Database) {
         leaf_min_message_count,
         merged_min_node_count,
         merged_target_tokens,
+        provider_kind,
         created_at,
         updated_at
       ) VALUES (
@@ -574,6 +601,7 @@ function migrate(db: Database.Database) {
         @leafMinMessageCount,
         @mergedMinNodeCount,
         @mergedTargetTokens,
+        'openai_compatible',
         @createdAt,
         @updatedAt
       )`

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -10,7 +10,10 @@ const nodeEnvSchema = z.object({
   EIDON_ADMIN_PASSWORD: z.string().min(8).optional(),
   EIDON_SESSION_SECRET: z.string().min(32).optional(),
   EIDON_ENCRYPTION_SECRET: z.string().min(32).optional(),
-  EIDON_DATA_DIR: z.string().default("./.data")
+  EIDON_DATA_DIR: z.string().default("./.data"),
+  EIDON_GITHUB_APP_CLIENT_ID: z.string().min(1).optional(),
+  EIDON_GITHUB_APP_CLIENT_SECRET: z.string().min(1).optional(),
+  EIDON_GITHUB_APP_CALLBACK_URL: z.string().url().optional()
 });
 
 const sensitiveEnvNames = [

--- a/lib/github-copilot.ts
+++ b/lib/github-copilot.ts
@@ -1,0 +1,256 @@
+import { SignJWT, jwtVerify } from "jose";
+import { CopilotClient } from "@github/copilot-sdk";
+
+import { decryptValue, encryptValue } from "@/lib/crypto";
+import { env } from "@/lib/env";
+import type {
+  GithubConnectionStatus,
+  ProviderProfile,
+  ProviderProfileWithApiKey
+} from "@/lib/types";
+
+type GithubConnectionInput = Pick<
+  ProviderProfile,
+  "providerKind" | "githubUserAccessTokenEncrypted" | "githubTokenExpiresAt"
+>;
+
+type GithubRefreshInput = Pick<ProviderProfile, "githubTokenExpiresAt">;
+
+type GithubClearInput = Pick<
+  ProviderProfile,
+  | "githubUserAccessTokenEncrypted"
+  | "githubRefreshTokenEncrypted"
+  | "githubTokenExpiresAt"
+  | "githubRefreshTokenExpiresAt"
+  | "githubAccountLogin"
+  | "githubAccountName"
+>;
+
+type GithubClearOutput = {
+  [K in keyof GithubClearInput]: K extends `${string}Encrypted` ? string : string | null;
+};
+
+const REFRESH_THRESHOLD_MS = 2 * 60 * 1000;
+
+export function getGithubConnectionStatus(
+  input: GithubConnectionInput
+): GithubConnectionStatus {
+  if (
+    input.providerKind !== "github_copilot" ||
+    !input.githubUserAccessTokenEncrypted
+  ) {
+    return "disconnected";
+  }
+
+  if (!input.githubTokenExpiresAt) {
+    return "disconnected";
+  }
+
+  if (new Date(input.githubTokenExpiresAt).getTime() < Date.now()) {
+    return "expired";
+  }
+
+  return "connected";
+}
+
+export function shouldRefreshGithubToken(input: GithubRefreshInput): boolean {
+  if (!input.githubTokenExpiresAt) {
+    return false;
+  }
+
+  const expiresAt = new Date(input.githubTokenExpiresAt).getTime();
+  return expiresAt - Date.now() < REFRESH_THRESHOLD_MS;
+}
+
+export function clearGithubCopilotConnection(
+  _input: GithubClearInput
+): GithubClearOutput {
+  return {
+    githubUserAccessTokenEncrypted: "",
+    githubRefreshTokenEncrypted: "",
+    githubTokenExpiresAt: null,
+    githubRefreshTokenExpiresAt: null,
+    githubAccountLogin: null,
+    githubAccountName: null
+  };
+}
+
+export async function createGithubOauthState(
+  profileId: string,
+  userId: string
+): Promise<string> {
+  const secret = new TextEncoder().encode(env.EIDON_SESSION_SECRET);
+
+  return new SignJWT({ profileId, userId })
+    .setProtectedHeader({ alg: "HS256" })
+    .setExpirationTime("10m")
+    .setIssuedAt()
+    .sign(secret);
+}
+
+export async function verifyGithubOauthState(
+  state: string
+): Promise<{ profileId: string; userId: string }> {
+  const secret = new TextEncoder().encode(env.EIDON_SESSION_SECRET);
+  const { payload } = await jwtVerify(state, secret);
+
+  return {
+    profileId: payload.profileId as string,
+    userId: payload.userId as string
+  };
+}
+
+export function getGithubAuthorizeUrl(state: string): string {
+  const params = new URLSearchParams({
+    client_id: env.EIDON_GITHUB_APP_CLIENT_ID!,
+    redirect_uri: env.EIDON_GITHUB_APP_CALLBACK_URL!,
+    state,
+    scope: "read:user"
+  });
+
+  return `https://github.com/login/oauth/authorize?${params.toString()}`;
+}
+
+export async function exchangeGithubCodeForTokens(code: string) {
+  const response = await fetch(
+    "https://github.com/login/oauth/access_token",
+    {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        client_id: env.EIDON_GITHUB_APP_CLIENT_ID,
+        client_secret: env.EIDON_GITHUB_APP_CLIENT_SECRET,
+        code
+      })
+    }
+  );
+
+  return response.json() as Promise<{
+    access_token: string;
+    token_type: string;
+    scope: string;
+    refresh_token?: string;
+    expires_in?: number;
+    refresh_token_expires_in?: number;
+  }>;
+}
+
+export async function refreshGithubUserToken(
+  profile: ProviderProfile
+): Promise<{
+  githubUserAccessTokenEncrypted: string;
+  githubRefreshTokenEncrypted: string;
+  githubTokenExpiresAt: string;
+  githubRefreshTokenExpiresAt: string | null;
+}> {
+  const refreshToken = decryptValue(profile.githubRefreshTokenEncrypted);
+
+  const response = await fetch(
+    "https://github.com/login/oauth/access_token",
+    {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        client_id: env.EIDON_GITHUB_APP_CLIENT_ID,
+        client_secret: env.EIDON_GITHUB_APP_CLIENT_SECRET,
+        grant_type: "refresh_token",
+        refresh_token: refreshToken
+      })
+    }
+  );
+
+  const tokens = (await response.json()) as {
+    access_token: string;
+    refresh_token?: string;
+    expires_in?: number;
+    refresh_token_expires_in?: number;
+  };
+
+  const now = Date.now();
+
+  return {
+    githubUserAccessTokenEncrypted: encryptValue(tokens.access_token),
+    githubRefreshTokenEncrypted: tokens.refresh_token
+      ? encryptValue(tokens.refresh_token)
+      : profile.githubRefreshTokenEncrypted,
+    githubTokenExpiresAt: new Date(
+      now + (tokens.expires_in ?? 28800) * 1000
+    ).toISOString(),
+    githubRefreshTokenExpiresAt: tokens.refresh_token_expires_in
+      ? new Date(now + tokens.refresh_token_expires_in * 1000).toISOString()
+      : null
+  };
+}
+
+export async function listGithubCopilotModels(
+  profile: ProviderProfileWithApiKey
+) {
+  const accessToken = decryptValue(
+    profile.githubUserAccessTokenEncrypted
+  );
+
+  const client = new CopilotClient({
+    githubToken: accessToken,
+    useLoggedInUser: false
+  });
+
+  return client.listModels();
+}
+
+export async function buildGithubCopilotClient(
+  profile: ProviderProfileWithApiKey
+) {
+  const accessToken = decryptValue(
+    profile.githubUserAccessTokenEncrypted
+  );
+
+  return new CopilotClient({
+    githubToken: accessToken,
+    useLoggedInUser: false
+  });
+}
+
+export async function runGithubCopilotChat(
+  input: ProviderProfileWithApiKey & {
+    messages: Array<{ role: string; content: string }>;
+  }
+) {
+  const client = await buildGithubCopilotClient(input);
+
+  const session = await client.createSession({
+    model: input.model,
+    onPermissionRequest: () => ({ kind: "approved" as const })
+  });
+
+  const result = await session.send({
+    prompt: input.messages.map((m) => m.content).join("\n")
+  });
+
+  return result;
+}
+
+export async function streamGithubCopilotChat(
+  input: ProviderProfileWithApiKey & {
+    messages: Array<{ role: string; content: string }>;
+    onEvent: (event: unknown) => void;
+  }
+) {
+  const client = await buildGithubCopilotClient(input);
+
+  const session = await client.createSession({
+    model: input.model,
+    streaming: true,
+    onPermissionRequest: () => ({ kind: "approved" as const }),
+    onEvent: input.onEvent
+  });
+
+  await session.send({
+    prompt: input.messages.map((m) => m.content).join("\n")
+  });
+}

--- a/lib/github-copilot.ts
+++ b/lib/github-copilot.ts
@@ -8,6 +8,7 @@ import type {
   ProviderProfile,
   ProviderProfileWithApiKey
 } from "@/lib/types";
+import { updateGithubCopilotCredentials } from "@/lib/settings";
 
 type GithubConnectionInput = Pick<
   ProviderProfile,
@@ -185,6 +186,30 @@ export async function refreshGithubUserToken(
     githubRefreshTokenExpiresAt: tokens.refresh_token_expires_in
       ? new Date(now + tokens.refresh_token_expires_in * 1000).toISOString()
       : null
+  };
+}
+
+export async function ensureFreshGithubAccessToken(
+  profile: ProviderProfileWithApiKey
+): Promise<ProviderProfileWithApiKey> {
+  if (!shouldRefreshGithubToken(profile)) {
+    return profile;
+  }
+
+  const refreshed = await refreshGithubUserToken(profile);
+
+  updateGithubCopilotCredentials(profile.id, {
+    githubUserAccessToken: decryptValue(refreshed.githubUserAccessTokenEncrypted),
+    githubRefreshToken: decryptValue(refreshed.githubRefreshTokenEncrypted),
+    githubTokenExpiresAt: refreshed.githubTokenExpiresAt,
+    githubRefreshTokenExpiresAt: refreshed.githubRefreshTokenExpiresAt,
+    githubAccountLogin: profile.githubAccountLogin,
+    githubAccountName: profile.githubAccountName
+  });
+
+  return {
+    ...profile,
+    ...refreshed
   };
 }
 

--- a/lib/github-copilot.ts
+++ b/lib/github-copilot.ts
@@ -1,3 +1,7 @@
+import { mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 import { SignJWT, jwtVerify } from "jose";
 import { CopilotClient } from "@github/copilot-sdk";
 
@@ -9,6 +13,13 @@ import type {
   ProviderProfileWithApiKey
 } from "@/lib/types";
 import { updateGithubCopilotCredentials } from "@/lib/settings";
+
+const COPILOT_WORK_DIR = join(tmpdir(), "eidon-copilot");
+
+function ensureCopilotWorkDir(): string {
+  mkdirSync(COPILOT_WORK_DIR, { recursive: true });
+  return COPILOT_WORK_DIR;
+}
 
 type GithubConnectionInput = Pick<
   ProviderProfile,
@@ -130,12 +141,14 @@ export async function exchangeGithubCodeForTokens(code: string) {
   );
 
   return response.json() as Promise<{
-    access_token: string;
-    token_type: string;
-    scope: string;
+    access_token?: string;
+    token_type?: string;
+    scope?: string;
     refresh_token?: string;
     expires_in?: number;
     refresh_token_expires_in?: number;
+    error?: string;
+    error_description?: string;
   }>;
 }
 
@@ -225,7 +238,13 @@ export async function listGithubCopilotModels(
     useLoggedInUser: false
   });
 
-  return client.listModels();
+  await client.start();
+
+  try {
+    return await client.listModels();
+  } finally {
+    await client.stop();
+  }
 }
 
 export async function buildGithubCopilotClient(
@@ -268,14 +287,44 @@ export async function streamGithubCopilotChat(
 ) {
   const client = await buildGithubCopilotClient(input);
 
-  const session = await client.createSession({
-    model: input.model,
-    streaming: true,
-    onPermissionRequest: () => ({ kind: "approved" as const }),
-    onEvent: input.onEvent
-  });
+  try {
+    let resolveTurn: () => void;
+    let rejectTurn: (error: Error) => void;
+    const turnComplete = new Promise<void>((resolve, reject) => {
+      resolveTurn = resolve;
+      rejectTurn = reject;
+    });
 
-  await session.send({
-    prompt: input.messages.map((m) => m.content).join("\n")
-  });
+    const sessionConfig = {
+      model: input.model,
+      streaming: true as const,
+      workingDirectory: ensureCopilotWorkDir(),
+      availableTools: [] as string[],
+      onPermissionRequest: () => ({ kind: "approved" as const }),
+      onEvent: (rawEvent: unknown) => {
+        const event = rawEvent as { type: string; data?: Record<string, unknown> };
+
+        input.onEvent(rawEvent);
+
+        if (event.type === "assistant.turn_end" || event.type === "session.idle") {
+          resolveTurn();
+        } else if (event.type === "session.error" && event.data?.message) {
+          rejectTurn(new Error(event.data.message as string));
+        }
+      },
+      ...(input.systemPrompt
+        ? { systemMessage: { mode: "replace" as const, content: input.systemPrompt } }
+        : {})
+    };
+
+    const session = await client.createSession(sessionConfig);
+
+    await session.send({
+      prompt: input.messages.map((m) => m.content).join("\n")
+    });
+
+    await turnComplete;
+  } finally {
+    await client.stop();
+  }
 }

--- a/lib/provider-presets.ts
+++ b/lib/provider-presets.ts
@@ -23,6 +23,7 @@ type ProviderPresetDefinition = {
 };
 
 type PresetCompatibleProfile = {
+  providerKind?: string;
   name: string;
   apiBaseUrl: string;
   model: string;
@@ -88,6 +89,10 @@ export function applyProviderPreset<T extends PresetCompatibleProfile>(
   profile: T,
   presetId: ProviderPresetId
 ) {
+  if (profile.providerKind && profile.providerKind !== "openai_compatible") {
+    return profile;
+  }
+
   return {
     ...profile,
     ...getProviderPreset(presetId).values
@@ -97,6 +102,10 @@ export function applyProviderPreset<T extends PresetCompatibleProfile>(
 export function getMatchingProviderPresetId(
   profile: PresetCompatibleProfile
 ): ProviderPresetId | null {
+  if (profile.providerKind && profile.providerKind !== "openai_compatible") {
+    return null;
+  }
+
   const preset = PROVIDER_PRESETS.find((entry) => {
     const { values } = entry;
 

--- a/lib/provider.ts
+++ b/lib/provider.ts
@@ -306,15 +306,68 @@ export async function* streamProviderResponse(input: {
       typeof m.content === "string" ? m.content : m.content.map((p) => "text" in p ? p.text : "").join("")
     );
 
-    await streamGithubCopilotChat({
+    type CopilotEvent = { type: string; data?: Record<string, unknown> };
+    type QueueItem = { done: true } | { event: ChatStreamEvent };
+
+    const eventQueue: QueueItem[] = [];
+    let resolveQueue: ((item: QueueItem) => void) | null = null;
+
+    function enqueue(item: QueueItem) {
+      if (resolveQueue) {
+        const r = resolveQueue;
+        resolveQueue = null;
+        r(item);
+      } else {
+        eventQueue.push(item);
+      }
+    }
+
+    function dequeue(): Promise<QueueItem> {
+      if (eventQueue.length > 0) {
+        return Promise.resolve(eventQueue.shift()!);
+      }
+      return new Promise<QueueItem>((resolve) => {
+        resolveQueue = resolve;
+      });
+    }
+
+    let answer = "";
+    let thinking = "";
+
+    const copilotPromise = streamGithubCopilotChat({
       ...freshSettings,
-      messages: messageTexts.map((content) => ({ role: "user", content })),
-      onEvent: (event: unknown) => {
-        void event;
+      messages: messageTexts.map((content) => ({ role: "user" as const, content })),
+      onEvent: (rawEvent: unknown) => {
+        const event = rawEvent as CopilotEvent;
+
+        if (event.type === "assistant.message_delta" && event.data?.deltaContent) {
+          answer += event.data.deltaContent as string;
+          enqueue({ event: { type: "answer_delta", text: event.data.deltaContent as string } });
+        } else if (event.type === "assistant.reasoning_delta" && event.data?.deltaContent) {
+          thinking += event.data.deltaContent as string;
+          enqueue({ event: { type: "thinking_delta", text: event.data.deltaContent as string } });
+        } else if (event.type === "session.error" && event.data?.message) {
+          enqueue({ event: { type: "error", message: event.data.message as string } });
+        }
       }
     });
 
-    return { answer: "", thinking: "", usage: { inputTokens: 0 } };
+    copilotPromise.catch((error: Error) => {
+      console.error("[copilot/stream] promise rejected:", error.message);
+      enqueue({ event: { type: "error", message: error.message } });
+    });
+
+    copilotPromise.finally(() => {
+      enqueue({ done: true });
+    });
+
+    let item = await dequeue();
+    while (!("done" in item)) {
+      yield item.event;
+      item = await dequeue();
+    }
+
+    return { answer, thinking, usage: { inputTokens: estimatePromptTokens(promptMessages) } };
   }
 
   const client = createClient(settings, settings.apiKey);

--- a/lib/provider.ts
+++ b/lib/provider.ts
@@ -1,6 +1,7 @@
 import OpenAI from "openai";
 
 import { getAttachmentDataUrl } from "@/lib/attachments";
+import { ensureFreshGithubAccessToken, runGithubCopilotChat, streamGithubCopilotChat } from "@/lib/github-copilot";
 import { supportsVisibleReasoning } from "@/lib/model-capabilities";
 import { estimatePromptTokens, setActiveTokenizer } from "@/lib/tokenization";
 import { normalizeLineBreaks } from "@/lib/utils";
@@ -235,6 +236,17 @@ export async function callProviderText(input: {
   conversationId?: string;
 }) {
   const { settings } = input;
+
+  if (settings.providerKind === "github_copilot") {
+    const freshSettings = await ensureFreshGithubAccessToken(settings);
+    const result = await runGithubCopilotChat({
+      ...freshSettings,
+      messages: [{ role: "user", content: input.prompt }]
+    });
+
+    return typeof result === "string" ? result : JSON.stringify(result);
+  }
+
   const client = createClient(settings, settings.apiKey);
 
   if (settings.apiMode === "responses") {
@@ -287,6 +299,24 @@ export async function* streamProviderResponse(input: {
 > {
   const { settings, promptMessages } = input;
   setActiveTokenizer(settings.tokenizerModel ?? "gpt-tokenizer");
+
+  if (settings.providerKind === "github_copilot") {
+    const freshSettings = await ensureFreshGithubAccessToken(settings);
+    const messageTexts = promptMessages.map((m) =>
+      typeof m.content === "string" ? m.content : m.content.map((p) => "text" in p ? p.text : "").join("")
+    );
+
+    await streamGithubCopilotChat({
+      ...freshSettings,
+      messages: messageTexts.map((content) => ({ role: "user", content })),
+      onEvent: (event: unknown) => {
+        void event;
+      }
+    });
+
+    return { answer: "", thinking: "", usage: { inputTokens: 0 } };
+  }
+
   const client = createClient(settings, settings.apiKey);
   const abortController = new AbortController();
   let answer = "";

--- a/lib/settings.ts
+++ b/lib/settings.ts
@@ -288,6 +288,61 @@ function withApiKey(profile: ProviderProfile): ProviderProfileWithApiKey {
   };
 }
 
+export function updateGithubCopilotCredentials(
+  profileId: string,
+  input: {
+    githubUserAccessToken: string;
+    githubRefreshToken: string;
+    githubTokenExpiresAt: string | null;
+    githubRefreshTokenExpiresAt: string | null;
+    githubAccountLogin: string | null;
+    githubAccountName: string | null;
+  }
+) {
+  const timestamp = new Date().toISOString();
+
+  getDb()
+    .prepare(
+      `UPDATE provider_profiles
+       SET github_user_access_token_encrypted = ?,
+           github_refresh_token_encrypted = ?,
+           github_token_expires_at = ?,
+           github_refresh_token_expires_at = ?,
+           github_account_login = ?,
+           github_account_name = ?,
+           updated_at = ?
+       WHERE id = ?`
+    )
+    .run(
+      input.githubUserAccessToken ? encryptValue(input.githubUserAccessToken) : "",
+      input.githubRefreshToken ? encryptValue(input.githubRefreshToken) : "",
+      input.githubTokenExpiresAt,
+      input.githubRefreshTokenExpiresAt,
+      input.githubAccountLogin,
+      input.githubAccountName,
+      timestamp,
+      profileId
+    );
+}
+
+export function clearGithubCopilotCredentials(profileId: string) {
+  const timestamp = new Date().toISOString();
+
+  getDb()
+    .prepare(
+      `UPDATE provider_profiles
+       SET github_user_access_token_encrypted = '',
+           github_refresh_token_encrypted = '',
+           github_token_expires_at = NULL,
+           github_refresh_token_expires_at = NULL,
+           github_account_login = NULL,
+           github_account_name = NULL,
+           updated_at = ?
+       WHERE id = ?`
+    )
+    .run(timestamp, profileId);
+}
+
 export function getSettings() {
   const row = getDb()
     .prepare(

--- a/lib/settings.ts
+++ b/lib/settings.ts
@@ -20,9 +20,9 @@ const runtimeSettingsSchema = z.object({
   providerKind: z.enum(["openai_compatible", "github_copilot"]).default("openai_compatible"),
   apiBaseUrl: z.string().default(""),
   apiKey: z.string().optional().default(""),
-  model: z.string().min(1),
+  model: z.string().min(0),
   apiMode: z.enum(["responses", "chat_completions"]),
-  systemPrompt: z.string().min(1),
+  systemPrompt: z.string().min(0),
   temperature: z.coerce.number().min(0).max(2),
   maxOutputTokens: z.coerce.number().int().min(128).max(32768),
   reasoningEffort: z.enum(["low", "medium", "high", "xhigh"]),
@@ -50,12 +50,28 @@ const providerProfileInputSchema = runtimeSettingsSchema.extend({
   id: z.string().min(1),
   name: z.string().min(1)
 }).superRefine((value, context) => {
-  if (value.providerKind === "openai_compatible" && !value.apiBaseUrl) {
-    context.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: "API base URL is required for OpenAI-compatible profiles",
-      path: ["apiBaseUrl"]
-    });
+  if (value.providerKind === "openai_compatible") {
+    if (!value.apiBaseUrl) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "API base URL is required for OpenAI-compatible profiles",
+        path: ["apiBaseUrl"]
+      });
+    }
+    if (!value.model) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Model is required for OpenAI-compatible profiles",
+        path: ["model"]
+      });
+    }
+    if (!value.systemPrompt) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "System prompt is required for OpenAI-compatible profiles",
+        path: ["systemPrompt"]
+      });
+    }
   }
 });
 

--- a/lib/settings.ts
+++ b/lib/settings.ts
@@ -9,6 +9,7 @@ import { decryptValue, encryptValue } from "@/lib/crypto";
 import { getDb } from "@/lib/db";
 import type {
   AppSettings,
+  GithubConnectionStatus,
   ProviderProfile,
   ProviderProfileWithApiKey,
   ReasoningEffort,
@@ -16,7 +17,8 @@ import type {
 } from "@/lib/types";
 
 const runtimeSettingsSchema = z.object({
-  apiBaseUrl: z.string().url(),
+  providerKind: z.enum(["openai_compatible", "github_copilot"]).default("openai_compatible"),
+  apiBaseUrl: z.string().default(""),
   apiKey: z.string().optional().default(""),
   model: z.string().min(1),
   apiMode: z.enum(["responses", "chat_completions"]),
@@ -35,12 +37,26 @@ const runtimeSettingsSchema = z.object({
   mergedMinNodeCount: z.coerce.number().int().min(2).max(20).default(4),
   mergedTargetTokens: z.coerce.number().int().min(128).max(16000).default(1600),
   visionMode: z.enum(["none", "native", "mcp"]).default("native"),
-  visionMcpServerId: z.string().nullable().default(null)
+  visionMcpServerId: z.string().nullable().default(null),
+  githubUserAccessTokenEncrypted: z.string().default(""),
+  githubRefreshTokenEncrypted: z.string().default(""),
+  githubAccountLogin: z.string().nullable().default(null),
+  githubAccountName: z.string().nullable().default(null),
+  githubTokenExpiresAt: z.string().nullable().default(null),
+  githubRefreshTokenExpiresAt: z.string().nullable().default(null)
 });
 
 const providerProfileInputSchema = runtimeSettingsSchema.extend({
   id: z.string().min(1),
   name: z.string().min(1)
+}).superRefine((value, context) => {
+  if (value.providerKind === "openai_compatible" && !value.apiBaseUrl) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "API base URL is required for OpenAI-compatible profiles",
+      path: ["apiBaseUrl"]
+    });
+  }
 });
 
 const settingsSchema = z
@@ -112,6 +128,13 @@ type ProviderProfileRow = {
   merged_target_tokens: number;
   vision_mode: string;
   vision_mcp_server_id: string | null;
+  provider_kind: string;
+  github_user_access_token_encrypted: string;
+  github_refresh_token_encrypted: string;
+  github_token_expires_at: string | null;
+  github_refresh_token_expires_at: string | null;
+  github_account_login: string | null;
+  github_account_name: string | null;
   created_at: string;
   updated_at: string;
 };
@@ -132,6 +155,7 @@ function rowToSettings(row: AppSettingsRow): AppSettings {
 function rowToProviderProfile(row: ProviderProfileRow): ProviderProfile {
   return {
     id: row.id,
+    providerKind: row.provider_kind as ProviderProfile["providerKind"],
     name: row.name,
     apiBaseUrl: row.api_base_url,
     apiKeyEncrypted: row.api_key_encrypted,
@@ -153,6 +177,12 @@ function rowToProviderProfile(row: ProviderProfileRow): ProviderProfile {
     mergedTargetTokens: row.merged_target_tokens,
     visionMode: row.vision_mode as VisionMode,
     visionMcpServerId: row.vision_mcp_server_id,
+    githubUserAccessTokenEncrypted: row.github_user_access_token_encrypted,
+    githubRefreshTokenEncrypted: row.github_refresh_token_encrypted,
+    githubTokenExpiresAt: row.github_token_expires_at,
+    githubRefreshTokenExpiresAt: row.github_refresh_token_expires_at,
+    githubAccountLogin: row.github_account_login,
+    githubAccountName: row.github_account_name,
     createdAt: row.created_at,
     updatedAt: row.updated_at
   };
@@ -184,6 +214,13 @@ function listProviderProfileRows() {
         merged_target_tokens,
         vision_mode,
         vision_mcp_server_id,
+        provider_kind,
+        github_user_access_token_encrypted,
+        github_refresh_token_encrypted,
+        github_token_expires_at,
+        github_refresh_token_expires_at,
+        github_account_login,
+        github_account_name,
         created_at,
         updated_at
       FROM provider_profiles
@@ -218,6 +255,13 @@ function getProviderProfileRow(profileId: string) {
         merged_target_tokens,
         vision_mode,
         vision_mcp_server_id,
+        provider_kind,
+        github_user_access_token_encrypted,
+        github_refresh_token_encrypted,
+        github_token_expires_at,
+        github_refresh_token_expires_at,
+        github_account_login,
+        github_account_name,
         created_at,
         updated_at
       FROM provider_profiles
@@ -294,11 +338,22 @@ export function getDefaultProviderProfileWithApiKey() {
 export function getSanitizedSettings() {
   const settings = getSettings();
   const providerProfiles = listProviderProfiles().map((profile) => {
-    const { apiKeyEncrypted: _apiKeyEncrypted, ...sanitizedProfile } = profile;
+    const {
+      apiKeyEncrypted: _apiKeyEncrypted,
+      githubUserAccessTokenEncrypted: _githubUserAccessTokenEncrypted,
+      githubRefreshTokenEncrypted: _githubRefreshTokenEncrypted,
+      ...sanitizedProfile
+    } = profile;
+
+    const githubConnectionStatus: GithubConnectionStatus =
+      profile.providerKind !== "github_copilot" || !profile.githubUserAccessTokenEncrypted
+        ? "disconnected"
+        : "connected";
 
     return {
       ...sanitizedProfile,
-      hasApiKey: Boolean(profile.apiKeyEncrypted)
+      hasApiKey: Boolean(profile.apiKeyEncrypted),
+      githubConnectionStatus
     };
   });
 
@@ -342,6 +397,13 @@ export function updateSettings(input: unknown) {
         merged_target_tokens,
         vision_mode,
         vision_mcp_server_id,
+        provider_kind,
+        github_user_access_token_encrypted,
+        github_refresh_token_encrypted,
+        github_token_expires_at,
+        github_refresh_token_expires_at,
+        github_account_login,
+        github_account_name,
         created_at,
         updated_at
       ) VALUES (
@@ -367,6 +429,13 @@ export function updateSettings(input: unknown) {
         @mergedTargetTokens,
         @visionMode,
         @visionMcpServerId,
+        @providerKind,
+        @githubUserAccessTokenEncrypted,
+        @githubRefreshTokenEncrypted,
+        @githubTokenExpiresAt,
+        @githubRefreshTokenExpiresAt,
+        @githubAccountLogin,
+        @githubAccountName,
         @createdAt,
         @updatedAt
       )
@@ -392,6 +461,13 @@ export function updateSettings(input: unknown) {
         merged_target_tokens = excluded.merged_target_tokens,
         vision_mode = excluded.vision_mode,
         vision_mcp_server_id = excluded.vision_mcp_server_id,
+        provider_kind = excluded.provider_kind,
+        github_user_access_token_encrypted = excluded.github_user_access_token_encrypted,
+        github_refresh_token_encrypted = excluded.github_refresh_token_encrypted,
+        github_token_expires_at = excluded.github_token_expires_at,
+        github_refresh_token_expires_at = excluded.github_refresh_token_expires_at,
+        github_account_login = excluded.github_account_login,
+        github_account_name = excluded.github_account_name,
         updated_at = excluded.updated_at`
     );
 
@@ -422,6 +498,13 @@ export function updateSettings(input: unknown) {
         mergedTargetTokens: profile.mergedTargetTokens,
         visionMode: profile.visionMode ?? "native",
         visionMcpServerId: profile.visionMcpServerId ?? null,
+        providerKind: profile.providerKind,
+        githubUserAccessTokenEncrypted: profile.githubUserAccessTokenEncrypted ?? "",
+        githubRefreshTokenEncrypted: profile.githubRefreshTokenEncrypted ?? "",
+        githubTokenExpiresAt: profile.githubTokenExpiresAt ?? null,
+        githubRefreshTokenExpiresAt: profile.githubRefreshTokenExpiresAt ?? null,
+        githubAccountLogin: profile.githubAccountLogin ?? null,
+        githubAccountName: profile.githubAccountName ?? null,
         createdAt: current?.createdAt ?? timestamp,
         updatedAt: timestamp
       });

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -6,6 +6,10 @@ export type ReasoningEffort = "low" | "medium" | "high" | "xhigh";
 
 export type VisionMode = "none" | "native" | "mcp";
 
+export type ProviderKind = "openai_compatible" | "github_copilot";
+
+export type GithubConnectionStatus = "disconnected" | "connected" | "expired";
+
 export type MessageRole = "user" | "assistant" | "system";
 
 export type MessageStatus = "idle" | "streaming" | "completed" | "error";
@@ -28,6 +32,7 @@ export type SystemMessageKind = "compaction_notice";
 
 export type ProviderProfile = {
   id: string;
+  providerKind: ProviderKind;
   name: string;
   apiBaseUrl: string;
   apiKeyEncrypted: string;
@@ -49,6 +54,12 @@ export type ProviderProfile = {
   mergedTargetTokens: number;
   visionMode: VisionMode;
   visionMcpServerId: string | null;
+  githubUserAccessTokenEncrypted: string;
+  githubRefreshTokenEncrypted: string;
+  githubTokenExpiresAt: string | null;
+  githubRefreshTokenExpiresAt: string | null;
+  githubAccountLogin: string | null;
+  githubAccountName: string | null;
   createdAt: string;
   updatedAt: string;
 };
@@ -57,8 +68,12 @@ export type ProviderProfileWithApiKey = ProviderProfile & {
   apiKey: string;
 };
 
-export type ProviderProfileSummary = Omit<ProviderProfile, "apiKeyEncrypted"> & {
+export type ProviderProfileSummary = Omit<
+  ProviderProfile,
+  "apiKeyEncrypted" | "githubUserAccessTokenEncrypted" | "githubRefreshTokenEncrypted"
+> & {
   hasApiKey: boolean;
+  githubConnectionStatus: GithubConnectionStatus;
 };
 
 export type AppSettings = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
+        "@github/copilot-sdk": "^0.2.1",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@radix-ui/react-scroll-area": "^1.2.2",
         "@radix-ui/react-slot": "^1.1.1",
@@ -975,6 +976,142 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@github/copilot": {
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.21.tgz",
+      "integrity": "sha512-P+nORjNKAtl92jYCG6Qr1Rsw2JoyScgeQSkIR6O2WB37WS5JVdA4ax1WVualMbfuc9V58CPHX6fwyNpkI89FkQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "bin": {
+        "copilot": "npm-loader.js"
+      },
+      "optionalDependencies": {
+        "@github/copilot-darwin-arm64": "1.0.21",
+        "@github/copilot-darwin-x64": "1.0.21",
+        "@github/copilot-linux-arm64": "1.0.21",
+        "@github/copilot-linux-x64": "1.0.21",
+        "@github/copilot-win32-arm64": "1.0.21",
+        "@github/copilot-win32-x64": "1.0.21"
+      }
+    },
+    "node_modules/@github/copilot-darwin-arm64": {
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.21.tgz",
+      "integrity": "sha512-aB+s9ldTwcyCOYmzjcQ4SknV6g81z92T8aUJEJZBwOXOTBeWKAJtk16ooAKangZgdwuLgO3or1JUjx1FJAm5nQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "copilot-darwin-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-darwin-x64": {
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.21.tgz",
+      "integrity": "sha512-aNad81DOGuGShmaiFNIxBUSZLwte0dXmDYkGfAF9WJIgY4qP4A8CPWFoNr8//gY+4CwaIf9V+f/OC6k2BdECbw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "copilot-darwin-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linux-arm64": {
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.21.tgz",
+      "integrity": "sha512-FL0NsCnHax4czHVv1S8iBqPLGZDhZ28N3+6nT29xWGhmjBWTkIofxLThKUPcyyMsfPTTxIlrdwWa8qQc5z2Q+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linux-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linux-x64": {
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.21.tgz",
+      "integrity": "sha512-S7pWVI16hesZtxYbIyfw+MHZpc5ESoGKUVr5Y+lZJNaM2340gJGPQzQwSpvKIRMLHRKI2hXLwciAnYeMFxE/Tg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linux-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-sdk": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-0.2.1.tgz",
+      "integrity": "sha512-S1n/4X1viqbSAWcHDZcFyZ/7hgTLAXr3NY7yNmHoX/CL4LTuYIJ6y5w2jrqUnrJNQgtNrMDSFGwFU+H1GeynFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@github/copilot": "^1.0.17",
+        "vscode-jsonrpc": "^8.2.1",
+        "zod": "^4.3.6"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@github/copilot-sdk/node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@github/copilot-win32-arm64": {
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.21.tgz",
+      "integrity": "sha512-a9qc2Ku+XbyBkXCclbIvBbIVnECACTIWnPctmXWsQeSdeapGxgfHGux7y8hAFV5j6+nhCm6cnyEMS3rkZjAhdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "copilot-win32-arm64": "copilot.exe"
+      }
+    },
+    "node_modules/@github/copilot-win32-x64": {
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.21.tgz",
+      "integrity": "sha512-9klu+7NQ6tEyb8sibb0rsbimBivDrnNltZho10Bgbf1wh3o+erTjffXDjW9Zkyaw8lZA9Fz8bqhVkKntZq58Lg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "copilot-win32-x64": "copilot.exe"
       }
     },
     "node_modules/@hono/node-server": {
@@ -12031,6 +12168,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.1.tgz",
+      "integrity": "sha512-kdjOSJ2lLIn7r1rtrMbbNCHjyMPfRnowdKjBQ+mGq6NAW5QY2bEZC/khaC5OR8svbbjvLEaIXkOq45e2X9BIbQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,8 +36,9 @@
       "devDependencies": {
         "@playwright/test": "^1.52.0",
         "@tailwindcss/postcss": "^4.1.3",
-        "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.2.0",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
         "@types/better-sqlite3": "^7.6.12",
         "@types/node": "^22.13.10",
@@ -111,7 +112,6 @@
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
@@ -2013,7 +2013,7 @@
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
       "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.58.2"
@@ -2940,7 +2940,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3040,8 +3039,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/better-sqlite3": {
       "version": "7.6.13",
@@ -3147,6 +3145,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -3156,7 +3155,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -4871,6 +4870,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -5120,8 +5120,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -8019,7 +8018,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -9702,7 +9700,7 @@
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
       "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.58.2"
@@ -9721,7 +9719,7 @@
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
       "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -9819,7 +9817,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -9835,7 +9832,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -10031,8 +10027,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",

--- a/package.json
+++ b/package.json
@@ -43,8 +43,9 @@
   "devDependencies": {
     "@playwright/test": "^1.52.0",
     "@tailwindcss/postcss": "^4.1.3",
-    "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.2.0",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
     "@types/better-sqlite3": "^7.6.12",
     "@types/node": "^22.13.10",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@github/copilot-sdk": "^0.2.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@radix-ui/react-scroll-area": "^1.2.2",
     "@radix-ui/react-slot": "^1.1.1",

--- a/tests/unit/assistant-runtime.test.ts
+++ b/tests/unit/assistant-runtime.test.ts
@@ -85,6 +85,13 @@ function createSettings(): ProviderProfileWithApiKey {
     mergedTargetTokens: 1600,
     visionMode: "native" as const,
     visionMcpServerId: null,
+    providerKind: "openai_compatible",
+    githubUserAccessTokenEncrypted: "",
+    githubRefreshTokenEncrypted: "",
+    githubTokenExpiresAt: null,
+    githubRefreshTokenExpiresAt: null,
+    githubAccountLogin: null,
+    githubAccountName: null,
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString()
   };

--- a/tests/unit/chat-turn.test.ts
+++ b/tests/unit/chat-turn.test.ts
@@ -52,6 +52,13 @@ function setupProviderProfile(): { profileId: string; profile: ProviderProfileWi
     mergedTargetTokens: 1600,
     visionMode: "native" as const,
     visionMcpServerId: null,
+    providerKind: "openai_compatible",
+    githubUserAccessTokenEncrypted: "",
+    githubRefreshTokenEncrypted: "",
+    githubTokenExpiresAt: null,
+    githubRefreshTokenExpiresAt: null,
+    githubAccountLogin: null,
+    githubAccountName: null,
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString()
   };

--- a/tests/unit/chat-view.test.ts
+++ b/tests/unit/chat-view.test.ts
@@ -114,9 +114,15 @@ function createPayload() {
         mergedTargetTokens: 1600,
         visionMode: "native" as const,
         visionMcpServerId: null,
+        providerKind: "openai_compatible" as "openai_compatible" | "github_copilot",
+        githubTokenExpiresAt: null,
+        githubRefreshTokenExpiresAt: null,
+        githubAccountLogin: null,
+        githubAccountName: null,
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
-        hasApiKey: true
+        hasApiKey: true,
+        githubConnectionStatus: "disconnected" as "disconnected" | "connected" | "expired"
       }
     ],
     defaultProviderProfileId: "profile_default",

--- a/tests/unit/conversation-title-generator.test.ts
+++ b/tests/unit/conversation-title-generator.test.ts
@@ -23,6 +23,13 @@ function createSettings(): ProviderProfileWithApiKey {
     modelContextLimit: 16000,
     compactionThreshold: 0.8,
     freshTailCount: 12,
+    providerKind: "openai_compatible",
+    githubUserAccessTokenEncrypted: "",
+    githubRefreshTokenEncrypted: "",
+    githubTokenExpiresAt: null,
+    githubRefreshTokenExpiresAt: null,
+    githubAccountLogin: null,
+    githubAccountName: null,
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString()
   };

--- a/tests/unit/env.test.ts
+++ b/tests/unit/env.test.ts
@@ -63,6 +63,24 @@ describe("env validation", () => {
     expect(env.EIDON_ENCRYPTION_SECRET).toBe("production-encryption-secret-32-chars");
   });
 
+  it("reads GitHub Copilot OAuth environment variables when provided", () => {
+    const env = parseEnv({
+      NODE_ENV: "production",
+      EIDON_ADMIN_PASSWORD: "production-admin-password-32-chars",
+      EIDON_SESSION_SECRET: "production-session-secret-with-32-chars",
+      EIDON_ENCRYPTION_SECRET: "production-encryption-secret-32-chars",
+      EIDON_GITHUB_APP_CLIENT_ID: "Iv23exampleclientid",
+      EIDON_GITHUB_APP_CLIENT_SECRET: "github-app-client-secret-value",
+      EIDON_GITHUB_APP_CALLBACK_URL: "https://eidon.example.com/api/providers/github/callback"
+    });
+
+    expect(env.EIDON_GITHUB_APP_CLIENT_ID).toBe("Iv23exampleclientid");
+    expect(env.EIDON_GITHUB_APP_CLIENT_SECRET).toBe("github-app-client-secret-value");
+    expect(env.EIDON_GITHUB_APP_CALLBACK_URL).toBe(
+      "https://eidon.example.com/api/providers/github/callback"
+    );
+  });
+
   it("defers production secret validation until a sensitive value is accessed", async () => {
     const previous = {
       NODE_ENV: process.env.NODE_ENV,

--- a/tests/unit/github-copilot-routes.test.ts
+++ b/tests/unit/github-copilot-routes.test.ts
@@ -1,0 +1,126 @@
+import { encryptValue } from "@/lib/crypto";
+import {
+  getProviderProfile,
+  listProviderProfiles,
+  updateSettings
+} from "@/lib/settings";
+
+import { GET as connect } from "@/app/api/providers/github/connect/route";
+import { GET as callback } from "@/app/api/providers/github/callback/route";
+import { POST as disconnect } from "@/app/api/providers/github/disconnect/route";
+import { GET as models } from "@/app/api/providers/github/models/route";
+
+vi.mock("@/lib/auth", () => ({
+  requireUser: vi.fn().mockResolvedValue({
+    id: "user_test",
+    username: "admin",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z"
+  })
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: vi.fn(() => {
+    throw new Error("NEXT_REDIRECT");
+  })
+}));
+
+function buildProfile(
+  overrides: Record<string, unknown> = {}
+) {
+  return {
+    id: overrides.id ?? `profile_${crypto.randomUUID()}`,
+    name: overrides.name ?? "Profile",
+    apiBaseUrl: overrides.apiBaseUrl ?? "https://api.example.com/v1",
+    apiKey: overrides.apiKey ?? "",
+    model: overrides.model ?? "gpt-test",
+    apiMode: "responses" as const,
+    systemPrompt: "Be exact.",
+    temperature: 0.4,
+    maxOutputTokens: 512,
+    reasoningEffort: "medium" as const,
+    reasoningSummaryEnabled: true,
+    modelContextLimit: 16384,
+    compactionThreshold: 0.8,
+    freshTailCount: 12,
+    ...overrides
+  };
+}
+
+function seedCopilotProfile(overrides: Record<string, unknown> = {}) {
+  const id = (overrides.id as string) ?? "profile_copilot";
+
+  updateSettings({
+    defaultProviderProfileId: id,
+    skillsEnabled: true,
+    providerProfiles: [
+      buildProfile({
+        id,
+        name: "Copilot",
+        providerKind: "github_copilot",
+        apiBaseUrl: "",
+        apiKey: "",
+        ...overrides
+      })
+    ]
+  });
+
+  return id;
+}
+
+describe("github copilot routes", () => {
+  it("rejects connect requests for non-copilot profiles", async () => {
+    const id = seedCopilotProfile();
+
+    const response = await connect(
+      new Request(
+        `http://localhost/api/providers/github/connect?providerProfileId=missing`
+      )
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("rejects callback requests with an invalid state token", async () => {
+    const response = await callback(
+      new Request(
+        "http://localhost/api/providers/github/callback?code=test-code&state=invalid-state"
+      )
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("clears oauth credentials on disconnect", async () => {
+    const id = seedCopilotProfile({
+      githubUserAccessTokenEncrypted: encryptValue("ghu_token"),
+      githubTokenExpiresAt: new Date(Date.now() + 60_000).toISOString()
+    });
+
+    const response = await disconnect(
+      new Request("http://localhost/api/providers/github/disconnect", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ providerProfileId: id })
+      })
+    );
+
+    expect(response.status).toBe(200);
+
+    const profile = getProviderProfile(id);
+    expect(profile?.githubUserAccessTokenEncrypted).toBe("");
+    expect(profile?.githubTokenExpiresAt).toBeNull();
+  });
+
+  it("rejects model discovery for disconnected profiles", async () => {
+    const id = seedCopilotProfile();
+
+    const response = await models(
+      new Request(
+        `http://localhost/api/providers/github/models?providerProfileId=${id}`
+      )
+    );
+
+    expect(response.status).toBe(400);
+  });
+});

--- a/tests/unit/github-copilot.test.ts
+++ b/tests/unit/github-copilot.test.ts
@@ -1,11 +1,115 @@
-import { encryptValue } from "@/lib/crypto";
+import { decryptValue, encryptValue } from "@/lib/crypto";
+
+const {
+  updateGithubCopilotCredentials,
+  copilotClientCtor
+} = vi.hoisted(() => ({
+  updateGithubCopilotCredentials: vi.fn(),
+  copilotClientCtor: vi.fn()
+}));
+
+vi.mock("@/lib/settings", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/settings")>("@/lib/settings");
+
+  return {
+    ...actual,
+    updateGithubCopilotCredentials
+  };
+});
+
+vi.mock("@github/copilot-sdk", () => ({
+  CopilotClient: copilotClientCtor
+}));
+
 import {
+  buildGithubCopilotClient,
   clearGithubCopilotConnection,
+  createGithubOauthState,
+  ensureFreshGithubAccessToken,
+  exchangeGithubCodeForTokens,
+  getGithubAuthorizeUrl,
   getGithubConnectionStatus,
-  shouldRefreshGithubToken
+  listGithubCopilotModels,
+  refreshGithubUserToken,
+  runGithubCopilotChat,
+  shouldRefreshGithubToken,
+  streamGithubCopilotChat,
+  verifyGithubOauthState
 } from "@/lib/github-copilot";
 
+function createProfile(overrides: Record<string, unknown> = {}) {
+  const now = new Date().toISOString();
+
+  return {
+    id: "profile_copilot",
+    providerKind: "github_copilot" as const,
+    name: "Copilot",
+    apiBaseUrl: "",
+    apiKeyEncrypted: "",
+    model: "openai/gpt-4.1",
+    apiMode: "responses" as const,
+    systemPrompt: "Be exact.",
+    temperature: 0.2,
+    maxOutputTokens: 512,
+    reasoningEffort: "medium" as const,
+    reasoningSummaryEnabled: true,
+    modelContextLimit: 16000,
+    compactionThreshold: 0.8,
+    freshTailCount: 12,
+    tokenizerModel: "gpt-tokenizer" as const,
+    safetyMarginTokens: 1200,
+    leafSourceTokenLimit: 12000,
+    leafMinMessageCount: 6,
+    mergedMinNodeCount: 4,
+    mergedTargetTokens: 1600,
+    visionMode: "native" as const,
+    visionMcpServerId: null,
+    githubUserAccessTokenEncrypted: encryptValue("ghu_access"),
+    githubRefreshTokenEncrypted: encryptValue("ghr_refresh"),
+    githubTokenExpiresAt: new Date(Date.now() + 10 * 60_000).toISOString(),
+    githubRefreshTokenExpiresAt: new Date(Date.now() + 60 * 60_000).toISOString(),
+    githubAccountLogin: "octocat",
+    githubAccountName: "The Octocat",
+    createdAt: now,
+    updatedAt: now,
+    hasApiKey: false,
+    githubConnectionStatus: "connected" as const,
+    ...overrides
+  };
+}
+
+type MockSession = {
+  send: ReturnType<typeof vi.fn>;
+};
+
+type MockClient = {
+  start: ReturnType<typeof vi.fn>;
+  stop: ReturnType<typeof vi.fn>;
+  listModels: ReturnType<typeof vi.fn>;
+  createSession: ReturnType<typeof vi.fn>;
+};
+
+function createMockClient(overrides: Partial<MockClient> = {}): MockClient {
+  return {
+    start: vi.fn().mockResolvedValue(undefined),
+    stop: vi.fn().mockResolvedValue(undefined),
+    listModels: vi.fn().mockResolvedValue([{ id: "openai/gpt-4.1", name: "GPT-4.1" }]),
+    createSession: vi.fn(),
+    ...overrides
+  };
+}
+
 describe("github copilot helpers", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+    process.env.EIDON_GITHUB_APP_CLIENT_ID = "github-client-id";
+    process.env.EIDON_GITHUB_APP_CLIENT_SECRET = "github-client-secret";
+    process.env.EIDON_GITHUB_APP_CALLBACK_URL =
+      "http://localhost/api/providers/github/callback";
+    global.fetch = vi.fn();
+  });
+
   it("detects when a token should be refreshed", () => {
     expect(
       shouldRefreshGithubToken({
@@ -16,6 +120,14 @@ describe("github copilot helpers", () => {
     expect(
       shouldRefreshGithubToken({
         githubTokenExpiresAt: new Date(Date.now() + 15 * 60_000).toISOString()
+      })
+    ).toBe(false);
+  });
+
+  it("does not refresh a github token when no expiry is stored", () => {
+    expect(
+      shouldRefreshGithubToken({
+        githubTokenExpiresAt: null
       })
     ).toBe(false);
   });
@@ -36,6 +148,24 @@ describe("github copilot helpers", () => {
         githubTokenExpiresAt: new Date(Date.now() + 60_000).toISOString()
       })
     ).toBe("connected");
+
+    expect(
+      getGithubConnectionStatus({
+        providerKind: "github_copilot",
+        githubUserAccessTokenEncrypted: encryptValue("ghu_123"),
+        githubTokenExpiresAt: new Date(Date.now() - 60_000).toISOString()
+      })
+    ).toBe("expired");
+  });
+
+  it("treats copilot profiles without an expiry timestamp as disconnected", () => {
+    expect(
+      getGithubConnectionStatus({
+        providerKind: "github_copilot",
+        githubUserAccessTokenEncrypted: encryptValue("ghu_123"),
+        githubTokenExpiresAt: null
+      })
+    ).toBe("disconnected");
   });
 
   it("clears only github oauth fields when disconnecting", () => {
@@ -56,5 +186,286 @@ describe("github copilot helpers", () => {
       githubAccountLogin: null,
       githubAccountName: null
     });
+  });
+
+  it("creates and verifies oauth state tokens", async () => {
+    const state = await createGithubOauthState("profile_1", "user_1");
+
+    await expect(verifyGithubOauthState(state)).resolves.toEqual({
+      profileId: "profile_1",
+      userId: "user_1"
+    });
+  });
+
+  it("builds the github authorize url from env config", () => {
+    const url = new URL(getGithubAuthorizeUrl("state-token"));
+
+    expect(url.origin + url.pathname).toBe("https://github.com/login/oauth/authorize");
+    expect(url.searchParams.get("client_id")).toBe("github-client-id");
+    expect(url.searchParams.get("redirect_uri")).toBe(
+      "http://localhost/api/providers/github/callback"
+    );
+    expect(url.searchParams.get("state")).toBe("state-token");
+    expect(url.searchParams.get("scope")).toBe("read:user");
+  });
+
+  it("exchanges an oauth code for tokens", async () => {
+    vi.mocked(global.fetch).mockResolvedValue({
+      json: async () => ({ access_token: "ghu_new" })
+    } as Response);
+
+    await expect(exchangeGithubCodeForTokens("oauth-code")).resolves.toEqual({
+      access_token: "ghu_new"
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://github.com/login/oauth/access_token",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          client_id: "github-client-id",
+          client_secret: "github-client-secret",
+          code: "oauth-code"
+        })
+      })
+    );
+  });
+
+  it("refreshes a github user token and preserves the stored refresh token when omitted", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-09T10:00:00.000Z"));
+    vi.mocked(global.fetch).mockResolvedValue({
+      json: async () => ({
+        access_token: "ghu_refreshed",
+        expires_in: 120
+      })
+    } as Response);
+
+    const profile = createProfile();
+
+    const refreshed = await refreshGithubUserToken(profile);
+
+    expect(refreshed.githubRefreshTokenEncrypted).toBe(profile.githubRefreshTokenEncrypted);
+    expect(decryptValue(refreshed.githubUserAccessTokenEncrypted)).toBe(
+      "ghu_refreshed"
+    );
+    expect(refreshed.githubTokenExpiresAt).toBe("2026-04-09T10:02:00.000Z");
+    expect(refreshed.githubRefreshTokenExpiresAt).toBeNull();
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://github.com/login/oauth/access_token",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          client_id: "github-client-id",
+          client_secret: "github-client-secret",
+          grant_type: "refresh_token",
+          refresh_token: "ghr_refresh"
+        })
+      })
+    );
+  });
+
+  it("returns the same profile when the github token is still fresh", async () => {
+    const profile = createProfile({
+      githubTokenExpiresAt: new Date(Date.now() + 30 * 60_000).toISOString()
+    });
+
+    await expect(ensureFreshGithubAccessToken(profile)).resolves.toBe(profile);
+    expect(updateGithubCopilotCredentials).not.toHaveBeenCalled();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("refreshes expiring github credentials and persists the new values", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-09T10:00:00.000Z"));
+    vi.mocked(global.fetch).mockResolvedValue({
+      json: async () => ({
+        access_token: "ghu_refreshed",
+        refresh_token: "ghr_rotated",
+        expires_in: 300,
+        refresh_token_expires_in: 7200
+      })
+    } as Response);
+
+    const profile = createProfile({
+      githubTokenExpiresAt: new Date(Date.now() + 30_000).toISOString()
+    });
+
+    const refreshed = await ensureFreshGithubAccessToken(profile);
+
+    expect(decryptValue(refreshed.githubUserAccessTokenEncrypted)).toBe(
+      "ghu_refreshed"
+    );
+    expect(decryptValue(refreshed.githubRefreshTokenEncrypted)).toBe(
+      "ghr_rotated"
+    );
+    expect(refreshed.githubTokenExpiresAt).toBe("2026-04-09T10:05:00.000Z");
+    expect(refreshed.githubRefreshTokenExpiresAt).toBe(
+      "2026-04-09T12:00:00.000Z"
+    );
+    expect(updateGithubCopilotCredentials).toHaveBeenCalledWith("profile_copilot", {
+      githubUserAccessToken: "ghu_refreshed",
+      githubRefreshToken: "ghr_rotated",
+      githubTokenExpiresAt: "2026-04-09T10:05:00.000Z",
+      githubRefreshTokenExpiresAt: "2026-04-09T12:00:00.000Z",
+      githubAccountLogin: "octocat",
+      githubAccountName: "The Octocat"
+    });
+  });
+
+  it("lists github copilot models with a started and stopped client", async () => {
+    const client = createMockClient();
+    copilotClientCtor.mockImplementation(() => client);
+
+    await expect(listGithubCopilotModels(createProfile())).resolves.toEqual([
+      { id: "openai/gpt-4.1", name: "GPT-4.1" }
+    ]);
+
+    expect(copilotClientCtor).toHaveBeenCalledWith({
+      githubToken: "ghu_access",
+      useLoggedInUser: false
+    });
+    expect(client.start).toHaveBeenCalledTimes(1);
+    expect(client.listModels).toHaveBeenCalledTimes(1);
+    expect(client.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it("builds a github copilot client with the decrypted token", async () => {
+    const client = createMockClient();
+    copilotClientCtor.mockImplementation(() => client);
+
+    await expect(buildGithubCopilotClient(createProfile())).resolves.toBe(client);
+    expect(copilotClientCtor).toHaveBeenCalledWith({
+      githubToken: "ghu_access",
+      useLoggedInUser: false
+    });
+  });
+
+  it("runs a copilot chat turn with the joined prompt", async () => {
+    const session: MockSession = {
+      send: vi.fn().mockResolvedValue({ reply: "done" })
+    };
+    const client = createMockClient({
+      createSession: vi.fn().mockResolvedValue(session)
+    });
+    copilotClientCtor.mockImplementation(() => client);
+
+    await expect(
+      runGithubCopilotChat({
+        ...createProfile(),
+        messages: [
+          { role: "user", content: "First line" },
+          { role: "assistant", content: "Second line" }
+        ]
+      })
+    ).resolves.toEqual({ reply: "done" });
+
+    expect(client.createSession).toHaveBeenCalledWith({
+      model: "openai/gpt-4.1",
+      onPermissionRequest: expect.any(Function)
+    });
+    const onPermissionRequest = client.createSession.mock.calls[0]?.[0]?.onPermissionRequest;
+    expect(onPermissionRequest()).toEqual({ kind: "approved" });
+    expect(session.send).toHaveBeenCalledWith({
+      prompt: "First line\nSecond line"
+    });
+  });
+
+  it("streams a copilot chat turn until the assistant finishes", async () => {
+    const events: unknown[] = [];
+    const session: MockSession = {
+      send: vi.fn().mockResolvedValue(undefined)
+    };
+    const client = createMockClient({
+      createSession: vi.fn().mockImplementation(async (config: Record<string, unknown>) => {
+        const onEvent = config.onEvent as (event: unknown) => void;
+        queueMicrotask(() => onEvent({ type: "assistant.turn_end" }));
+        return session;
+      })
+    });
+    copilotClientCtor.mockImplementation(() => client);
+
+    await expect(
+      streamGithubCopilotChat({
+        ...createProfile(),
+        messages: [{ role: "user", content: "Ship it" }],
+        onEvent: (event) => events.push(event)
+      })
+    ).resolves.toBeUndefined();
+
+    expect(client.createSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: "openai/gpt-4.1",
+        streaming: true,
+        availableTools: [],
+        systemMessage: { mode: "replace", content: "Be exact." },
+        onPermissionRequest: expect.any(Function),
+        onEvent: expect.any(Function),
+        workingDirectory: expect.stringContaining("eidon-copilot")
+      })
+    );
+    expect(session.send).toHaveBeenCalledWith({
+      prompt: "Ship it"
+    });
+    expect(events).toEqual([{ type: "assistant.turn_end" }]);
+    expect(client.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects a streaming copilot chat turn when the session reports an error", async () => {
+    const session: MockSession = {
+      send: vi.fn().mockResolvedValue(undefined)
+    };
+    const client = createMockClient({
+      createSession: vi.fn().mockImplementation(async (config: Record<string, unknown>) => {
+        const onEvent = config.onEvent as (event: unknown) => void;
+        queueMicrotask(() =>
+          onEvent({
+            type: "session.error",
+            data: { message: "stream failed" }
+          })
+        );
+        return session;
+      })
+    });
+    copilotClientCtor.mockImplementation(() => client);
+
+    await expect(
+      streamGithubCopilotChat({
+        ...createProfile(),
+        messages: [{ role: "user", content: "Ship it" }],
+        onEvent: vi.fn()
+      })
+    ).rejects.toThrow("stream failed");
+
+    expect(client.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it("streams without a system prompt and resolves when the session goes idle", async () => {
+    const session: MockSession = {
+      send: vi.fn().mockResolvedValue(undefined)
+    };
+    const client = createMockClient({
+      createSession: vi.fn().mockImplementation(async (config: Record<string, unknown>) => {
+        const onEvent = config.onEvent as (event: unknown) => void;
+        queueMicrotask(() => onEvent({ type: "session.idle" }));
+        return session;
+      })
+    });
+    copilotClientCtor.mockImplementation(() => client);
+
+    await expect(
+      streamGithubCopilotChat({
+        ...createProfile({ systemPrompt: "" }),
+        messages: [{ role: "user", content: "Ship it" }],
+        onEvent: vi.fn()
+      })
+    ).resolves.toBeUndefined();
+
+    expect(client.createSession).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        systemMessage: expect.anything()
+      })
+    );
+    expect(client.stop).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/unit/github-copilot.test.ts
+++ b/tests/unit/github-copilot.test.ts
@@ -1,0 +1,60 @@
+import { encryptValue } from "@/lib/crypto";
+import {
+  clearGithubCopilotConnection,
+  getGithubConnectionStatus,
+  shouldRefreshGithubToken
+} from "@/lib/github-copilot";
+
+describe("github copilot helpers", () => {
+  it("detects when a token should be refreshed", () => {
+    expect(
+      shouldRefreshGithubToken({
+        githubTokenExpiresAt: new Date(Date.now() + 30_000).toISOString()
+      })
+    ).toBe(true);
+
+    expect(
+      shouldRefreshGithubToken({
+        githubTokenExpiresAt: new Date(Date.now() + 15 * 60_000).toISOString()
+      })
+    ).toBe(false);
+  });
+
+  it("computes connection state from stored credentials", () => {
+    expect(
+      getGithubConnectionStatus({
+        providerKind: "github_copilot",
+        githubUserAccessTokenEncrypted: "",
+        githubTokenExpiresAt: null
+      })
+    ).toBe("disconnected");
+
+    expect(
+      getGithubConnectionStatus({
+        providerKind: "github_copilot",
+        githubUserAccessTokenEncrypted: encryptValue("ghu_123"),
+        githubTokenExpiresAt: new Date(Date.now() + 60_000).toISOString()
+      })
+    ).toBe("connected");
+  });
+
+  it("clears only github oauth fields when disconnecting", () => {
+    expect(
+      clearGithubCopilotConnection({
+        githubUserAccessTokenEncrypted: "ciphertext-access",
+        githubRefreshTokenEncrypted: "ciphertext-refresh",
+        githubTokenExpiresAt: "2026-04-08T16:00:00.000Z",
+        githubRefreshTokenExpiresAt: "2026-10-08T16:00:00.000Z",
+        githubAccountLogin: "octocat",
+        githubAccountName: "The Octocat"
+      })
+    ).toEqual({
+      githubUserAccessTokenEncrypted: "",
+      githubRefreshTokenEncrypted: "",
+      githubTokenExpiresAt: null,
+      githubRefreshTokenExpiresAt: null,
+      githubAccountLogin: null,
+      githubAccountName: null
+    });
+  });
+});

--- a/tests/unit/home-view.test.tsx
+++ b/tests/unit/home-view.test.tsx
@@ -36,9 +36,15 @@ function createProviderProfile() {
     mergedTargetTokens: 1600,
     visionMode: "native" as const,
     visionMcpServerId: null,
+    providerKind: "openai_compatible" as "openai_compatible" | "github_copilot",
+    githubTokenExpiresAt: null,
+    githubRefreshTokenExpiresAt: null,
+    githubAccountLogin: null,
+    githubAccountName: null,
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
-    hasApiKey: true
+    hasApiKey: true,
+    githubConnectionStatus: "disconnected" as "disconnected" | "connected" | "expired"
   };
 }
 

--- a/tests/unit/provider.test.ts
+++ b/tests/unit/provider.test.ts
@@ -37,6 +37,7 @@ function createSettings(
   overrides: Partial<{
     id: string;
     name: string;
+    providerKind: "openai_compatible" | "github_copilot";
     apiBaseUrl: string;
     apiKeyEncrypted: string;
     apiKey: string;
@@ -50,6 +51,12 @@ function createSettings(
     modelContextLimit: number;
     compactionThreshold: number;
     freshTailCount: number;
+    githubUserAccessTokenEncrypted: string;
+    githubRefreshTokenEncrypted: string;
+    githubTokenExpiresAt: string | null;
+    githubRefreshTokenExpiresAt: string | null;
+    githubAccountLogin: string | null;
+    githubAccountName: string | null;
     createdAt: string;
     updatedAt: string;
   }> = {}
@@ -57,6 +64,7 @@ function createSettings(
   return {
     id: "profile_test",
     name: "Test profile",
+    providerKind: "openai_compatible",
     apiBaseUrl: "https://api.example.com/v1",
     apiKeyEncrypted: "",
     apiKey: "sk-test",
@@ -78,6 +86,12 @@ function createSettings(
     mergedTargetTokens: 1600,
     visionMode: "native" as const,
     visionMcpServerId: null,
+    githubUserAccessTokenEncrypted: "",
+    githubRefreshTokenEncrypted: "",
+    githubTokenExpiresAt: null,
+    githubRefreshTokenExpiresAt: null,
+    githubAccountLogin: null,
+    githubAccountName: null,
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
     ...overrides
@@ -89,6 +103,46 @@ describe("provider integration", () => {
     responsesCreate.mockReset();
     chatCreate.mockReset();
     getAttachmentDataUrl.mockClear();
+  });
+
+  it("routes github copilot profiles through the copilot client", async () => {
+    const runGithubCopilotChat = vi.fn().mockResolvedValue("connected");
+
+    vi.doMock("@/lib/github-copilot", () => ({
+      runGithubCopilotChat,
+      ensureFreshGithubAccessToken: vi.fn(async (profile) => profile),
+      streamGithubCopilotChat: vi.fn(),
+      buildGithubCopilotClient: vi.fn(),
+      listGithubCopilotModels: vi.fn(),
+      getGithubConnectionStatus: vi.fn(),
+      shouldRefreshGithubToken: vi.fn(),
+      clearGithubCopilotConnection: vi.fn(),
+      createGithubOauthState: vi.fn(),
+      verifyGithubOauthState: vi.fn(),
+      getGithubAuthorizeUrl: vi.fn(),
+      exchangeGithubCodeForTokens: vi.fn(),
+      refreshGithubUserToken: vi.fn()
+    }));
+
+    const { callProviderText } = await import("@/lib/provider");
+
+    await expect(
+      callProviderText({
+        settings: createSettings({
+          providerKind: "github_copilot",
+          apiKey: "",
+          apiBaseUrl: ""
+        }),
+        prompt: "Reply with connected",
+        purpose: "test"
+      })
+    ).resolves.toBe("connected");
+
+    expect(runGithubCopilotChat).toHaveBeenCalledOnce();
+    expect(responsesCreate).not.toHaveBeenCalled();
+    expect(chatCreate).not.toHaveBeenCalled();
+
+    vi.doUnmock("@/lib/github-copilot");
   });
 
   it("calls responses text generation and returns output text", async () => {

--- a/tests/unit/providers-section.test.tsx
+++ b/tests/unit/providers-section.test.tsx
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import { ProvidersSection } from "@/components/settings/sections/providers-section";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    refresh: vi.fn()
+  })
+}));
+
+describe("providers section", () => {
+  beforeEach(() => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ servers: [], models: [] })
+    } as Response);
+  });
+
+  it("shows github connection controls for copilot profiles", async () => {
+    render(
+      React.createElement(ProvidersSection, {
+        settings: {
+          defaultProviderProfileId: "profile_copilot",
+          skillsEnabled: true,
+          providerProfiles: [
+            {
+              id: "profile_copilot",
+              providerKind: "github_copilot",
+              name: "Copilot",
+              apiBaseUrl: "",
+              model: "openai/gpt-4.1",
+              apiMode: "responses",
+              systemPrompt: "Be exact.",
+              temperature: 0.2,
+              maxOutputTokens: 512,
+              reasoningEffort: "medium",
+              reasoningSummaryEnabled: true,
+              modelContextLimit: 16000,
+              compactionThreshold: 0.8,
+              freshTailCount: 12,
+              tokenizerModel: "gpt-tokenizer",
+              safetyMarginTokens: 1200,
+              leafSourceTokenLimit: 12000,
+              leafMinMessageCount: 6,
+              mergedMinNodeCount: 4,
+              mergedTargetTokens: 1600,
+              visionMode: "native",
+              visionMcpServerId: null,
+              githubAccountLogin: null,
+              githubAccountName: null,
+              githubTokenExpiresAt: null,
+              githubRefreshTokenExpiresAt: null,
+              githubConnectionStatus: "disconnected",
+              createdAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString(),
+              hasApiKey: false
+            }
+          ],
+          updatedAt: new Date().toISOString()
+        }
+      })
+    );
+
+    expect(screen.getByRole("button", { name: "Connect GitHub" })).toBeInTheDocument();
+    expect(screen.queryByLabelText("API key")).toBeNull();
+  });
+
+  it("shows fetched github models for a connected copilot profile", async () => {
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        servers: [],
+        models: [{ id: "openai/gpt-4.1", name: "GPT-4.1" }]
+      })
+    } as Response);
+
+    render(
+      React.createElement(ProvidersSection, {
+        settings: {
+          defaultProviderProfileId: "profile_copilot",
+          skillsEnabled: true,
+          providerProfiles: [
+            {
+              id: "profile_copilot",
+              providerKind: "github_copilot",
+              name: "Copilot",
+              apiBaseUrl: "",
+              model: "openai/gpt-4.1",
+              apiMode: "responses",
+              systemPrompt: "Be exact.",
+              temperature: 0.2,
+              maxOutputTokens: 512,
+              reasoningEffort: "medium",
+              reasoningSummaryEnabled: true,
+              modelContextLimit: 16000,
+              compactionThreshold: 0.8,
+              freshTailCount: 12,
+              tokenizerModel: "gpt-tokenizer",
+              safetyMarginTokens: 1200,
+              leafSourceTokenLimit: 12000,
+              leafMinMessageCount: 6,
+              mergedMinNodeCount: 4,
+              mergedTargetTokens: 1600,
+              visionMode: "native",
+              visionMcpServerId: null,
+              githubAccountLogin: "octocat",
+              githubAccountName: "The Octocat",
+              githubTokenExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+              githubRefreshTokenExpiresAt: new Date(Date.now() + 3600_000).toISOString(),
+              githubConnectionStatus: "connected",
+              createdAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString(),
+              hasApiKey: false
+            }
+          ],
+          updatedAt: new Date().toISOString()
+        }
+      })
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("option", { name: "GPT-4.1" })).toBeInTheDocument();
+    });
+  });
+});

--- a/tests/unit/settings.test.ts
+++ b/tests/unit/settings.test.ts
@@ -232,4 +232,112 @@ describe("settings storage", () => {
       })
     ).toThrow();
   });
+
+  it("stores github copilot profiles without requiring an api key", () => {
+    const copilot = {
+      ...buildProfile({
+        id: "profile_copilot",
+        name: "Copilot"
+      }),
+      providerKind: "github_copilot" as const,
+      apiKey: "",
+      apiBaseUrl: "",
+      githubUserAccessTokenEncrypted: "",
+      githubRefreshTokenEncrypted: "",
+      githubTokenExpiresAt: null,
+      githubRefreshTokenExpiresAt: null,
+      githubAccountLogin: null,
+      githubAccountName: null
+    };
+
+    updateSettings({
+      defaultProviderProfileId: copilot.id,
+      skillsEnabled: true,
+      providerProfiles: [copilot]
+    });
+
+    const stored = getProviderProfile(copilot.id);
+
+    expect(stored?.providerKind).toBe("github_copilot");
+    expect(stored?.apiKeyEncrypted).toBe("");
+  });
+
+  it("keeps duplicated copilot profiles disconnected", () => {
+    const connected = {
+      ...buildProfile({
+        id: "profile_copilot",
+        name: "Copilot"
+      }),
+      providerKind: "github_copilot" as const,
+      apiKey: "",
+      apiBaseUrl: "",
+      githubUserAccessTokenEncrypted: "ciphertext-access",
+      githubRefreshTokenEncrypted: "ciphertext-refresh",
+      githubTokenExpiresAt: "2026-04-08T16:00:00.000Z",
+      githubRefreshTokenExpiresAt: "2026-10-08T16:00:00.000Z",
+      githubAccountLogin: "octocat",
+      githubAccountName: "The Octocat"
+    };
+
+    const duplicate = {
+      ...connected,
+      id: "profile_copilot_copy",
+      name: "Copilot Copy",
+      githubUserAccessTokenEncrypted: "",
+      githubRefreshTokenEncrypted: "",
+      githubTokenExpiresAt: null,
+      githubRefreshTokenExpiresAt: null,
+      githubAccountLogin: null,
+      githubAccountName: null
+    };
+
+    updateSettings({
+      defaultProviderProfileId: connected.id,
+      skillsEnabled: true,
+      providerProfiles: [connected, duplicate]
+    });
+
+    expect(getProviderProfile("profile_copilot_copy")).toMatchObject({
+      providerKind: "github_copilot",
+      githubUserAccessTokenEncrypted: "",
+      githubRefreshTokenEncrypted: "",
+      githubAccountLogin: null
+    });
+  });
+
+  it("does not expose github oauth credentials in sanitized settings", () => {
+    const copilot = {
+      ...buildProfile({
+        id: "profile_copilot",
+        name: "Copilot"
+      }),
+      providerKind: "github_copilot" as const,
+      apiKey: "",
+      apiBaseUrl: "",
+      githubUserAccessTokenEncrypted: "ciphertext-access",
+      githubRefreshTokenEncrypted: "ciphertext-refresh",
+      githubTokenExpiresAt: "2026-04-08T16:00:00.000Z",
+      githubRefreshTokenExpiresAt: "2026-10-08T16:00:00.000Z",
+      githubAccountLogin: "octocat",
+      githubAccountName: "The Octocat"
+    };
+
+    updateSettings({
+      defaultProviderProfileId: copilot.id,
+      skillsEnabled: true,
+      providerProfiles: [copilot]
+    });
+
+    const settings = getSanitizedSettings();
+    const profile = settings.providerProfiles.find((entry) => entry.id === copilot.id);
+
+    expect(profile).toMatchObject({
+      id: "profile_copilot",
+      providerKind: "github_copilot",
+      githubAccountLogin: "octocat",
+      githubConnectionStatus: "connected"
+    });
+    expect("githubUserAccessTokenEncrypted" in (profile ?? {})).toBe(false);
+    expect("githubRefreshTokenEncrypted" in (profile ?? {})).toBe(false);
+  });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from "vitest/config";
 import path from "node:path";
 
 export default defineConfig({
+  esbuild: {
+    jsx: "automatic"
+  },
   resolve: {
     alias: {
       "@": path.resolve(__dirname)


### PR DESCRIPTION
## Summary

Adds a GitHub Copilot provider that routes chat through a Copilot subscription via OAuth, along with numerous UX fixes discovered during end-to-end testing.

Key changes:
- GitHub OAuth flow (connect/disconnect) with encrypted token persistence
- Copilot SDK streaming integration (async generator bridging callback events)
- Provider settings UI: hides irrelevant fields for Copilot, shows model picker with auto-filled context limit, placeholder when not connected
- Chat route guards for Copilot auth (both HTTP and WebSocket)
- Zod validation relaxed for Copilot profiles (model/systemPrompt not required)
- Copilot CLI built-in tools disabled, system prompt replaced to prevent filesystem access
- Docker and docker-compose examples include EIDON_GITHUB_APP_* vars

## Test plan

- [ ] Add a new provider profile, switch to GitHub Copilot — model and system prompt fields clear
- [ ] Advanced settings hide temperature, max output tokens, API mode, tokenizer, compaction fields for Copilot
- [ ] Click "Connect GitHub" — saves settings first, then redirects to GitHub OAuth
- [ ] After OAuth callback, redirected to /settings/providers with connected status
- [ ] Model dropdown populates after connecting, selecting a model auto-fills context limit
- [ ] Start a Copilot chat — receives streamed answer and thinking content
- [ ] Start a Copilot chat without connecting GitHub — shows appropriate error
- [ ] `npm run lint` and `npm run test` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)