### PR TITLE
Show context gauge as threshold percent

### DIFF
--- a/components/context-gauge.tsx
+++ b/components/context-gauge.tsx
@@ -29,6 +29,7 @@ export function ContextGauge({ usedTokens, usableLimit, maxLimit }: ContextGauge
   const [showTooltip, setShowTooltip] = useState(false);
 
   const percentage = usedTokens !== null ? Math.min(100, (usedTokens / usableLimit) * 100) : 0;
+  const roundedPercentage = usedTokens !== null && usedTokens > 0 ? Math.max(1, Math.round(percentage)) : 0;
   const color = getGaugeColor(percentage);
 
   // SVG circle properties
@@ -55,6 +56,7 @@ export function ContextGauge({ usedTokens, usableLimit, maxLimit }: ContextGauge
   }
 
   const usedFormatted = formatTokens(usedTokens);
+  const percentageFormatted = `${roundedPercentage}%`;
   const usableFormatted = formatTokens(usableLimit);
   const maxFormatted = formatTokens(maxLimit);
   const thresholdPercent = Math.round((usableLimit / maxLimit) * 100);
@@ -64,10 +66,10 @@ export function ContextGauge({ usedTokens, usableLimit, maxLimit }: ContextGauge
       <button
         type="button"
         role="progressbar"
-        aria-valuenow={Math.round(percentage)}
+        aria-valuenow={roundedPercentage}
         aria-valuemin={0}
         aria-valuemax={100}
-        aria-label={`${Math.round(percentage)}% context used`}
+        aria-label={`${roundedPercentage}% context used`}
         className="flex items-center justify-center p-1 rounded-lg hover:bg-white/5 transition-colors"
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
@@ -101,7 +103,7 @@ export function ContextGauge({ usedTokens, usableLimit, maxLimit }: ContextGauge
           />
         </svg>
       </button>
-      <span className="text-[10px] text-white/40">{usedFormatted}</span>
+      <span className="text-[10px] text-white/40">{percentageFormatted}</span>
 
       {showTooltip && (
         <div

--- a/tests/unit/chat-view.test.ts
+++ b/tests/unit/chat-view.test.ts
@@ -1142,6 +1142,6 @@ describe("chat view", () => {
       expect(screen.getByRole("progressbar")).toBeInTheDocument();
     });
 
-    expect(screen.getByText("50K")).toBeInTheDocument();
+    expect(screen.getByText("100%")).toBeInTheDocument();
   });
 });

--- a/tests/unit/context-gauge.test.tsx
+++ b/tests/unit/context-gauge.test.tsx
@@ -14,11 +14,18 @@ describe("ContextGauge", () => {
   it("renders circular gauge with percentage fill", () => {
     render(<ContextGauge {...defaultProps} />);
 
-    // Should show used tokens label
-    expect(screen.getByText("50K")).toBeInTheDocument();
+    // Should show threshold-relative percentage label
+    expect(screen.getByText("63%")).toBeInTheDocument();
 
     // Should have progressbar role for accessibility
     expect(screen.getByRole("progressbar")).toBeInTheDocument();
+  });
+
+  it("shows at least 1% when usage is nonzero but below half a percent", () => {
+    render(<ContextGauge usedTokens={1} usableLimit={80000} maxLimit={100000} />);
+
+    expect(screen.getByText("1%")).toBeInTheDocument();
+    expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuenow", "1");
   });
 
   it("shows green color when usage is below 50%", () => {
@@ -73,14 +80,37 @@ describe("ContextGauge", () => {
     expect(screen.queryByText(/50K used/)).not.toBeInTheDocument();
   });
 
-  it("formats large token counts with K suffix", () => {
+  it("shows the visible label as percentage for large token counts", () => {
     render(<ContextGauge {...defaultProps} usedTokens={1500} />);
-    expect(screen.getByText("1.5K")).toBeInTheDocument();
+    expect(screen.getByText("2%")).toBeInTheDocument();
   });
 
-  it("formats millions with M suffix", () => {
+  it("shows the visible label as percentage for million-scale token counts", () => {
     render(<ContextGauge {...defaultProps} usedTokens={1500000} usableLimit={2000000} maxLimit={2000000} />);
-    expect(screen.getByText("1.5M")).toBeInTheDocument();
+    expect(screen.getByText("75%")).toBeInTheDocument();
+  });
+
+  it("formats large token counts with K suffix in the tooltip", () => {
+    render(<ContextGauge {...defaultProps} usedTokens={1500} />);
+
+    const gauge = screen.getByRole("progressbar");
+    fireEvent.mouseEnter(gauge);
+
+    expect(screen.getByText(/1.5K used/)).toBeInTheDocument();
+  });
+
+  it("formats millions with M suffix in the tooltip", () => {
+    render(<ContextGauge {...defaultProps} usedTokens={1500000} usableLimit={2000000} maxLimit={2000000} />);
+
+    const gauge = screen.getByRole("progressbar");
+    fireEvent.mouseEnter(gauge);
+
+    expect(screen.getByText(/1.5M used/)).toBeInTheDocument();
+  });
+
+  it("caps the label at 100% when usage exceeds the compaction threshold", () => {
+    render(<ContextGauge {...defaultProps} usedTokens={95000} />);
+    expect(screen.getByText("100%")).toBeInTheDocument();
   });
 
   it("toggles tooltip on mobile tap", () => {


### PR DESCRIPTION
## Summary
- replace the chat composer context label with the percentage of auto-compaction threshold used
- keep tooltip token details intact and floor nonzero usage to 1% so the gauge never appears idle while context is in use
- update unit and chat-view coverage for the new label behavior, tooltip formatting, and 100% clamping

## Verification
- npm test