### PR TITLE
Fix local shell runner fallback

### DIFF
--- a/lib/local-shell.ts
+++ b/lib/local-shell.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { accessSync, constants as fsConstants } from "node:fs";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 const MAX_OUTPUT_CHARS = 8_000;
@@ -59,6 +60,25 @@ function validateCommand(command: string, allowedPrefixes: string[]) {
   return trimmed;
 }
 
+function resolveShellPath() {
+  const shellPath = process.env.SHELL?.trim();
+
+  if (!shellPath) {
+    return "/bin/sh";
+  }
+
+  if (!shellPath.includes("/")) {
+    return shellPath;
+  }
+
+  try {
+    accessSync(shellPath, fsConstants.X_OK);
+    return shellPath;
+  } catch {
+    return "/bin/sh";
+  }
+}
+
 export async function executeLocalShellCommand(input: {
   command: string;
   allowedPrefixes: string[];
@@ -69,7 +89,7 @@ export async function executeLocalShellCommand(input: {
   const timeoutMs = input.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 
   return await new Promise<ShellExecutionResult>((resolve) => {
-    const child = spawn("zsh", ["-lc", command], {
+    const child = spawn(resolveShellPath(), ["-lc", command], {
       cwd: input.cwd ?? process.cwd(),
       env: process.env
     });
@@ -77,6 +97,17 @@ export async function executeLocalShellCommand(input: {
     let stdout = "";
     let stderr = "";
     let timedOut = false;
+    let settled = false;
+
+    const finish = (result: ShellExecutionResult) => {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    };
 
     const timer = setTimeout(() => {
       timedOut = true;
@@ -91,10 +122,18 @@ export async function executeLocalShellCommand(input: {
       stderr += chunk.toString();
     });
 
-    child.on("close", (exitCode) => {
-      clearTimeout(timer);
+    child.on("error", (error) => {
+      finish({
+        stdout: truncateOutput(stdout.trim()),
+        stderr: truncateOutput((stderr ? `${stderr}\n` : "") + error.message),
+        exitCode: null,
+        timedOut,
+        isError: true
+      });
+    });
 
-      resolve({
+    child.on("close", (exitCode) => {
+      finish({
         stdout: truncateOutput(stdout.trim()),
         stderr: truncateOutput(stderr.trim()),
         exitCode,

--- a/tests/unit/local-shell.test.ts
+++ b/tests/unit/local-shell.test.ts
@@ -13,9 +13,25 @@ class MockChild extends EventEmitter {
 }
 
 describe("local shell", () => {
+  const originalShell = process.env.SHELL;
+  const expectedInitialShell = originalShell?.trim() || "/bin/sh";
+  const restoreShellEnv = () => {
+    if (originalShell === undefined) {
+      delete process.env.SHELL;
+      return;
+    }
+
+    process.env.SHELL = originalShell;
+  };
+
   beforeEach(() => {
     spawnMock.mockReset();
     vi.useRealTimers();
+    restoreShellEnv();
+  });
+
+  afterAll(() => {
+    restoreShellEnv();
   });
 
   it("rejects empty, unsafe, and disallowed commands", async () => {
@@ -55,7 +71,7 @@ describe("local shell", () => {
     });
 
     expect(spawnMock).toHaveBeenCalledWith(
-      "zsh",
+      expectedInitialShell,
       ["-lc", "git status && git diff"],
       expect.objectContaining({
         cwd: "/tmp/eidon",
@@ -75,6 +91,96 @@ describe("local shell", () => {
     expect(result.stdout.endsWith("...[truncated]")).toBe(true);
     expect(result.stderr).toBe("warning");
     expect(summarizeShellResult(result)).toContain("warning");
+  });
+
+  it("falls back to /bin/sh when SHELL is unavailable", async () => {
+    delete process.env.SHELL;
+
+    const { executeLocalShellCommand } = await import("@/lib/local-shell");
+    const child = new MockChild();
+    spawnMock.mockReturnValue(child);
+
+    const resultPromise = executeLocalShellCommand({
+      command: "git status",
+      allowedPrefixes: ["git"]
+    });
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      "/bin/sh",
+      ["-lc", "git status"],
+      expect.objectContaining({
+        cwd: process.cwd(),
+        env: process.env
+      })
+    );
+
+    child.emit("close", 0);
+
+    await expect(resultPromise).resolves.toMatchObject({
+      exitCode: 0,
+      timedOut: false,
+      isError: false
+    });
+  });
+
+  it("falls back to /bin/sh when SHELL points to a missing binary", async () => {
+    process.env.SHELL = "/missing/zsh";
+
+    const { executeLocalShellCommand } = await import("@/lib/local-shell");
+    const child = new MockChild();
+    spawnMock.mockReturnValue(child);
+
+    const resultPromise = executeLocalShellCommand({
+      command: "git status",
+      allowedPrefixes: ["git"]
+    });
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      "/bin/sh",
+      ["-lc", "git status"],
+      expect.objectContaining({
+        cwd: process.cwd(),
+        env: process.env
+      })
+    );
+
+    child.emit("close", 0);
+
+    await expect(resultPromise).resolves.toMatchObject({
+      exitCode: 0,
+      timedOut: false,
+      isError: false
+    });
+  });
+
+  it("returns a structured error when spawn fails before close", async () => {
+    const { executeLocalShellCommand, summarizeShellResult } = await import("@/lib/local-shell");
+    const child = new MockChild();
+    spawnMock.mockReturnValue(child);
+
+    const resultPromise = executeLocalShellCommand({
+      command: "git status",
+      allowedPrefixes: ["git"]
+    });
+
+    child.emit("error", new Error("spawn zsh ENOENT"));
+
+    await expect(resultPromise).resolves.toMatchObject({
+      stdout: "",
+      stderr: "spawn zsh ENOENT",
+      exitCode: null,
+      timedOut: false,
+      isError: true
+    });
+    expect(
+      summarizeShellResult({
+        stdout: "",
+        stderr: "spawn zsh ENOENT",
+        exitCode: null,
+        timedOut: false,
+        isError: true
+      })
+    ).toBe("spawn zsh ENOENT");
   });
 
   it("marks timed out commands as errors and summarizes empty output states", async () => {

--- a/tests/unit/local-shell.test.ts
+++ b/tests/unit/local-shell.test.ts
@@ -153,6 +153,36 @@ describe("local shell", () => {
     });
   });
 
+  it("uses a relative SHELL command name as-is", async () => {
+    process.env.SHELL = "zsh";
+
+    const { executeLocalShellCommand } = await import("@/lib/local-shell");
+    const child = new MockChild();
+    spawnMock.mockReturnValue(child);
+
+    const resultPromise = executeLocalShellCommand({
+      command: "git status",
+      allowedPrefixes: ["git"]
+    });
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      "zsh",
+      ["-lc", "git status"],
+      expect.objectContaining({
+        cwd: process.cwd(),
+        env: process.env
+      })
+    );
+
+    child.emit("close", 0);
+
+    await expect(resultPromise).resolves.toMatchObject({
+      exitCode: 0,
+      timedOut: false,
+      isError: false
+    });
+  });
+
   it("returns a structured error when spawn fails before close", async () => {
     const { executeLocalShellCommand, summarizeShellResult } = await import("@/lib/local-shell");
     const child = new MockChild();
@@ -181,6 +211,28 @@ describe("local shell", () => {
         isError: true
       })
     ).toBe("spawn zsh ENOENT");
+  });
+
+  it("ignores duplicate completion events after the command has already settled", async () => {
+    const { executeLocalShellCommand } = await import("@/lib/local-shell");
+    const child = new MockChild();
+    spawnMock.mockReturnValue(child);
+
+    const resultPromise = executeLocalShellCommand({
+      command: "git status",
+      allowedPrefixes: ["git"]
+    });
+
+    child.emit("error", new Error("spawn zsh ENOENT"));
+    child.emit("close", 0);
+
+    await expect(resultPromise).resolves.toMatchObject({
+      stdout: "",
+      stderr: "spawn zsh ENOENT",
+      exitCode: null,
+      timedOut: false,
+      isError: true
+    });
   });
 
   it("marks timed out commands as errors and summarizes empty output states", async () => {


### PR DESCRIPTION
This updates the local shell command runner to stop hardcoding zsh, prefer the SHELL environment when it is usable, and fall back to /bin/sh when it is missing or invalid. It also handles child-process spawn errors so failed shell launches return a tool error instead of hanging. The PR adds regression coverage for missing SHELL, invalid shell paths, and spawn failures before close. Verification: npx vitest run tests/unit/local-shell.test.ts tests/unit/assistant-runtime.test.ts --coverage.enabled false, npx eslint lib/local-shell.ts tests/unit/local-shell.test.ts, and docker-based local-shell regression tests on node:22-bookworm-slim.