### PR TITLE
Refresh login page copy and styling

### DIFF
--- a/components/login-form.tsx
+++ b/components/login-form.tsx
@@ -67,8 +67,8 @@ export function LoginForm() {
       >
         Eidon
       </span>
-      <p className="text-sm leading-relaxed text-[var(--muted)] px-8">
-        A private conversational workspace with streaming, visible thinking, and long-memory compaction.
+      <p className="px-8 text-sm leading-relaxed text-[var(--muted)] italic text-center text-balance">
+        The seeker enters in uncertainty and departs in knowing.
       </p>
 
       <div className="space-y-3 px-8">
@@ -94,7 +94,7 @@ export function LoginForm() {
             <LoaderCircle className="h-4 w-4 animate-spin" />
           ) : (
             <>
-              Enter workspace
+              Proceed
               <ArrowRight className="h-4 w-4" />
             </>
           )}

--- a/tests/e2e/features.spec.ts
+++ b/tests/e2e/features.spec.ts
@@ -4,7 +4,7 @@ async function signIn(page: import("@playwright/test").Page) {
   await page.goto("/");
   await page.getByPlaceholder("Username").fill("admin");
   await page.getByPlaceholder("Password").fill("changeme123");
-  await page.getByRole("button", { name: "Enter workspace" }).click();
+  await page.getByRole("button", { name: "Proceed" }).click();
   await page.waitForURL(/localhost:3117\/$/, { timeout: 15000 });
 }
 

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -6,7 +6,7 @@ test("redirects to login, signs in, opens settings, and creates a chat", async (
 
   await page.getByPlaceholder("Username").fill("admin");
   await page.getByPlaceholder("Password").fill("changeme123");
-  await page.getByRole("button", { name: "Enter workspace" }).click();
+  await page.getByRole("button", { name: "Proceed" }).click();
   await page.waitForURL("http://localhost:3117/", { timeout: 15000 });
 
   await expect(page.getByRole("link", { name: "Open settings" })).toBeVisible({ timeout: 10000 });

--- a/tests/unit/login-form.test.tsx
+++ b/tests/unit/login-form.test.tsx
@@ -1,0 +1,16 @@
+// @vitest-environment jsdom
+
+import { render, screen } from "@testing-library/react";
+
+import { LoginForm } from "@/components/login-form";
+
+describe("login form", () => {
+  it("renders the approved quote in italic with the new proceed button", () => {
+    render(<LoginForm />);
+
+    expect(
+      screen.getByText("The seeker enters in uncertainty and departs in knowing.")
+    ).toHaveClass("italic");
+    expect(screen.getByRole("button", { name: "Proceed" })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Updates the login page tagline from the descriptive product text to a prophetic quote styled as a centered, italic, text-balanced line to prevent orphan words. Renames the login button from "Enter workspace" to "Proceed". E2e tests updated for the new button label, and a unit test added for the quote and button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)