### PR TITLE
Close mobile settings sidebar on navigation

### DIFF
--- a/components/settings/settings-nav.tsx
+++ b/components/settings/settings-nav.tsx
@@ -73,6 +73,7 @@ export function SettingsNav({ onCloseAction }: { onCloseAction: () => void }) {
                     event.button === 0
                   ) {
                     event.preventDefault();
+                    onCloseAction();
                     router.push(item.href);
                   }
                 }}


### PR DESCRIPTION
On mobile, clicking a settings menu item navigated to the page but left the sidebar open. Added `onCloseAction()` call to each nav item's click handler so the sidebar closes when navigating between settings pages, matching the existing behavior of the "Back to chat" button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)