### PR TITLE
Fix mobile settings layout and header

### DIFF
--- a/components/settings/sections/general-section.tsx
+++ b/components/settings/sections/general-section.tsx
@@ -49,7 +49,7 @@ export function GeneralSection({ settings }: { settings: AppSettings }) {
   }
 
   return (
-    <div className="max-w-[55%] p-6 md:p-8 space-y-6">
+    <div className="w-full max-w-none space-y-6 p-4 sm:p-6 md:max-w-[55%] md:p-8">
       <SettingsCard title="Conversation Retention">
         <SettingRow
           label="Keep conversations for"
@@ -58,7 +58,7 @@ export function GeneralSection({ settings }: { settings: AppSettings }) {
           <select
             value={conversationRetention}
             onChange={(e) => setConversationRetention(e.target.value as ConversationRetention)}
-            className="rounded-lg border border-white/6 bg-white/[0.03] px-3 py-2 text-sm outline-none focus:border-[var(--accent)]/30 transition-all duration-200"
+            className="w-full rounded-lg border border-white/6 bg-white/[0.03] px-3 py-2 text-sm outline-none transition-all duration-200 focus:border-[var(--accent)]/30 sm:w-auto"
           >
             <option value="forever">Forever</option>
             <option value="90d">90 days</option>
@@ -96,13 +96,13 @@ export function GeneralSection({ settings }: { settings: AppSettings }) {
             max={600}
             value={Math.round(mcpTimeout / 1000)}
             onChange={(e) => setMcpTimeout(Number(e.target.value) * 1000)}
-            className="w-20 rounded-lg border border-white/6 bg-white/[0.03] px-3 py-2 text-sm outline-none focus:border-[var(--accent)]/30 transition-all duration-200"
+            className="w-full rounded-lg border border-white/6 bg-white/[0.03] px-3 py-2 text-sm outline-none transition-all duration-200 focus:border-[var(--accent)]/30 sm:w-20"
           />
         </SettingRow>
       </SettingsCard>
 
       <div className="flex flex-wrap items-center gap-3">
-        <Button onClick={() => void save()} disabled={isPending}>
+        <Button className="w-full sm:w-auto" onClick={() => void save()} disabled={isPending}>
           Save settings
         </Button>
         {success ? <span className="text-sm text-emerald-400">{success}</span> : null}

--- a/components/settings/setting-row.tsx
+++ b/components/settings/setting-row.tsx
@@ -8,14 +8,14 @@ export function SettingRow({
   children: React.ReactNode;
 }) {
   return (
-    <div className="flex items-center justify-between gap-4">
+    <div className="flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
       <div className="min-w-0">
         <div className="text-[13px] text-[var(--text)]">{label}</div>
         {description ? (
           <div className="mt-0.5 text-xs text-[var(--muted)]">{description}</div>
         ) : null}
       </div>
-      <div className="flex-shrink-0">{children}</div>
+      <div className="w-full sm:w-auto sm:flex-shrink-0">{children}</div>
     </div>
   );
 }

--- a/components/shell.tsx
+++ b/components/shell.tsx
@@ -66,44 +66,40 @@ export function Shell({
           </button>
 
           {isSettingsPage ? (
-            <>
-              <span className="text-sm font-semibold tracking-[0.01em] text-[var(--text)]">
-                Settings
-              </span>
-              <div className="w-9" aria-hidden="true" />
-            </>
+            <span className="text-sm font-semibold tracking-[0.01em] text-[var(--text)]">
+              Settings
+            </span>
           ) : (
-            <>
-              <span
-                className="font-bold tracking-[0.12em] leading-none inline-block text-lg"
-                style={{
-                  fontFamily: "var(--font-wordmark), 'Eurostile', 'Space Grotesk', sans-serif",
-                  WebkitBackgroundClip: "text",
-                  backgroundClip: "text",
-                  WebkitTextFillColor: "transparent",
-                  backgroundImage: "linear-gradient(to bottom, #FFFFFF 0%, #D4C8FF 40%, #8b5cf6 100%)",
-                  filter: "drop-shadow(0 0 8px rgba(139,92,246,0.5)) drop-shadow(0 0 20px rgba(139,92,246,0.25)) drop-shadow(0 0 36px rgba(139,92,246,0.12))",
-                }}
-              >
-                Eidon
-              </span>
-
-              <button
-                type="button"
-                className="p-2 -mr-2 text-[var(--text)] hover:bg-white/5 rounded-lg transition-colors duration-200"
-                onClick={async () => {
-                  try {
-                    await deleteConversationIfStillEmpty(activeConversationId);
-                    const res = await fetch("/api/conversations", { method: "POST" });
-                    const data = (await res.json()) as { conversation: Conversation };
-                    router.push(`/chat/${data.conversation.id}`);
-                  } catch (e) {}
-                }}
-              >
-                <Plus className="h-5 w-5" />
-              </button>
-            </>
+            <span
+              className="font-bold tracking-[0.12em] leading-none inline-block text-lg"
+              style={{
+                fontFamily: "var(--font-wordmark), 'Eurostile', 'Space Grotesk', sans-serif",
+                WebkitBackgroundClip: "text",
+                backgroundClip: "text",
+                WebkitTextFillColor: "transparent",
+                backgroundImage: "linear-gradient(to bottom, #FFFFFF 0%, #D4C8FF 40%, #8b5cf6 100%)",
+                filter: "drop-shadow(0 0 8px rgba(139,92,246,0.5)) drop-shadow(0 0 20px rgba(139,92,246,0.25)) drop-shadow(0 0 36px rgba(139,92,246,0.12))",
+              }}
+            >
+              Eidon
+            </span>
           )}
+
+          <button
+            type="button"
+            className="p-2 -mr-2 text-[var(--text)] hover:bg-white/5 rounded-lg transition-colors duration-200"
+            onClick={async () => {
+              try {
+                await deleteConversationIfStillEmpty(activeConversationId);
+                const res = await fetch("/api/conversations", { method: "POST" });
+                const data = (await res.json()) as { conversation: Conversation };
+                router.push(`/chat/${data.conversation.id}`);
+              } catch (e) {}
+            }}
+            aria-label="New chat"
+          >
+            <Plus className="h-5 w-5" />
+          </button>
         </div>
 
         <ContextTokensProvider>{children}</ContextTokensProvider>

--- a/components/shell.tsx
+++ b/components/shell.tsx
@@ -24,6 +24,7 @@ export function Shell({
     ? pathname.split("/chat/")[1]
     : null;
   const isSettingsPage = pathname.startsWith("/settings");
+  const mobileMenuLabel = isSettingsPage ? "Open settings menu" : "Open menu";
 
   return (
     <div className="flex h-[100dvh] w-full bg-[var(--background)] overflow-hidden">
@@ -59,39 +60,50 @@ export function Shell({
             type="button"
             className="p-2 -ml-2 text-[var(--text)] hover:bg-white/5 rounded-lg transition-colors duration-200"
             onClick={() => setIsSidebarOpen(true)}
-            aria-label="Open menu"
+            aria-label={mobileMenuLabel}
           >
             <Menu className="h-5 w-5" />
           </button>
 
-          <span
-            className="font-bold tracking-[0.12em] leading-none inline-block text-lg"
-            style={{
-              fontFamily: "var(--font-wordmark), 'Eurostile', 'Space Grotesk', sans-serif",
-              WebkitBackgroundClip: "text",
-              backgroundClip: "text",
-              WebkitTextFillColor: "transparent",
-              backgroundImage: "linear-gradient(to bottom, #FFFFFF 0%, #D4C8FF 40%, #8b5cf6 100%)",
-              filter: "drop-shadow(0 0 8px rgba(139,92,246,0.5)) drop-shadow(0 0 20px rgba(139,92,246,0.25)) drop-shadow(0 0 36px rgba(139,92,246,0.12))",
-            }}
-          >
-            Eidon
-          </span>
+          {isSettingsPage ? (
+            <>
+              <span className="text-sm font-semibold tracking-[0.01em] text-[var(--text)]">
+                Settings
+              </span>
+              <div className="w-9" aria-hidden="true" />
+            </>
+          ) : (
+            <>
+              <span
+                className="font-bold tracking-[0.12em] leading-none inline-block text-lg"
+                style={{
+                  fontFamily: "var(--font-wordmark), 'Eurostile', 'Space Grotesk', sans-serif",
+                  WebkitBackgroundClip: "text",
+                  backgroundClip: "text",
+                  WebkitTextFillColor: "transparent",
+                  backgroundImage: "linear-gradient(to bottom, #FFFFFF 0%, #D4C8FF 40%, #8b5cf6 100%)",
+                  filter: "drop-shadow(0 0 8px rgba(139,92,246,0.5)) drop-shadow(0 0 20px rgba(139,92,246,0.25)) drop-shadow(0 0 36px rgba(139,92,246,0.12))",
+                }}
+              >
+                Eidon
+              </span>
 
-          <button
-            type="button"
-            className="p-2 -mr-2 text-[var(--text)] hover:bg-white/5 rounded-lg transition-colors duration-200"
-            onClick={async () => {
-              try {
-                await deleteConversationIfStillEmpty(activeConversationId);
-                const res = await fetch("/api/conversations", { method: "POST" });
-                const data = (await res.json()) as { conversation: Conversation };
-                router.push(`/chat/${data.conversation.id}`);
-              } catch (e) {}
-            }}
-          >
-            <Plus className="h-5 w-5" />
-          </button>
+              <button
+                type="button"
+                className="p-2 -mr-2 text-[var(--text)] hover:bg-white/5 rounded-lg transition-colors duration-200"
+                onClick={async () => {
+                  try {
+                    await deleteConversationIfStillEmpty(activeConversationId);
+                    const res = await fetch("/api/conversations", { method: "POST" });
+                    const data = (await res.json()) as { conversation: Conversation };
+                    router.push(`/chat/${data.conversation.id}`);
+                  } catch (e) {}
+                }}
+              >
+                <Plus className="h-5 w-5" />
+              </button>
+            </>
+          )}
         </div>
 
         <ContextTokensProvider>{children}</ContextTokensProvider>

--- a/tests/unit/settings-layout.test.tsx
+++ b/tests/unit/settings-layout.test.tsx
@@ -1,0 +1,113 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import { GeneralSection } from "@/components/settings/sections/general-section";
+import { SettingRow } from "@/components/settings/setting-row";
+import { Shell } from "@/components/shell";
+import type { AppSettings, ConversationListPage } from "@/lib/types";
+
+const mockRefresh = vi.fn();
+const mockPush = vi.fn();
+let mockPathname = "/settings/general";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => mockPathname,
+  useRouter: () => ({
+    push: mockPush,
+    refresh: mockRefresh
+  })
+}));
+
+vi.mock("framer-motion", () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  motion: {
+    div: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+      <div {...props}>{children}</div>
+    )
+  }
+}));
+
+vi.mock("@/components/sidebar", () => ({
+  Sidebar: () => <aside data-testid="chat-sidebar">Chat sidebar</aside>
+}));
+
+vi.mock("@/components/settings/settings-nav", () => ({
+  SettingsNav: () => <aside data-testid="settings-nav">Settings nav</aside>
+}));
+
+vi.mock("@/lib/ws-client", () => ({
+  useGlobalWebSocket: vi.fn()
+}));
+
+vi.mock("@/lib/conversation-drafts", () => ({
+  deleteConversationIfStillEmpty: vi.fn().mockResolvedValue(undefined)
+}));
+
+const settings: AppSettings = {
+  defaultProviderProfileId: "profile_default",
+  skillsEnabled: true,
+  conversationRetention: "forever",
+  autoCompaction: true,
+  memoriesEnabled: true,
+  memoriesMaxCount: 100,
+  mcpTimeout: 120_000,
+  updatedAt: new Date().toISOString()
+};
+
+const conversationPage: ConversationListPage = {
+  conversations: [],
+  nextCursor: null,
+  hasMore: false
+};
+
+describe("settings mobile layout", () => {
+  beforeEach(() => {
+    mockPathname = "/settings/general";
+    mockRefresh.mockReset();
+    mockPush.mockReset();
+  });
+
+  it("lets the general section use the full viewport width on mobile", () => {
+    const { container } = render(React.createElement(GeneralSection, { settings }));
+
+    expect(container.firstElementChild).toHaveClass("w-full");
+    expect(container.firstElementChild).toHaveClass("max-w-none");
+    expect(container.firstElementChild).toHaveClass("md:max-w-[55%]");
+    expect(container.firstElementChild).not.toHaveClass("max-w-[55%]");
+  });
+
+  it("stacks setting rows vertically before the small breakpoint", () => {
+    const { container } = render(
+      <SettingRow
+        label="Keep conversations for"
+        description="Older conversations will be automatically deleted"
+      >
+        <select aria-label="Retention" />
+      </SettingRow>
+    );
+
+    expect(container.firstElementChild).toHaveClass("flex-col");
+    expect(container.firstElementChild).toHaveClass("items-start");
+    expect(container.firstElementChild).toHaveClass("sm:flex-row");
+    expect(container.firstElementChild).toHaveClass("sm:items-center");
+    expect(container.firstElementChild).toHaveClass("sm:justify-between");
+  });
+
+  it("shows a settings-specific mobile header when browsing settings", () => {
+    render(
+      React.createElement(
+        Shell,
+        {
+          conversationPage
+        },
+        React.createElement("div", null, "Settings content")
+      )
+    );
+
+    expect(screen.getByRole("button", { name: "Open settings menu" })).toBeInTheDocument();
+    expect(screen.getByText("Settings")).toBeInTheDocument();
+    expect(screen.queryByText("Eidon")).not.toBeInTheDocument();
+  });
+});

--- a/tests/unit/settings-layout.test.tsx
+++ b/tests/unit/settings-layout.test.tsx
@@ -107,6 +107,7 @@ describe("settings mobile layout", () => {
     );
 
     expect(screen.getByRole("button", { name: "Open settings menu" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "New chat" })).toBeInTheDocument();
     expect(screen.getByText("Settings")).toBeInTheDocument();
     expect(screen.queryByText("Eidon")).not.toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary
- let the General settings page use the full mobile width instead of a desktop-only narrow column
- stack shared settings rows on small screens so labels and controls do not squeeze each other
- make the mobile settings header clearer while preserving the existing new-chat action
- add regression coverage for the mobile settings layout and header

## Testing
- npm run test
- agent-browser mobile validation on /settings/general and /settings/providers