### PR TITLE
Add conversation forking from assistant messages

### DIFF
--- a/app/api/messages/[messageId]/fork/route.ts
+++ b/app/api/messages/[messageId]/fork/route.ts
@@ -1,0 +1,38 @@
+import { z } from "zod";
+
+import { requireUser } from "@/lib/auth";
+import { forkConversationFromMessage } from "@/lib/conversations";
+import { badRequest, ok } from "@/lib/http";
+
+const paramsSchema = z.object({
+  messageId: z.string().min(1)
+});
+
+export async function POST(
+  _request: Request,
+  context: { params: Promise<{ messageId: string }> }
+) {
+  const user = await requireUser();
+  const params = paramsSchema.safeParse(await context.params);
+
+  if (!params.success) {
+    return badRequest("Invalid message id");
+  }
+
+  try {
+    const conversation = forkConversationFromMessage(params.data.messageId, user.id);
+    return ok({ conversation }, { status: 201 });
+  } catch (error) {
+    if (error instanceof Error) {
+      if (error.message === "Message not found" || error.message === "Conversation not found") {
+        return badRequest(error.message, 404);
+      }
+
+      if (error.message === "Only assistant messages can be forked") {
+        return badRequest(error.message, 400);
+      }
+    }
+
+    throw error;
+  }
+}

--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -301,6 +301,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
   const streamMessageIdRef = useRef<string | null>(null);
   const streamTimelineRef = useRef<MessageTimelineItem[]>([]);
   const [updatingMessageId, setUpdatingMessageId] = useState<string | null>(null);
+  const [forkingMessageId, setForkingMessageId] = useState<string | null>(null);
   const titlePollTimeoutRef = useRef<number | null>(null);
   const titlePollAttemptsRef = useRef(0);
   const messageSyncTimeoutRef = useRef<number | null>(null);
@@ -1107,6 +1108,50 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
     }
   }
 
+  async function forkAssistantMessage(messageId: string) {
+    if (forkingMessageId) {
+      return;
+    }
+
+    setError("");
+    setForkingMessageId(messageId);
+
+    try {
+      const response = await fetch(`/api/messages/${messageId}/fork`, {
+        method: "POST"
+      });
+
+      if (!response.ok) {
+        let message = "Unable to fork conversation";
+
+        try {
+          const failure = (await response.json()) as { error?: string };
+          message = failure.error ?? message;
+        } catch {}
+
+        throw new Error(message);
+      }
+
+      const result = (await response.json()) as {
+        conversationId?: string;
+        newConversationId?: string;
+      };
+      const nextConversationId = result.newConversationId ?? result.conversationId;
+
+      if (!nextConversationId) {
+        throw new Error("Unable to fork conversation");
+      }
+
+      router.push(`/chat/${nextConversationId}`);
+    } catch (caughtError) {
+      setError(
+        caughtError instanceof Error ? caughtError.message : "Unable to fork conversation"
+      );
+    } finally {
+      setForkingMessageId((current) => (current === messageId ? null : current));
+    }
+  }
+
   async function updateProviderProfile(nextProviderProfileId: string) {
     const previousProviderProfileId = providerProfileId;
     setError("");
@@ -1327,6 +1372,8 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
                 hasThinking={message.id === streamMessageId ? Boolean(streamThinkingTarget) : false}
                 onUpdateUserMessage={updateUserMessage}
                 isUpdating={updatingMessageId === message.id}
+                onForkAssistantMessage={forkAssistantMessage}
+                isForking={forkingMessageId === message.id}
               />
             </div>
           ))}

--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -1133,10 +1133,11 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
       }
 
       const result = (await response.json()) as {
-        conversationId?: string;
-        newConversationId?: string;
+        conversation?: {
+          id?: string;
+        };
       };
-      const nextConversationId = result.newConversationId ?? result.conversationId;
+      const nextConversationId = result.conversation?.id;
 
       if (!nextConversationId) {
         throw new Error("Unable to fork conversation");

--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -373,7 +373,7 @@ export function MessageBubble({
   const copyResetHandle = useRef<number | null>(null);
   const showThinkingShell = !awaitingFirstToken && (thinkingInProgress || hasThinking || Boolean(thinkingContent));
   const showUserBubbleActions = Boolean(content) && !awaitingFirstToken;
-  const showAssistantBubbleActions = Boolean(assistantText) && !awaitingFirstToken && message.status === "completed";
+  const showAssistantBubbleActions = Boolean(assistantText) && !awaitingFirstToken;
 
   useEffect(() => {
     setDraft(message.content);
@@ -648,7 +648,7 @@ export function MessageBubble({
                         <Copy className="h-3.5 w-3.5" />
                       )}
                     </ActionButton>
-                    {onForkAssistantMessage ? (
+                    {onForkAssistantMessage && message.status === "completed" ? (
                       <ActionButton
                         label="Fork conversation from message"
                         onClick={() => onForkAssistantMessage(message.id)}

--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useEffect, useRef, useState } from "react";
-import { Brain, Check, ChevronDown, ChevronRight, Copy, FileText, LoaderCircle, Pencil, Square, X } from "lucide-react";
+import { Brain, Check, ChevronDown, ChevronRight, Copy, FileText, GitFork, LoaderCircle, Pencil, Square, X } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
@@ -251,7 +251,8 @@ export function MessageBubble({
   thinkingDuration,
   hasThinking = false,
   onUpdateUserMessage,
-  isUpdating = false
+  isUpdating = false,
+  onForkAssistantMessage
 }: {
   message: Message;
   streamingTimeline?: MessageTimelineItem[];
@@ -264,6 +265,7 @@ export function MessageBubble({
   hasThinking?: boolean;
   onUpdateUserMessage?: (messageId: string, content: string) => Promise<void>;
   isUpdating?: boolean;
+  onForkAssistantMessage?: (messageId: string) => void;
 }) {
   const rawContent = streamingAnswer ?? message.content;
   const rawThinking = streamingThinking ?? message.thinkingContent;
@@ -371,7 +373,7 @@ export function MessageBubble({
   const copyResetHandle = useRef<number | null>(null);
   const showThinkingShell = !awaitingFirstToken && (thinkingInProgress || hasThinking || Boolean(thinkingContent));
   const showUserBubbleActions = Boolean(content) && !awaitingFirstToken;
-  const showAssistantBubbleActions = Boolean(assistantText) && !awaitingFirstToken;
+  const showAssistantBubbleActions = Boolean(assistantText) && !awaitingFirstToken && message.status === "completed";
 
   useEffect(() => {
     setDraft(message.content);
@@ -646,6 +648,14 @@ export function MessageBubble({
                         <Copy className="h-3.5 w-3.5" />
                       )}
                     </ActionButton>
+                    {onForkAssistantMessage ? (
+                      <ActionButton
+                        label="Fork conversation from message"
+                        onClick={() => onForkAssistantMessage(message.id)}
+                      >
+                        <GitFork className="h-3.5 w-3.5" />
+                      </ActionButton>
+                    ) : null}
                   </div>
                 ) : null}
               </div>
@@ -666,7 +676,8 @@ export function StreamingPlaceholder({
   compactionInProgress = false,
   thinkingInProgress,
   thinkingDuration,
-  hasThinking = false
+  hasThinking = false,
+  onForkAssistantMessage
 }: {
   createdAt: string;
   thinking: string;
@@ -677,6 +688,7 @@ export function StreamingPlaceholder({
   thinkingInProgress: boolean;
   thinkingDuration?: number;
   hasThinking?: boolean;
+  onForkAssistantMessage?: (messageId: string) => void;
 }) {
   return (
     <MessageBubble
@@ -700,6 +712,7 @@ export function StreamingPlaceholder({
       thinkingInProgress={thinkingInProgress}
       thinkingDuration={thinkingDuration}
       hasThinking={hasThinking}
+      onForkAssistantMessage={onForkAssistantMessage}
     />
   );
 }

--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -252,7 +252,8 @@ export function MessageBubble({
   hasThinking = false,
   onUpdateUserMessage,
   isUpdating = false,
-  onForkAssistantMessage
+  onForkAssistantMessage,
+  isForking = false
 }: {
   message: Message;
   streamingTimeline?: MessageTimelineItem[];
@@ -266,6 +267,7 @@ export function MessageBubble({
   onUpdateUserMessage?: (messageId: string, content: string) => Promise<void>;
   isUpdating?: boolean;
   onForkAssistantMessage?: (messageId: string) => void;
+  isForking?: boolean;
 }) {
   const rawContent = streamingAnswer ?? message.content;
   const rawThinking = streamingThinking ?? message.thinkingContent;
@@ -652,8 +654,13 @@ export function MessageBubble({
                       <ActionButton
                         label="Fork conversation from message"
                         onClick={() => onForkAssistantMessage(message.id)}
+                        disabled={isForking}
                       >
-                        <GitFork className="h-3.5 w-3.5" />
+                        {isForking ? (
+                          <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
+                        ) : (
+                          <GitFork className="h-3.5 w-3.5" />
+                        )}
                       </ActionButton>
                     ) : null}
                   </div>

--- a/docs/superpowers/plans/2026-04-11-branching-fork-conversation.md
+++ b/docs/superpowers/plans/2026-04-11-branching-fork-conversation.md
@@ -1,0 +1,1095 @@
+# Branching / Fork Conversation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an assistant-message fork action that creates a new conversation containing the exact persisted thread prefix through the selected assistant message and redirects the user into the new conversation.
+
+**Architecture:** The server owns forking semantics through a new message-scoped API endpoint backed by a transactional cloning helper in `lib/conversations.ts`. The client adds a fork control next to the assistant copy action and delegates request, error handling, and navigation to `ChatView`, keeping the UI thin and the copy logic centralized.
+
+**Tech Stack:** Next.js App Router, React 19, TypeScript, better-sqlite3, Vitest, Testing Library
+
+---
+
+## File Map
+
+### Existing files to modify
+
+- `lib/conversations.ts`
+  Add a transactional `forkConversationFromMessage` helper plus small internal helpers for prefix lookup, row remapping, and compaction eligibility.
+- `components/message-bubble.tsx`
+  Extend the assistant action row UI to render a fork button next to copy and accept an optional callback for assistant message fork actions.
+- `components/chat-view.tsx`
+  Own the fork request lifecycle, local loading/error state, and `router.push()` success navigation.
+- `tests/unit/conversations.test.ts`
+  Add data-layer coverage for prefix cloning, ID remapping, attachment preservation, and compaction filtering.
+- `tests/unit/message-bubble.test.ts`
+  Add rendering coverage for the fork affordance on assistant messages only.
+- `tests/unit/chat-view.test.ts`
+  Add interaction coverage for request dispatch, redirect, and failure behavior.
+
+### New files to create
+
+- `app/api/messages/[messageId]/fork/route.ts`
+  Message-scoped POST endpoint for authenticated assistant-message forking.
+
+### Existing files to reference while implementing
+
+- `app/api/messages/[messageId]/route.ts`
+  Existing message-scoped route style and validation shape.
+- `app/chat/[conversationId]/page.tsx`
+  Existing chat page load path after redirect.
+- `tests/setup.ts`
+  Shared unit test environment setup if additional browser APIs need stubbing.
+
+---
+
+### Task 1: Add failing data-layer tests for transactional prefix cloning
+
+**Files:**
+- Modify: `tests/unit/conversations.test.ts`
+- Modify: `lib/conversations.ts`
+- Reference: `tests/unit/attachments.test.ts`
+
+- [ ] **Step 1: Write the failing data-layer tests**
+
+Add the following tests near the other `conversation helpers` cases in `tests/unit/conversations.test.ts`:
+
+```ts
+import {
+  createConversation,
+  createMessage,
+  createMessageAction,
+  createMessageTextSegment,
+  createConversationAttachment,
+  createCompactionEvent,
+  createMemoryNode,
+  forkConversationFromMessage,
+  getConversation,
+  listMessages,
+  listVisibleMessages
+} from "@/lib/conversations";
+
+it("forks a conversation through the selected assistant message and remaps related rows", () => {
+  const source = createConversation("Source conversation");
+  const user = createMessage({
+    conversationId: source.id,
+    role: "user",
+    content: "Original request"
+  });
+  const assistant = createMessage({
+    conversationId: source.id,
+    role: "assistant",
+    content: "First answer",
+    thinkingContent: "Reasoning block"
+  });
+  createMessageAction({
+    messageId: assistant.id,
+    kind: "mcp_tool_call",
+    status: "completed",
+    serverId: "docs",
+    skillId: null,
+    toolName: "search_docs",
+    label: "Search docs",
+    detail: "query=fork",
+    arguments: { query: "fork" },
+    resultSummary: "Done",
+    sortOrder: 0
+  });
+  createMessageTextSegment({
+    messageId: assistant.id,
+    content: "First answer",
+    sortOrder: 0
+  });
+  createConversationAttachment({
+    conversationId: source.id,
+    messageId: assistant.id,
+    filename: "diagram.txt",
+    mimeType: "text/plain",
+    byteSize: 5,
+    sha256: "abc123",
+    relativePath: `${source.id}/diagram.txt`,
+    kind: "text",
+    extractedText: "fork"
+  });
+
+  const tail = createMessage({
+    conversationId: source.id,
+    role: "assistant",
+    content: "Later answer"
+  });
+
+  const eligibleNode = createMemoryNode({
+    conversationId: source.id,
+    type: "leaf_summary",
+    depth: 0,
+    content: "Summary through first answer",
+    sourceStartMessageId: user.id,
+    sourceEndMessageId: assistant.id,
+    sourceTokenCount: 50,
+    summaryTokenCount: 10,
+    childNodeIds: []
+  });
+
+  createCompactionEvent({
+    conversationId: source.id,
+    nodeId: eligibleNode.id,
+    sourceStartMessageId: user.id,
+    sourceEndMessageId: assistant.id,
+    noticeMessageId: null
+  });
+
+  createMemoryNode({
+    conversationId: source.id,
+    type: "leaf_summary",
+    depth: 0,
+    content: "Summary including later answer",
+    sourceStartMessageId: user.id,
+    sourceEndMessageId: tail.id,
+    sourceTokenCount: 60,
+    summaryTokenCount: 12,
+    childNodeIds: []
+  });
+
+  const forked = forkConversationFromMessage(assistant.id);
+
+  expect(forked.id).not.toBe(source.id);
+  expect(forked.providerProfileId).toBe(getConversation(source.id)?.providerProfileId ?? null);
+
+  const forkMessages = listMessages(forked.id);
+  expect(forkMessages.map((message) => message.content)).toEqual([
+    "Original request",
+    "First answer"
+  ]);
+  expect(forkMessages[1]?.thinkingContent).toBe("Reasoning block");
+  expect(forkMessages[1]?.actions).toHaveLength(1);
+  expect(forkMessages[1]?.textSegments).toHaveLength(1);
+  expect(forkMessages[1]?.attachments).toHaveLength(1);
+
+  expect(forkMessages.some((message) => message.content === "Later answer")).toBe(false);
+  expect(forkMessages[1]?.id).not.toBe(assistant.id);
+  expect(forkMessages[1]?.actions?.[0]?.messageId).toBe(forkMessages[1]?.id);
+  expect(forkMessages[1]?.textSegments?.[0]?.messageId).toBe(forkMessages[1]?.id);
+  expect(forkMessages[1]?.attachments?.[0]?.messageId).toBe(forkMessages[1]?.id);
+});
+
+it("rejects forking a non-assistant message", () => {
+  const source = createConversation("Source conversation");
+  const user = createMessage({
+    conversationId: source.id,
+    role: "user",
+    content: "Original request"
+  });
+
+  expect(() => forkConversationFromMessage(user.id)).toThrow("Only assistant messages can be forked");
+});
+```
+
+- [ ] **Step 2: Run the targeted data-layer tests to verify they fail**
+
+Run:
+
+```bash
+npx vitest run tests/unit/conversations.test.ts
+```
+
+Expected: FAIL with `forkConversationFromMessage` missing and missing helper/create functions referenced by the new tests.
+
+- [ ] **Step 3: Add the minimal cloning helper and supporting test fixtures**
+
+Implement the data-layer API in `lib/conversations.ts` and add any small exported test helpers the tests require, following this shape:
+
+```ts
+export function forkConversationFromMessage(messageId: string, userId?: string) {
+  const transaction = getDb().transaction((targetMessageId: string, targetUserId?: string) => {
+    const sourceMessage = getMessage(targetMessageId, targetUserId);
+
+    if (!sourceMessage) {
+      throw new Error("Message not found");
+    }
+
+    if (sourceMessage.role !== "assistant") {
+      throw new Error("Only assistant messages can be forked");
+    }
+
+    const sourceConversation = getConversation(sourceMessage.conversationId, targetUserId);
+    if (!sourceConversation) {
+      throw new Error("Conversation not found");
+    }
+
+    const sourceMessages = listMessages(sourceConversation.id);
+    const branchIndex = sourceMessages.findIndex((message) => message.id === sourceMessage.id);
+    if (branchIndex === -1) {
+      throw new Error("Message not found");
+    }
+
+    const retainedMessages = sourceMessages.slice(0, branchIndex + 1);
+    const retainedMessageIds = new Set(retainedMessages.map((message) => message.id));
+    const forkedConversation = createConversation(null, sourceConversation.folderId, {
+      providerProfileId: sourceConversation.providerProfileId
+    }, targetUserId ?? getConversationOwnerId(sourceConversation.id) ?? undefined);
+
+    const messageIdMap = new Map<string, string>();
+
+    for (const message of retainedMessages) {
+      const cloned = createMessage({
+        conversationId: forkedConversation.id,
+        role: message.role,
+        content: message.content,
+        thinkingContent: message.thinkingContent,
+        status: message.status,
+        systemKind: message.systemKind,
+        estimatedTokens: message.estimatedTokens
+      });
+      messageIdMap.set(message.id, cloned.id);
+
+      for (const action of message.actions ?? []) {
+        createMessageAction({
+          messageId: cloned.id,
+          kind: action.kind,
+          status: action.status,
+          serverId: action.serverId,
+          skillId: action.skillId,
+          toolName: action.toolName,
+          label: action.label,
+          detail: action.detail,
+          arguments: action.arguments,
+          resultSummary: action.resultSummary,
+          sortOrder: action.sortOrder
+        });
+      }
+
+      for (const segment of message.textSegments ?? []) {
+        createMessageTextSegment({
+          messageId: cloned.id,
+          content: segment.content,
+          sortOrder: segment.sortOrder
+        });
+      }
+
+      for (const attachment of message.attachments ?? []) {
+        createConversationAttachment({
+          conversationId: forkedConversation.id,
+          messageId: cloned.id,
+          filename: attachment.filename,
+          mimeType: attachment.mimeType,
+          byteSize: attachment.byteSize,
+          sha256: attachment.sha256,
+          relativePath: attachment.relativePath,
+          kind: attachment.kind,
+          extractedText: attachment.extractedText
+        });
+      }
+    }
+
+    cloneEligibleCompactionState({
+      sourceConversationId: sourceConversation.id,
+      targetConversationId: forkedConversation.id,
+      retainedMessageIds,
+      messageIdMap
+    });
+
+    return forkedConversation;
+  });
+
+  return transaction(messageId, userId);
+}
+```
+
+Also add small DB-backed helpers only if needed by tests and implementation:
+
+```ts
+export function createConversationAttachment(input: {
+  conversationId: string;
+  messageId: string | null;
+  filename: string;
+  mimeType: string;
+  byteSize: number;
+  sha256: string;
+  relativePath: string;
+  kind: AttachmentKind;
+  extractedText: string;
+}) {
+  const attachment = {
+    id: createId("att"),
+    createdAt: nowIso(),
+    ...input
+  };
+
+  getDb()
+    .prepare(
+      `INSERT INTO message_attachments (
+        id, conversation_id, message_id, filename, mime_type, byte_size,
+        sha256, relative_path, kind, extracted_text, created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    )
+    .run(
+      attachment.id,
+      attachment.conversationId,
+      attachment.messageId,
+      attachment.filename,
+      attachment.mimeType,
+      attachment.byteSize,
+      attachment.sha256,
+      attachment.relativePath,
+      attachment.kind,
+      attachment.extractedText,
+      attachment.createdAt
+    );
+
+  return attachment;
+}
+
+export function createMemoryNode(input: {
+  conversationId: string;
+  type: MemoryNodeType;
+  depth: number;
+  content: string;
+  sourceStartMessageId: string;
+  sourceEndMessageId: string;
+  sourceTokenCount: number;
+  summaryTokenCount: number;
+  childNodeIds: string[];
+}) {
+  const node = {
+    id: createId("mem"),
+    supersededByNodeId: null,
+    createdAt: nowIso(),
+    ...input
+  };
+
+  getDb()
+    .prepare(
+      `INSERT INTO memory_nodes (
+        id, conversation_id, type, depth, content, source_start_message_id,
+        source_end_message_id, source_token_count, summary_token_count,
+        child_node_ids, superseded_by_node_id, created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    )
+    .run(
+      node.id,
+      node.conversationId,
+      node.type,
+      node.depth,
+      node.content,
+      node.sourceStartMessageId,
+      node.sourceEndMessageId,
+      node.sourceTokenCount,
+      node.summaryTokenCount,
+      JSON.stringify(node.childNodeIds),
+      node.supersededByNodeId,
+      node.createdAt
+    );
+
+  return node;
+}
+
+export function createCompactionEvent(input: {
+  conversationId: string;
+  nodeId: string;
+  sourceStartMessageId: string;
+  sourceEndMessageId: string;
+  noticeMessageId: string | null;
+}) {
+  const event = {
+    id: createId("cmp"),
+    createdAt: nowIso(),
+    ...input
+  };
+
+  getDb()
+    .prepare(
+      `INSERT INTO compaction_events (
+        id, conversation_id, node_id, source_start_message_id,
+        source_end_message_id, notice_message_id, created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?)`
+    )
+    .run(
+      event.id,
+      event.conversationId,
+      event.nodeId,
+      event.sourceStartMessageId,
+      event.sourceEndMessageId,
+      event.noticeMessageId,
+      event.createdAt
+    );
+
+  return event;
+}
+
+function cloneEligibleCompactionState(input: {
+  sourceConversationId: string;
+  targetConversationId: string;
+  retainedMessageIds: Set<string>;
+  messageIdMap: Map<string, string>;
+}) {
+  const sourceNodes = getDb()
+    .prepare(
+      `SELECT
+        id, type, depth, content, source_start_message_id, source_end_message_id,
+        source_token_count, summary_token_count, child_node_ids
+       FROM memory_nodes
+       WHERE conversation_id = ?
+       ORDER BY created_at ASC`
+    )
+    .all(input.sourceConversationId) as Array<{
+      id: string;
+      type: MemoryNodeType;
+      depth: number;
+      content: string;
+      source_start_message_id: string;
+      source_end_message_id: string;
+      source_token_count: number;
+      summary_token_count: number;
+      child_node_ids: string;
+    }>;
+
+  const eligibleNodeIds = new Map<string, string>();
+
+  for (const node of sourceNodes) {
+    if (
+      !input.retainedMessageIds.has(node.source_start_message_id) ||
+      !input.retainedMessageIds.has(node.source_end_message_id)
+    ) {
+      continue;
+    }
+
+    const cloned = createMemoryNode({
+      conversationId: input.targetConversationId,
+      type: node.type,
+      depth: node.depth,
+      content: node.content,
+      sourceStartMessageId: input.messageIdMap.get(node.source_start_message_id)!,
+      sourceEndMessageId: input.messageIdMap.get(node.source_end_message_id)!,
+      sourceTokenCount: node.source_token_count,
+      summaryTokenCount: node.summary_token_count,
+      childNodeIds: JSON.parse(node.child_node_ids) as string[]
+    });
+
+    eligibleNodeIds.set(node.id, cloned.id);
+  }
+
+  const sourceEvents = getDb()
+    .prepare(
+      `SELECT
+        node_id, source_start_message_id, source_end_message_id, notice_message_id
+       FROM compaction_events
+       WHERE conversation_id = ?
+       ORDER BY created_at ASC`
+    )
+    .all(input.sourceConversationId) as Array<{
+      node_id: string;
+      source_start_message_id: string;
+      source_end_message_id: string;
+      notice_message_id: string | null;
+    }>;
+
+  for (const event of sourceEvents) {
+    const clonedNodeId = eligibleNodeIds.get(event.node_id);
+
+    if (
+      !clonedNodeId ||
+      !input.retainedMessageIds.has(event.source_start_message_id) ||
+      !input.retainedMessageIds.has(event.source_end_message_id)
+    ) {
+      continue;
+    }
+
+    createCompactionEvent({
+      conversationId: input.targetConversationId,
+      nodeId: clonedNodeId,
+      sourceStartMessageId: input.messageIdMap.get(event.source_start_message_id)!,
+      sourceEndMessageId: input.messageIdMap.get(event.source_end_message_id)!,
+      noticeMessageId: event.notice_message_id
+        ? input.messageIdMap.get(event.notice_message_id) ?? null
+        : null
+    });
+  }
+}
+```
+
+- [ ] **Step 4: Run the targeted data-layer tests to verify they pass**
+
+Run:
+
+```bash
+npx vitest run tests/unit/conversations.test.ts
+```
+
+Expected: PASS for the new forking tests and existing conversation helper coverage.
+
+- [ ] **Step 5: Commit the data-layer foundation**
+
+```bash
+git add lib/conversations.ts tests/unit/conversations.test.ts
+git commit -m "feat: add conversation fork data helper"
+```
+
+### Task 2: Add failing API route tests for message-scoped forking
+
+**Files:**
+- Create: `app/api/messages/[messageId]/fork/route.ts`
+- Modify: `tests/unit/conversations.test.ts`
+- Modify: `lib/conversations.ts`
+
+- [ ] **Step 1: Write the failing API route tests**
+
+Append route coverage to `tests/unit/conversations.test.ts` using the same unit style as other route-adjacent helper tests:
+
+```ts
+const { requireUserMock } = vi.hoisted(() => ({
+  requireUserMock: vi.fn()
+}));
+
+vi.mock("@/lib/auth", () => ({
+  requireUser: requireUserMock
+}));
+
+it("fork route creates a forked conversation for an assistant message", async () => {
+  requireUserMock.mockResolvedValue({
+    id: "user_route",
+    username: "route-user",
+    role: "user",
+    authSource: "local",
+    passwordManagedBy: "local",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z"
+  });
+  const { POST } = await import("@/app/api/messages/[messageId]/fork/route");
+  const user = await createLocalUser({
+    username: "fork-route-user",
+    password: "Password123!",
+    role: "user"
+  });
+  const source = createConversation("Source", null, undefined, user.id);
+  const assistant = createMessage({
+    conversationId: source.id,
+    role: "assistant",
+    content: "Fork from here"
+  });
+
+  const response = await POST(
+    new Request("http://localhost/api/messages/msg/fork", { method: "POST" }),
+    { params: Promise.resolve({ messageId: assistant.id }) }
+  );
+  const payload = await response.json() as { conversation?: { id: string } };
+
+  expect(response.status).toBe(201);
+  expect(payload.conversation?.id).toBeTruthy();
+  expect(listVisibleMessages(payload.conversation!.id).map((message) => message.content)).toEqual([
+    "Fork from here"
+  ]);
+});
+
+it("fork route rejects user messages", async () => {
+  requireUserMock.mockResolvedValue({
+    id: "user_route_two",
+    username: "route-user-two",
+    role: "user",
+    authSource: "local",
+    passwordManagedBy: "local",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z"
+  });
+  const { POST } = await import("@/app/api/messages/[messageId]/fork/route");
+  const user = await createLocalUser({
+    username: "fork-route-user-two",
+    password: "Password123!",
+    role: "user"
+  });
+  const source = createConversation("Source", null, undefined, user.id);
+  const userMessage = createMessage({
+    conversationId: source.id,
+    role: "user",
+    content: "Cannot fork me"
+  });
+
+  const response = await POST(
+    new Request("http://localhost/api/messages/msg/fork", { method: "POST" }),
+    { params: Promise.resolve({ messageId: userMessage.id }) }
+  );
+
+  expect(response.status).toBe(400);
+});
+```
+
+- [ ] **Step 2: Run the targeted tests to verify they fail**
+
+Run:
+
+```bash
+npx vitest run tests/unit/conversations.test.ts
+```
+
+Expected: FAIL because `app/api/messages/[messageId]/fork/route.ts` does not exist.
+
+- [ ] **Step 3: Add the minimal fork route**
+
+Create `app/api/messages/[messageId]/fork/route.ts` with this implementation:
+
+```ts
+import { z } from "zod";
+
+import { requireUser } from "@/lib/auth";
+import { forkConversationFromMessage } from "@/lib/conversations";
+import { badRequest, ok } from "@/lib/http";
+
+const paramsSchema = z.object({
+  messageId: z.string().min(1)
+});
+
+export async function POST(
+  _request: Request,
+  context: { params: Promise<{ messageId: string }> }
+) {
+  const user = await requireUser();
+  const params = paramsSchema.safeParse(await context.params);
+
+  if (!params.success) {
+    return badRequest("Invalid message id");
+  }
+
+  try {
+    const conversation = forkConversationFromMessage(params.data.messageId, user.id);
+    return ok({ conversation }, { status: 201 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unable to fork conversation";
+
+    if (message === "Message not found" || message === "Conversation not found") {
+      return badRequest(message, 404);
+    }
+
+    if (message === "Only assistant messages can be forked") {
+      return badRequest(message, 400);
+    }
+
+    throw error;
+  }
+}
+```
+
+- [ ] **Step 4: Run the targeted tests to verify they pass**
+
+Run:
+
+```bash
+npx vitest run tests/unit/conversations.test.ts
+```
+
+Expected: PASS for the new route coverage and existing conversation tests.
+
+- [ ] **Step 5: Commit the API slice**
+
+```bash
+git add app/api/messages/[messageId]/fork/route.ts lib/conversations.ts tests/unit/conversations.test.ts
+git commit -m "feat: add message fork api route"
+```
+
+### Task 3: Add failing UI tests for the assistant fork action rendering
+
+**Files:**
+- Modify: `components/message-bubble.tsx`
+- Modify: `tests/unit/message-bubble.test.ts`
+
+- [ ] **Step 1: Write the failing UI rendering tests**
+
+Add these tests to `tests/unit/message-bubble.test.ts`:
+
+```ts
+it("renders a fork action for completed assistant messages", () => {
+  render(
+    React.createElement(MessageBubble, {
+      message: createAssistantMessage(),
+      onForkAssistantMessage: vi.fn()
+    })
+  );
+
+  expect(screen.getByRole("button", { name: "Fork conversation from message" })).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: "Copy message" })).toBeInTheDocument();
+});
+
+it("does not render a fork action for user messages", () => {
+  render(
+    React.createElement(MessageBubble, {
+      message: createUserMessage(),
+      onForkAssistantMessage: vi.fn()
+    })
+  );
+
+  expect(screen.queryByRole("button", { name: "Fork conversation from message" })).toBeNull();
+});
+
+it("does not render a fork action for streaming placeholders", () => {
+  render(
+    React.createElement(StreamingPlaceholder, {
+      createdAt: new Date().toISOString(),
+      thinking: "",
+      answer: "Streaming answer",
+      awaitingFirstToken: false,
+      thinkingInProgress: false,
+      timeline: []
+    })
+  );
+
+  expect(screen.queryByRole("button", { name: "Fork conversation from message" })).toBeNull();
+});
+```
+
+- [ ] **Step 2: Run the targeted UI test file to verify it fails**
+
+Run:
+
+```bash
+npx vitest run tests/unit/message-bubble.test.ts
+```
+
+Expected: FAIL because `MessageBubble` does not yet accept or render the fork action.
+
+- [ ] **Step 3: Add the minimal fork button support in the message bubble**
+
+Update `components/message-bubble.tsx` with these focused changes:
+
+```ts
+import { GitFork, Brain, Check, ChevronDown, ChevronRight, Copy, FileText, LoaderCircle, Pencil, Square, X } from "lucide-react";
+
+export function MessageBubble({
+  message,
+  onForkAssistantMessage,
+  ...rest
+}: {
+  message: Message;
+  onForkAssistantMessage?: (messageId: string) => void | Promise<void>;
+  // keep existing props unchanged
+}) {
+  const showAssistantBubbleActions =
+    message.role === "assistant" &&
+    message.id !== "streaming" &&
+    message.status !== "streaming";
+
+  const canForkAssistantMessage =
+    message.role === "assistant" &&
+    message.id !== "streaming" &&
+    message.status !== "streaming" &&
+    Boolean(onForkAssistantMessage);
+
+  // existing assistant action row...
+  {showAssistantBubbleActions ? (
+    <div className="mt-2 flex items-center gap-1 opacity-100 transition md:pointer-events-none md:translate-y-1 md:opacity-0 md:group-hover:pointer-events-auto md:group-hover:translate-y-0 md:group-hover:opacity-100 md:group-focus-within:pointer-events-auto md:group-focus-within:translate-y-0 md:group-focus-within:opacity-100">
+      {canForkAssistantMessage ? (
+        <ActionButton
+          label="Fork conversation from message"
+          onClick={() => {
+            void onForkAssistantMessage?.(message.id);
+          }}
+        >
+          <GitFork className="h-3.5 w-3.5" />
+        </ActionButton>
+      ) : null}
+      <ActionButton
+        label={copyState === "copied" ? "Copied" : "Copy message"}
+        onClick={() => void handleCopy()}
+      >
+        {/* keep existing copy icon state logic unchanged */}
+      </ActionButton>
+    </div>
+  ) : null}
+}
+```
+
+- [ ] **Step 4: Run the targeted UI test file to verify it passes**
+
+Run:
+
+```bash
+npx vitest run tests/unit/message-bubble.test.ts
+```
+
+Expected: PASS for the new rendering coverage and existing message bubble tests.
+
+- [ ] **Step 5: Commit the message bubble UI support**
+
+```bash
+git add components/message-bubble.tsx tests/unit/message-bubble.test.ts
+git commit -m "feat: add assistant message fork action"
+```
+
+### Task 4: Add failing chat view tests for fork request, redirect, and error handling
+
+**Files:**
+- Modify: `components/chat-view.tsx`
+- Modify: `tests/unit/chat-view.test.ts`
+
+- [ ] **Step 1: Write the failing chat view interaction tests**
+
+Add these tests to `tests/unit/chat-view.test.ts`:
+
+```ts
+it("forks an assistant message and redirects to the new conversation", async () => {
+  const payload = createPayload();
+  payload.messages = [
+    {
+      id: "msg_assistant",
+      conversationId: "conv_1",
+      role: "assistant",
+      content: "Branch here",
+      thinkingContent: "",
+      status: "completed",
+      estimatedTokens: 0,
+      systemKind: null,
+      compactedAt: null,
+      createdAt: new Date().toISOString(),
+      actions: []
+    }
+  ];
+
+  vi.mocked(global.fetch)
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ personas: [] })
+    } as Response)
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        conversation: {
+          id: "conv_forked"
+        }
+      })
+    } as Response);
+
+  renderWithProvider(React.createElement(ChatView, { payload }));
+
+  fireEvent.click(screen.getByRole("button", { name: "Fork conversation from message" }));
+
+  await waitFor(() => {
+    expect(global.fetch).toHaveBeenCalledWith("/api/messages/msg_assistant/fork", {
+      method: "POST"
+    });
+    expect(push).toHaveBeenCalledWith("/chat/conv_forked");
+  });
+});
+
+it("shows a local error when the fork request fails", async () => {
+  const payload = createPayload();
+  payload.messages = [
+    {
+      id: "msg_assistant",
+      conversationId: "conv_1",
+      role: "assistant",
+      content: "Branch here",
+      thinkingContent: "",
+      status: "completed",
+      estimatedTokens: 0,
+      systemKind: null,
+      compactedAt: null,
+      createdAt: new Date().toISOString(),
+      actions: []
+    }
+  ];
+
+  vi.mocked(global.fetch)
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ personas: [] })
+    } as Response)
+    .mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ error: "Unable to fork conversation" })
+    } as Response);
+
+  renderWithProvider(React.createElement(ChatView, { payload }));
+
+  fireEvent.click(screen.getByRole("button", { name: "Fork conversation from message" }));
+
+  await waitFor(() => {
+    expect(screen.getByText("Unable to fork conversation")).toBeInTheDocument();
+  });
+
+  expect(push).not.toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 2: Run the targeted chat view tests to verify they fail**
+
+Run:
+
+```bash
+npx vitest run tests/unit/chat-view.test.ts
+```
+
+Expected: FAIL because `ChatView` does not yet wire the fork action into `MessageBubble`.
+
+- [ ] **Step 3: Add the minimal chat view fork flow**
+
+Update `components/chat-view.tsx` with a focused request handler and pass-through prop:
+
+```ts
+const [forkingMessageId, setForkingMessageId] = useState<string | null>(null);
+
+async function forkAssistantMessage(messageId: string) {
+  if (forkingMessageId) {
+    return;
+  }
+
+  setError("");
+  setForkingMessageId(messageId);
+
+  try {
+    const response = await fetch(`/api/messages/${messageId}/fork`, {
+      method: "POST"
+    });
+
+    if (!response.ok) {
+      let message = "Unable to fork conversation";
+
+      try {
+        const failure = (await response.json()) as { error?: string };
+        message = failure.error ?? message;
+      } catch {}
+
+      throw new Error(message);
+    }
+
+    const payload = (await response.json()) as { conversation: { id: string } };
+    router.push(`/chat/${payload.conversation.id}`);
+  } catch (error) {
+    setError(error instanceof Error ? error.message : "Unable to fork conversation");
+  } finally {
+    setForkingMessageId((current) => (current === messageId ? null : current));
+  }
+}
+```
+
+Pass the handler into assistant `MessageBubble` rendering:
+
+```ts
+<MessageBubble
+  message={message}
+  onUpdateUserMessage={updateUserMessage}
+  onForkAssistantMessage={forkAssistantMessage}
+  isUpdating={updatingMessageId === message.id || forkingMessageId === message.id}
+/>
+```
+
+If `isUpdating` is already used for user-message editing only, split it into a dedicated disabled prop instead of conflating states:
+
+```ts
+isForking={forkingMessageId === message.id}
+```
+
+Then consume that in `MessageBubble` to disable only the fork control.
+
+- [ ] **Step 4: Run the targeted chat view tests to verify they pass**
+
+Run:
+
+```bash
+npx vitest run tests/unit/chat-view.test.ts
+```
+
+Expected: PASS for the new fork interaction coverage and existing chat view tests.
+
+- [ ] **Step 5: Commit the chat view integration**
+
+```bash
+git add components/chat-view.tsx components/message-bubble.tsx tests/unit/chat-view.test.ts
+git commit -m "feat: wire assistant message fork flow"
+```
+
+### Task 5: Run focused regression checks and browser validation
+
+**Files:**
+- Modify: none
+- Verify: `tests/unit/conversations.test.ts`
+- Verify: `tests/unit/message-bubble.test.ts`
+- Verify: `tests/unit/chat-view.test.ts`
+- Verify: running dev server via `.dev-server`
+
+- [ ] **Step 1: Run the focused regression suite**
+
+Run:
+
+```bash
+npx vitest run tests/unit/conversations.test.ts tests/unit/message-bubble.test.ts tests/unit/chat-view.test.ts
+```
+
+Expected: PASS with all fork-related unit coverage green.
+
+- [ ] **Step 2: Run typecheck for the touched surfaces**
+
+Run:
+
+```bash
+npm run typecheck
+```
+
+Expected: PASS with no TypeScript errors in the new fork route, data helper, or chat UI changes.
+
+- [ ] **Step 3: Start or reuse the dev server**
+
+Run:
+
+```bash
+if [ -f .dev-server ]; then
+  head -n 1 .dev-server
+else
+  npm run dev
+fi
+```
+
+Expected: a localhost URL from `.dev-server`. If the recorded server is unreachable, delete `.dev-server`, restart `npm run dev`, wait for `.dev-server` to appear, then read the first line again.
+
+- [ ] **Step 4: Validate the UI in the browser using agent-browser**
+
+Run:
+
+```bash
+agent-browser open http://localhost:PORT/chat/CONVERSATION_ID
+agent-browser snapshot
+agent-browser screenshot /tmp/branch-fork-conversation.png
+```
+
+Then interact with the assistant fork control:
+
+```bash
+agent-browser click <fork-button-ref>
+agent-browser snapshot
+agent-browser screenshot /tmp/branch-fork-result.png
+```
+
+Expected:
+
+- The assistant message shows a fork button next to copy
+- Clicking the fork button redirects to a new `/chat/<id>` route
+- The new conversation shows only the retained prefix
+- The original thread remains unchanged when revisited
+
+- [ ] **Step 5: Commit the verification checkpoint**
+
+```bash
+git add .
+git commit -m "test: verify branching fork conversation flow"
+```
+
+---
+
+## Self-Review
+
+### Spec coverage
+
+- Assistant-only fork affordance: covered by Task 3 and Task 4
+- Inclusive cutoff through selected assistant message: covered by Task 1 and Task 2
+- Full persisted detail copy: covered by Task 1
+- Immediate redirect into new chat: covered by Task 4 and Task 5
+- Failure rollback and local error handling: covered by Task 1, Task 2, and Task 4
+- Browser validation requirement from `AGENTS.md`: covered by Task 5
+
+### Placeholder scan
+
+- No `TODO`, `TBD`, or deferred implementation notes remain
+- Every code-changing step includes concrete code
+- Every verification step includes an exact command and expected result
+
+### Type consistency
+
+- The plan consistently uses `forkConversationFromMessage`
+- The route path is consistently `app/api/messages/[messageId]/fork/route.ts`
+- The client action label is consistently `Fork conversation from message`

--- a/docs/superpowers/specs/2026-04-11-branching-fork-conversation-design.md
+++ b/docs/superpowers/specs/2026-04-11-branching-fork-conversation-design.md
@@ -1,0 +1,222 @@
+# Branching / Fork Conversation Design
+
+**Date:** 2026-04-11
+**Status:** Draft
+
+## Summary
+
+Add a fork action to assistant messages so a user can branch a conversation from any completed assistant turn into a new conversation with inherited context. The fork should behave as a historical cutoff: the new conversation contains the exact persisted state of the original thread from the beginning through the selected assistant message, and excludes everything after it.
+
+The fork action appears as a small double-arrow icon in the assistant message action row, directly next to the existing copy icon. Clicking it immediately creates the branched conversation and navigates the user into the new `/chat/<conversationId>` route.
+
+## Goals
+
+- Let users explore an alternative path without losing the original thread
+- Make branching available directly from assistant messages where users naturally decide to diverge
+- Preserve full persisted conversation detail in the fork, including thinking, actions, attachments, and eligible compaction state
+- Keep the client implementation thin by making the server the source of truth for cloning behavior
+
+## Non-Goals
+
+- Adding fork support to user messages
+- Keeping the user in the original thread after the fork is created
+- Creating a lightweight summary-only branch format
+- Introducing shared references between the original conversation and the fork
+- Redesigning the message action row beyond adding the new affordance
+
+## Product Decisions
+
+### Branch point semantics
+
+- Forking is only available on assistant messages
+- The selected assistant message is inclusive
+- The forked conversation contains every message from the start of the source conversation through the selected assistant message
+- Any message after the selected assistant message is excluded from the fork
+
+This is a true branch-from-here model, not a full clone with a labeled anchor.
+
+### Navigation behavior
+
+- After a successful fork, the app navigates immediately to the new conversation
+- The user should land on the normal chat route for that conversation
+- The original conversation remains unchanged and available in the sidebar
+
+### Fidelity
+
+- The fork preserves all persisted message detail, not only visible text
+- Thinking content, tool/action rows, streamed text segments, attachments, and eligible compaction artifacts are copied into the new conversation
+
+## Recommended Approach
+
+Implement the feature as a dedicated server-side fork endpoint scoped to the selected message, such as:
+
+- `POST /api/messages/[messageId]/fork`
+
+This endpoint should:
+
+1. Authenticate the user
+2. Load the selected message and verify it belongs to the user via its parent conversation
+3. Reject requests where the message role is not `assistant`
+4. Create a new conversation that inherits the original conversation's folder and provider profile
+5. Clone the source conversation prefix through the selected message inside a single database transaction
+6. Return the new conversation so the client can navigate immediately
+
+This keeps the cloning contract centralized and reusable, avoids leaking copy logic into the client, and makes it easier to preserve fidelity across related tables.
+
+## UX Design
+
+### Assistant message affordance
+
+The assistant action row in [components/message-bubble.tsx](/Users/charles/.codex/worktrees/4dc4/Eidon-AI/components/message-bubble.tsx) currently exposes a copy button. Add a sibling action button using a small double-arrow icon with the same visual treatment and hover behavior.
+
+Behavior rules:
+
+- Render the fork button only for assistant messages
+- Render it only when the assistant message is fully materialized, not for streaming placeholders
+- Place it immediately beside the copy button
+- Disable it while the fork request is in flight for that message
+
+The button should feel like a secondary utility action, not a primary CTA.
+
+### Success flow
+
+- Clicking fork sends a single request to the fork endpoint
+- On success, the client navigates to `/chat/<newConversationId>`
+- The new conversation loads through the existing chat page and sidebar mechanisms
+
+### Error handling
+
+- If the request fails, the app stays on the current conversation
+- Show a small local error state or toast-style message rather than redirecting
+- No partially created fork should remain visible if cloning fails
+
+## Data Copy Semantics
+
+The copy must produce a new independent conversation with newly generated IDs for cloned rows. Nothing should be shared by reference between the original conversation and the fork.
+
+### Conversation row
+
+Create a fresh conversation row with:
+
+- a new conversation ID
+- the same `user_id`
+- the same `folder_id`
+- the same `provider_profile_id`
+- manual conversation origin
+- a fresh `created_at` and `updated_at`
+- `is_active = false`
+
+The fork should not duplicate the original title verbatim. It should use the normal default title generation behavior so the new branch can acquire its own title and remain distinguishable in the sidebar.
+
+### Message prefix
+
+Clone each message from the beginning of the source conversation through the selected assistant message, preserving:
+
+- role
+- content
+- thinking content
+- status
+- estimated tokens
+- system kind
+- compacted timestamp
+- relative ordering
+
+Each cloned message gets a new message ID and the new `conversation_id`.
+
+### Per-message detail
+
+For every copied message, also clone:
+
+- `message_actions`, remapping `message_id`
+- `message_text_segments`, remapping `message_id`
+- `message_attachments` associations and referenced attachment metadata needed for rendering in the fork
+
+The fork must display copied images/files exactly as the original prefix did.
+
+### Compaction state
+
+Copy compaction artifacts conservatively:
+
+- copy `memory_nodes` only if their covered source range falls entirely within the retained message prefix
+- copy `compaction_events` only if they reference copied nodes and do not depend on discarded tail messages
+
+If a compaction artifact spans beyond the branch point, omit it from the fork. The cloned conversation must not contain summary state that depends on excluded messages.
+
+## Implementation Shape
+
+### Server
+
+Primary implementation surfaces:
+
+- [app/api/messages/[messageId]/route.ts](/Users/charles/.codex/worktrees/4dc4/Eidon-AI/app/api/messages/[messageId]/route.ts)
+- [lib/conversations.ts](/Users/charles/.codex/worktrees/4dc4/Eidon-AI/lib/conversations.ts)
+
+Recommended structure:
+
+- add a new message fork API handler at `app/api/messages/[messageId]/fork/route.ts`
+- add a dedicated conversation helper in `lib/conversations.ts` such as `forkConversationFromMessage`
+- keep all row cloning and ID remapping in the data layer rather than inside the route
+
+The data-layer helper should run transactionally so the fork is all-or-nothing.
+
+### Client
+
+Primary implementation surfaces:
+
+- [components/message-bubble.tsx](/Users/charles/.codex/worktrees/4dc4/Eidon-AI/components/message-bubble.tsx)
+- [components/chat-view.tsx](/Users/charles/.codex/worktrees/4dc4/Eidon-AI/components/chat-view.tsx)
+
+Recommended structure:
+
+- extend the assistant message action row with a fork callback
+- let `ChatView` own the request and navigation behavior, since it already manages message mutations and routing concerns
+- keep the UI unaware of cloning rules beyond "request fork for this message"
+
+## Edge Cases
+
+- Reject attempts to fork a non-assistant message
+- Reject attempts to fork a message the user does not own
+- Reject attempts to fork a missing message
+- Do not show the fork button for streaming assistant placeholders
+- If the selected assistant message is the last message in the conversation, the fork is still valid and produces a full prefix clone
+- If attachments or compaction artifacts cannot be copied consistently, fail the fork and roll back rather than creating a degraded partial clone
+
+## Testing
+
+### Data-layer coverage
+
+- Forking clones messages only through the selected assistant message
+- Cloned rows receive fresh IDs
+- Message actions, text segments, and attachment associations are remapped to cloned message IDs
+- Eligible memory nodes and compaction events are copied only when fully contained in the retained prefix
+- The transaction rolls back cleanly on failure
+
+### API coverage
+
+- Authorized user can fork an assistant message successfully
+- Requests for missing messages return `404`
+- Requests for non-assistant messages return `400`
+- Requests for messages owned by another user are rejected
+
+### UI coverage
+
+- Assistant messages render the fork button next to copy
+- User messages do not render the fork button
+- Clicking fork disables the control during submission
+- Successful fork redirects to the new `/chat/<id>` route
+- Failed fork leaves the user in place and surfaces an error
+
+### Manual validation
+
+- Fork a middle assistant message and confirm the new conversation excludes all later turns
+- Confirm copied thinking content, tool rows, and attachments render correctly in the fork
+- Confirm the original conversation remains unchanged
+- Confirm the new conversation appears in the sidebar and opens correctly after navigation
+
+## Risks
+
+- The main correctness risk is incomplete remapping across related tables, especially attachments and compaction artifacts
+- A second risk is accidentally copying summary state that depends on excluded tail messages
+- A UX risk is duplicate submissions if the fork control is not disabled during the request
+
+Keeping the copy logic server-side and transactional is the key mitigation for all three risks.

--- a/lib/conversations.ts
+++ b/lib/conversations.ts
@@ -1090,7 +1090,7 @@ export function forkConversationFromMessage(messageId: string, userId?: string) 
         return;
       }
 
-      message.actions.forEach((action) => {
+      (message.actions ?? []).forEach((action) => {
         db.prepare(
           `INSERT INTO message_actions (
             id,
@@ -1126,7 +1126,7 @@ export function forkConversationFromMessage(messageId: string, userId?: string) 
         );
       });
 
-      message.textSegments.forEach((segment) => {
+      (message.textSegments ?? []).forEach((segment) => {
         db.prepare(
           `INSERT INTO message_text_segments (
             id,

--- a/lib/conversations.ts
+++ b/lib/conversations.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs";
+import path from "node:path";
+
 import {
   assignAttachmentsToMessage,
   deleteConversationAttachmentFiles,
@@ -9,6 +12,7 @@ import {
   generateConversationTitle
 } from "@/lib/conversation-title-generator";
 import { getDb } from "@/lib/db";
+import { env } from "@/lib/env";
 import { createId } from "@/lib/ids";
 import {
   getDefaultProviderProfileWithApiKey,
@@ -969,6 +973,351 @@ export function bindAttachmentsToMessage(conversationId: string, messageId: stri
   const attachments = assignAttachmentsToMessage(conversationId, messageId, attachmentIds);
   updateMessageEstimatedTokens(messageId);
   return attachments;
+}
+
+function getAttachmentsRoot() {
+  const root = path.resolve(env.EIDON_DATA_DIR, "attachments");
+  fs.mkdirSync(root, { recursive: true });
+  return root;
+}
+
+function cloneAttachmentFile(input: {
+  sourceRelativePath: string;
+  targetRelativePath: string;
+}) {
+  const sourcePath = path.resolve(getAttachmentsRoot(), input.sourceRelativePath);
+  const targetPath = path.resolve(getAttachmentsRoot(), input.targetRelativePath);
+  fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+  fs.copyFileSync(sourcePath, targetPath);
+}
+
+export function forkConversationFromMessage(messageId: string, userId?: string) {
+  const sourceMessage = getMessage(messageId, userId);
+
+  if (!sourceMessage) {
+    throw new Error("Message not found");
+  }
+
+  if (sourceMessage.role !== "assistant") {
+    throw new Error("Only assistant messages can be forked");
+  }
+
+  const sourceConversation = getConversation(sourceMessage.conversationId, userId);
+
+  if (!sourceConversation) {
+    throw new Error("Conversation not found");
+  }
+
+  const sourceConversationOwnerId = getConversationOwnerId(sourceConversation.id);
+  const sourceMessages = listMessages(sourceConversation.id);
+  const selectedIndex = sourceMessages.findIndex((message) => message.id === messageId);
+
+  if (selectedIndex < 0) {
+    throw new Error("Message not found");
+  }
+
+  const retainedMessages = sourceMessages.slice(0, selectedIndex + 1);
+  const retainedMessageIds = new Set(retainedMessages.map((message) => message.id));
+
+  const db = getDb();
+  let forkConversation: Conversation | null = null;
+  const clonedMessageIdBySourceId = new Map<string, string>();
+  const clonedNodeIdBySourceId = new Map<string, string>();
+  const copiedAttachmentPaths: string[] = [];
+
+  const cleanupCopiedAttachments = () => {
+    copiedAttachmentPaths.forEach((relativePath) => {
+      const absolutePath = path.resolve(getAttachmentsRoot(), relativePath);
+      try {
+        fs.unlinkSync(absolutePath);
+      } catch {}
+    });
+  };
+
+  const transaction = db.transaction(() => {
+    forkConversation = createConversation(
+      undefined,
+      sourceConversation.folderId,
+      {
+        providerProfileId: sourceConversation.providerProfileId ?? undefined
+      },
+      sourceConversationOwnerId ?? userId
+    );
+
+    if (!forkConversation) {
+      throw new Error("Conversation not created");
+    }
+
+    if (sourceConversation.providerProfileId === null) {
+      db.prepare("UPDATE conversations SET provider_profile_id = NULL WHERE id = ?").run(forkConversation.id);
+    }
+
+    retainedMessages.forEach((message) => {
+      const clonedMessage = createMessage({
+        conversationId: forkConversation.id,
+        role: message.role,
+        content: message.content,
+        thinkingContent: message.thinkingContent,
+        status: message.status,
+        systemKind: message.systemKind,
+        estimatedTokens: message.estimatedTokens
+      });
+
+      clonedMessageIdBySourceId.set(message.id, clonedMessage.id);
+    });
+
+    retainedMessages.forEach((message) => {
+      const clonedMessageId = clonedMessageIdBySourceId.get(message.id);
+
+      if (!clonedMessageId) {
+        return;
+      }
+
+      message.actions.forEach((action) => {
+        createMessageAction({
+          messageId: clonedMessageId,
+          kind: action.kind,
+          status: action.status,
+          serverId: action.serverId,
+          skillId: action.skillId,
+          toolName: action.toolName,
+          label: action.label,
+          detail: action.detail,
+          arguments: action.arguments,
+          resultSummary: action.resultSummary,
+          sortOrder: action.sortOrder
+        });
+      });
+
+      message.textSegments.forEach((segment) => {
+        createMessageTextSegment({
+          messageId: clonedMessageId,
+          content: segment.content,
+          sortOrder: segment.sortOrder
+        });
+      });
+    });
+
+    retainedMessages.forEach((message) => {
+      const clonedMessageId = clonedMessageIdBySourceId.get(message.id);
+
+      if (!clonedMessageId) {
+        return;
+      }
+
+      message.attachments.forEach((attachment) => {
+        const clonedAttachmentId = createId("att");
+        const clonedRelativePath = path.join(
+          forkConversation.id,
+          `${clonedAttachmentId}_${attachment.filename}`
+        );
+
+        cloneAttachmentFile({
+          sourceRelativePath: attachment.relativePath,
+          targetRelativePath: clonedRelativePath
+        });
+        copiedAttachmentPaths.push(clonedRelativePath);
+
+        db.prepare(
+          `INSERT INTO message_attachments (
+            id,
+            conversation_id,
+            message_id,
+            filename,
+            mime_type,
+            byte_size,
+            sha256,
+            relative_path,
+            kind,
+            extracted_text,
+            created_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        ).run(
+          clonedAttachmentId,
+          forkConversation.id,
+          clonedMessageId,
+          attachment.filename,
+          attachment.mimeType,
+          attachment.byteSize,
+          attachment.sha256,
+          clonedRelativePath,
+          attachment.kind,
+          attachment.extractedText,
+          attachment.createdAt
+        );
+      });
+
+      const refreshedMessage = getMessage(clonedMessageId);
+      if (refreshedMessage) {
+        db.prepare("UPDATE messages SET estimated_tokens = ? WHERE id = ?").run(
+          estimateMessageTokens(refreshedMessage),
+          clonedMessageId
+        );
+      }
+    });
+
+    const sourceMemoryNodes = db
+      .prepare(
+        `SELECT
+          id,
+          type,
+          depth,
+          content,
+          source_start_message_id,
+          source_end_message_id,
+          source_token_count,
+          summary_token_count,
+          child_node_ids,
+          superseded_by_node_id,
+          created_at
+         FROM memory_nodes
+         WHERE conversation_id = ?
+         ORDER BY created_at ASC, rowid ASC`
+      )
+      .all(sourceConversation.id) as Array<{
+      id: string;
+      type: "leaf_summary" | "merged_summary";
+      depth: number;
+      content: string;
+      source_start_message_id: string;
+      source_end_message_id: string;
+      source_token_count: number;
+      summary_token_count: number;
+      child_node_ids: string;
+      superseded_by_node_id: string | null;
+      created_at: string;
+    }>;
+
+    const retainedMemoryNodes = sourceMemoryNodes
+      .filter((node) => {
+        return (
+          retainedMessageIds.has(node.source_start_message_id) &&
+          retainedMessageIds.has(node.source_end_message_id)
+        );
+      })
+      .map((node) => ({
+        ...node,
+        clonedNodeId: createId("mem")
+      }));
+
+    retainedMemoryNodes.forEach((node) => {
+      clonedNodeIdBySourceId.set(node.id, node.clonedNodeId);
+    });
+
+    retainedMemoryNodes.forEach((node) => {
+      const clonedStartMessageId = clonedMessageIdBySourceId.get(node.source_start_message_id);
+      const clonedEndMessageId = clonedMessageIdBySourceId.get(node.source_end_message_id);
+
+      if (!clonedStartMessageId || !clonedEndMessageId) {
+        return;
+      }
+
+      const childNodeIds = (JSON.parse(node.child_node_ids) as string[])
+        .map((childNodeId) => clonedNodeIdBySourceId.get(childNodeId))
+        .filter((childNodeId): childNodeId is string => Boolean(childNodeId));
+      const clonedSupersededByNodeId = node.superseded_by_node_id
+        ? clonedNodeIdBySourceId.get(node.superseded_by_node_id) ?? null
+        : null;
+
+      db.prepare(
+        `INSERT INTO memory_nodes (
+          id,
+          conversation_id,
+          type,
+          depth,
+          content,
+          source_start_message_id,
+          source_end_message_id,
+          source_token_count,
+          summary_token_count,
+          child_node_ids,
+          superseded_by_node_id,
+          created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      ).run(
+        node.clonedNodeId,
+        forkConversation.id,
+        node.type,
+        node.depth,
+        node.content,
+        clonedStartMessageId,
+        clonedEndMessageId,
+        node.source_token_count,
+        node.summary_token_count,
+        JSON.stringify(childNodeIds),
+        clonedSupersededByNodeId,
+        node.created_at
+      );
+    });
+
+    const sourceCompactionEvents = db
+      .prepare(
+        `SELECT
+          id,
+          node_id,
+          source_start_message_id,
+          source_end_message_id,
+          notice_message_id,
+          created_at
+         FROM compaction_events
+         WHERE conversation_id = ?
+         ORDER BY created_at ASC, rowid ASC`
+      )
+      .all(sourceConversation.id) as Array<{
+      id: string;
+      node_id: string;
+      source_start_message_id: string;
+      source_end_message_id: string;
+      notice_message_id: string | null;
+      created_at: string;
+    }>;
+
+    sourceCompactionEvents.forEach((event) => {
+      const clonedNodeId = clonedNodeIdBySourceId.get(event.node_id);
+      const clonedStartMessageId = clonedMessageIdBySourceId.get(event.source_start_message_id);
+      const clonedEndMessageId = clonedMessageIdBySourceId.get(event.source_end_message_id);
+      const clonedNoticeMessageId = event.notice_message_id
+        ? clonedMessageIdBySourceId.get(event.notice_message_id) ?? null
+        : null;
+
+      if (!clonedNodeId || !clonedStartMessageId || !clonedEndMessageId) {
+        return;
+      }
+
+      db.prepare(
+        `INSERT INTO compaction_events (
+          id,
+          conversation_id,
+          node_id,
+          source_start_message_id,
+          source_end_message_id,
+          notice_message_id,
+          created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)`
+      ).run(
+        createId("cmp"),
+        forkConversation.id,
+        clonedNodeId,
+        clonedStartMessageId,
+        clonedEndMessageId,
+        clonedNoticeMessageId,
+        event.created_at
+      );
+    });
+  });
+
+  try {
+    transaction();
+  } catch (error) {
+    cleanupCopiedAttachments();
+    throw error;
+  }
+
+  if (!forkConversation) {
+    throw new Error("Conversation not created");
+  }
+
+  return getConversation(forkConversation.id) ?? forkConversation;
 }
 
 export function createMessageAction(input: {

--- a/lib/conversations.ts
+++ b/lib/conversations.ts
@@ -992,37 +992,7 @@ function cloneAttachmentFile(input: {
 }
 
 export function forkConversationFromMessage(messageId: string, userId?: string) {
-  const sourceMessage = getMessage(messageId, userId);
-
-  if (!sourceMessage) {
-    throw new Error("Message not found");
-  }
-
-  if (sourceMessage.role !== "assistant") {
-    throw new Error("Only assistant messages can be forked");
-  }
-
-  const sourceConversation = getConversation(sourceMessage.conversationId, userId);
-
-  if (!sourceConversation) {
-    throw new Error("Conversation not found");
-  }
-
-  const sourceConversationOwnerId = getConversationOwnerId(sourceConversation.id);
-  const sourceMessages = listMessages(sourceConversation.id);
-  const selectedIndex = sourceMessages.findIndex((message) => message.id === messageId);
-
-  if (selectedIndex < 0) {
-    throw new Error("Message not found");
-  }
-
-  const retainedMessages = sourceMessages.slice(0, selectedIndex + 1);
-  const retainedMessageIds = new Set(retainedMessages.map((message) => message.id));
-
   const db = getDb();
-  let forkConversation: Conversation | null = null;
-  const clonedMessageIdBySourceId = new Map<string, string>();
-  const clonedNodeIdBySourceId = new Map<string, string>();
   const copiedAttachmentPaths: string[] = [];
 
   const cleanupCopiedAttachments = () => {
@@ -1035,7 +1005,37 @@ export function forkConversationFromMessage(messageId: string, userId?: string) 
   };
 
   const transaction = db.transaction(() => {
-    forkConversation = createConversation(
+    const sourceMessage = getMessage(messageId, userId);
+
+    if (!sourceMessage) {
+      throw new Error("Message not found");
+    }
+
+    if (sourceMessage.role !== "assistant") {
+      throw new Error("Only assistant messages can be forked");
+    }
+
+    const sourceConversation = getConversation(sourceMessage.conversationId, userId);
+
+    if (!sourceConversation) {
+      throw new Error("Conversation not found");
+    }
+
+    const sourceConversationOwnerRow = db
+      .prepare("SELECT user_id FROM conversations WHERE id = ?")
+      .get(sourceConversation.id) as { user_id: string | null } | undefined;
+    const sourceConversationOwnerId = sourceConversationOwnerRow?.user_id ?? null;
+    const sourceMessages = listMessages(sourceConversation.id);
+    const selectedIndex = sourceMessages.findIndex((message) => message.id === messageId);
+
+    if (selectedIndex < 0) {
+      throw new Error("Message not found");
+    }
+
+    const retainedMessages = sourceMessages.slice(0, selectedIndex + 1);
+    const retainedMessageIds = new Set(retainedMessages.map((message) => message.id));
+
+    const forkConversation = createConversation(
       undefined,
       sourceConversation.folderId,
       {
@@ -1044,26 +1044,43 @@ export function forkConversationFromMessage(messageId: string, userId?: string) 
       sourceConversationOwnerId ?? userId
     );
 
-    if (!forkConversation) {
-      throw new Error("Conversation not created");
+    if (sourceConversation.providerProfileId === null) {
+      db.prepare("UPDATE conversations SET provider_profile_id = NULL WHERE id = ?").run(
+        forkConversation.id
+      );
     }
 
-    if (sourceConversation.providerProfileId === null) {
-      db.prepare("UPDATE conversations SET provider_profile_id = NULL WHERE id = ?").run(forkConversation.id);
-    }
+    const clonedMessageIdBySourceId = new Map<string, string>();
 
     retainedMessages.forEach((message) => {
-      const clonedMessage = createMessage({
-        conversationId: forkConversation.id,
-        role: message.role,
-        content: message.content,
-        thinkingContent: message.thinkingContent,
-        status: message.status,
-        systemKind: message.systemKind,
-        estimatedTokens: message.estimatedTokens
-      });
+      const clonedMessageId = createId("msg");
+      clonedMessageIdBySourceId.set(message.id, clonedMessageId);
 
-      clonedMessageIdBySourceId.set(message.id, clonedMessage.id);
+      db.prepare(
+        `INSERT INTO messages (
+          id,
+          conversation_id,
+          role,
+          content,
+          thinking_content,
+          status,
+          estimated_tokens,
+          system_kind,
+          compacted_at,
+          created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      ).run(
+        clonedMessageId,
+        forkConversation.id,
+        message.role,
+        message.content,
+        message.thinkingContent,
+        message.status,
+        message.estimatedTokens,
+        message.systemKind,
+        message.compactedAt,
+        message.createdAt
+      );
     });
 
     retainedMessages.forEach((message) => {
@@ -1074,27 +1091,51 @@ export function forkConversationFromMessage(messageId: string, userId?: string) 
       }
 
       message.actions.forEach((action) => {
-        createMessageAction({
-          messageId: clonedMessageId,
-          kind: action.kind,
-          status: action.status,
-          serverId: action.serverId,
-          skillId: action.skillId,
-          toolName: action.toolName,
-          label: action.label,
-          detail: action.detail,
-          arguments: action.arguments,
-          resultSummary: action.resultSummary,
-          sortOrder: action.sortOrder
-        });
+        db.prepare(
+          `INSERT INTO message_actions (
+            id,
+            message_id,
+            kind,
+            status,
+            server_id,
+            skill_id,
+            tool_name,
+            label,
+            detail,
+            arguments_json,
+            result_summary,
+            sort_order,
+            started_at,
+            completed_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        ).run(
+          createId("act"),
+          clonedMessageId,
+          action.kind,
+          action.status,
+          action.serverId,
+          action.skillId,
+          action.toolName,
+          action.label,
+          action.detail,
+          action.arguments ? JSON.stringify(action.arguments) : null,
+          action.resultSummary,
+          action.sortOrder,
+          action.startedAt,
+          action.completedAt
+        );
       });
 
       message.textSegments.forEach((segment) => {
-        createMessageTextSegment({
-          messageId: clonedMessageId,
-          content: segment.content,
-          sortOrder: segment.sortOrder
-        });
+        db.prepare(
+          `INSERT INTO message_text_segments (
+            id,
+            message_id,
+            content,
+            sort_order,
+            created_at
+          ) VALUES (?, ?, ?, ?, ?)`
+        ).run(createId("seg"), clonedMessageId, segment.content, segment.sortOrder, segment.createdAt);
       });
     });
 
@@ -1146,14 +1187,6 @@ export function forkConversationFromMessage(messageId: string, userId?: string) 
           attachment.createdAt
         );
       });
-
-      const refreshedMessage = getMessage(clonedMessageId);
-      if (refreshedMessage) {
-        db.prepare("UPDATE messages SET estimated_tokens = ? WHERE id = ?").run(
-          estimateMessageTokens(refreshedMessage),
-          clonedMessageId
-        );
-      }
     });
 
     const sourceMemoryNodes = db
@@ -1188,23 +1221,49 @@ export function forkConversationFromMessage(messageId: string, userId?: string) 
       created_at: string;
     }>;
 
-    const retainedMemoryNodes = sourceMemoryNodes
-      .filter((node) => {
-        return (
-          retainedMessageIds.has(node.source_start_message_id) &&
-          retainedMessageIds.has(node.source_end_message_id)
-        );
-      })
-      .map((node) => ({
-        ...node,
-        clonedNodeId: createId("mem")
-      }));
-
-    retainedMemoryNodes.forEach((node) => {
-      clonedNodeIdBySourceId.set(node.id, node.clonedNodeId);
+    const retainedMemoryNodes = sourceMemoryNodes.filter((node) => {
+      return (
+        retainedMessageIds.has(node.source_start_message_id) &&
+        retainedMessageIds.has(node.source_end_message_id)
+      );
     });
 
-    retainedMemoryNodes.forEach((node) => {
+    const cloneableMemoryNodeIds = new Set(retainedMemoryNodes.map((node) => node.id));
+    let hasChanges = true;
+
+    while (hasChanges) {
+      hasChanges = false;
+
+      for (const node of retainedMemoryNodes) {
+        if (!cloneableMemoryNodeIds.has(node.id)) {
+          continue;
+        }
+
+        const childNodeIds = JSON.parse(node.child_node_ids) as string[];
+        const referencesMissingChild = childNodeIds.some((childNodeId) => {
+          return !cloneableMemoryNodeIds.has(childNodeId);
+        });
+        const referencesMissingSupersededNode =
+          node.superseded_by_node_id !== null &&
+          !cloneableMemoryNodeIds.has(node.superseded_by_node_id);
+
+        if (referencesMissingChild || referencesMissingSupersededNode) {
+          cloneableMemoryNodeIds.delete(node.id);
+          hasChanges = true;
+        }
+      }
+    }
+
+    const cloneableRetainedMemoryNodes = retainedMemoryNodes.filter((node) =>
+      cloneableMemoryNodeIds.has(node.id)
+    );
+    const clonedNodeIdBySourceId = new Map<string, string>();
+
+    cloneableRetainedMemoryNodes.forEach((node) => {
+      clonedNodeIdBySourceId.set(node.id, createId("mem"));
+    });
+
+    cloneableRetainedMemoryNodes.forEach((node) => {
       const clonedStartMessageId = clonedMessageIdBySourceId.get(node.source_start_message_id);
       const clonedEndMessageId = clonedMessageIdBySourceId.get(node.source_end_message_id);
 
@@ -1212,9 +1271,15 @@ export function forkConversationFromMessage(messageId: string, userId?: string) 
         return;
       }
 
-      const childNodeIds = (JSON.parse(node.child_node_ids) as string[])
+      const childNodeIds = JSON.parse(node.child_node_ids) as string[];
+      const clonedChildNodeIds = childNodeIds
         .map((childNodeId) => clonedNodeIdBySourceId.get(childNodeId))
         .filter((childNodeId): childNodeId is string => Boolean(childNodeId));
+
+      if (clonedChildNodeIds.length !== childNodeIds.length) {
+        return;
+      }
+
       const clonedSupersededByNodeId = node.superseded_by_node_id
         ? clonedNodeIdBySourceId.get(node.superseded_by_node_id) ?? null
         : null;
@@ -1235,7 +1300,7 @@ export function forkConversationFromMessage(messageId: string, userId?: string) 
           created_at
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
       ).run(
-        node.clonedNodeId,
+        clonedNodeIdBySourceId.get(node.id),
         forkConversation.id,
         node.type,
         node.depth,
@@ -1244,7 +1309,7 @@ export function forkConversationFromMessage(messageId: string, userId?: string) 
         clonedEndMessageId,
         node.source_token_count,
         node.summary_token_count,
-        JSON.stringify(childNodeIds),
+        JSON.stringify(clonedChildNodeIds),
         clonedSupersededByNodeId,
         node.created_at
       );
@@ -1276,11 +1341,20 @@ export function forkConversationFromMessage(messageId: string, userId?: string) 
       const clonedNodeId = clonedNodeIdBySourceId.get(event.node_id);
       const clonedStartMessageId = clonedMessageIdBySourceId.get(event.source_start_message_id);
       const clonedEndMessageId = clonedMessageIdBySourceId.get(event.source_end_message_id);
+
+      if (!clonedNodeId || !clonedStartMessageId || !clonedEndMessageId) {
+        return;
+      }
+
+      if (event.notice_message_id && !retainedMessageIds.has(event.notice_message_id)) {
+        return;
+      }
+
       const clonedNoticeMessageId = event.notice_message_id
         ? clonedMessageIdBySourceId.get(event.notice_message_id) ?? null
         : null;
 
-      if (!clonedNodeId || !clonedStartMessageId || !clonedEndMessageId) {
+      if (event.notice_message_id && !clonedNoticeMessageId) {
         return;
       }
 
@@ -1304,20 +1378,23 @@ export function forkConversationFromMessage(messageId: string, userId?: string) 
         event.created_at
       );
     });
+
+    return forkConversation.id;
   });
 
   try {
-    transaction();
+    const forkConversationId = transaction();
+    const forkConversation = getConversation(forkConversationId);
+
+    if (!forkConversation) {
+      throw new Error("Conversation not created");
+    }
+
+    return forkConversation;
   } catch (error) {
     cleanupCopiedAttachments();
     throw error;
   }
-
-  if (!forkConversation) {
-    throw new Error("Conversation not created");
-  }
-
-  return getConversation(forkConversation.id) ?? forkConversation;
 }
 
 export function createMessageAction(input: {

--- a/lib/conversations.ts
+++ b/lib/conversations.ts
@@ -63,12 +63,12 @@ type ConversationCursor = {
 };
 
 function conversationActivityTimestampSql(alias: string) {
-  return `COALESCE((
+  return `MAX(COALESCE((
     SELECT MAX(m.created_at)
     FROM messages m
     WHERE m.conversation_id = ${alias}.id
       AND m.role != 'system'
-  ), ${alias}.updated_at)`;
+  ), ''), ${alias}.updated_at)`;
 }
 
 function nowIso() {
@@ -1036,7 +1036,7 @@ export function forkConversationFromMessage(messageId: string, userId?: string) 
     const retainedMessageIds = new Set(retainedMessages.map((message) => message.id));
 
     const forkConversation = createConversation(
-      undefined,
+      `Fork ${sourceConversation.title}`,
       sourceConversation.folderId,
       {
         providerProfileId: sourceConversation.providerProfileId ?? undefined

--- a/lib/conversations.ts
+++ b/lib/conversations.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 
@@ -991,6 +992,20 @@ function cloneAttachmentFile(input: {
   fs.copyFileSync(sourcePath, targetPath);
 }
 
+function recoverTextAttachmentFile(input: {
+  targetRelativePath: string;
+  extractedText: string;
+}) {
+  const targetPath = path.resolve(getAttachmentsRoot(), input.targetRelativePath);
+  const bytes = Buffer.from(input.extractedText, "utf8");
+  fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+  fs.writeFileSync(targetPath, bytes);
+  return {
+    byteSize: bytes.length,
+    sha256: createHash("sha256").update(bytes).digest("hex")
+  };
+}
+
 export function forkConversationFromMessage(messageId: string, userId?: string) {
   const db = getDb();
   const copiedAttachmentPaths: string[] = [];
@@ -1152,11 +1167,31 @@ export function forkConversationFromMessage(messageId: string, userId?: string) 
           forkConversation.id,
           `${clonedAttachmentId}_${attachment.filename}`
         );
+        let clonedByteSize = attachment.byteSize;
+        let clonedSha256 = attachment.sha256;
 
-        cloneAttachmentFile({
-          sourceRelativePath: attachment.relativePath,
-          targetRelativePath: clonedRelativePath
-        });
+        try {
+          cloneAttachmentFile({
+            sourceRelativePath: attachment.relativePath,
+            targetRelativePath: clonedRelativePath
+          });
+        } catch (error) {
+          if (
+            attachment.kind === "text" &&
+            error instanceof Error &&
+            "code" in error &&
+            error.code === "ENOENT"
+          ) {
+            const recovered = recoverTextAttachmentFile({
+              targetRelativePath: clonedRelativePath,
+              extractedText: attachment.extractedText
+            });
+            clonedByteSize = recovered.byteSize;
+            clonedSha256 = recovered.sha256;
+          } else {
+            throw error;
+          }
+        }
         copiedAttachmentPaths.push(clonedRelativePath);
 
         db.prepare(
@@ -1179,8 +1214,8 @@ export function forkConversationFromMessage(messageId: string, userId?: string) 
           clonedMessageId,
           attachment.filename,
           attachment.mimeType,
-          attachment.byteSize,
-          attachment.sha256,
+          clonedByteSize,
+          clonedSha256,
           clonedRelativePath,
           attachment.kind,
           attachment.extractedText,

--- a/lib/conversations.ts
+++ b/lib/conversations.ts
@@ -1243,11 +1243,7 @@ export function forkConversationFromMessage(messageId: string, userId?: string) 
         const referencesMissingChild = childNodeIds.some((childNodeId) => {
           return !cloneableMemoryNodeIds.has(childNodeId);
         });
-        const referencesMissingSupersededNode =
-          node.superseded_by_node_id !== null &&
-          !cloneableMemoryNodeIds.has(node.superseded_by_node_id);
-
-        if (referencesMissingChild || referencesMissingSupersededNode) {
+        if (referencesMissingChild) {
           cloneableMemoryNodeIds.delete(node.id);
           hasChanges = true;
         }
@@ -1280,9 +1276,10 @@ export function forkConversationFromMessage(messageId: string, userId?: string) 
         return;
       }
 
-      const clonedSupersededByNodeId = node.superseded_by_node_id
-        ? clonedNodeIdBySourceId.get(node.superseded_by_node_id) ?? null
-        : null;
+      const clonedSupersededByNodeId =
+        node.superseded_by_node_id && cloneableMemoryNodeIds.has(node.superseded_by_node_id)
+          ? clonedNodeIdBySourceId.get(node.superseded_by_node_id) ?? null
+          : null;
 
       db.prepare(
         `INSERT INTO memory_nodes (

--- a/tests/unit/chat-view.test.ts
+++ b/tests/unit/chat-view.test.ts
@@ -138,6 +138,22 @@ function createPayload(): ChatViewPayload {
   };
 }
 
+function createMessage(overrides: Partial<Message> = {}): Message {
+  return {
+    id: "msg_1",
+    conversationId: "conv_1",
+    role: "assistant",
+    content: "Assistant reply",
+    thinkingContent: "",
+    status: "completed",
+    estimatedTokens: 3,
+    systemKind: null,
+    compactedAt: null,
+    createdAt: new Date().toISOString(),
+    ...overrides
+  };
+}
+
 async function flushAnimationFrame() {
   await act(async () => {
     await new Promise<void>((resolve) => {
@@ -452,6 +468,143 @@ describe("chat view", () => {
     await waitFor(() => {
       expect(screen.getByText("Hello")).toBeInTheDocument();
       expect(screen.getByText("Hi there!")).toBeInTheDocument();
+    });
+  });
+
+  it("forks from an assistant message and redirects to the new conversation", async () => {
+    vi.mocked(global.fetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ personas: [] })
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ conversationId: "conv_forked" })
+      } as Response);
+
+    renderWithProvider(
+      React.createElement(ChatView, {
+        payload: {
+          ...createPayload(),
+          messages: [
+            createMessage({
+              id: "msg_assistant",
+              content: "Fork me"
+            })
+          ]
+        }
+      })
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Fork conversation from message" }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith("/api/messages/msg_assistant/fork", {
+        method: "POST"
+      });
+    });
+
+    await waitFor(() => {
+      expect(push).toHaveBeenCalledWith("/chat/conv_forked");
+    });
+  });
+
+  it("shows a local fork error and does not navigate when the fork request fails", async () => {
+    vi.mocked(global.fetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ personas: [] })
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: false,
+        json: async () => ({ error: "Fork denied" })
+      } as Response);
+
+    renderWithProvider(
+      React.createElement(ChatView, {
+        payload: {
+          ...createPayload(),
+          messages: [
+            createMessage({
+              id: "msg_assistant",
+              content: "Fork me"
+            })
+          ]
+        }
+      })
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Fork conversation from message" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Fork denied")).toBeInTheDocument();
+    });
+
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("prevents duplicate fork requests while a fork is already in flight", async () => {
+    let resolveForkResponse: ((value: Response) => void) | null = null;
+    const forkResponse = new Promise<Response>((resolve) => {
+      resolveForkResponse = resolve;
+    });
+
+    vi.mocked(global.fetch).mockImplementation((input) => {
+      if (input === "/api/personas") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ personas: [] })
+        } as Response);
+      }
+
+      if (input === "/api/messages/msg_assistant/fork") {
+        return forkResponse;
+      }
+
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({})
+      } as Response);
+    });
+
+    renderWithProvider(
+      React.createElement(ChatView, {
+        payload: {
+          ...createPayload(),
+          messages: [
+            createMessage({
+              id: "msg_assistant",
+              content: "Fork me"
+            })
+          ]
+        }
+      })
+    );
+
+    const forkButton = screen.getByRole("button", { name: "Fork conversation from message" });
+
+    fireEvent.click(forkButton);
+    fireEvent.click(forkButton);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith("/api/messages/msg_assistant/fork", {
+        method: "POST"
+      });
+    });
+
+    expect(
+      vi
+        .mocked(global.fetch)
+        .mock.calls.filter(([input]) => input === "/api/messages/msg_assistant/fork")
+    ).toHaveLength(1);
+
+    resolveForkResponse?.({
+      ok: true,
+      json: async () => ({ conversationId: "conv_forked" })
+    } as Response);
+
+    await waitFor(() => {
+      expect(push).toHaveBeenCalledWith("/chat/conv_forked");
     });
   });
 

--- a/tests/unit/chat-view.test.ts
+++ b/tests/unit/chat-view.test.ts
@@ -544,7 +544,7 @@ describe("chat view", () => {
   });
 
   it("prevents duplicate fork requests while a fork is already in flight", async () => {
-    let resolveForkResponse: ((value: Response) => void) | null = null;
+    let resolveForkResponse: ((value: Response) => void) | undefined;
     const forkResponse = new Promise<Response>((resolve) => {
       resolveForkResponse = resolve;
     });
@@ -598,6 +598,7 @@ describe("chat view", () => {
         .mock.calls.filter(([input]) => input === "/api/messages/msg_assistant/fork")
     ).toHaveLength(1);
 
+    expect(resolveForkResponse).toBeDefined();
     resolveForkResponse?.({
       ok: true,
       json: async () => ({ conversation: { id: "conv_forked" } })

--- a/tests/unit/chat-view.test.ts
+++ b/tests/unit/chat-view.test.ts
@@ -479,7 +479,7 @@ describe("chat view", () => {
       } as Response)
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ conversationId: "conv_forked" })
+        json: async () => ({ conversation: { id: "conv_forked" } })
       } as Response);
 
     renderWithProvider(
@@ -600,7 +600,7 @@ describe("chat view", () => {
 
     resolveForkResponse?.({
       ok: true,
-      json: async () => ({ conversationId: "conv_forked" })
+      json: async () => ({ conversation: { id: "conv_forked" } })
     } as Response);
 
     await waitFor(() => {

--- a/tests/unit/conversations-extended.test.ts
+++ b/tests/unit/conversations-extended.test.ts
@@ -35,6 +35,28 @@ describe("conversations extended", () => {
     expect(results2[0].folderId).toBeNull();
   });
 
+  it("moves conversations between folders only for the requested user", async () => {
+    const userA = await createLocalUser({
+      username: "conversation-folder-a",
+      password: "Password123!",
+      role: "user"
+    });
+    const userB = await createLocalUser({
+      username: "conversation-folder-b",
+      password: "Password123!",
+      role: "user"
+    });
+    const folderA = createFolder("Folder A", userA.id);
+    const ownedConversation = createConversation("Owned chat", null, undefined, userA.id);
+    const otherConversation = createConversation("Other chat", null, undefined, userB.id);
+
+    moveConversationToFolder(ownedConversation.id, folderA.id, userA.id);
+    moveConversationToFolder(otherConversation.id, folderA.id, userA.id);
+
+    expect(searchConversations("Owned chat", userA.id)[0]?.folderId).toBe(folderA.id);
+    expect(searchConversations("Other chat", userB.id)[0]?.folderId).toBeNull();
+  });
+
   it("reorders conversations", () => {
     const c1 = createConversation("C1");
     const c2 = createConversation("C2");
@@ -230,9 +252,14 @@ describe("conversations extended", () => {
     expect(() => listConversationsPage({ cursor: "invalid" })).toThrow();
   });
 
-  it("orders pagination by the latest visible message activity", () => {
-    const olderConversation = createConversation("Older");
-    const newerConversation = createConversation("Newer");
+  it("orders pagination by the latest conversation activity", async () => {
+    const user = await createLocalUser({
+      username: "conversation-pagination-owner",
+      password: "Password123!",
+      role: "user"
+    });
+    const olderConversation = createConversation("Older", null, undefined, user.id);
+    const newerConversation = createConversation("Newer", null, undefined, user.id);
 
     const olderMessage = createMessage({
       conversationId: olderConversation.id,
@@ -252,15 +279,19 @@ describe("conversations extended", () => {
       .prepare("UPDATE messages SET created_at = ? WHERE id = ?")
       .run("2026-03-31T12:00:00.000Z", newerMessage.id);
     getDb()
-      .prepare("UPDATE conversations SET updated_at = ? WHERE id IN (?, ?)")
-      .run("2026-04-01T00:00:00.000Z", olderConversation.id, newerConversation.id);
+      .prepare("UPDATE conversations SET updated_at = ? WHERE id = ?")
+      .run("2026-04-01T00:00:00.000Z", olderConversation.id);
+    getDb()
+      .prepare("UPDATE conversations SET updated_at = ? WHERE id = ?")
+      .run("2026-03-29T00:00:00.000Z", newerConversation.id);
 
-    const page = listConversationsPage({ limit: 2 });
+    const page = listConversationsPage({ limit: 2, userId: user.id });
 
     expect(page.conversations.map((conversation) => conversation.id)).toEqual([
-      newerConversation.id,
-      olderConversation.id
+      olderConversation.id,
+      newerConversation.id
     ]);
-    expect(page.conversations[0]?.updatedAt).toBe("2026-03-31T12:00:00.000Z");
+    expect(page.conversations[0]?.updatedAt).toBe("2026-04-01T00:00:00.000Z");
+    expect(page.conversations[1]?.updatedAt).toBe("2026-03-31T12:00:00.000Z");
   });
 });

--- a/tests/unit/conversations.test.ts
+++ b/tests/unit/conversations.test.ts
@@ -427,6 +427,50 @@ describe("conversation helpers", () => {
     expect(getConversation(conversation.id)?.providerProfileId).toBe(nextProfileId);
   });
 
+  it("updates the conversation provider profile only for the requested user", async () => {
+    updateSettings({
+      ...getSettings(),
+      providerProfiles: [
+        ...listProviderProfiles(),
+        {
+          id: "profile_secondary",
+          name: "Secondary",
+          apiBaseUrl: "https://api.example.com/v1",
+          apiKey: "sk-secondary",
+          model: "gpt-5-mini",
+          apiMode: "responses",
+          systemPrompt: "Be exact.",
+          temperature: 0.2,
+          maxOutputTokens: 512,
+          reasoningEffort: "medium",
+          reasoningSummaryEnabled: true,
+          modelContextLimit: 16000,
+          compactionThreshold: 0.8,
+          freshTailCount: 12
+        }
+      ]
+    });
+    const nextProfileId = "profile_secondary";
+    const userA = await createLocalUser({
+      username: "provider-profile-owner-a",
+      password: "Password123!",
+      role: "user"
+    });
+    const userB = await createLocalUser({
+      username: "provider-profile-owner-b",
+      password: "Password123!",
+      role: "user"
+    });
+    const ownedConversation = createConversation("Owned", null, undefined, userA.id);
+    const otherConversation = createConversation("Other", null, undefined, userB.id);
+
+    updateConversationProviderProfile(ownedConversation.id, nextProfileId, userA.id);
+    updateConversationProviderProfile(otherConversation.id, nextProfileId, userA.id);
+
+    expect(getConversation(ownedConversation.id)?.providerProfileId).toBe(nextProfileId);
+    expect(getConversation(otherConversation.id)?.providerProfileId).not.toBe(nextProfileId);
+  });
+
   it("stores message actions on assistant turns and hydrates them from message reads", () => {
     const conversation = createConversation();
     const message = createMessage({
@@ -1000,6 +1044,51 @@ describe("conversation helpers", () => {
     expect(
       fs.existsSync(path.resolve(process.env.EIDON_DATA_DIR!, "attachments", forkAttachment?.relativePath ?? ""))
     ).toBe(true);
+  });
+
+  it("forks text attachments even when the source file is missing", async () => {
+    const user = await createLocalUser({
+      username: "fork-missing-text-attachment-owner",
+      password: "Password123!",
+      role: "user"
+    });
+    const sourceConversation = createConversation("Source thread", null, {
+      providerProfileId: "profile_default"
+    }, user.id);
+    createMessage({
+      conversationId: sourceConversation.id,
+      role: "user",
+      content: "First prompt"
+    });
+    const assistantMessage = createMessage({
+      conversationId: sourceConversation.id,
+      role: "assistant",
+      content: "First reply"
+    });
+    const [attachment] = createAttachments(sourceConversation.id, [
+      {
+        filename: "notes.txt",
+        mimeType: "text/plain",
+        bytes: Buffer.from("source attachment", "utf8")
+      }
+    ]);
+
+    bindAttachmentsToMessage(sourceConversation.id, assistantMessage.id, [attachment.id]);
+    fs.unlinkSync(path.resolve(process.env.EIDON_DATA_DIR!, "attachments", attachment.relativePath));
+
+    const forkConversation = forkConversationFromMessage(assistantMessage.id, user.id);
+    const forkAssistantMessage = listMessages(forkConversation.id)[1];
+    const forkAttachment = forkAssistantMessage?.attachments?.[0];
+    const forkAttachmentPath = path.resolve(
+      process.env.EIDON_DATA_DIR!,
+      "attachments",
+      forkAttachment?.relativePath ?? ""
+    );
+
+    expect(forkAttachment?.filename).toBe("notes.txt");
+    expect(forkAttachment?.extractedText).toBe("source attachment");
+    expect(fs.existsSync(forkAttachmentPath)).toBe(true);
+    expect(fs.readFileSync(forkAttachmentPath, "utf8")).toBe("source attachment");
   });
 
   it("rejects forking a missing message", () => {

--- a/tests/unit/conversations.test.ts
+++ b/tests/unit/conversations.test.ts
@@ -565,8 +565,8 @@ describe("conversation helpers", () => {
     );
 
     const sourceAssistantMessage = getMessage(assistantMessage.id);
-    const sourceAssistantAction = sourceAssistantMessage?.actions[0];
-    const sourceAssistantTextSegment = sourceAssistantMessage?.textSegments[0];
+    const sourceAssistantAction = sourceAssistantMessage?.actions?.[0];
+    const sourceAssistantTextSegment = sourceAssistantMessage?.textSegments?.[0];
 
     db.prepare(
       `INSERT INTO memory_nodes (

--- a/tests/unit/conversations.test.ts
+++ b/tests/unit/conversations.test.ts
@@ -698,6 +698,35 @@ describe("conversation helpers", () => {
         child_node_ids,
         superseded_by_node_id,
         created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      "mem_retained_with_tail_superseder",
+      sourceConversation.id,
+      "leaf_summary",
+      0,
+      "Retained memory with tail superseder",
+      userMessage.id,
+      assistantMessage.id,
+      18,
+      9,
+      JSON.stringify([]),
+      "mem_external_superseder",
+      "2026-04-11T10:00:45.000Z"
+    );
+    db.prepare(
+      `INSERT INTO memory_nodes (
+        id,
+        conversation_id,
+        type,
+        depth,
+        content,
+        source_start_message_id,
+        source_end_message_id,
+        source_token_count,
+        summary_token_count,
+        child_node_ids,
+        superseded_by_node_id,
+        created_at
       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?)`
     ).run(
       "mem_external_child",
@@ -711,6 +740,34 @@ describe("conversation helpers", () => {
       3,
       JSON.stringify([]),
       "2026-04-11T10:00:50.000Z"
+    );
+    db.prepare(
+      `INSERT INTO memory_nodes (
+        id,
+        conversation_id,
+        type,
+        depth,
+        content,
+        source_start_message_id,
+        source_end_message_id,
+        source_token_count,
+        summary_token_count,
+        child_node_ids,
+        superseded_by_node_id,
+        created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?)`
+    ).run(
+      "mem_external_superseder",
+      sourceConversation.id,
+      "leaf_summary",
+      0,
+      "External superseder",
+      laterAssistantMessage.id,
+      laterAssistantMessage.id,
+      6,
+      3,
+      JSON.stringify([]),
+      "2026-04-11T10:00:55.000Z"
     );
     db.prepare(
       `INSERT INTO memory_nodes (
@@ -852,7 +909,7 @@ describe("conversation helpers", () => {
       notice_message_id: string | null;
     }>;
 
-    expect(forkMemoryNodes).toHaveLength(3);
+    expect(forkMemoryNodes).toHaveLength(4);
     expect(forkMemoryNodes[0]).toEqual(expect.objectContaining({
       content: "Prefix memory",
       source_start_message_id: forkUserMessage?.id,
@@ -866,6 +923,15 @@ describe("conversation helpers", () => {
     }));
     expect(forkMemoryNodes[0].superseded_by_node_id).toBe(forkMemoryNodes[1].id);
     expect(forkMemoryNodes.find((node) => node.content === "Notice memory")).toBeDefined();
+    expect(
+      forkMemoryNodes.find((node) => node.content === "Retained memory with tail superseder")
+    ).toEqual(
+      expect.objectContaining({
+        source_start_message_id: forkUserMessage?.id,
+        source_end_message_id: forkAssistantMessage?.id,
+        superseded_by_node_id: null
+      })
+    );
     expect(forkMemoryNodes.find((node) => node.content === "Partial child memory")).toBeUndefined();
     expect(forkCompactionEvents).toHaveLength(1);
     expect(forkCompactionEvents[0]).toEqual(expect.objectContaining({

--- a/tests/unit/conversations.test.ts
+++ b/tests/unit/conversations.test.ts
@@ -209,6 +209,47 @@ describe("conversation helpers", () => {
     expect(getConversation(conversation.id)?.titleGenerationStatus).toBe("pending");
   });
 
+  it("sorts a newly forked conversation above its source in the sidebar", () => {
+    const db = getDb();
+    const sourceConversation = createConversation("Source thread");
+    const userMessage = createMessage({
+      conversationId: sourceConversation.id,
+      role: "user",
+      content: "Explore approach A"
+    });
+    const branchAssistantMessage = createMessage({
+      conversationId: sourceConversation.id,
+      role: "assistant",
+      content: "Approach A details"
+    });
+    createMessage({
+      conversationId: sourceConversation.id,
+      role: "assistant",
+      content: "Later continuation"
+    });
+
+    db.prepare("UPDATE messages SET created_at = ? WHERE id = ?").run(
+      "2026-04-11T10:00:00.000Z",
+      userMessage.id
+    );
+    db.prepare("UPDATE messages SET created_at = ? WHERE id = ?").run(
+      "2026-04-11T10:01:00.000Z",
+      branchAssistantMessage.id
+    );
+    db.prepare(
+      "UPDATE messages SET created_at = ? WHERE conversation_id = ? AND content = ?"
+    ).run("2026-04-11T10:02:00.000Z", sourceConversation.id, "Later continuation");
+    db.prepare("UPDATE conversations SET updated_at = ? WHERE id = ?").run(
+      "2026-04-11T10:02:00.000Z",
+      sourceConversation.id
+    );
+
+    const forkConversation = forkConversationFromMessage(branchAssistantMessage.id);
+    const conversationIds = listConversationsPage().conversations.map((conversation) => conversation.id);
+
+    expect(conversationIds.slice(0, 2)).toEqual([forkConversation.id, sourceConversation.id]);
+  });
+
   it("retrieves messages only for the requested user", async () => {
     const userA = await createLocalUser({
       username: "message-owner-a",
@@ -841,8 +882,8 @@ describe("conversation helpers", () => {
     expect(forkConversation.id).not.toBe(sourceConversation.id);
     expect(forkConversation.folderId).toBe(sourceConversation.folderId);
     expect(forkConversation.providerProfileId).toBe(sourceConversation.providerProfileId);
-    expect(forkConversation.title).toBe("Conversation");
-    expect(forkConversation.titleGenerationStatus).toBe("pending");
+    expect(forkConversation.title).toBe("Fork Source thread");
+    expect(forkConversation.titleGenerationStatus).toBe("completed");
 
     const forkMessages = listMessages(forkConversation.id);
     const [forkUserMessage, forkAssistantMessage] = forkMessages;
@@ -1121,8 +1162,9 @@ describe("message fork routes", () => {
 
     expect(response.status).toBe(201);
 
-    const body = (await response.json()) as { conversation: { id: string } };
+    const body = (await response.json()) as { conversation: { id: string; title: string } };
     expect(body.conversation.id).toBeTruthy();
+    expect(body.conversation.title).toBe("Fork Forkable thread");
     expect(listVisibleMessages(body.conversation.id).map((message) => message.content)).toEqual([
       "Start here",
       "Selected answer"

--- a/tests/unit/conversations.test.ts
+++ b/tests/unit/conversations.test.ts
@@ -38,6 +38,10 @@ const { generateConversationTitle } = vi.hoisted(() => ({
   generateConversationTitle: vi.fn()
 }));
 
+const { requireUserMock } = vi.hoisted(() => ({
+  requireUserMock: vi.fn()
+}));
+
 vi.mock("@/lib/conversation-title-generator", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/conversation-title-generator")>();
 
@@ -46,6 +50,10 @@ vi.mock("@/lib/conversation-title-generator", async (importOriginal) => {
     generateConversationTitle
   };
 });
+
+vi.mock("@/lib/auth", () => ({
+  requireUser: requireUserMock
+}));
 
 describe("conversation helpers", () => {
   beforeEach(() => {
@@ -995,5 +1003,92 @@ describe("conversation helpers", () => {
     expect(snapshot!.messages[1].textSegments).toHaveLength(1);
     expect(snapshot!.messages[1].textSegments![0].content).toBe("partial answer");
     expect(snapshot!.messages[1].actions).toHaveLength(1);
+  });
+});
+
+describe("message fork routes", () => {
+  beforeEach(() => {
+    requireUserMock.mockReset();
+    requireUserMock.mockResolvedValue({
+      id: "user_fork_route",
+      username: "fork-route-user",
+      role: "user",
+      authSource: "local",
+      passwordManagedBy: "local",
+      createdAt: "2026-04-11T00:00:00.000Z",
+      updatedAt: "2026-04-11T00:00:00.000Z"
+    });
+  });
+
+  it("creates a forked conversation from an assistant message", async () => {
+    const user = await createLocalUser({
+      username: "fork-route-owner",
+      password: "Password123!",
+      role: "user"
+    });
+    requireUserMock.mockResolvedValueOnce(user);
+
+    const conversation = createConversation("Forkable thread", null, undefined, user.id);
+    createMessage({
+      conversationId: conversation.id,
+      role: "user",
+      content: "Start here"
+    });
+    const assistantMessage = createMessage({
+      conversationId: conversation.id,
+      role: "assistant",
+      content: "Selected answer"
+    });
+    createMessage({
+      conversationId: conversation.id,
+      role: "user",
+      content: "Later follow-up"
+    });
+
+    const { POST } = await import("@/app/api/messages/[messageId]/fork/route");
+    const response = await POST(
+      new Request(`http://localhost/api/messages/${assistantMessage.id}/fork`, {
+        method: "POST"
+      }),
+      { params: Promise.resolve({ messageId: assistantMessage.id }) }
+    );
+
+    expect(response.status).toBe(201);
+
+    const body = (await response.json()) as { conversation: { id: string } };
+    expect(body.conversation.id).toBeTruthy();
+    expect(listVisibleMessages(body.conversation.id).map((message) => message.content)).toEqual([
+      "Start here",
+      "Selected answer"
+    ]);
+  });
+
+  it("rejects forks for user messages", async () => {
+    const user = await createLocalUser({
+      username: "fork-route-rejector",
+      password: "Password123!",
+      role: "user"
+    });
+    requireUserMock.mockResolvedValueOnce(user);
+
+    const conversation = createConversation("Forkable thread", null, undefined, user.id);
+    const userMessage = createMessage({
+      conversationId: conversation.id,
+      role: "user",
+      content: "Do not fork me"
+    });
+
+    const { POST } = await import("@/app/api/messages/[messageId]/fork/route");
+    const response = await POST(
+      new Request(`http://localhost/api/messages/${userMessage.id}/fork`, {
+        method: "POST"
+      }),
+      { params: Promise.resolve({ messageId: userMessage.id }) }
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Only assistant messages can be forked"
+    });
   });
 });

--- a/tests/unit/conversations.test.ts
+++ b/tests/unit/conversations.test.ts
@@ -1091,4 +1091,26 @@ describe("message fork routes", () => {
       error: "Only assistant messages can be forked"
     });
   });
+
+  it("returns 404 for a missing message", async () => {
+    const user = await createLocalUser({
+      username: "fork-route-missing",
+      password: "Password123!",
+      role: "user"
+    });
+    requireUserMock.mockResolvedValueOnce(user);
+
+    const { POST } = await import("@/app/api/messages/[messageId]/fork/route");
+    const response = await POST(
+      new Request("http://localhost/api/messages/msg_missing/fork", {
+        method: "POST"
+      }),
+      { params: Promise.resolve({ messageId: "msg_missing" }) }
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: "Message not found"
+    });
+  });
 });

--- a/tests/unit/conversations.test.ts
+++ b/tests/unit/conversations.test.ts
@@ -494,6 +494,18 @@ describe("conversation helpers", () => {
       content: "First reply",
       thinkingContent: "Reasoning kept"
     });
+    const sourceMessageTimes = {
+      user: "2026-04-11T10:00:00.000Z",
+      assistant: "2026-04-11T10:00:30.000Z",
+      laterAssistant: "2026-04-11T10:01:30.000Z"
+    };
+    const sourceActionTimes = {
+      startedAt: "2026-04-11T10:00:45.000Z",
+      completedAt: "2026-04-11T10:01:00.000Z"
+    };
+    const sourceTextSegmentTime = "2026-04-11T10:00:40.000Z";
+    const db = getDb();
+
     createMessageAction({
       messageId: assistantMessage.id,
       kind: "mcp_tool_call",
@@ -511,6 +523,21 @@ describe("conversation helpers", () => {
       content: "Partial answer",
       sortOrder: 0
     });
+    db.prepare("UPDATE messages SET created_at = ? WHERE id = ?").run(sourceMessageTimes.user, userMessage.id);
+    db.prepare("UPDATE messages SET created_at = ? WHERE id = ?").run(
+      sourceMessageTimes.assistant,
+      assistantMessage.id
+    );
+    db.prepare("UPDATE message_actions SET started_at = ?, completed_at = ?, status = ? WHERE message_id = ?").run(
+      sourceActionTimes.startedAt,
+      sourceActionTimes.completedAt,
+      "completed",
+      assistantMessage.id
+    );
+    db.prepare("UPDATE message_text_segments SET created_at = ? WHERE message_id = ?").run(
+      sourceTextSegmentTime,
+      assistantMessage.id
+    );
     const [attachment] = createAttachments(sourceConversation.id, [
       {
         filename: "notes.txt",
@@ -524,8 +551,15 @@ describe("conversation helpers", () => {
       role: "assistant",
       content: "Later tail"
     });
+    db.prepare("UPDATE messages SET created_at = ? WHERE id = ?").run(
+      sourceMessageTimes.laterAssistant,
+      laterAssistantMessage.id
+    );
 
-    const db = getDb();
+    const sourceAssistantMessage = getMessage(assistantMessage.id);
+    const sourceAssistantAction = sourceAssistantMessage?.actions[0];
+    const sourceAssistantTextSegment = sourceAssistantMessage?.textSegments[0];
+
     db.prepare(
       `INSERT INTO memory_nodes (
         id,
@@ -552,7 +586,7 @@ describe("conversation helpers", () => {
       20,
       10,
       JSON.stringify([]),
-      "2026-04-11T10:00:00.000Z"
+      "2026-04-11T10:00:10.000Z"
     );
     db.prepare(
       `INSERT INTO memory_nodes (
@@ -580,11 +614,95 @@ describe("conversation helpers", () => {
       10,
       5,
       JSON.stringify([]),
-      "2026-04-11T10:00:30.000Z"
+      "2026-04-11T10:00:20.000Z"
     );
     db.prepare("UPDATE memory_nodes SET superseded_by_node_id = ? WHERE id = ?").run(
       "mem_superseding",
       "mem_prefix"
+    );
+    db.prepare(
+      `INSERT INTO memory_nodes (
+        id,
+        conversation_id,
+        type,
+        depth,
+        content,
+        source_start_message_id,
+        source_end_message_id,
+        source_token_count,
+        summary_token_count,
+        child_node_ids,
+        superseded_by_node_id,
+        created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?)`
+    ).run(
+      "mem_noticeful",
+      sourceConversation.id,
+      "leaf_summary",
+      0,
+      "Notice memory",
+      userMessage.id,
+      assistantMessage.id,
+      30,
+      15,
+      JSON.stringify([]),
+      "2026-04-11T10:00:30.000Z"
+    );
+    db.prepare(
+      `INSERT INTO memory_nodes (
+        id,
+        conversation_id,
+        type,
+        depth,
+        content,
+        source_start_message_id,
+        source_end_message_id,
+        source_token_count,
+        summary_token_count,
+        child_node_ids,
+        superseded_by_node_id,
+        created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?)`
+    ).run(
+      "mem_partial_child",
+      sourceConversation.id,
+      "leaf_summary",
+      0,
+      "Partial child memory",
+      userMessage.id,
+      assistantMessage.id,
+      15,
+      8,
+      JSON.stringify(["mem_external_child"]),
+      "2026-04-11T10:00:40.000Z"
+    );
+    db.prepare(
+      `INSERT INTO memory_nodes (
+        id,
+        conversation_id,
+        type,
+        depth,
+        content,
+        source_start_message_id,
+        source_end_message_id,
+        source_token_count,
+        summary_token_count,
+        child_node_ids,
+        superseded_by_node_id,
+        created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?)`
+    ).run(
+      "mem_external_child",
+      sourceConversation.id,
+      "leaf_summary",
+      0,
+      "External child memory",
+      laterAssistantMessage.id,
+      laterAssistantMessage.id,
+      5,
+      3,
+      JSON.stringify([]),
+      "2026-04-11T10:00:50.000Z"
     );
     db.prepare(
       `INSERT INTO memory_nodes (
@@ -633,6 +751,25 @@ describe("conversation helpers", () => {
       null,
       "2026-04-11T10:02:00.000Z"
     );
+    db.prepare(
+      `INSERT INTO compaction_events (
+        id,
+        conversation_id,
+        node_id,
+        source_start_message_id,
+        source_end_message_id,
+        notice_message_id,
+        created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      "cmp_notice",
+      sourceConversation.id,
+      "mem_noticeful",
+      userMessage.id,
+      assistantMessage.id,
+      laterAssistantMessage.id,
+      "2026-04-11T10:02:30.000Z"
+    );
 
     const forkConversation = forkConversationFromMessage(assistantMessage.id, user.id);
 
@@ -650,6 +787,8 @@ describe("conversation helpers", () => {
 
     expect(forkMessages.map((message) => message.role)).toEqual(["user", "assistant"]);
     expect(forkMessages.map((message) => message.content)).toEqual(["First prompt", "First reply"]);
+    expect(forkUserMessage?.createdAt).toBe(sourceMessageTimes.user);
+    expect(forkAssistantMessage?.createdAt).toBe(sourceMessageTimes.assistant);
     expect(forkAssistantMessage?.thinkingContent).toBe("Reasoning kept");
     expect(forkAction).toEqual(expect.objectContaining({
       messageId: forkAssistantMessage?.id,
@@ -657,10 +796,13 @@ describe("conversation helpers", () => {
       toolName: "search_docs",
       resultSummary: "Found docs"
     }));
+    expect(forkAction?.startedAt).toBe(sourceAssistantAction?.startedAt);
+    expect(forkAction?.completedAt).toBe(sourceAssistantAction?.completedAt);
     expect(forkTextSegment).toEqual(expect.objectContaining({
       messageId: forkAssistantMessage?.id,
       content: "Partial answer"
     }));
+    expect(forkTextSegment?.createdAt).toBe(sourceAssistantTextSegment?.createdAt);
     expect(forkAttachment).toEqual(expect.objectContaining({
       conversationId: forkConversation.id,
       messageId: forkAssistantMessage?.id,
@@ -670,10 +812,11 @@ describe("conversation helpers", () => {
     expect(forkUserMessage?.id).not.toBe(userMessage.id);
     expect(forkAssistantMessage?.id).not.toBe(assistantMessage.id);
     expect(forkAttachment?.id).not.toBe(attachment.id);
+    expect(forkAttachment?.relativePath).not.toBe(attachment.relativePath);
 
     const forkMemoryNodes = db
       .prepare(
-        `SELECT id, content, source_start_message_id, source_end_message_id, superseded_by_node_id
+        `SELECT id, content, source_start_message_id, source_end_message_id, superseded_by_node_id, child_node_ids
          FROM memory_nodes
          WHERE conversation_id = ?
          ORDER BY created_at ASC`
@@ -684,10 +827,11 @@ describe("conversation helpers", () => {
       source_start_message_id: string;
       source_end_message_id: string;
       superseded_by_node_id: string | null;
+      child_node_ids: string;
     }>;
     const forkCompactionEvents = db
       .prepare(
-        `SELECT id, node_id, source_start_message_id, source_end_message_id
+        `SELECT id, node_id, source_start_message_id, source_end_message_id, notice_message_id
          FROM compaction_events
          WHERE conversation_id = ?
          ORDER BY created_at ASC`
@@ -697,9 +841,10 @@ describe("conversation helpers", () => {
       node_id: string;
       source_start_message_id: string;
       source_end_message_id: string;
+      notice_message_id: string | null;
     }>;
 
-    expect(forkMemoryNodes).toHaveLength(2);
+    expect(forkMemoryNodes).toHaveLength(3);
     expect(forkMemoryNodes[0]).toEqual(expect.objectContaining({
       content: "Prefix memory",
       source_start_message_id: forkUserMessage?.id,
@@ -712,12 +857,15 @@ describe("conversation helpers", () => {
       superseded_by_node_id: null
     }));
     expect(forkMemoryNodes[0].superseded_by_node_id).toBe(forkMemoryNodes[1].id);
+    expect(forkMemoryNodes.find((node) => node.content === "Notice memory")).toBeDefined();
+    expect(forkMemoryNodes.find((node) => node.content === "Partial child memory")).toBeUndefined();
     expect(forkCompactionEvents).toHaveLength(1);
     expect(forkCompactionEvents[0]).toEqual(expect.objectContaining({
       source_start_message_id: forkUserMessage?.id,
       source_end_message_id: forkAssistantMessage?.id
     }));
     expect(forkMemoryNodes[0].id).toBe(forkCompactionEvents[0].node_id);
+    expect(forkCompactionEvents[0].notice_message_id).toBeNull();
 
     expect(
       db
@@ -729,6 +877,18 @@ describe("conversation helpers", () => {
         .prepare("SELECT id FROM compaction_events WHERE conversation_id = ? AND id = ?")
         .get(forkConversation.id, "cmp_prefix")
     ).toBeUndefined();
+
+    deleteConversation(sourceConversation.id);
+    expect(
+      fs.existsSync(path.resolve(process.env.EIDON_DATA_DIR!, "attachments", attachment.relativePath))
+    ).toBe(false);
+    expect(
+      fs.existsSync(path.resolve(process.env.EIDON_DATA_DIR!, "attachments", forkAttachment?.relativePath ?? ""))
+    ).toBe(true);
+  });
+
+  it("rejects forking a missing message", () => {
+    expect(() => forkConversationFromMessage("msg_missing")).toThrow("Message not found");
   });
 
   it("rejects forking a non-assistant message", async () => {

--- a/tests/unit/conversations.test.ts
+++ b/tests/unit/conversations.test.ts
@@ -3,10 +3,12 @@ import path from "node:path";
 
 import { createAttachments } from "@/lib/attachments";
 import { createAutomation, createAutomationRun } from "@/lib/automations";
+import { createFolder } from "@/lib/folders";
 import {
   claimConversationTitleGeneration,
   completeConversationTitleGeneration,
   createConversation,
+  bindAttachmentsToMessage,
   createMessageAction,
   createMessageTextSegment,
   createMessage,
@@ -17,6 +19,7 @@ import {
   getConversation,
   getMessage,
   isVisibleMessage,
+  forkConversationFromMessage,
   listConversations,
   listConversationsPage,
   listMessages,
@@ -27,6 +30,7 @@ import {
   getConversationSnapshot,
   updateMessageAction
 } from "@/lib/conversations";
+import { getDb } from "@/lib/db";
 import { getSettings, listProviderProfiles, updateSettings } from "@/lib/settings";
 import { createLocalUser } from "@/lib/users";
 
@@ -467,6 +471,277 @@ describe("conversation helpers", () => {
         sortOrder: 2
       })
     ]);
+  });
+
+  it("forks a conversation from an assistant message and clones the retained prefix", async () => {
+    const user = await createLocalUser({
+      username: "fork-owner",
+      password: "Password123!",
+      role: "user"
+    });
+    const folder = createFolder("Source folder", user.id);
+    const sourceConversation = createConversation("Source thread", folder.id, {
+      providerProfileId: "profile_default"
+    }, user.id);
+    const userMessage = createMessage({
+      conversationId: sourceConversation.id,
+      role: "user",
+      content: "First prompt"
+    });
+    const assistantMessage = createMessage({
+      conversationId: sourceConversation.id,
+      role: "assistant",
+      content: "First reply",
+      thinkingContent: "Reasoning kept"
+    });
+    createMessageAction({
+      messageId: assistantMessage.id,
+      kind: "mcp_tool_call",
+      serverId: "mcp_docs",
+      toolName: "search_docs",
+      label: "Search docs",
+      detail: "query=forking",
+      arguments: { query: "forking" },
+      status: "completed",
+      resultSummary: "Found docs",
+      sortOrder: 0
+    });
+    createMessageTextSegment({
+      messageId: assistantMessage.id,
+      content: "Partial answer",
+      sortOrder: 0
+    });
+    const [attachment] = createAttachments(sourceConversation.id, [
+      {
+        filename: "notes.txt",
+        mimeType: "text/plain",
+        bytes: Buffer.from("source attachment", "utf8")
+      }
+    ]);
+    bindAttachmentsToMessage(sourceConversation.id, assistantMessage.id, [attachment.id]);
+    const laterAssistantMessage = createMessage({
+      conversationId: sourceConversation.id,
+      role: "assistant",
+      content: "Later tail"
+    });
+
+    const db = getDb();
+    db.prepare(
+      `INSERT INTO memory_nodes (
+        id,
+        conversation_id,
+        type,
+        depth,
+        content,
+        source_start_message_id,
+        source_end_message_id,
+        source_token_count,
+        summary_token_count,
+        child_node_ids,
+        superseded_by_node_id,
+        created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?)`
+    ).run(
+      "mem_prefix",
+      sourceConversation.id,
+      "leaf_summary",
+      0,
+      "Prefix memory",
+      userMessage.id,
+      assistantMessage.id,
+      20,
+      10,
+      JSON.stringify([]),
+      "2026-04-11T10:00:00.000Z"
+    );
+    db.prepare(
+      `INSERT INTO memory_nodes (
+        id,
+        conversation_id,
+        type,
+        depth,
+        content,
+        source_start_message_id,
+        source_end_message_id,
+        source_token_count,
+        summary_token_count,
+        child_node_ids,
+        superseded_by_node_id,
+        created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?)`
+    ).run(
+      "mem_superseding",
+      sourceConversation.id,
+      "leaf_summary",
+      0,
+      "Superseding memory",
+      assistantMessage.id,
+      assistantMessage.id,
+      10,
+      5,
+      JSON.stringify([]),
+      "2026-04-11T10:00:30.000Z"
+    );
+    db.prepare("UPDATE memory_nodes SET superseded_by_node_id = ? WHERE id = ?").run(
+      "mem_superseding",
+      "mem_prefix"
+    );
+    db.prepare(
+      `INSERT INTO memory_nodes (
+        id,
+        conversation_id,
+        type,
+        depth,
+        content,
+        source_start_message_id,
+        source_end_message_id,
+        source_token_count,
+        summary_token_count,
+        child_node_ids,
+        superseded_by_node_id,
+        created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?)`
+    ).run(
+      "mem_spanning",
+      sourceConversation.id,
+      "leaf_summary",
+      0,
+      "Tail memory",
+      userMessage.id,
+      laterAssistantMessage.id,
+      40,
+      20,
+      JSON.stringify([]),
+      "2026-04-11T10:01:00.000Z"
+    );
+    db.prepare(
+      `INSERT INTO compaction_events (
+        id,
+        conversation_id,
+        node_id,
+        source_start_message_id,
+        source_end_message_id,
+        notice_message_id,
+        created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      "cmp_prefix",
+      sourceConversation.id,
+      "mem_prefix",
+      userMessage.id,
+      assistantMessage.id,
+      null,
+      "2026-04-11T10:02:00.000Z"
+    );
+
+    const forkConversation = forkConversationFromMessage(assistantMessage.id, user.id);
+
+    expect(forkConversation.id).not.toBe(sourceConversation.id);
+    expect(forkConversation.folderId).toBe(sourceConversation.folderId);
+    expect(forkConversation.providerProfileId).toBe(sourceConversation.providerProfileId);
+    expect(forkConversation.title).toBe("Conversation");
+    expect(forkConversation.titleGenerationStatus).toBe("pending");
+
+    const forkMessages = listMessages(forkConversation.id);
+    const [forkUserMessage, forkAssistantMessage] = forkMessages;
+    const forkAttachment = forkAssistantMessage?.attachments?.[0];
+    const forkAction = forkAssistantMessage?.actions?.[0];
+    const forkTextSegment = forkAssistantMessage?.textSegments?.[0];
+
+    expect(forkMessages.map((message) => message.role)).toEqual(["user", "assistant"]);
+    expect(forkMessages.map((message) => message.content)).toEqual(["First prompt", "First reply"]);
+    expect(forkAssistantMessage?.thinkingContent).toBe("Reasoning kept");
+    expect(forkAction).toEqual(expect.objectContaining({
+      messageId: forkAssistantMessage?.id,
+      label: "Search docs",
+      toolName: "search_docs",
+      resultSummary: "Found docs"
+    }));
+    expect(forkTextSegment).toEqual(expect.objectContaining({
+      messageId: forkAssistantMessage?.id,
+      content: "Partial answer"
+    }));
+    expect(forkAttachment).toEqual(expect.objectContaining({
+      conversationId: forkConversation.id,
+      messageId: forkAssistantMessage?.id,
+      filename: "notes.txt",
+      extractedText: "source attachment"
+    }));
+    expect(forkUserMessage?.id).not.toBe(userMessage.id);
+    expect(forkAssistantMessage?.id).not.toBe(assistantMessage.id);
+    expect(forkAttachment?.id).not.toBe(attachment.id);
+
+    const forkMemoryNodes = db
+      .prepare(
+        `SELECT id, content, source_start_message_id, source_end_message_id, superseded_by_node_id
+         FROM memory_nodes
+         WHERE conversation_id = ?
+         ORDER BY created_at ASC`
+      )
+      .all(forkConversation.id) as Array<{
+      id: string;
+      content: string;
+      source_start_message_id: string;
+      source_end_message_id: string;
+      superseded_by_node_id: string | null;
+    }>;
+    const forkCompactionEvents = db
+      .prepare(
+        `SELECT id, node_id, source_start_message_id, source_end_message_id
+         FROM compaction_events
+         WHERE conversation_id = ?
+         ORDER BY created_at ASC`
+      )
+      .all(forkConversation.id) as Array<{
+      id: string;
+      node_id: string;
+      source_start_message_id: string;
+      source_end_message_id: string;
+    }>;
+
+    expect(forkMemoryNodes).toHaveLength(2);
+    expect(forkMemoryNodes[0]).toEqual(expect.objectContaining({
+      content: "Prefix memory",
+      source_start_message_id: forkUserMessage?.id,
+      source_end_message_id: forkAssistantMessage?.id
+    }));
+    expect(forkMemoryNodes[1]).toEqual(expect.objectContaining({
+      content: "Superseding memory",
+      source_start_message_id: forkAssistantMessage?.id,
+      source_end_message_id: forkAssistantMessage?.id,
+      superseded_by_node_id: null
+    }));
+    expect(forkMemoryNodes[0].superseded_by_node_id).toBe(forkMemoryNodes[1].id);
+    expect(forkCompactionEvents).toHaveLength(1);
+    expect(forkCompactionEvents[0]).toEqual(expect.objectContaining({
+      source_start_message_id: forkUserMessage?.id,
+      source_end_message_id: forkAssistantMessage?.id
+    }));
+    expect(forkMemoryNodes[0].id).toBe(forkCompactionEvents[0].node_id);
+
+    expect(
+      db
+        .prepare("SELECT id FROM memory_nodes WHERE conversation_id = ? AND id = ?")
+        .get(forkConversation.id, "mem_spanning")
+    ).toBeUndefined();
+    expect(
+      db
+        .prepare("SELECT id FROM compaction_events WHERE conversation_id = ? AND id = ?")
+        .get(forkConversation.id, "cmp_prefix")
+    ).toBeUndefined();
+  });
+
+  it("rejects forking a non-assistant message", async () => {
+    const conversation = createConversation();
+    const message = createMessage({
+      conversationId: conversation.id,
+      role: "user",
+      content: "Nope"
+    });
+
+    expect(() => forkConversationFromMessage(message.id)).toThrow(
+      "Only assistant messages can be forked"
+    );
   });
 
   it("updates message content and returns the refreshed message row", () => {

--- a/tests/unit/message-bubble.test.ts
+++ b/tests/unit/message-bubble.test.ts
@@ -524,6 +524,24 @@ describe("message bubble", () => {
     ).toBeInTheDocument();
   });
 
+  it("keeps the copy action visible for non-completed assistant messages while hiding fork", () => {
+    render(
+      React.createElement(MessageBubble as React.ComponentType<any>, {
+        message: {
+          ...createAssistantMessage(),
+          status: "streaming",
+          content: "Still composing"
+        },
+        onForkAssistantMessage: vi.fn()
+      })
+    );
+
+    expect(screen.getByRole("button", { name: "Copy message" })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Fork conversation from message" })
+    ).toBeNull();
+  });
+
   it("does not render a fork action for user messages", () => {
     render(
       React.createElement(MessageBubble as React.ComponentType<any>, {

--- a/tests/unit/message-bubble.test.ts
+++ b/tests/unit/message-bubble.test.ts
@@ -507,6 +507,54 @@ describe("message bubble", () => {
     });
   });
 
+  it("renders a fork action for completed assistant messages", () => {
+    render(
+      React.createElement(MessageBubble as React.ComponentType<any>, {
+        message: {
+          ...createAssistantMessage(),
+          content: "Ready to fork"
+        },
+        onForkAssistantMessage: vi.fn()
+      })
+    );
+
+    expect(screen.getByRole("button", { name: "Copy message" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Fork conversation from message" })
+    ).toBeInTheDocument();
+  });
+
+  it("does not render a fork action for user messages", () => {
+    render(
+      React.createElement(MessageBubble as React.ComponentType<any>, {
+        message: createUserMessage(),
+        onForkAssistantMessage: vi.fn()
+      })
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Fork conversation from message" })
+    ).toBeNull();
+  });
+
+  it("does not render a fork action for streaming placeholders", () => {
+    render(
+      React.createElement(StreamingPlaceholder, {
+        createdAt: new Date().toISOString(),
+        thinking: "",
+        answer: "Still streaming",
+        awaitingFirstToken: false,
+        thinkingInProgress: false,
+        timeline: [],
+        onForkAssistantMessage: vi.fn()
+      } as any)
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Fork conversation from message" })
+    ).toBeNull();
+  });
+
   it("allows editing user messages through the inline controls", async () => {
     const onUpdateUserMessage = vi.fn().mockResolvedValue(undefined);
 


### PR DESCRIPTION
## Summary
- add a fork conversation API for assistant messages that clones the retained thread prefix
- add fork controls in the chat UI and redirect immediately into the new branched conversation
- preserve copied conversation state, including actions, text segments, attachments, and retained memory/compaction data
- update conversation ordering and fork titles so new branches appear at the top and are labeled with a `Fork ` prefix
- add spec/plan docs for the branching conversation design

## Testing
- `npx vitest run tests/unit/conversations.test.ts tests/unit/chat-view.test.ts tests/unit/message-bubble.test.ts`
- `npm run typecheck`