### PR TITLE
Fix default MCP timeout display

### DIFF
--- a/docs/superpowers/plans/2026-04-09-mcp-timeout-default.md
+++ b/docs/superpowers/plans/2026-04-09-mcp-timeout-default.md
@@ -1,0 +1,91 @@
+# MCP Timeout Default Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the General settings page show a default MCP tool call timeout of 120 seconds while still allowing users to save a different value.
+
+**Architecture:** Keep the fix at the settings data boundary. `getSettings()` should return the persisted `mcp_timeout` value so server-rendered settings pages hydrate with the existing database default and any saved override. Add a regression test in the settings storage suite, then validate the rendered settings page end to end.
+
+**Tech Stack:** Next.js App Router, React, TypeScript, SQLite, Vitest, Playwright/browser validation
+
+---
+
+### Task 1: Restore `mcp_timeout` in settings reads
+
+**Files:**
+- Modify: `tests/unit/settings.test.ts`
+- Modify: `lib/settings.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+it("returns the default MCP timeout from persisted settings", () => {
+  const alpha = buildProfile({
+    id: "profile_alpha",
+    name: "Alpha",
+    apiKey: "sk-alpha"
+  });
+
+  updateSettings({
+    defaultProviderProfileId: alpha.id,
+    skillsEnabled: true,
+    providerProfiles: [alpha]
+  });
+
+  expect(getSettings().mcpTimeout).toBe(120_000);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- tests/unit/settings.test.ts --runInBand`
+Expected: FAIL on the new assertion because `getSettings()` returns `undefined` for `mcpTimeout`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+export function getSettings() {
+  const row = getDb()
+    .prepare(
+      `SELECT
+        default_provider_profile_id,
+        skills_enabled,
+        conversation_retention,
+        auto_compaction,
+        memories_enabled,
+        memories_max_count,
+        mcp_timeout,
+        updated_at
+      FROM app_settings
+      WHERE id = ?`
+    )
+    .get(SETTINGS_ROW_ID) as AppSettingsRow;
+
+  return rowToSettings(row);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- tests/unit/settings.test.ts --runInBand`
+Expected: PASS
+
+### Task 2: Validate the settings UI
+
+**Files:**
+- Verify: `components/settings/sections/general-section.tsx`
+
+- [ ] **Step 1: Start or reuse the dev server**
+
+Run: check `.dev-server`; if missing or stale, run `npm run dev`
+Expected: a live local URL written to `.dev-server`
+
+- [ ] **Step 2: Open the General settings page and confirm the default value**
+
+Run: browser validation against `/settings/general`
+Expected: the `Max tool call timeout` input shows `120`
+
+- [ ] **Step 3: Confirm user editability still works**
+
+Run: change the input to another valid value, save, and confirm the new value remains after refresh
+Expected: user-entered timeout persists

--- a/lib/settings.ts
+++ b/lib/settings.ts
@@ -369,6 +369,7 @@ export function getSettings() {
         auto_compaction,
         memories_enabled,
         memories_max_count,
+        mcp_timeout,
         updated_at
       FROM app_settings
       WHERE id = ?`

--- a/package-lock.json
+++ b/package-lock.json
@@ -2013,7 +2013,7 @@
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
       "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.58.2"
@@ -3145,7 +3145,6 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -3155,7 +3154,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -4870,7 +4869,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -9700,7 +9698,7 @@
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
       "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.58.2"
@@ -9719,7 +9717,7 @@
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
       "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"

--- a/tests/unit/settings.test.ts
+++ b/tests/unit/settings.test.ts
@@ -219,6 +219,39 @@ describe("settings storage", () => {
     expect(listProviderProfiles()[0].reasoningSummaryEnabled).toBe(false);
   });
 
+  it("returns the default MCP timeout from persisted settings", () => {
+    const alpha = buildProfile({
+      id: "profile_alpha",
+      name: "Alpha",
+      apiKey: "sk-alpha"
+    });
+
+    updateSettings({
+      defaultProviderProfileId: alpha.id,
+      skillsEnabled: true,
+      providerProfiles: [alpha]
+    });
+
+    expect(getSettings().mcpTimeout).toBe(120_000);
+  });
+
+  it("returns a saved non-default MCP timeout", () => {
+    const alpha = buildProfile({
+      id: "profile_alpha",
+      name: "Alpha",
+      apiKey: "sk-alpha"
+    });
+
+    updateSettings({
+      defaultProviderProfileId: alpha.id,
+      skillsEnabled: true,
+      mcpTimeout: 45_000,
+      providerProfiles: [alpha]
+    });
+
+    expect(getSettings().mcpTimeout).toBe(45_000);
+  });
+
   it("rejects duplicate profile ids and invalid defaults", () => {
     const alpha = buildProfile({
       id: "profile_alpha"


### PR DESCRIPTION
Restore the MCP timeout setting read path so the General settings page shows the stored 120-second default instead of an empty field.

Add unit coverage for both the default timeout and a saved non-default override, and include the implementation plan artifact used for the change.

Validation: `npm test`, plus browser verification that `/settings/general` shows `120` by default and persists an edited value after save.