### PR TITLE
Hide context label until usage appears

### DIFF
--- a/components/chat-composer.tsx
+++ b/components/chat-composer.tsx
@@ -205,6 +205,7 @@ export function ChatComposer({
   const isSubmitDisabled =
     isSending || isUploadingAttachments || (!input.trim() && pendingAttachments.length === 0);
   const showStopButton = canStop && !isUploadingAttachments;
+  const showContextUsage = hasMessages && usedTokens !== null;
 
   // For the model selector, we want to show the profile name prominently
   const displayModels = providerProfiles.map(p => ({
@@ -382,7 +383,7 @@ export function ChatComposer({
         </div>
 
         <div className="flex items-center gap-2 sm:gap-3">
-          {hasMessages && (
+          {showContextUsage && (
             <div className="flex items-center gap-2 px-1">
               <span className="text-[10px] text-white/20 font-medium tracking-wider uppercase hidden md:inline-block">Context</span>
               <ContextGauge

--- a/tests/unit/chat-view.test.ts
+++ b/tests/unit/chat-view.test.ts
@@ -1144,4 +1144,48 @@ describe("chat view", () => {
 
     expect(screen.getByText("100%")).toBeInTheDocument();
   });
+
+  it("keeps the context label hidden until usage data arrives", async () => {
+    const payload = createPayload();
+    payload.conversation.id = "conv_no_usage";
+    renderWithProvider(React.createElement(ChatView, { payload }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Test conversation")).toBeInTheDocument();
+    });
+
+    const input = screen.getByPlaceholderText(
+      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
+    );
+    fireEvent.change(input, { target: { value: "Hello" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Hello")).toBeInTheDocument();
+    });
+
+    act(() => {
+      wsMock.onMessage!({
+        type: "snapshot",
+        conversationId: "conv_no_usage",
+        messages: [
+          {
+            id: "msg_user",
+            conversationId: "conv_no_usage",
+            role: "user",
+            content: "Hello",
+            thinkingContent: "",
+            status: "completed",
+            estimatedTokens: 5,
+            systemKind: null,
+            compactedAt: null,
+            createdAt: new Date().toISOString()
+          }
+        ]
+      });
+    });
+
+    expect(screen.queryByText("Context")).toBeNull();
+    expect(screen.queryByRole("progressbar")).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- Hide the composer Context block until usage data exists so the label never renders without the gauge.
- Add a regression test for conversations that have messages but have not received a usage event yet.

## Verification
- `npm test`
- `npx vitest run tests/unit/chat-view.test.ts -t "(keeps the context label hidden until usage data arrives|updates token usage gauge when usage event arrives)" --coverage.enabled=false`
- Browser validation with `agent-browser` on the home composer and a fresh chat composer at `http://localhost:3852/`