### PR TITLE
Add OpenRouter preset and fix streamed replies

### DIFF
--- a/docs/superpowers/plans/2026-04-13-openrouter-provider-preset.md
+++ b/docs/superpowers/plans/2026-04-13-openrouter-provider-preset.md
@@ -1,0 +1,285 @@
+# OpenRouter Provider Preset Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an OpenRouter template to Settings → Providers so users can create an OpenAI-compatible profile prefilled with the OpenRouter base URL and generic defaults.
+
+**Architecture:** Keep OpenRouter inside the existing `openai_compatible` provider flow. Extend the provider preset registry with a new `openrouter` preset, then verify the settings UI exposes it through the existing preset dropdown and applies the expected values to the active profile.
+
+**Tech Stack:** Next.js, React, TypeScript, Vitest, Testing Library
+
+---
+
+## File Structure
+
+- `lib/provider-presets.ts`
+  Owns the preset id union, preset definitions, and the helper functions that apply and match presets.
+- `tests/unit/provider-presets.test.ts`
+  Verifies preset values and preset matching behavior independently of the UI.
+- `tests/unit/providers-section.test.tsx`
+  Verifies the Providers settings screen exposes the preset and applies it through the existing dropdown.
+
+### Task 1: Add the OpenRouter preset to the preset registry
+
+**Files:**
+- Modify: `lib/provider-presets.ts`
+- Test: `tests/unit/provider-presets.test.ts`
+
+- [ ] **Step 1: Write the failing preset unit tests**
+
+Add these tests to `tests/unit/provider-presets.test.ts`:
+
+```ts
+  it("applies the OpenRouter preset values", () => {
+    const profile = applyProviderPreset(createProfile(), "openrouter");
+
+    expect(profile.name).toBe("OpenRouter");
+    expect(profile.apiBaseUrl).toBe("https://openrouter.ai/api/v1");
+    expect(profile.model).toBe("");
+    expect(profile.apiMode).toBe("responses");
+    expect(profile.reasoningEffort).toBe("medium");
+    expect(profile.reasoningSummaryEnabled).toBe(true);
+    expect(profile.modelContextLimit).toBe(200000);
+  });
+
+  it("matches a profile back to the OpenRouter preset when the provider fields align", () => {
+    const profile = {
+      ...createProfile(),
+      ...getProviderPreset("openrouter").values
+    };
+
+    expect(getMatchingProviderPresetId(profile)).toBe("openrouter");
+  });
+```
+
+- [ ] **Step 2: Run the preset test file to verify it fails**
+
+Run: `npx vitest run tests/unit/provider-presets.test.ts`
+
+Expected: FAIL with a TypeScript or runtime error because `"openrouter"` is not part of `ProviderPresetId` and `getProviderPreset("openrouter")` is unknown.
+
+- [ ] **Step 3: Implement the OpenRouter preset**
+
+Update `lib/provider-presets.ts` with this change:
+
+```ts
+export type ProviderPresetId =
+  | "openrouter"
+  | "ollama_cloud"
+  | "glm_coding_plan"
+  | "custom_openai_compatible";
+
+export const PROVIDER_PRESETS: ProviderPresetDefinition[] = [
+  {
+    id: "openrouter",
+    label: "OpenRouter",
+    values: {
+      name: "OpenRouter",
+      apiBaseUrl: "https://openrouter.ai/api/v1",
+      model: "",
+      apiMode: DEFAULT_PROVIDER_SETTINGS.apiMode,
+      reasoningEffort: DEFAULT_PROVIDER_SETTINGS.reasoningEffort,
+      reasoningSummaryEnabled: DEFAULT_PROVIDER_SETTINGS.reasoningSummaryEnabled,
+      modelContextLimit: 200000
+    }
+  },
+  {
+    id: "ollama_cloud",
+    label: "Ollama Cloud",
+    values: {
+      name: "Ollama Cloud",
+      apiBaseUrl: "https://ollama.com/v1",
+      model: "glm-4.7:cloud",
+      apiMode: "chat_completions",
+      reasoningEffort: "medium",
+      reasoningSummaryEnabled: true,
+      modelContextLimit: 64000
+    }
+  },
+```
+
+- [ ] **Step 4: Run the preset test file to verify it passes**
+
+Run: `npx vitest run tests/unit/provider-presets.test.ts`
+
+Expected: PASS with all preset tests green, including the new OpenRouter checks.
+
+- [ ] **Step 5: Commit the preset registry change**
+
+```bash
+git add lib/provider-presets.ts tests/unit/provider-presets.test.ts
+git commit -m "feat: add openrouter provider preset"
+```
+
+### Task 2: Add a settings regression test for selecting the OpenRouter preset
+
+**Files:**
+- Test: `tests/unit/providers-section.test.tsx`
+
+- [ ] **Step 1: Write the failing settings interaction test**
+
+Add this test to `tests/unit/providers-section.test.tsx`:
+
+```tsx
+  it("applies the OpenRouter preset from the providers settings dropdown", async () => {
+    const fetchMock = vi.mocked(global.fetch);
+    const settings = makeSettings();
+
+    render(React.createElement(ProvidersSection, { settings }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/mcp-servers");
+    });
+
+    fireEvent.change(screen.getByLabelText("Provider preset"), {
+      target: { value: "openrouter" }
+    });
+
+    expect(screen.getByDisplayValue("OpenRouter")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("https://openrouter.ai/api/v1")).toBeInTheDocument();
+    expect(screen.getByLabelText("Model")).toHaveValue("");
+  });
+```
+
+- [ ] **Step 2: Run the settings interaction test to verify it fails**
+
+Run: `npx vitest run tests/unit/providers-section.test.tsx -t "applies the OpenRouter preset from the providers settings dropdown"`
+
+Expected: FAIL because the preset dropdown does not yet contain an `openrouter` option before Task 1 is implemented on a clean branch.
+
+- [ ] **Step 3: Re-run after Task 1 and confirm no additional production code is needed**
+
+No production code change should be necessary here because `ProvidersSection` already renders:
+
+```tsx
+{PROVIDER_PRESETS.map((preset) => (
+  <option key={preset.id} value={preset.id}>
+    {preset.label}
+  </option>
+))}
+```
+
+and already applies selection through:
+
+```tsx
+applyPresetToActiveProviderProfile(nextPresetId);
+```
+
+The expected outcome is that Task 1's preset registry change makes this UI test pass unchanged.
+
+- [ ] **Step 4: Run the focused settings test to verify it passes**
+
+Run: `npx vitest run tests/unit/providers-section.test.tsx -t "applies the OpenRouter preset from the providers settings dropdown"`
+
+Expected: PASS, showing the dropdown now exposes OpenRouter and the selected draft updates to the OpenRouter values.
+
+- [ ] **Step 5: Run the combined regression slice**
+
+Run: `npx vitest run tests/unit/provider-presets.test.ts tests/unit/providers-section.test.tsx`
+
+Expected: PASS with both the preset registry tests and the Providers settings tests green.
+
+- [ ] **Step 6: Commit the regression coverage**
+
+```bash
+git add tests/unit/providers-section.test.tsx
+git commit -m "test: cover openrouter preset in settings"
+```
+
+### Task 3: Verify the settings UI manually in the browser
+
+**Files:**
+- Verify: `components/settings/sections/providers-section.tsx`
+
+- [ ] **Step 1: Start or reuse the dev server**
+
+Run:
+
+```bash
+if [ -f .dev-server ]; then
+  URL=$(head -n 1 .dev-server)
+  curl -sf "$URL/settings/providers" >/dev/null || rm .dev-server
+fi
+
+if [ ! -f .dev-server ]; then
+  npm run dev
+fi
+```
+
+Then run:
+
+```bash
+until [ -f .dev-server ]; do sleep 1; done
+head -n 1 .dev-server
+```
+
+Expected: a reachable local URL from `.dev-server` in the `3000`-`4000` range.
+
+- [ ] **Step 2: Open the Providers settings page with agent-browser**
+
+Run the browser workflow against the URL from `.dev-server`:
+
+```bash
+URL=$(head -n 1 .dev-server)
+agent-browser open "$URL/settings/providers"
+agent-browser wait --load networkidle
+agent-browser snapshot -i
+```
+
+Expected: the Providers settings page loads and exposes the provider list plus the provider detail form.
+
+- [ ] **Step 3: Validate the OpenRouter preset visually and interactively**
+
+Use the browser to:
+
+```bash
+agent-browser select <provider-preset-ref> "OpenRouter"
+agent-browser screenshot --full .context/openrouter-preset-settings.png
+agent-browser snapshot -i
+```
+
+Confirm all of the following in the page state:
+
+- profile name becomes `OpenRouter`
+- API base URL becomes `https://openrouter.ai/api/v1`
+- model field is empty
+- API key field remains empty
+- model context limit displays `200000`
+
+- [ ] **Step 4: Record verification evidence**
+
+Run:
+
+```bash
+ls -l .context/openrouter-preset-settings.png
+```
+
+Expected: the screenshot file exists and can be referenced in the completion summary.
+
+- [ ] **Step 5: Run the full required verification commands before claiming completion**
+
+Run:
+
+```bash
+npx vitest run tests/unit/provider-presets.test.ts tests/unit/providers-section.test.tsx
+npx vitest run --coverage
+```
+
+Expected:
+
+- first command passes
+- second command passes and reports overall coverage at or above the repository threshold
+
+- [ ] **Step 6: Commit any remaining verification-driven changes**
+
+```bash
+git status --short
+```
+
+Expected: only the intended source and test files are staged or modified. Do not attempt to commit `.context/openrouter-preset-settings.png`.
+
+## Self-Review
+
+- Spec coverage: covered preset registry addition, settings dropdown exposure, OpenRouter-specific values, no new provider type, and regression testing.
+- Placeholder scan: removed generic implementation language and replaced it with exact tests, commands, and code snippets.
+- Type consistency: the plan consistently uses `openrouter` as the preset id, `OpenRouter` as the label/name, `https://openrouter.ai/api/v1` as the base URL, and `200000` as the context limit.

--- a/docs/superpowers/specs/2026-04-13-openrouter-provider-design.md
+++ b/docs/superpowers/specs/2026-04-13-openrouter-provider-design.md
@@ -1,0 +1,94 @@
+# OpenRouter Provider Preset Design
+
+## Goal
+
+Add OpenRouter to the provider settings UI as a reusable template so users can create an OpenAI-compatible profile prefilled for OpenRouter without introducing a new provider type.
+
+## Scope
+
+This change is limited to the settings preset experience.
+
+Included:
+
+- Add an OpenRouter preset to the provider preset registry.
+- Surface the preset in the Providers settings preset dropdown.
+- Prefill OpenRouter-specific template values when the preset is selected.
+- Add regression tests for preset matching and settings UI behavior.
+
+Not included:
+
+- A new `providerKind`
+- OpenRouter-specific runtime branching in `lib/provider.ts`
+- Automatic model discovery from OpenRouter
+- Additional request headers such as `HTTP-Referer` or `X-OpenRouter-Title`
+
+## Product Decision
+
+OpenRouter should be treated as a generic OpenAI-compatible preset because it exposes many models with different capabilities and limits. The preset is only a starting template. Users are expected to choose their own model and API key after applying it.
+
+## Preset Behavior
+
+The new preset will live alongside the existing provider presets and will populate these values:
+
+- `name`: `OpenRouter`
+- `apiBaseUrl`: `https://openrouter.ai/api/v1`
+- `model`: `""`
+- `apiMode`: existing generic default value
+- `reasoningEffort`: existing generic default value
+- `reasoningSummaryEnabled`: existing generic default value
+- `modelContextLimit`: `200000`
+
+All other runtime settings should remain whatever the preset helper already derives from the generic defaults unless explicitly listed above.
+
+## Architecture
+
+### Provider model
+
+No schema or persistence changes are required. OpenRouter remains an `openai_compatible` provider profile.
+
+### Preset registry
+
+`lib/provider-presets.ts` will gain a new preset id and definition. The existing helper functions (`applyProviderPreset`, `getMatchingProviderPresetId`) should continue to work without structural changes because the OpenRouter preset fits the current matching model.
+
+### Settings UI
+
+`components/settings/sections/providers-section.tsx` already renders the preset dropdown for `openai_compatible` providers. No new UI control is needed. The only behavior change is that selecting `OpenRouter` applies the new preset values to the active profile.
+
+The empty `model` value is intentional. The UI should not try to infer or auto-fill a model for OpenRouter.
+
+## Error Handling
+
+No new error flows are needed.
+
+Existing validation remains responsible for requiring:
+
+- a non-empty API base URL
+- a non-empty model
+- a non-empty system prompt
+
+This means an OpenRouter preset can be applied and saved only after the user fills in a model. That is acceptable and matches the template-only intent.
+
+## Testing
+
+Add or update tests to cover:
+
+- the preset registry includes OpenRouter with the expected values
+- applying the OpenRouter preset updates the active provider draft with the OpenRouter base URL, empty model, and `200000` context limit
+- matching logic recognizes the OpenRouter preset when a profile has the full preset value set
+
+The most relevant existing coverage points are:
+
+- `tests/unit/provider-presets.test.ts`
+- `tests/unit/providers-section.test.tsx`
+
+## Files Expected To Change
+
+- `lib/provider-presets.ts`
+- `tests/unit/provider-presets.test.ts`
+- `tests/unit/providers-section.test.tsx`
+
+## Implementation Notes
+
+- Keep OpenRouter in the same preset dropdown as Ollama Cloud, GLM Coding Plan, and Custom OpenAI compatible.
+- Do not add documentation links or helper copy unless implementation reveals a clear usability gap.
+- Do not add OpenRouter-specific transport or capability logic in this change.

--- a/lib/assistant-runtime.ts
+++ b/lib/assistant-runtime.ts
@@ -964,8 +964,11 @@ export async function resolveAssistantTurn(input: {
         continue;
       }
 
-      if (!answer.trim() && step > 0) {
-        promptMessages = mergeSystemMessage(promptMessages, "Your previous response was empty after using tools. Answer the user directly. Do not emit an empty response.");
+      if (!answer.trim()) {
+        promptMessages = mergeSystemMessage(
+          promptMessages,
+          "Your previous response was empty. Answer the user directly. Do not emit an empty response."
+        );
         continue;
       }
       await commitAnswerSegment(answer);

--- a/lib/provider-presets.ts
+++ b/lib/provider-presets.ts
@@ -4,6 +4,7 @@ import type { ApiMode, ReasoningEffort } from "@/lib/types";
 export type ProviderPresetId =
   | "ollama_cloud"
   | "glm_coding_plan"
+  | "openrouter"
   | "custom_openai_compatible";
 
 type ProviderPresetValues = {
@@ -57,6 +58,19 @@ export const PROVIDER_PRESETS: ProviderPresetDefinition[] = [
       apiMode: "chat_completions",
       reasoningEffort: "medium",
       reasoningSummaryEnabled: true,
+      modelContextLimit: 200000
+    }
+  },
+  {
+    id: "openrouter",
+    label: "OpenRouter",
+    values: {
+      name: "OpenRouter",
+      apiBaseUrl: "https://openrouter.ai/api/v1",
+      model: "",
+      apiMode: DEFAULT_PROVIDER_SETTINGS.apiMode,
+      reasoningEffort: DEFAULT_PROVIDER_SETTINGS.reasoningEffort,
+      reasoningSummaryEnabled: DEFAULT_PROVIDER_SETTINGS.reasoningSummaryEnabled,
       modelContextLimit: 200000
     }
   },

--- a/lib/provider.ts
+++ b/lib/provider.ts
@@ -232,6 +232,68 @@ function getResponseText(output: unknown) {
   return "";
 }
 
+function getResponseOutputItemMessageText(item: unknown) {
+  if (
+    !item ||
+    typeof item !== "object" ||
+    !("content" in item) ||
+    !Array.isArray((item as { content?: unknown[] }).content)
+  ) {
+    return "";
+  }
+
+  return normalizeLineBreaks(
+    (item as { content: unknown[] }).content
+      .flatMap((part) => {
+        if (!part || typeof part !== "object") {
+          return [];
+        }
+
+        const text = "text" in part && typeof (part as { text?: string }).text === "string"
+          ? (part as { text: string }).text
+          : "";
+
+        if (!text) {
+          return [];
+        }
+
+        const type = "type" in part && typeof (part as { type?: string }).type === "string"
+          ? (part as { type: string }).type
+          : "";
+
+        if (!type || type === "output_text" || type === "text") {
+          return [text];
+        }
+
+        return [];
+      })
+      .join("")
+  );
+}
+
+function mergeRecoveredStreamText(current: string, recovered: string) {
+  const nextText = normalizeLineBreaks(recovered);
+
+  if (!nextText || nextText === current) {
+    return {
+      nextText: current,
+      delta: ""
+    };
+  }
+
+  if (nextText.startsWith(current)) {
+    return {
+      nextText,
+      delta: nextText.slice(current.length)
+    };
+  }
+
+  return {
+    nextText,
+    delta: ""
+  };
+}
+
 export async function callProviderText(input: {
   settings: ProviderProfileWithApiKey;
   prompt: string;
@@ -555,7 +617,10 @@ export async function* streamProviderResponse(input: {
             continue;
           }
 
-          if (event.type === "response.output_text.delta") {
+          if (
+            event.type === "response.output_text.delta" ||
+            event.type === "response.content_part.delta"
+          ) {
             const text = normalizeLineBreaks(String(event.delta ?? ""));
             answer += text;
             yield { type: "answer_delta", text };
@@ -585,6 +650,7 @@ export async function* streamProviderResponse(input: {
               arguments?: string;
               call_id?: string;
               summary?: Array<{ text?: string }>;
+              content?: unknown[];
             };
 
             if (item.type === "function_call" && item.call_id) {
@@ -596,14 +662,20 @@ export async function* streamProviderResponse(input: {
 
             if (item.type === "reasoning" && Array.isArray(item.summary)) {
               const combined = normalizeLineBreaks(item.summary.map((part) => part.text ?? "").join(""));
+              const recovery = mergeRecoveredStreamText(thinking, combined);
+              thinking = recovery.nextText;
 
-              if (combined && combined !== thinking) {
-                const delta = combined.slice(thinking.length);
-                thinking = combined;
+              if (recovery.delta) {
+                yield { type: "thinking_delta", text: recovery.delta };
+              }
+            }
 
-                if (delta) {
-                  yield { type: "thinking_delta", text: delta };
-                }
+            if (item.type === "message") {
+              const recovery = mergeRecoveredStreamText(answer, getResponseOutputItemMessageText(item));
+              answer = recovery.nextText;
+
+              if (recovery.delta) {
+                yield { type: "answer_delta", text: recovery.delta };
               }
             }
           }
@@ -642,7 +714,10 @@ export async function* streamProviderResponse(input: {
           continue;
         }
 
-        if (event.type === "response.output_text.delta") {
+        if (
+          event.type === "response.output_text.delta" ||
+          event.type === "response.content_part.delta"
+        ) {
           const text = normalizeLineBreaks(String(event.delta ?? ""));
           answer += text;
           yield { type: "answer_delta", text };
@@ -672,6 +747,7 @@ export async function* streamProviderResponse(input: {
             arguments?: string;
             call_id?: string;
             summary?: Array<{ text?: string }>;
+            content?: unknown[];
           };
 
           if (item.type === "function_call" && item.call_id) {
@@ -683,14 +759,20 @@ export async function* streamProviderResponse(input: {
 
           if (item.type === "reasoning" && Array.isArray(item.summary)) {
             const combined = normalizeLineBreaks(item.summary.map((part) => part.text ?? "").join(""));
+            const recovery = mergeRecoveredStreamText(thinking, combined);
+            thinking = recovery.nextText;
 
-            if (combined && combined !== thinking) {
-              const delta = combined.slice(thinking.length);
-              thinking = combined;
+            if (recovery.delta) {
+              yield { type: "thinking_delta", text: recovery.delta };
+            }
+          }
 
-              if (delta) {
-                yield { type: "thinking_delta", text: delta };
-              }
+          if (item.type === "message") {
+            const recovery = mergeRecoveredStreamText(answer, getResponseOutputItemMessageText(item));
+            answer = recovery.nextText;
+
+            if (recovery.delta) {
+              yield { type: "answer_delta", text: recovery.delta };
             }
           }
         }

--- a/tests/unit/assistant-runtime.test.ts
+++ b/tests/unit/assistant-runtime.test.ts
@@ -727,6 +727,43 @@ Run browser commands.`
     expect(result.answer).toBe("Final answer without more tools");
   });
 
+  it("retries when the provider returns an empty direct answer without tool calls", async () => {
+    streamProviderResponse
+      .mockReturnValueOnce(
+        createProviderStream([], {
+          answer: "",
+          thinking: "Reasoning only",
+          usage: { inputTokens: 5, reasoningTokens: 4 }
+        })
+      )
+      .mockReturnValueOnce(
+        createProviderStream([{ type: "answer_delta", text: "Connected" }], {
+          answer: "Connected",
+          thinking: "",
+          usage: { inputTokens: 3, outputTokens: 1 }
+        })
+      );
+
+    const { resolveAssistantTurn } = await import("@/lib/assistant-runtime");
+
+    const result = await resolveAssistantTurn({
+      settings: createSettings(),
+      promptMessages: [{ role: "user", content: "Reply with connected." }],
+      skills: [],
+      mcpToolSets: [],
+      onEvent: () => {}
+    });
+
+    expect(streamProviderResponse).toHaveBeenCalledTimes(2);
+    expect(streamProviderResponse.mock.calls[1][0].promptMessages[0]).toEqual(
+      expect.objectContaining({
+        role: "system",
+        content: expect.stringContaining("Do not emit an empty response.")
+      })
+    );
+    expect(result.answer).toBe("Connected");
+  });
+
   it("streams thinking and answer deltas before the provider finishes", async () => {
     const { resolveAssistantTurn } = await import("@/lib/assistant-runtime");
 

--- a/tests/unit/provider-presets.test.ts
+++ b/tests/unit/provider-presets.test.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_PROVIDER_SETTINGS } from "@/lib/constants";
 import {
   applyProviderPreset,
   getMatchingProviderPresetId,
@@ -61,6 +62,20 @@ describe("provider presets", () => {
     expect(profile.modelContextLimit).toBe(128000);
   });
 
+  it("applies the OpenRouter preset values", () => {
+    const profile = applyProviderPreset(createProfile(), "openrouter");
+
+    expect(profile.name).toBe("OpenRouter");
+    expect(profile.apiBaseUrl).toBe("https://openrouter.ai/api/v1");
+    expect(profile.model).toBe("");
+    expect(profile.apiMode).toBe(DEFAULT_PROVIDER_SETTINGS.apiMode);
+    expect(profile.reasoningEffort).toBe(DEFAULT_PROVIDER_SETTINGS.reasoningEffort);
+    expect(profile.reasoningSummaryEnabled).toBe(
+      DEFAULT_PROVIDER_SETTINGS.reasoningSummaryEnabled
+    );
+    expect(profile.modelContextLimit).toBe(200000);
+  });
+
   it("preserves non-provider tuning and secrets when applying a preset", () => {
     const original = createProfile();
     const profile = applyProviderPreset(original, "glm_coding_plan");
@@ -81,6 +96,15 @@ describe("provider presets", () => {
     };
 
     expect(getMatchingProviderPresetId(profile)).toBe("glm_coding_plan");
+  });
+
+  it("matches a profile back to the OpenRouter preset when the provider fields align", () => {
+    const profile = {
+      ...createProfile(),
+      ...getProviderPreset("openrouter").values
+    };
+
+    expect(getMatchingProviderPresetId(profile)).toBe("openrouter");
   });
 
   it("returns null when a profile no longer matches a preset exactly", () => {

--- a/tests/unit/provider.test.ts
+++ b/tests/unit/provider.test.ts
@@ -367,6 +367,94 @@ describe("provider integration", () => {
     });
   });
 
+  it("streams response content_part deltas as answer text", async () => {
+    responsesCreate.mockResolvedValue(
+      createAsyncStream([
+        { type: "response.content_part.delta", delta: "Hello " },
+        { type: "response.content_part.delta", delta: "world" }
+      ])
+    );
+
+    const { streamProviderResponse } = await import("@/lib/provider");
+    const stream = streamProviderResponse({
+      settings: createSettings(),
+      promptMessages: [{ role: "user", content: "Hi" }]
+    });
+
+    const events: ChatStreamEvent[] = [];
+
+    while (true) {
+      const next = await stream.next();
+
+      if (next.done) {
+        expect(next.value.answer).toBe("Hello world");
+        break;
+      }
+
+      events.push(next.value);
+    }
+
+    expect(events).toEqual([
+      { type: "answer_delta", text: "Hello " },
+      { type: "answer_delta", text: "world" },
+      expect.objectContaining({
+        type: "usage",
+        inputTokens: expect.any(Number),
+        outputTokens: undefined,
+        reasoningTokens: undefined
+      })
+    ]);
+  });
+
+  it("recovers final responses message text from output items when earlier deltas were missed", async () => {
+    responsesCreate.mockResolvedValue(
+      createAsyncStream([
+        { type: "response.output_text.delta", delta: "a short story. However" },
+        {
+          type: "response.output_item.done",
+          item: {
+            type: "message",
+            content: [
+              {
+                type: "output_text",
+                text: "I don't have any tools that are relevant for writing a short story. However"
+              }
+            ]
+          }
+        }
+      ])
+    );
+
+    const { streamProviderResponse } = await import("@/lib/provider");
+    const stream = streamProviderResponse({
+      settings: createSettings(),
+      promptMessages: [{ role: "user", content: "Hi" }]
+    });
+
+    const events: ChatStreamEvent[] = [];
+
+    while (true) {
+      const next = await stream.next();
+
+      if (next.done) {
+        expect(next.value.answer).toBe("I don't have any tools that are relevant for writing a short story. However");
+        break;
+      }
+
+      events.push(next.value);
+    }
+
+    expect(events).toEqual([
+      { type: "answer_delta", text: "a short story. However" },
+      expect.objectContaining({
+        type: "usage",
+        inputTokens: expect.any(Number),
+        outputTokens: undefined,
+        reasoningTokens: undefined
+      })
+    ]);
+  });
+
   it("accepts plain string responses and reasoning_text deltas", async () => {
     responsesCreate.mockResolvedValueOnce("plain text");
 

--- a/tests/unit/providers-section.test.tsx
+++ b/tests/unit/providers-section.test.tsx
@@ -267,6 +267,30 @@ describe("providers section", () => {
     });
   });
 
+  it("applies the OpenRouter preset from the providers settings dropdown", async () => {
+    const { container } = render(React.createElement(ProvidersSection, { settings: makeSettings() }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith("/api/mcp-servers");
+    });
+
+    const presetSelect = screen.getByDisplayValue("Manual configuration");
+    const profileNameInput = screen.getByDisplayValue("Default");
+    const apiBaseUrlInput = screen.getByDisplayValue("https://api.example.com/v1");
+    const modelInput = container.querySelector<HTMLInputElement>('input[name="provider-model"]');
+
+    expect(modelInput).toBeTruthy();
+    expect(modelInput).toHaveValue("gpt-test");
+
+    fireEvent.change(presetSelect, {
+      target: { value: "openrouter" }
+    });
+
+    expect(profileNameInput).toHaveValue("OpenRouter");
+    expect(apiBaseUrlInput).toHaveValue("https://openrouter.ai/api/v1");
+    expect(modelInput).toHaveValue("");
+  });
+
   it("shows compaction threshold as a percent and preserves top-level settings on save", async () => {
     const fetchMock = vi.mocked(global.fetch);
     const settings = makeSettings({

--- a/tests/unit/providers-section.test.tsx
+++ b/tests/unit/providers-section.test.tsx
@@ -279,6 +279,7 @@ describe("providers section", () => {
     const apiBaseUrlInput = screen.getByDisplayValue("https://api.example.com/v1");
     const modelInput = container.querySelector<HTMLInputElement>('input[name="provider-model"]');
 
+    expect(screen.getByRole("option", { name: "OpenRouter" })).toBeInTheDocument();
     expect(modelInput).toBeTruthy();
     expect(modelInput).toHaveValue("gpt-test");
 


### PR DESCRIPTION
Adds a generic OpenRouter provider preset, plus the supporting spec/plan docs and settings tests for that preset.

Also fixes streamed OpenRouter responses so assistant output is recovered from content-part and final message events, and retries empty no-tool replies instead of persisting thought-only turns.

Covers the streaming fixes in provider and assistant-runtime tests, and verifies the full suite with `npm test`.