### PR TITLE
Fix sidebar conversation transcript search

### DIFF
--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -56,10 +56,10 @@ import {
 import { deleteConversationIfStillEmpty } from "@/lib/conversation-drafts";
 import { addGlobalWsListener } from "@/lib/ws-client";
 import type { ServerMessage } from "@/lib/ws-protocol";
-import type { Conversation, ConversationListPage, Folder } from "@/lib/types";
+import type { Conversation, ConversationListPage, ConversationSearchResult, Folder } from "@/lib/types";
 import { SidebarFooterNav } from "@/components/sidebar-footer-nav";
 
-type SidebarConversation = Conversation & { matchSnippet?: string };
+type SidebarConversation = ConversationSearchResult;
 
 type ConversationSection = {
   label: string;
@@ -133,6 +133,34 @@ function buildConversationSections(conversations: SidebarConversation[]) {
     .filter((section) => section.conversations.length > 0);
 }
 
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+export function highlightMatch(text: string, query: string): string {
+  if (!query) {
+    return escapeHtml(text);
+  }
+
+  const escapedQuery = query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const splitRegex = new RegExp(`(${escapedQuery})`, "gi");
+  const wholeMatchRegex = new RegExp(`^${escapedQuery}$`, "i");
+
+  return text
+    .split(splitRegex)
+    .map((segment) =>
+      wholeMatchRegex.test(segment)
+        ? `<mark class="bg-[var(--accent)]/30 text-white rounded px-0.5">${escapeHtml(segment)}</mark>`
+        : escapeHtml(segment)
+    )
+    .join("");
+}
+
 function ConversationItem({
   conversation,
   active,
@@ -140,7 +168,8 @@ function ConversationItem({
   onDeleteConversation,
   onMoveConversation,
   allFolders,
-  dragEnabled
+  dragEnabled,
+  searchQuery
 }: {
   conversation: SidebarConversation;
   active: boolean;
@@ -149,6 +178,7 @@ function ConversationItem({
   onMoveConversation: (conversationId: string, folderId: string | null) => void;
   allFolders: Folder[];
   dragEnabled: boolean;
+  searchQuery: string;
 }) {
   const router = useRouter();
   const [menuOpen, setMenuOpen] = useState(false);
@@ -167,6 +197,14 @@ function ConversationItem({
     transform: CSS.Transform.toString(transform),
     transition
   };
+  const trimmedSearchQuery = searchQuery.trim();
+  const highlightedTitle = trimmedSearchQuery
+    ? highlightMatch(conversation.title, trimmedSearchQuery)
+    : null;
+  const highlightedMatchSnippet =
+    trimmedSearchQuery && conversation.matchSnippet
+      ? highlightMatch(conversation.matchSnippet, trimmedSearchQuery)
+      : null;
 
   function handleNavigate(event: ReactMouseEvent<HTMLAnchorElement>) {
     if (
@@ -251,13 +289,23 @@ function ConversationItem({
         )}
 
         <div className="relative min-w-0 flex-1 overflow-hidden">
-          {conversation.matchSnippet ? (
-            <div className="truncate" dangerouslySetInnerHTML={{ __html: conversation.matchSnippet }} />
+          {highlightedTitle ? (
+            <div
+              className={`truncate ${active ? "pr-8" : "group-hover:pr-8"}`}
+              dangerouslySetInnerHTML={{ __html: highlightedTitle }}
+            />
           ) : (
             <div className={`truncate ${active ? "pr-8" : "group-hover:pr-8"}`}>
               {conversation.title}
             </div>
           )}
+
+          {highlightedMatchSnippet ? (
+            <div
+              className={`mt-0.5 truncate pr-8 text-xs ${active ? "text-white/55" : "text-white/40 group-hover:text-white/50"}`}
+              dangerouslySetInnerHTML={{ __html: highlightedMatchSnippet }}
+            />
+          ) : null}
 
           <div
             className={`absolute right-0 top-0 bottom-0 flex items-center bg-gradient-to-l from-transparent via-transparent to-transparent pl-4 pr-1 transition-opacity duration-300 ${
@@ -353,7 +401,8 @@ function FolderItem({
   onCreateInFolder,
   dragEnabled,
   showCount,
-  isDraggingConversation
+  isDraggingConversation,
+  searchQuery
 }: {
   folder: Folder;
   conversations: SidebarConversation[];
@@ -366,6 +415,7 @@ function FolderItem({
   dragEnabled: boolean;
   showCount: boolean;
   isDraggingConversation: boolean;
+  searchQuery: string;
 }) {
   const [collapsed, setCollapsed] = useState(true);
   const [renaming, setRenaming] = useState(false);
@@ -557,6 +607,7 @@ function FolderItem({
               onMoveConversation={onMoveConversation}
               allFolders={allFolders}
               dragEnabled={dragEnabled}
+              searchQuery={searchQuery}
             />
           ))}
         </div>
@@ -707,13 +758,8 @@ export function Sidebar({
 
     searchTimeoutRef.current = setTimeout(async () => {
       const res = await fetch(`/api/conversations/search?q=${encodeURIComponent(query)}`);
-      const data = (await res.json()) as { conversations: Conversation[] };
-
-      const highlighted = data.conversations.map((c) => ({
-        ...c,
-        matchSnippet: highlightMatch(c.title, query)
-      }));
-      setSearchResults(highlighted);
+      const data = (await res.json()) as { conversations: ConversationSearchResult[] };
+      setSearchResults(data.conversations);
     }, 200);
   }, []);
 
@@ -755,10 +801,7 @@ export function Sidebar({
               conversation.id === detail.conversationId
                 ? {
                     ...conversation,
-                    title: detail.title,
-                    matchSnippet: searchQuery.trim()
-                      ? highlightMatch(detail.title, searchQuery)
-                      : conversation.matchSnippet
+                    title: detail.title
                   }
                 : conversation
             )
@@ -777,7 +820,7 @@ export function Sidebar({
         handleConversationTitleUpdated as EventListener
       );
     };
-  }, [searchQuery]);
+  }, []);
 
   useEffect(() => {
     function handleConversationRemoved(event: Event) {
@@ -880,11 +923,6 @@ export function Sidebar({
       }
     });
   }, []);
-
-  function highlightMatch(text: string, query: string): string {
-    const regex = new RegExp(`(${query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")})`, "gi");
-    return text.replace(regex, '<mark class="bg-[var(--accent)]/30 text-white rounded px-0.5">$1</mark>');
-  }
 
   async function handleCreate(folderId?: string) {
     await deleteConversationIfStillEmpty(activeConversationId);
@@ -1008,6 +1046,7 @@ export function Sidebar({
                 dragEnabled={enableDrag}
                 showCount={showFolderCounts}
                 isDraggingConversation={draggingConversation}
+                searchQuery={searchQuery}
               />
             </div>
           );
@@ -1035,6 +1074,7 @@ export function Sidebar({
                     onMoveConversation={moveConversationInState}
                     allFolders={localFolders}
                     dragEnabled={enableDrag}
+                    searchQuery={searchQuery}
                   />
                 ))}
               </div>

--- a/lib/conversations.ts
+++ b/lib/conversations.ts
@@ -26,6 +26,7 @@ import type {
   Conversation,
   ConversationListPage,
   ConversationOrigin,
+  ConversationSearchResult,
   ConversationTitleGenerationStatus,
   Message,
   MessageAttachment,
@@ -93,6 +94,26 @@ function rowToConversation(row: ConversationRow): Conversation {
     updatedAt: row.updated_at,
     isActive: row.is_active === 1
   };
+}
+
+function buildConversationMatchSnippet(content: string, query: string) {
+  const normalizedContent = content.replace(/\s+/g, " ").trim();
+  const normalizedQuery = query.replace(/\s+/g, " ").trim();
+
+  if (!normalizedContent || !normalizedQuery) {
+    return normalizedContent;
+  }
+
+  const matchIndex = normalizedContent.toLowerCase().indexOf(normalizedQuery.toLowerCase());
+
+  if (matchIndex === -1) {
+    return normalizedContent.slice(0, 120);
+  }
+
+  const start = Math.max(0, matchIndex - 36);
+  const end = Math.min(normalizedContent.length, matchIndex + normalizedQuery.length + 48);
+
+  return `${start > 0 ? "…" : ""}${normalizedContent.slice(start, end).trim()}${end < normalizedContent.length ? "…" : ""}`;
 }
 
 function rowToMessage(row: {
@@ -1878,14 +1899,14 @@ export function reorderConversations(
   );
 }
 
-export function searchConversations(query: string, userId?: string) {
+export function searchConversations(query: string, userId?: string): ConversationSearchResult[] {
   const likeQuery = `%${query}%`;
   const activityTimestamp = conversationActivityTimestampSql("c");
   const userCondition = userId ? "c.user_id = ? AND " : "";
 
   const rows = getDb()
     .prepare(
-      `SELECT DISTINCT
+      `SELECT
         c.id,
         c.title,
         c.title_generation_status,
@@ -1897,20 +1918,50 @@ export function searchConversations(query: string, userId?: string) {
         c.sort_order,
         c.created_at,
         ${activityTimestamp} AS updated_at,
-        c.is_active
+        c.is_active,
+        m.content AS matched_message_content
        FROM conversations c
-       LEFT JOIN messages m ON c.id = m.conversation_id
+       LEFT JOIN messages m
+         ON c.id = m.conversation_id
+        AND m.content LIKE ?
+        AND (m.role != 'system' OR m.system_kind IS NOT NULL)
        WHERE ${userCondition}c.conversation_origin = ?
          AND (
            c.title LIKE ?
-           OR (
-             m.content LIKE ?
-             AND (m.role != 'system' OR m.system_kind IS NOT NULL)
-           )
+           OR m.id IS NOT NULL
          )
-       ORDER BY ${activityTimestamp} DESC, c.id DESC`
+       ORDER BY ${activityTimestamp} DESC, c.id DESC, m.created_at ASC`
     )
-    .all(...(userId ? [userId] : []), MANUAL_CONVERSATION_ORIGIN, likeQuery, likeQuery) as ConversationRow[];
+    .all(
+      likeQuery,
+      ...(userId ? [userId] : []),
+      MANUAL_CONVERSATION_ORIGIN,
+      likeQuery
+    ) as Array<ConversationRow & { matched_message_content: string | null }>;
 
-  return rows.map(rowToConversation);
+  const normalizedQuery = query.trim().toLowerCase();
+  const results: ConversationSearchResult[] = [];
+  const seenConversationIds = new Set<string>();
+
+  rows.forEach((row) => {
+    if (seenConversationIds.has(row.id)) {
+      return;
+    }
+
+    seenConversationIds.add(row.id);
+
+    const conversation = rowToConversation(row);
+    const titleMatches = row.title.toLowerCase().includes(normalizedQuery);
+
+    results.push(
+      titleMatches || !row.matched_message_content
+        ? conversation
+        : {
+            ...conversation,
+            matchSnippet: buildConversationMatchSnippet(row.matched_message_content, query)
+          }
+    );
+  });
+
+  return results;
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -127,6 +127,10 @@ export type Conversation = {
   isActive: boolean;
 };
 
+export type ConversationSearchResult = Conversation & {
+  matchSnippet?: string;
+};
+
 export type Automation = {
   id: string;
   name: string;

--- a/tests/unit/conversations-extended.test.ts
+++ b/tests/unit/conversations-extended.test.ts
@@ -158,6 +158,21 @@ describe("conversations extended", () => {
     expect(results[0].id).toBe(conv.id);
   });
 
+  it("returns the matched transcript text for message-content search hits", () => {
+    const conv = createConversation("Sprint Notes");
+    createMessage({
+      conversationId: conv.id,
+      role: "assistant",
+      content: "The launch code phrase is silver moon tonight."
+    });
+
+    const results = searchConversations("silver moon");
+
+    expect(results).toHaveLength(1);
+    expect(results[0].id).toBe(conv.id);
+    expect((results[0] as { matchSnippet?: string }).matchSnippet).toContain("silver moon");
+  });
+
   it("excludes automation conversations from manual search results", () => {
     const defaultProviderProfileId =
       getSettings().defaultProviderProfileId ?? listProviderProfiles()[0]?.id ?? "";

--- a/tests/unit/sidebar.test.tsx
+++ b/tests/unit/sidebar.test.tsx
@@ -1,0 +1,16 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from "vitest";
+
+import { highlightMatch } from "@/components/sidebar";
+
+describe("highlightMatch", () => {
+  it("escapes raw html while preserving highlighted search text", () => {
+    const result = highlightMatch('<img src=x onerror="alert(1)"> silver moon', "silver moon");
+
+    expect(result).toContain("&lt;img src=x onerror=&quot;alert(1)&quot;&gt;");
+    expect(result).toContain('<mark class="bg-[var(--accent)]/30 text-white rounded px-0.5">silver moon</mark>');
+    expect(result).not.toContain("<img");
+    expect(result).not.toContain('onerror="alert(1)"');
+  });
+});


### PR DESCRIPTION
This updates sidebar search so message-body matches return the conversation title plus a snippet from the matched transcript instead of looking title-only. The backend now includes a match snippet in conversation search results while leaving title matches unchanged. It also escapes highlighted search markup before rendering and adds regression coverage for transcript snippets and safe highlighting. Validation: npm run typecheck, npm test, npm run lint (existing components/message-bubble.tsx img warnings only), and live agent-browser verification against a transcript-only query.