### PR TITLE
Split Docker PR checks by scope

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,6 +19,22 @@ jobs:
       - name: Lowercase repository name
         run: echo "REPO_LOWERCASE=${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
 
+      - name: Detect deployment-sensitive changes
+        id: changes
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            deployment:
+              - 'Dockerfile'
+              - '.dockerignore'
+              - '.github/workflows/docker.yml'
+              - '.github/workflows/test.yml'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'next.config.*'
+              - 'server.cjs'
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -29,10 +45,25 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build Docker image
+      - name: Build full production image
+        if: github.event_name == 'push' || steps.changes.outputs.deployment == 'true'
         uses: docker/build-push-action@v6
         with:
           context: .
+          push: false
+          cache-from: |
+            type=gha
+            type=registry,ref=ghcr.io/${{ env.REPO_LOWERCASE }}/buildcache:main
+          cache-to: |
+            type=gha,mode=max
+            type=registry,ref=ghcr.io/${{ env.REPO_LOWERCASE }}/buildcache:main,mode=max
+
+      - name: Build lightweight builder image
+        if: github.event_name == 'pull_request' && steps.changes.outputs.deployment != 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: builder
           push: false
           cache-from: |
             type=gha

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,6 +12,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      pull-requests: read
 
     steps:
       - uses: actions/checkout@v4
@@ -33,6 +34,7 @@ jobs:
               - 'package.json'
               - 'package-lock.json'
               - 'next.config.*'
+              - 'public/**'
               - 'server.cjs'
 
       - name: Set up Docker Buildx

--- a/docs/superpowers/plans/2026-04-09-faster-docker-pr-gate.md
+++ b/docs/superpowers/plans/2026-04-09-faster-docker-pr-gate.md
@@ -1,0 +1,197 @@
+# Faster Docker PR Gate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reduce PR CI latency by running a lightweight Docker build for normal PRs while preserving full production-image builds on `main` and on deployment-sensitive PRs.
+
+**Architecture:** Keep the existing Docker workflow in a single file and add an explicit change-detection step for PRs. Use that result to choose between a `builder`-target Docker build for normal PRs and the full default image build for deployment-sensitive PRs or pushes to `main`.
+
+**Tech Stack:** GitHub Actions, Docker Buildx, docker/build-push-action, dorny/paths-filter, npm, Vitest
+
+---
+
+## File Structure
+
+- Modify: `.github/workflows/docker.yml`
+  Purpose: Split PR Docker validation into lightweight and full-image paths while preserving full builds on `main`.
+- Reference: `Dockerfile`
+  Purpose: Confirm the `builder` stage is the correct lightweight target and the `runner` stage remains the full-image path.
+- Reference/Test: `.github/workflows/test.yml`
+  Purpose: Confirm the existing PR test gate remains unchanged and still covers application correctness.
+
+### Task 1: Add explicit PR change detection and split Docker build modes
+
+**Files:**
+- Modify: `.github/workflows/docker.yml`
+
+- [ ] **Step 1: Inspect the current workflow and identify the exact build step to replace**
+
+Run:
+
+```bash
+sed -n '1,220p' .github/workflows/docker.yml
+```
+
+Expected: one `build` job with a single `docker/build-push-action@v6` step that always builds the full image for PRs and pushes to `main`.
+
+- [ ] **Step 2: Edit the workflow to detect deployment-sensitive changes on PRs**
+
+Replace the current workflow contents with:
+
+```yaml
+name: Docker Build
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Lowercase repository name
+        run: echo "REPO_LOWERCASE=${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
+
+      - name: Detect deployment-sensitive changes
+        id: changes
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            deployment:
+              - 'Dockerfile'
+              - '.dockerignore'
+              - '.github/workflows/docker.yml'
+              - '.github/workflows/test.yml'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'next.config.*'
+              - 'server.cjs'
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build full production image
+        if: github.event_name == 'push' || steps.changes.outputs.deployment == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          cache-from: |
+            type=gha
+            type=registry,ref=ghcr.io/${{ env.REPO_LOWERCASE }}/buildcache:main
+          cache-to: |
+            type=gha,mode=max
+            type=registry,ref=ghcr.io/${{ env.REPO_LOWERCASE }}/buildcache:main,mode=max
+
+      - name: Build lightweight builder image
+        if: github.event_name == 'pull_request' && steps.changes.outputs.deployment != 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: builder
+          push: false
+          cache-from: |
+            type=gha
+            type=registry,ref=ghcr.io/${{ env.REPO_LOWERCASE }}/buildcache:main
+          cache-to: |
+            type=gha,mode=max
+            type=registry,ref=ghcr.io/${{ env.REPO_LOWERCASE }}/buildcache:main,mode=max
+```
+
+Expected: the workflow now has one change-detection step and two mutually exclusive Docker build steps with explicit names.
+
+- [ ] **Step 3: Review the edited workflow for branching correctness**
+
+Run:
+
+```bash
+sed -n '1,260p' .github/workflows/docker.yml
+```
+
+Expected:
+- PRs always run the `Detect deployment-sensitive changes` step
+- PRs touching deployment files run `Build full production image`
+- PRs not touching deployment files run `Build lightweight builder image`
+- pushes to `main` skip change detection and run `Build full production image`
+
+- [ ] **Step 4: Commit the workflow split**
+
+Run:
+
+```bash
+git add .github/workflows/docker.yml
+git commit -m "ci: split docker PR gate by change scope"
+```
+
+Expected: a single commit containing only the workflow split.
+
+### Task 2: Verify lightweight and full Docker builds still work locally
+
+**Files:**
+- Reference: `Dockerfile`
+
+- [ ] **Step 1: Run the existing automated test suite**
+
+Run:
+
+```bash
+npm test
+```
+
+Expected: PASS with coverage output and no regressions.
+
+- [ ] **Step 2: Run the lightweight Docker build locally**
+
+Run:
+
+```bash
+docker build --target builder -t eidon:builder-check .
+```
+
+Expected: PASS and completion after the Next.js build and `ws-handler` bundle steps, without entering the heavy runtime package-install layer.
+
+- [ ] **Step 3: Run the full Docker build locally**
+
+Run:
+
+```bash
+docker build -t eidon:full-check .
+```
+
+Expected: PASS and completion through the final `runner` stage including Chromium and `agent-browser` installation.
+
+- [ ] **Step 4: Inspect the final diff and recent commits**
+
+Run:
+
+```bash
+git diff --stat HEAD~1..HEAD && git log --oneline -n 3
+```
+
+Expected: the last commit is `ci: split docker PR gate by change scope`, and the diff only contains the intended workflow change.
+
+## Self-Review
+
+- Spec coverage:
+  - Lightweight PR build path: covered in Task 1 Step 2.
+  - Deployment-sensitive PR escalation: covered in Task 1 Step 2.
+  - Full `main` build retention: covered in Task 1 Step 2.
+  - Verification of tests and both Docker modes: covered in Task 2.
+- Placeholder scan: no `TODO`, `TBD`, or underspecified steps remain.
+- Type consistency: workflow step names, path-filter output key, and Docker target names are consistent throughout the plan.

--- a/docs/superpowers/specs/2026-04-09-faster-docker-pr-gate-design.md
+++ b/docs/superpowers/specs/2026-04-09-faster-docker-pr-gate-design.md
@@ -1,0 +1,102 @@
+# Faster Docker PR Gate
+
+## Summary
+
+Reduce pull request wait time by splitting the Docker CI gate into two levels:
+
+- Most PRs run a lightweight Docker build that validates the application can still build inside Docker.
+- Full production image builds run on pushes to `main` and on PRs that touch deployment-sensitive files.
+
+This keeps a pre-merge Docker-aware quality gate while avoiding repeated 10-minute runtime image builds for small fixes. The existing post-merge deployment webhook remains the final production validation step because it already rebuilds with `docker compose up -d --build` and alerts on failure.
+
+## Current State
+
+- [`.github/workflows/docker.yml`](../../../.github/workflows/docker.yml) runs on every PR to `main` and every push to `main`.
+- The workflow builds the full image from [`Dockerfile`](../../../Dockerfile) with `docker/build-push-action@v6`.
+- The Docker `runner` stage installs `chromium` and global `agent-browser`, which adds substantial time to CI and is not relevant to most application-only changes.
+- [`.github/workflows/test.yml`](../../../.github/workflows/test.yml) already runs `npm ci` and `npm test` on PRs.
+- Production deployment already rebuilds from `main` through an external webhook, and failures are surfaced through alerting.
+
+## Goals
+
+- Cut PR feedback time for small fixes.
+- Preserve a Docker-based pre-merge signal for normal code changes.
+- Preserve full runtime-image validation before or at branch head for deployment-sensitive changes.
+- Avoid duplicating the same expensive runtime build on every PR when deployment already rebuilds from `main`.
+
+## Non-Goals
+
+- Replace the existing deployment webhook.
+- Remove Docker validation from CI entirely.
+- Redesign the Dockerfile beyond what is necessary for the workflow split.
+
+## Design
+
+### PR behavior
+
+For `pull_request` events targeting `main`, the Docker workflow will choose between two paths:
+
+1. Default path: build a lightweight Docker target, expected to be the `builder` stage.
+2. Escalated path: build the full default image when the PR touches deployment-sensitive files.
+
+The lightweight path validates that:
+
+- dependencies install successfully inside Docker
+- source code copies cleanly into the Docker context
+- `npm run build` succeeds in the Docker builder stage
+- the PR has not broken Docker-specific build assumptions for the app itself
+
+The lightweight path does not validate runtime-only layers such as Chromium installation or global `agent-browser` installation.
+
+### Deployment-sensitive file detection
+
+Full image builds should still run on PRs when any of the following change:
+
+- [`Dockerfile`](../../../Dockerfile)
+- [`.dockerignore`](../../../.dockerignore)
+- [`.github/workflows/docker.yml`](../../../.github/workflows/docker.yml)
+- [`.github/workflows/test.yml`](../../../.github/workflows/test.yml)
+- deployment documentation in [`README.md`](../../../README.md)
+
+This list is intentionally conservative. It covers files that can affect Docker build semantics, CI behavior, or operational deployment instructions.
+
+### `main` behavior
+
+For pushes to `main`, the workflow continues to build the full production image.
+
+This provides:
+
+- a branch-head CI signal for the real runtime image
+- cache warm-up for subsequent builds
+- a second line of defense before the post-merge deploy rebuild and alert path
+
+### Workflow shape
+
+The Docker workflow should be restructured so the build target and step naming are explicit rather than implicit. A simple approach is:
+
+- compute whether the PR touched deployment-sensitive files
+- use that result to choose either `target: builder` or the default full image build
+- keep existing Buildx cache usage
+
+The workflow should remain a single file unless complexity forces a split. The point is faster execution, not a more fragmented CI layout.
+
+## Testing and Validation
+
+Implementation must verify:
+
+- normal PR path triggers the lightweight Docker build only
+- deployment-sensitive PR path triggers the full image build
+- push to `main` still triggers the full image build
+- existing unit test workflow still passes
+
+Local verification should include:
+
+- `npm test`
+- a local Docker build for the lightweight target
+- a local full Docker build
+
+## Expected Outcome
+
+- Most small PRs stop waiting for the heavy runtime image layer.
+- Docker-related regressions in application build logic are still caught before merge.
+- Runtime-image regressions are still caught on `main`, on deployment-sensitive PRs, and by the existing deployment rebuild alerting flow.

--- a/docs/superpowers/specs/2026-04-09-faster-docker-pr-gate-design.md
+++ b/docs/superpowers/specs/2026-04-09-faster-docker-pr-gate-design.md
@@ -56,9 +56,12 @@ Full image builds should still run on PRs when any of the following change:
 - [`.dockerignore`](../../../.dockerignore)
 - [`.github/workflows/docker.yml`](../../../.github/workflows/docker.yml)
 - [`.github/workflows/test.yml`](../../../.github/workflows/test.yml)
-- deployment documentation in [`README.md`](../../../README.md)
+- [`package.json`](../../../package.json)
+- [`package-lock.json`](../../../package-lock.json)
+- `next.config.*`
+- [`server.cjs`](../../../server.cjs)
 
-This list is intentionally conservative. It covers files that can affect Docker build semantics, CI behavior, or operational deployment instructions.
+This list is intentionally conservative. It covers files that can affect Docker build semantics, CI behavior, runtime dependency installation, or the final image layout.
 
 ### `main` behavior
 

--- a/docs/superpowers/specs/2026-04-09-faster-docker-pr-gate-design.md
+++ b/docs/superpowers/specs/2026-04-09-faster-docker-pr-gate-design.md
@@ -59,6 +59,7 @@ Full image builds should still run on PRs when any of the following change:
 - [`package.json`](../../../package.json)
 - [`package-lock.json`](../../../package-lock.json)
 - `next.config.*`
+- `public/**`
 - [`server.cjs`](../../../server.cjs)
 
 This list is intentionally conservative. It covers files that can affect Docker build semantics, CI behavior, runtime dependency installation, or the final image layout.
@@ -79,6 +80,7 @@ The Docker workflow should be restructured so the build target and step naming a
 
 - compute whether the PR touched deployment-sensitive files
 - use that result to choose either `target: builder` or the default full image build
+- grant the workflow `pull-requests: read` so PR file matching can access the changed-file list
 - keep existing Buildx cache usage
 
 The workflow should remain a single file unless complexity forces a split. The point is faster execution, not a more fragmented CI layout.


### PR DESCRIPTION
This changes the Docker PR gate so normal PRs build the lighter `builder` target, while pushes to `main` and deployment-sensitive PRs still build the full production image. It also grants the workflow `pull-requests: read` for path filtering and treats `public/**` as deployment-sensitive so final-image copy regressions still take the full path. The branch includes the matching design spec and implementation plan under `docs/superpowers/`. Verification run on this branch: `npm test`, `docker build --target builder -t eidon:builder-check .`, and `docker build -t eidon:full-check .`.