### PR TITLE
Compact the initial loading shell in chat

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -129,7 +129,7 @@ select {
 
 @keyframes typing-dot {
   0%, 60%, 100% { transform: translateY(0); opacity: 0.3; }
-  30% { transform: translateY(-6px); opacity: 1; }
+  30% { transform: translateY(calc(var(--typing-dot-lift, 6px) * -1)); opacity: 1; }
 }
 
 .animate-fade-in {

--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -19,13 +19,13 @@ import { normalizeMarkdownLineBreaks } from "@/lib/utils";
 const MARKDOWN_PLUGINS = [remarkGfm, remarkBreaks];
 const COPY_RESET_DELAY_MS = 1600;
 
-function TypingIndicator() {
+function TypingIndicator({ compact = false }: { compact?: boolean }) {
   return (
-    <div className="flex items-center gap-1.5 py-2 px-1">
+    <div className={compact ? "flex items-center gap-1" : "flex items-center gap-1.5 px-1 py-2"}>
       {[0, 1, 2].map((i) => (
         <div
           key={i}
-          className="h-1.5 w-1.5 rounded-full bg-white/40"
+          className="typing-dot h-1.5 w-1.5 rounded-full bg-white/40"
           style={{
             animation: "typing-dot 1.4s ease-in-out infinite",
             animationDelay: `${i * 0.2}s`
@@ -98,6 +98,8 @@ function CollapsibleActionRow({
 const ASSISTANT_MAX_WIDTH = "max-w-[96%] md:max-w-[95%]";
 const ASSISTANT_BUBBLE =
   "w-fit rounded-2xl border border-white/8 bg-white/[0.03] px-2.5 py-2 md:px-4 md:py-3 text-[var(--text)] shadow-[0_8px_24px_rgba(0,0,0,0.28)]";
+const ASSISTANT_LOADING_SHELL =
+  "inline-flex items-center rounded-lg border border-white/5 bg-white/[0.015] px-2 py-1";
 
 function getActionSignature(action: Pick<MessageAction, "kind" | "label" | "detail" | "toolName">) {
   return [action.kind, action.label, action.detail, action.toolName ?? ""].join("\u0000");
@@ -587,8 +589,11 @@ export function MessageBubble({
               compactionInProgress ? (
                 <CompactionIndicator />
               ) : (
-                <div className={`${ASSISTANT_MAX_WIDTH} ${ASSISTANT_BUBBLE}`} data-testid="assistant-message-bubble">
-                  <TypingIndicator />
+                <div
+                  className={ASSISTANT_LOADING_SHELL}
+                  data-testid="assistant-loading-shell"
+                >
+                  <TypingIndicator compact />
                 </div>
               )
             ) : assistantBlocks.length || content ? (

--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -27,6 +27,7 @@ function TypingIndicator({ compact = false }: { compact?: boolean }) {
           key={i}
           className="typing-dot h-1.5 w-1.5 rounded-full bg-white/40"
           style={{
+            ["--typing-dot-lift" as string]: compact ? "3px" : "6px",
             animation: "typing-dot 1.4s ease-in-out infinite",
             animationDelay: `${i * 0.2}s`
           }}
@@ -99,7 +100,7 @@ const ASSISTANT_MAX_WIDTH = "max-w-[96%] md:max-w-[95%]";
 const ASSISTANT_BUBBLE =
   "w-fit rounded-2xl border border-white/8 bg-white/[0.03] px-2.5 py-2 md:px-4 md:py-3 text-[var(--text)] shadow-[0_8px_24px_rgba(0,0,0,0.28)]";
 const ASSISTANT_LOADING_SHELL =
-  "inline-flex items-center rounded-lg border border-white/5 bg-white/[0.015] px-2 py-1";
+  "mt-1 inline-flex items-center overflow-hidden rounded-lg border border-white/5 bg-white/[0.015] px-2 py-1";
 
 function getActionSignature(action: Pick<MessageAction, "kind" | "label" | "detail" | "toolName">) {
   return [action.kind, action.label, action.detail, action.toolName ?? ""].join("\u0000");

--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -27,7 +27,7 @@ function TypingIndicator({ compact = false }: { compact?: boolean }) {
           key={i}
           className="typing-dot h-1.5 w-1.5 rounded-full bg-white/40"
           style={{
-            ["--typing-dot-lift" as string]: compact ? "3px" : "6px",
+            ["--typing-dot-lift" as string]: compact ? "2px" : "6px",
             animation: "typing-dot 1.4s ease-in-out infinite",
             animationDelay: `${i * 0.2}s`
           }}
@@ -100,7 +100,7 @@ const ASSISTANT_MAX_WIDTH = "max-w-[96%] md:max-w-[95%]";
 const ASSISTANT_BUBBLE =
   "w-fit rounded-2xl border border-white/8 bg-white/[0.03] px-2.5 py-2 md:px-4 md:py-3 text-[var(--text)] shadow-[0_8px_24px_rgba(0,0,0,0.28)]";
 const ASSISTANT_LOADING_SHELL =
-  "mt-1 inline-flex items-center overflow-hidden rounded-lg border border-white/5 bg-white/[0.015] px-2 py-1";
+  "mt-[6px] inline-flex items-center overflow-hidden rounded-lg border border-white/5 bg-white/[0.015] px-2 py-1";
 
 function getActionSignature(action: Pick<MessageAction, "kind" | "label" | "detail" | "toolName">) {
   return [action.kind, action.label, action.detail, action.toolName ?? ""].join("\u0000");

--- a/docs/superpowers/plans/2026-04-09-loading-indicator-size.md
+++ b/docs/superpowers/plans/2026-04-09-loading-indicator-size.md
@@ -1,0 +1,205 @@
+# Loading Indicator Size Adjustment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the pre-stream three-dot loading indicator visually match the compact thinking shell while keeping the dots-only appearance.
+
+**Architecture:** Keep the change isolated to the assistant loading branch in `MessageBubble`. Add a dedicated compact loading shell plus a targeted unit test so the initial loading state no longer reuses the larger assistant message bubble styling.
+
+**Tech Stack:** Next.js 15, React 19, TypeScript, Tailwind utility classes, Vitest, agent-browser
+
+---
+
+### Task 1: Add a failing test and implement the compact loading shell
+
+**Files:**
+- Modify: `tests/unit/message-bubble.test.ts`
+- Modify: `components/message-bubble.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Add this test near the other streaming placeholder tests in `tests/unit/message-bubble.test.ts`:
+
+```typescript
+  it("renders a compact loading shell while awaiting the first token", () => {
+    const { container } = render(
+      React.createElement(StreamingPlaceholder, {
+        createdAt: new Date().toISOString(),
+        thinking: "",
+        answer: "",
+        awaitingFirstToken: true,
+        thinkingInProgress: false,
+        timeline: []
+      })
+    );
+
+    const loadingShell = screen.getByTestId("assistant-loading-shell");
+
+    expect(loadingShell).toBeInTheDocument();
+    expect(loadingShell.className).toContain("rounded-lg");
+    expect(loadingShell.className).not.toContain("rounded-2xl");
+    expect(screen.queryByTestId("assistant-message-bubble")).toBeNull();
+    expect(container.querySelectorAll(".typing-dot")).toHaveLength(3);
+  });
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+
+```bash
+npx vitest run tests/unit/message-bubble.test.ts -t "renders a compact loading shell while awaiting the first token"
+```
+
+Expected: FAIL because `assistant-loading-shell` does not exist and the loading state is still rendered inside the larger assistant bubble.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+In `components/message-bubble.tsx`, add a dedicated compact shell constant, give `TypingIndicator` a compact mode, and use that shell only in the `awaitingFirstToken && !compactionInProgress` path.
+
+Use this implementation shape:
+
+```typescript
+function TypingIndicator({ compact = false }: { compact?: boolean }) {
+  return (
+    <div className={compact ? "flex items-center gap-1" : "flex items-center gap-1.5 px-1 py-2"}>
+      {[0, 1, 2].map((i) => (
+        <div
+          key={i}
+          className="typing-dot h-1.5 w-1.5 rounded-full bg-white/40"
+          style={{
+            animation: "typing-dot 1.4s ease-in-out infinite",
+            animationDelay: `${i * 0.2}s`
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+const ASSISTANT_LOADING_SHELL =
+  "inline-flex items-center rounded-lg border border-white/5 bg-white/[0.015] px-2 py-1";
+```
+
+Then replace the current loading branch:
+
+```typescript
+            {awaitingFirstToken ? (
+              compactionInProgress ? (
+                <CompactionIndicator />
+              ) : (
+                <div
+                  className={ASSISTANT_LOADING_SHELL}
+                  data-testid="assistant-loading-shell"
+                >
+                  <TypingIndicator compact />
+                </div>
+              )
+            ) : assistantBlocks.length || content ? (
+```
+
+Do not change:
+- `ASSISTANT_BUBBLE`
+- the thinking shell classes
+- the compaction indicator branch
+
+- [ ] **Step 4: Run the targeted test to verify it passes**
+
+Run:
+
+```bash
+npx vitest run tests/unit/message-bubble.test.ts -t "renders a compact loading shell while awaiting the first token"
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run the message bubble test file to check for regressions**
+
+Run:
+
+```bash
+npx vitest run tests/unit/message-bubble.test.ts
+```
+
+Expected: PASS with the new loading-shell test plus the existing message bubble tests.
+
+- [ ] **Step 6: Commit the focused code change**
+
+Run:
+
+```bash
+git add tests/unit/message-bubble.test.ts components/message-bubble.tsx
+git commit -m "fix: compact initial loading shell"
+```
+
+Expected: a commit containing only the loading shell test and implementation change.
+
+### Task 2: Verify in the browser and capture evidence
+
+**Files:**
+- Review: `.dev-server`
+- Review: `.context/`
+- Review: `components/message-bubble.tsx`
+
+- [ ] **Step 1: Reuse or start the dev server using the project convention**
+
+If `.dev-server` exists, read the URL and test it first:
+
+```bash
+if [ -f .dev-server ]; then
+  sed -n '1p' .dev-server
+fi
+```
+
+If the printed URL does not load, remove the stale file and start a fresh server:
+
+```bash
+rm -f .dev-server
+npm run dev > .context/loading-indicator-dev.log 2>&1 &
+while [ ! -f .dev-server ]; do sleep 1; done
+sed -n '1p' .dev-server
+```
+
+Expected: a localhost URL in the `3000-4000` range.
+
+- [ ] **Step 2: Open the app with agent-browser and reach the chat surface**
+
+Run:
+
+```bash
+agent-browser open "$(sed -n '1p' .dev-server)"
+agent-browser wait --load networkidle
+agent-browser snapshot -i
+```
+
+If the app redirects to `/login`, sign in with the local test account configured for this workspace before continuing. If no test credentials are available in the workspace, stop and ask the user for them before proceeding.
+
+- [ ] **Step 3: Trigger the loading state and visually verify the smaller shell**
+
+Use `agent-browser snapshot -i` to identify the chat composer input and send button, submit a short prompt, and confirm the first assistant placeholder appears as a compact dots-only shell before the thinking card or answer text arrives.
+
+Capture a screenshot after submission:
+
+```bash
+agent-browser screenshot .context/loading-indicator-shell.png
+```
+
+Expected:
+- the initial three-dot shell is visibly smaller than the old assistant bubble footprint
+- the shell uses the same calm border/background treatment as the thinking card
+- the state remains dots-only
+
+- [ ] **Step 4: Re-run the critical local checks**
+
+Run:
+
+```bash
+npx vitest run tests/unit/message-bubble.test.ts
+npm run typecheck
+```
+
+Expected: both commands pass.
+
+- [ ] **Step 5: Record verification status**
+
+If browser validation matches the spec and no additional code changes were needed, do not create another commit. Leave the screenshot in `.context/loading-indicator-shell.png` as evidence for review.

--- a/docs/superpowers/specs/2026-04-09-loading-indicator-size-design.md
+++ b/docs/superpowers/specs/2026-04-09-loading-indicator-size-design.md
@@ -1,0 +1,49 @@
+# Loading Indicator Size Adjustment
+
+**Date:** 2026-04-09
+**Status:** Draft
+
+## Problem
+
+The assistant's initial pre-stream loading state uses the standard assistant bubble container, which makes the three-dot indicator noticeably larger than the compact thinking shell that appears immediately after reasoning begins. This creates an avoidable visual jump between the "waiting for first token" state and the "thinking" state.
+
+## Design
+
+### Recommended Approach
+
+Introduce a dedicated compact loading shell for the `awaitingFirstToken && !compactionInProgress` branch in `MessageBubble`.
+
+### Behavior
+
+- The loading state remains dots-only.
+- The dot animation timing and behavior remain unchanged.
+- The compact loading shell should be visually close to the existing thinking shell in footprint and density.
+- The thinking shell remains unchanged.
+- The compaction indicator path remains unchanged.
+
+### Styling Direction
+
+- Replace the large assistant bubble wrapper for the initial loading state with a small shell that uses:
+  - tight horizontal padding
+  - short vertical padding
+  - compact border radius
+  - the same subdued border and background treatment already used by the thinking shell
+- Keep the three animated dots centered inside the shell.
+- Slightly tighten the dot spacing if needed so the shell width stays close to the thinking card width.
+
+### Scope
+
+- Update the loading shell styling in `components/message-bubble.tsx`.
+- Keep the rest of the assistant bubble styling untouched.
+
+## Testing
+
+- Add or update a unit test covering the awaiting-first-token loading shell so the compact loading state is distinguishable from the larger assistant message bubble.
+- Validate the chat UI in the browser and capture a screenshot showing the smaller loading shell before streaming begins.
+
+## Out of Scope
+
+- Changing the thinking card layout
+- Changing the dot animation itself
+- Changing streamed assistant message bubble sizing
+- Any broader chat layout refactor

--- a/tests/unit/message-bubble.test.ts
+++ b/tests/unit/message-bubble.test.ts
@@ -282,6 +282,27 @@ describe("message bubble", () => {
     expect(toolButtons).toHaveLength(1);
   });
 
+  it("renders a compact loading shell while awaiting the first token", () => {
+    const { container } = render(
+      React.createElement(StreamingPlaceholder, {
+        createdAt: new Date().toISOString(),
+        thinking: "",
+        answer: "",
+        awaitingFirstToken: true,
+        thinkingInProgress: false,
+        timeline: []
+      })
+    );
+
+    const loadingShell = screen.getByTestId("assistant-loading-shell");
+
+    expect(loadingShell).toBeInTheDocument();
+    expect(loadingShell.className).toContain("rounded-lg");
+    expect(loadingShell.className).not.toContain("rounded-2xl");
+    expect(screen.queryByTestId("assistant-message-bubble")).toBeNull();
+    expect(container.querySelectorAll(".typing-dot")).toHaveLength(3);
+  });
+
   it("keeps the thinking shell visible while streamed reasoning is buffered", () => {
     render(
       React.createElement(StreamingPlaceholder, {

--- a/tests/unit/message-bubble.test.ts
+++ b/tests/unit/message-bubble.test.ts
@@ -299,11 +299,11 @@ describe("message bubble", () => {
     expect(loadingShell).toBeInTheDocument();
     expect(loadingShell.className).toContain("rounded-lg");
     expect(loadingShell.className).toContain("overflow-hidden");
-    expect(loadingShell.className).toContain("mt-1");
+    expect(loadingShell.className).toContain("mt-[6px]");
     expect(loadingShell.className).not.toContain("rounded-2xl");
     expect(screen.queryByTestId("assistant-message-bubble")).toBeNull();
     expect(container.querySelectorAll(".typing-dot")).toHaveLength(3);
-    expect(container.querySelector(".typing-dot")).toHaveStyle("--typing-dot-lift: 3px");
+    expect(container.querySelector(".typing-dot")).toHaveStyle("--typing-dot-lift: 2px");
   });
 
   it("keeps the thinking shell visible while streamed reasoning is buffered", () => {

--- a/tests/unit/message-bubble.test.ts
+++ b/tests/unit/message-bubble.test.ts
@@ -298,9 +298,12 @@ describe("message bubble", () => {
 
     expect(loadingShell).toBeInTheDocument();
     expect(loadingShell.className).toContain("rounded-lg");
+    expect(loadingShell.className).toContain("overflow-hidden");
+    expect(loadingShell.className).toContain("mt-1");
     expect(loadingShell.className).not.toContain("rounded-2xl");
     expect(screen.queryByTestId("assistant-message-bubble")).toBeNull();
     expect(container.querySelectorAll(".typing-dot")).toHaveLength(3);
+    expect(container.querySelector(".typing-dot")).toHaveStyle("--typing-dot-lift: 3px");
   });
 
   it("keeps the thinking shell visible while streamed reasoning is buffered", () => {


### PR DESCRIPTION
## Summary
- replace the pre-stream assistant loading bubble with a compact shell that matches the thinking card more closely
- tune the compact dot animation and vertical alignment so the dots stay contained and the shell lines up with the assistant avatar
- add a regression test for the awaiting-first-token loading shell and include the matching design/plan docs

## Test Plan
- [x] npm test
- [x] npx vitest run tests/unit/message-bubble.test.ts
- [x] Browser validation via agent-browser on the local dev server