### PR TITLE
Add automations sidebar entry and remove redundant settings shortcut

### DIFF
--- a/components/settings/sections/automations-section.tsx
+++ b/components/settings/sections/automations-section.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Link from "next/link";
 import { useEffect, useState } from "react";
 import { CalendarDays, Check, Clock3, Plus, Trash2 } from "lucide-react";
 
@@ -299,13 +298,6 @@ export function AutomationsSection() {
               </p>
             </div>
             <div className="flex items-center gap-2">
-              <Link
-                href="/automations"
-                aria-label="Open automations workspace"
-                className="rounded-lg border border-white/6 px-3 py-1.5 text-[0.72rem] font-medium text-[#a1a1aa] transition-colors hover:border-white/12 hover:text-[#f4f4f5]"
-              >
-                Open workspace
-              </Link>
               <button
                 type="button"
                 onClick={openNewAutomation}

--- a/components/sidebar-footer-nav.tsx
+++ b/components/sidebar-footer-nav.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import Link from "next/link";
+import type { MouseEvent as ReactMouseEvent } from "react";
+import { Clock3, Settings } from "lucide-react";
+
+const baseLinkClassName =
+  "flex w-full items-center gap-3 rounded-2xl px-4 py-3 text-sm text-white/30 transition-all duration-300 hover:bg-white/[0.03] hover:text-white/60";
+
+type SidebarFooterNavProps = {
+  onNavigateAction: (href: string) => void | Promise<void>;
+};
+
+function interceptNavigation(
+  event: ReactMouseEvent<HTMLAnchorElement>,
+  href: string,
+  onNavigateAction: SidebarFooterNavProps["onNavigateAction"]
+) {
+  if (
+    event.defaultPrevented ||
+    event.button !== 0 ||
+    event.metaKey ||
+    event.ctrlKey ||
+    event.shiftKey ||
+    event.altKey
+  ) {
+    return;
+  }
+
+  event.preventDefault();
+  void onNavigateAction(href);
+}
+
+export function SidebarFooterNav({ onNavigateAction }: SidebarFooterNavProps) {
+  return (
+    <div className="mt-6 flex flex-col gap-2 border-t border-white/5 pt-6">
+      <Link
+        href="/automations"
+        aria-label="Open automations"
+        className={baseLinkClassName}
+        onClick={(event) => interceptNavigation(event, "/automations", onNavigateAction)}
+      >
+        <Clock3 className="h-4.5 w-4.5 opacity-60" />
+        <span className="font-medium">Automations</span>
+      </Link>
+
+      <Link
+        href="/settings"
+        aria-label="Open settings"
+        className={baseLinkClassName}
+        onClick={(event) => interceptNavigation(event, "/settings", onNavigateAction)}
+      >
+        <Settings className="h-4.5 w-4.5 opacity-60" />
+        <span className="font-medium">Settings</span>
+      </Link>
+    </div>
+  );
+}

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -6,7 +6,6 @@ import Link from "next/link";
 import {
   Plus,
   Search,
-  Settings,
   MoreHorizontal,
   FolderIcon,
   FolderOpen,
@@ -58,6 +57,7 @@ import { deleteConversationIfStillEmpty } from "@/lib/conversation-drafts";
 import { addGlobalWsListener } from "@/lib/ws-client";
 import type { ServerMessage } from "@/lib/ws-protocol";
 import type { Conversation, ConversationListPage, Folder } from "@/lib/types";
+import { SidebarFooterNav } from "@/components/sidebar-footer-nav";
 
 type SidebarConversation = Conversation & { matchSnippet?: string };
 
@@ -1225,31 +1225,7 @@ export function Sidebar({
           )}
         </div>
 
-        <div className="mt-6 flex items-center pt-6 border-t border-white/5">
-          <Link
-            href="/settings"
-            onClick={(event) => {
-              if (
-                event.defaultPrevented ||
-                event.button !== 0 ||
-                event.metaKey ||
-                event.ctrlKey ||
-                event.shiftKey ||
-                event.altKey
-              ) {
-                return;
-              }
-
-              event.preventDefault();
-              void navigateToHref("/settings");
-            }}
-            aria-label="Open settings"
-            className="flex w-full items-center gap-3 rounded-2xl px-4 py-3 text-sm text-white/30 hover:bg-white/[0.03] hover:text-white/60 transition-all duration-300"
-          >
-            <Settings className="h-4.5 w-4.5 opacity-60" />
-            <span className="font-medium">Settings</span>
-          </Link>
-        </div>
+        <SidebarFooterNav onNavigateAction={navigateToHref} />
       </div>
     </aside>
   );

--- a/docs/superpowers/plans/2026-04-10-automations-sidebar-entry.md
+++ b/docs/superpowers/plans/2026-04-10-automations-sidebar-entry.md
@@ -1,0 +1,302 @@
+# Automations Sidebar Entry Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a top-level `Automations` entry to the main sidebar above `Settings`, visible on desktop and mobile, that opens the existing `/automations` overview while keeping automation creation in Settings.
+
+**Architecture:** Keep the change isolated to the main sidebar footer. Extract the footer links into a small, testable client component so the new navigation can be validated without rendering the full drag-and-drop chat sidebar, then wire that component back into `Sidebar` using the existing `navigateToHref` helper so desktop and mobile behavior stay consistent.
+
+**Tech Stack:** Next.js 15 App Router, React 19, TypeScript, lucide-react, Vitest, Testing Library, agent-browser
+
+---
+
+## File Map
+
+- `components/sidebar-footer-nav.tsx` — new focused footer navigation component for `Automations` and `Settings`
+- `components/sidebar.tsx` — replace the inline settings footer with the extracted footer nav and reuse the existing sidebar route helper
+- `tests/unit/sidebar-footer-nav.test.tsx` — focused regression coverage for order, href targets, and click delegation
+- `.dev-server` — dev server discovery for browser validation
+
+### Task 1: Add a focused footer-nav component with regression tests
+
+**Files:**
+- Create: `components/sidebar-footer-nav.tsx`
+- Modify: `components/sidebar.tsx`
+- Create: `tests/unit/sidebar-footer-nav.test.tsx`
+
+- [ ] **Step 1: Write the failing footer-nav test**
+
+Create `tests/unit/sidebar-footer-nav.test.tsx` with this content:
+
+```tsx
+// @vitest-environment jsdom
+
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { SidebarFooterNav } from "@/components/sidebar-footer-nav";
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    onClick,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) => (
+    <a href={href} onClick={onClick} {...props}>
+      {children}
+    </a>
+  )
+}));
+
+describe("SidebarFooterNav", () => {
+  it("renders Automations above Settings with the correct hrefs", () => {
+    render(<SidebarFooterNav onNavigateAction={vi.fn()} />);
+
+    const automationsLink = screen.getByRole("link", { name: "Open automations" });
+    const settingsLink = screen.getByRole("link", { name: "Open settings" });
+
+    expect(automationsLink).toHaveAttribute("href", "/automations");
+    expect(settingsLink).toHaveAttribute("href", "/settings");
+    expect(
+      automationsLink.compareDocumentPosition(settingsLink) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
+
+  it("delegates plain left-click navigation through the provided action", () => {
+    const onNavigateAction = vi.fn();
+
+    render(<SidebarFooterNav onNavigateAction={onNavigateAction} />);
+
+    fireEvent.click(screen.getByRole("link", { name: "Open automations" }), { button: 0 });
+
+    expect(onNavigateAction).toHaveBeenCalledWith("/automations");
+  });
+
+  it("does not intercept modified clicks", () => {
+    const onNavigateAction = vi.fn();
+
+    render(<SidebarFooterNav onNavigateAction={onNavigateAction} />);
+
+    fireEvent.click(screen.getByRole("link", { name: "Open settings" }), {
+      button: 0,
+      metaKey: true
+    });
+
+    expect(onNavigateAction).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+
+```bash
+npx vitest run tests/unit/sidebar-footer-nav.test.tsx
+```
+
+Expected: FAIL because `@/components/sidebar-footer-nav` does not exist yet.
+
+- [ ] **Step 3: Implement the extracted footer-nav component**
+
+Create `components/sidebar-footer-nav.tsx` with this implementation:
+
+```tsx
+"use client";
+
+import Link from "next/link";
+import type { MouseEvent as ReactMouseEvent } from "react";
+import { Clock3, Settings } from "lucide-react";
+
+const baseLinkClassName =
+  "flex w-full items-center gap-3 rounded-2xl px-4 py-3 text-sm text-white/30 transition-all duration-300 hover:bg-white/[0.03] hover:text-white/60";
+
+type SidebarFooterNavProps = {
+  onNavigateAction: (href: string) => void | Promise<void>;
+};
+
+function interceptNavigation(
+  event: ReactMouseEvent<HTMLAnchorElement>,
+  href: string,
+  onNavigateAction: SidebarFooterNavProps["onNavigateAction"]
+) {
+  if (
+    event.defaultPrevented ||
+    event.button !== 0 ||
+    event.metaKey ||
+    event.ctrlKey ||
+    event.shiftKey ||
+    event.altKey
+  ) {
+    return;
+  }
+
+  event.preventDefault();
+  void onNavigateAction(href);
+}
+
+export function SidebarFooterNav({ onNavigateAction }: SidebarFooterNavProps) {
+  return (
+    <div className="mt-6 flex flex-col gap-2 border-t border-white/5 pt-6">
+      <Link
+        href="/automations"
+        aria-label="Open automations"
+        className={baseLinkClassName}
+        onClick={(event) => interceptNavigation(event, "/automations", onNavigateAction)}
+      >
+        <Clock3 className="h-4.5 w-4.5 opacity-60" />
+        <span className="font-medium">Automations</span>
+      </Link>
+
+      <Link
+        href="/settings"
+        aria-label="Open settings"
+        className={baseLinkClassName}
+        onClick={(event) => interceptNavigation(event, "/settings", onNavigateAction)}
+      >
+        <Settings className="h-4.5 w-4.5 opacity-60" />
+        <span className="font-medium">Settings</span>
+      </Link>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Wire the new footer nav into the main sidebar**
+
+Update `components/sidebar.tsx` in two places.
+
+Add the import near the other component imports:
+
+```tsx
+import { SidebarFooterNav } from "@/components/sidebar-footer-nav";
+```
+
+Replace the existing single `Settings` footer block at the bottom of the component with:
+
+```tsx
+        <SidebarFooterNav onNavigateAction={navigateToHref} />
+```
+
+Do not change:
+
+- `navigateToHref`
+- conversation rendering
+- folder drag-and-drop logic
+- the mobile shell header in `components/shell.tsx`
+
+- [ ] **Step 5: Run the focused sidebar tests**
+
+Run:
+
+```bash
+npx vitest run tests/unit/sidebar-footer-nav.test.tsx
+```
+
+Expected: PASS with all three footer-nav tests passing.
+
+- [ ] **Step 6: Run adjacent regression tests**
+
+Run:
+
+```bash
+npx vitest run tests/unit/sidebar-footer-nav.test.tsx tests/unit/settings-layout.test.tsx tests/unit/automations-section.test.tsx
+```
+
+Expected: PASS. This confirms the new sidebar link is covered, the settings shell behavior still works, and the settings automations page still links to `/automations`.
+
+- [ ] **Step 7: Commit the focused sidebar change**
+
+Run:
+
+```bash
+git add components/sidebar-footer-nav.tsx components/sidebar.tsx tests/unit/sidebar-footer-nav.test.tsx
+git commit -m "feat: add automations entry to sidebar"
+```
+
+Expected: a single commit containing only the new footer-nav component, the sidebar integration, and the focused unit test.
+
+### Task 2: Validate desktop and mobile behavior in the browser
+
+**Files:**
+- Review: `.dev-server`
+- Review: `components/sidebar-footer-nav.tsx`
+- Review: `components/sidebar.tsx`
+
+- [ ] **Step 1: Reuse or start the dev server using the project convention**
+
+If `.dev-server` exists, read and test the first line first:
+
+```bash
+if [ -f .dev-server ]; then
+  sed -n '1p' .dev-server
+fi
+```
+
+If the URL does not load, remove the stale file and start a fresh server:
+
+```bash
+rm -f .dev-server
+npm run dev > .context/automations-sidebar-dev.log 2>&1 &
+while [ ! -f .dev-server ]; do sleep 1; done
+sed -n '1p' .dev-server
+```
+
+Expected: a localhost URL in the `3000-4000` range.
+
+- [ ] **Step 2: Open the app with agent-browser and verify desktop sidebar placement**
+
+Run:
+
+```bash
+agent-browser open "$(sed -n '1p' .dev-server)"
+agent-browser wait --load networkidle
+agent-browser snapshot -i
+```
+
+If the app redirects to `/login`, authenticate with the local workspace credentials before continuing. If those credentials are not available in the workspace, stop and ask the user for them.
+
+On desktop, verify:
+
+- `Automations` appears above `Settings`
+- both entries use the footer-link treatment
+- clicking `Automations` opens `/automations`
+
+Capture a screenshot:
+
+```bash
+agent-browser screenshot .context/automations-sidebar-desktop.png
+```
+
+- [ ] **Step 3: Resize to a mobile viewport and verify the same destination order**
+
+Use the browser tooling to switch to a narrow mobile viewport, open the sidebar/menu, and confirm:
+
+- `Automations` is visible on mobile
+- it still appears above `Settings`
+- tapping `Automations` closes the drawer and opens `/automations`
+
+Capture a second screenshot:
+
+```bash
+agent-browser screenshot .context/automations-sidebar-mobile.png
+```
+
+- [ ] **Step 4: Re-run the critical local checks**
+
+Run:
+
+```bash
+npx vitest run tests/unit/sidebar-footer-nav.test.tsx tests/unit/settings-layout.test.tsx tests/unit/automations-section.test.tsx
+npm run typecheck
+```
+
+Expected: both commands pass.
+
+- [ ] **Step 5: Record verification evidence**
+
+If browser validation matches the spec and no additional code changes were needed, do not create another commit. Keep these artifacts for review:
+
+- `.context/automations-sidebar-desktop.png`
+- `.context/automations-sidebar-mobile.png`

--- a/docs/superpowers/specs/2026-04-10-automations-sidebar-entry-design.md
+++ b/docs/superpowers/specs/2026-04-10-automations-sidebar-entry-design.md
@@ -1,0 +1,136 @@
+# Automations Sidebar Entry Design
+
+## Summary
+
+Promote the existing automations runs workspace into the main application sidebar so users can reach it without first going through Settings. The new top-level `Automations` entry should appear in the main sidebar above `Settings`, use the existing clock/ticker icon, and navigate to the existing `/automations` overview page on both desktop and mobile.
+
+This is a navigation and discoverability change, not a workspace redesign. Automation creation, editing, enabling, disabling, and deletion remain in `Settings > Automations`.
+
+## Goals
+
+- Make automation run history discoverable from the main app navigation
+- Preserve the existing separation between operational history and configuration
+- Reuse the current `/automations` workspace rather than introducing new routes
+- Keep the main sidebar behavior consistent across desktop and mobile
+
+## Non-Goals
+
+- Redesign the automations workspace layout
+- Move automation creation into the main sidebar or `/automations`
+- Change the existing settings ownership of automation authoring
+- Rework the automations workspace back-link behavior beyond what is already shipped
+
+## Product Decisions
+
+### Primary entry point
+
+- Add a new top-level `Automations` destination to the main sidebar
+- Place `Automations` directly above `Settings`
+- Keep `Settings` as the lowest sidebar option
+- Show the new destination on both desktop and mobile
+
+### Navigation target
+
+- Clicking `Automations` always navigates to `/automations`
+- Do not deep-link to the most recent automation or most recent run
+- Do not route the main entry to `/settings/automations`
+
+### Information architecture
+
+Maintain the existing split:
+
+- `Automations` means viewing automation runs and history
+- `Settings > Automations` means managing automation definitions and schedule configuration
+
+This preserves a clean mental model:
+
+- operational monitoring lives in the automations workspace
+- authoring and configuration live in settings
+
+## UX Design
+
+### Main sidebar
+
+The main sidebar footer currently exposes `Settings` as a single destination. Replace that single-link footer with a simple stacked two-link block:
+
+1. `Automations`
+2. `Settings`
+
+The new `Automations` row should:
+
+- reuse the existing clock/ticker icon already associated with automations
+- match the current footer-link visual treatment used by `Settings`
+- use the same transition and navigation behavior as other top-level sidebar destinations
+- close the mobile drawer after navigation, just like the existing settings link
+
+### Automations workspace
+
+No workspace restructure is required. The current route model remains the same:
+
+- `/automations` for overview and automation selection
+- `/automations/[automationId]` for per-automation run history
+- `/automations/[automationId]/runs/[runId]` for viewing a run transcript
+
+The overview page remains the default landing page for the new sidebar entry, even when no automations exist.
+
+### Settings page
+
+`/settings/automations` remains the only place where users can:
+
+- create automations
+- edit automation prompts and schedules
+- enable or disable automations
+- delete automations
+
+No creation controls should be added to the main sidebar as part of this change.
+
+## Implementation Shape
+
+### Primary change surface
+
+The main implementation surface is:
+
+- [components/sidebar.tsx](/Users/charles/.codex/worktrees/18eb/Eidon-AI/components/sidebar.tsx)
+
+That component should be updated to render both footer destinations in the agreed order while preserving the existing navigation helper behavior already used for `Settings`.
+
+### Existing routes reused as-is
+
+These existing pages remain the sources of truth:
+
+- [app/automations/page.tsx](/Users/charles/.codex/worktrees/18eb/Eidon-AI/app/automations/page.tsx)
+- [app/automations/[automationId]/page.tsx](/Users/charles/.codex/worktrees/18eb/Eidon-AI/app/automations/[automationId]/page.tsx)
+- [app/settings/automations/page.tsx](/Users/charles/.codex/worktrees/18eb/Eidon-AI/app/settings/automations/page.tsx)
+
+No new route is required for this feature.
+
+## States And Edge Cases
+
+- `Automations` must remain visible even when there are zero automation definitions
+- In the zero-automation case, `/automations` should continue showing its existing empty state
+- The sidebar entry should not be conditional on runtime data such as run count or enabled automations
+- Mobile and desktop should expose the same destinations in the same order
+
+## Testing
+
+Add focused regression coverage for navigation behavior.
+
+### Unit coverage
+
+- Verify the main sidebar renders `Automations` and `Settings`
+- Verify `Automations` is rendered above `Settings`
+- Verify the `Automations` link points to `/automations`
+- Verify the settings link still points to `/settings`
+
+### Manual validation
+
+- Confirm the new entry appears in the desktop sidebar
+- Confirm the new entry appears in the mobile sidebar/menu
+- Confirm clicking `Automations` lands on `/automations`
+- Confirm the mobile drawer closes after navigation
+- Confirm the existing zero-state behavior still works when no automations exist
+
+## Risks
+
+- The main risk is navigation inconsistency if the new link uses a different transition path than `Settings`
+- A secondary risk is accidental scope expansion into automations workspace redesign; this work should stay limited to entry-point discoverability and tests

--- a/tests/unit/automations-section.test.tsx
+++ b/tests/unit/automations-section.test.tsx
@@ -152,16 +152,13 @@ describe("automations section", () => {
     ).toBeTruthy();
   });
 
-  it("links directly to the automations workspace from settings", async () => {
+  it("does not show a redundant workspace shortcut in settings", async () => {
     render(React.createElement(AutomationsSection));
 
     await waitFor(() => {
       expect(screen.getByRole("button", { name: "Add automation" })).toBeInTheDocument();
     });
 
-    expect(screen.getByRole("link", { name: "Open automations workspace" })).toHaveAttribute(
-      "href",
-      "/automations"
-    );
+    expect(screen.queryByRole("link", { name: "Open automations workspace" })).toBeNull();
   });
 });

--- a/tests/unit/sidebar-footer-nav.test.tsx
+++ b/tests/unit/sidebar-footer-nav.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { SidebarFooterNav } from "@/components/sidebar-footer-nav";
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    onClick,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) => (
+    <a
+      href={href}
+      onClick={(event) => {
+        onClick?.(event);
+
+        if (
+          event.button !== 0 ||
+          event.metaKey ||
+          event.ctrlKey ||
+          event.shiftKey ||
+          event.altKey
+        ) {
+          event.preventDefault();
+        }
+      }}
+      {...props}
+    >
+      {children}
+    </a>
+  )
+}));
+
+describe("SidebarFooterNav", () => {
+  it("renders Automations above Settings with the correct hrefs", () => {
+    render(<SidebarFooterNav onNavigateAction={vi.fn()} />);
+
+    const automationsLink = screen.getByRole("link", { name: "Open automations" });
+    const settingsLink = screen.getByRole("link", { name: "Open settings" });
+
+    expect(automationsLink).toHaveAttribute("href", "/automations");
+    expect(settingsLink).toHaveAttribute("href", "/settings");
+    expect(
+      automationsLink.compareDocumentPosition(settingsLink) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
+
+  it("delegates plain left-click navigation through the provided action", () => {
+    const onNavigateAction = vi.fn();
+
+    render(<SidebarFooterNav onNavigateAction={onNavigateAction} />);
+
+    fireEvent.click(screen.getByRole("link", { name: "Open automations" }), { button: 0 });
+
+    expect(onNavigateAction).toHaveBeenCalledWith("/automations");
+  });
+
+  it("does not intercept modified clicks", () => {
+    const onNavigateAction = vi.fn();
+
+    render(<SidebarFooterNav onNavigateAction={onNavigateAction} />);
+
+    fireEvent.click(screen.getByRole("link", { name: "Open settings" }), {
+      button: 0,
+      metaKey: true
+    });
+
+    expect(onNavigateAction).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add a dedicated `Automations` footer entry above `Settings` in the main sidebar
- extract sidebar footer navigation into a reusable `SidebarFooterNav` component
- remove the redundant `Open workspace` shortcut from settings automations
- add focused unit coverage for sidebar footer navigation and update settings tests
- include the design spec and implementation plan used for the change

## Testing
- `npx vitest run tests/unit/sidebar-footer-nav.test.tsx tests/unit/settings-layout.test.tsx tests/unit/automations-section.test.tsx`
- `npx vitest run tests/unit/automations-section.test.tsx`
- `npm run typecheck` *(fails due to pre-existing unrelated issues in `tests/unit/copilot-tools.test.ts` and `tests/unit/ws-handler.test.ts`)*