### PR TITLE
Support edit-and-restart chat history

### DIFF
--- a/app/api/messages/[messageId]/edit-restart/route.ts
+++ b/app/api/messages/[messageId]/edit-restart/route.ts
@@ -21,14 +21,6 @@ const bodySchema = z.object({
   content: z.string().trim().min(1)
 });
 
-function getRestartFailureStatus(status: "failed" | "skipped" | "stopped") {
-  if (status === "failed") {
-    return 500;
-  }
-
-  return 409;
-}
-
 export async function POST(
   request: Request,
   context: { params: Promise<{ messageId: string }> }
@@ -83,19 +75,12 @@ export async function POST(
     user.id
   );
 
-  const restartResult = await startAssistantTurnFromExistingUserMessage(
+  void startAssistantTurnFromExistingUserMessage(
     getConversationManager(),
     rewritten.conversation.id,
     message.id,
     undefined
   );
-
-  if (restartResult.status !== "completed") {
-    return badRequest(
-      restartResult.errorMessage ?? "Unable to restart assistant response",
-      getRestartFailureStatus(restartResult.status)
-    );
-  }
 
   return ok(rewritten);
 }

--- a/app/api/messages/[messageId]/edit-restart/route.ts
+++ b/app/api/messages/[messageId]/edit-restart/route.ts
@@ -1,0 +1,71 @@
+import { z } from "zod";
+
+import { requireUser } from "@/lib/auth";
+import { startAssistantTurnFromExistingUserMessage } from "@/lib/chat-turn";
+import {
+  getConversationSnapshot,
+  getMessage,
+  rewriteConversationFromEditedUserMessage
+} from "@/lib/conversations";
+import { badRequest, ok } from "@/lib/http";
+import { getConversationManager } from "@/lib/ws-singleton";
+
+const paramsSchema = z.object({
+  messageId: z.string().min(1)
+});
+
+const bodySchema = z.object({
+  content: z.string().trim().min(1)
+});
+
+export async function POST(
+  request: Request,
+  context: { params: Promise<{ messageId: string }> }
+) {
+  const user = await requireUser();
+  const params = paramsSchema.safeParse(await context.params);
+  if (!params.success) {
+    return badRequest("Invalid message id");
+  }
+
+  const body = bodySchema.safeParse(await request.json());
+  if (!body.success) {
+    return badRequest("Invalid message update");
+  }
+
+  const message = getMessage(params.data.messageId, user.id);
+  if (!message) {
+    return badRequest("Message not found", 404);
+  }
+  if (message.role !== "user") {
+    return badRequest("Only user messages can be edited", 400);
+  }
+
+  const snapshot = getConversationSnapshot(message.conversationId, user.id);
+  if (!snapshot) {
+    return badRequest("Conversation not found", 404);
+  }
+  if (snapshot.conversation.isActive) {
+    return badRequest(
+      "Wait for the current assistant response to finish before editing this conversation",
+      409
+    );
+  }
+
+  const rewritten = rewriteConversationFromEditedUserMessage(
+    message.id,
+    {
+      content: body.data.content
+    },
+    user.id
+  );
+
+  await startAssistantTurnFromExistingUserMessage(
+    getConversationManager(),
+    rewritten.conversation.id,
+    message.id,
+    undefined
+  );
+
+  return ok(rewritten);
+}

--- a/app/api/messages/[messageId]/edit-restart/route.ts
+++ b/app/api/messages/[messageId]/edit-restart/route.ts
@@ -1,7 +1,10 @@
 import { z } from "zod";
 
 import { requireUser } from "@/lib/auth";
-import { startAssistantTurnFromExistingUserMessage } from "@/lib/chat-turn";
+import {
+  getAssistantTurnStartPreflight,
+  startAssistantTurnFromExistingUserMessage
+} from "@/lib/chat-turn";
 import {
   getConversationSnapshot,
   getMessage,
@@ -18,6 +21,14 @@ const bodySchema = z.object({
   content: z.string().trim().min(1)
 });
 
+function getRestartFailureStatus(status: "failed" | "skipped" | "stopped") {
+  if (status === "failed") {
+    return 500;
+  }
+
+  return 409;
+}
+
 export async function POST(
   request: Request,
   context: { params: Promise<{ messageId: string }> }
@@ -28,7 +39,14 @@ export async function POST(
     return badRequest("Invalid message id");
   }
 
-  const body = bodySchema.safeParse(await request.json());
+  let rawBody: unknown;
+  try {
+    rawBody = await request.json();
+  } catch {
+    return badRequest("Invalid message update");
+  }
+
+  const body = bodySchema.safeParse(rawBody);
   if (!body.success) {
     return badRequest("Invalid message update");
   }
@@ -52,6 +70,11 @@ export async function POST(
     );
   }
 
+  const preflight = getAssistantTurnStartPreflight(message.conversationId);
+  if (!preflight.ok) {
+    return badRequest(preflight.errorMessage, preflight.statusCode);
+  }
+
   const rewritten = rewriteConversationFromEditedUserMessage(
     message.id,
     {
@@ -60,12 +83,19 @@ export async function POST(
     user.id
   );
 
-  await startAssistantTurnFromExistingUserMessage(
+  const restartResult = await startAssistantTurnFromExistingUserMessage(
     getConversationManager(),
     rewritten.conversation.id,
     message.id,
     undefined
   );
+
+  if (restartResult.status !== "completed") {
+    return badRequest(
+      restartResult.errorMessage ?? "Unable to restart assistant response",
+      getRestartFailureStatus(restartResult.status)
+    );
+  }
 
   return ok(rewritten);
 }

--- a/app/api/messages/[messageId]/edit-restart/route.ts
+++ b/app/api/messages/[messageId]/edit-restart/route.ts
@@ -10,6 +10,7 @@ import {
   getMessage,
   rewriteConversationFromEditedUserMessage
 } from "@/lib/conversations";
+import { claimChatTurnStart, releaseChatTurnStart } from "@/lib/chat-turn-control";
 import { badRequest, ok } from "@/lib/http";
 import { getConversationManager } from "@/lib/ws-singleton";
 
@@ -67,20 +68,40 @@ export async function POST(
     return badRequest(preflight.errorMessage, preflight.statusCode);
   }
 
-  const rewritten = rewriteConversationFromEditedUserMessage(
-    message.id,
-    {
-      content: body.data.content
-    },
-    user.id
-  );
+  const claimed = claimChatTurnStart(message.conversationId);
+  if (!claimed.ok) {
+    return badRequest(
+      "Wait for the current assistant response to finish before editing this conversation",
+      409
+    );
+  }
 
-  void startAssistantTurnFromExistingUserMessage(
-    getConversationManager(),
-    rewritten.conversation.id,
-    message.id,
-    undefined
-  );
+  try {
+    const rewritten = rewriteConversationFromEditedUserMessage(
+      message.id,
+      {
+        content: body.data.content
+      },
+      user.id
+    );
 
-  return ok(rewritten);
+    void startAssistantTurnFromExistingUserMessage(
+      getConversationManager(),
+      rewritten.conversation.id,
+      message.id,
+      undefined,
+      {
+        control: claimed.control,
+        preflight
+      }
+    ).catch((error) => {
+      releaseChatTurnStart(message.conversationId, claimed.control);
+      console.error("[message-edit-restart-route] continuation failed:", error);
+    });
+
+    return ok(rewritten);
+  } catch (error) {
+    releaseChatTurnStart(message.conversationId, claimed.control);
+    throw error;
+  }
 }

--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -400,6 +400,22 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
     }
   }
 
+  function resetStreamingState() {
+    clearCompactionIndicator();
+    setStreamMessageId(null);
+    updateStreamTimeline([]);
+    setStreamThinkingTarget("");
+    setStreamThinkingDisplay("");
+    setStreamAnswerTarget("");
+    setStreamAnswerDisplay("");
+    streamAnswerTargetRef.current = "";
+    streamThinkingTargetRef.current = "";
+    setHasReceivedFirstToken(false);
+    thinkingStartTimeRef.current = null;
+    setThinkingDuration(undefined);
+    setIsStopPending(false);
+  }
+
   useEffect(() => {
     setConversationTitle(payload.conversation.title);
   }, [payload.conversation.title]);
@@ -1110,20 +1126,10 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
 
     setError("");
     setUpdatingMessageId(messageId);
-    setMessages((current) =>
-      current.map((message) =>
-        message.id === messageId
-          ? {
-              ...message,
-              content
-            }
-          : message
-      )
-    );
 
     try {
-      const response = await fetch(`/api/messages/${messageId}`, {
-        method: "PATCH",
+      const response = await fetch(`/api/messages/${messageId}/edit-restart`, {
+        method: "POST",
         headers: {
           "Content-Type": "application/json"
         },
@@ -1131,7 +1137,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
       });
 
       if (!response.ok) {
-        let message = "Unable to update message";
+        let message = "Unable to restart from edited message";
 
         try {
           const failure = (await response.json()) as { error?: string };
@@ -1141,19 +1147,28 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
         throw new Error(message);
       }
 
-      const result = (await response.json()) as { message?: Message };
+      const result = (await response.json()) as {
+        conversation?: Conversation;
+        messages?: Message[];
+      };
 
-      if (result.message) {
-        setMessages((current) =>
-          current.map((message) => (message.id === result.message?.id ? result.message : message))
-        );
+      resetStreamingState();
+
+      if (result.messages) {
+        setMessages(sanitizeMessages(result.messages));
       }
 
-      router.refresh();
+      if (result.conversation) {
+        setConversationTitle(result.conversation.title);
+        setTitleGenerationStatus(result.conversation.titleGenerationStatus);
+        dispatchConversationActivityUpdated({
+          conversationId: result.conversation.id,
+          isActive: true
+        });
+      }
+
+      setIsSending(true);
     } catch (caughtError) {
-      setMessages((current) =>
-        current.map((message) => (message.id === previousMessage.id ? previousMessage : message))
-      );
       setError(caughtError instanceof Error ? caughtError.message : "Unable to update message");
       throw caughtError;
     } finally {
@@ -1320,7 +1335,8 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
       speechSnapshot.phase === "transcribing" ||
       (!value && nextPendingAttachments.length === 0) ||
       isSending ||
-      isUploadingAttachments
+      isUploadingAttachments ||
+      updatingMessageId !== null
     ) {
       return;
     }
@@ -1521,7 +1537,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
             input={input}
             onInputChange={setInput}
             onSubmit={submit}
-            isSending={isSending}
+            isSending={isSending || updatingMessageId !== null}
             pendingAttachments={pendingAttachments}
             isUploadingAttachments={isUploadingAttachments}
             onUploadFiles={uploadFiles}

--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -774,8 +774,10 @@ export function MessageBubble({
       return;
     }
 
-    await onUpdateUserMessage(message.id, nextContent);
-    setIsEditing(false);
+    try {
+      await onUpdateUserMessage(message.id, nextContent);
+      setIsEditing(false);
+    } catch {}
   }
 
   function handleCancelEdit() {

--- a/docs/superpowers/plans/2026-04-13-edit-chat-restart.md
+++ b/docs/superpowers/plans/2026-04-13-edit-chat-restart.md
@@ -1,0 +1,977 @@
+# Edit Chat Restart Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a user edit one of their own previous chat messages in place, delete every later turn in the same conversation, and regenerate the assistant response from that exact point without creating a new conversation.
+
+**Architecture:** The server owns history rewrite semantics through a new transactional helper in `lib/conversations.ts` plus a dedicated `POST /api/messages/[messageId]/edit-restart` route. After the rewrite, the route starts an assistant-only continuation from the existing edited user message by extracting the assistant half of `startChatTurn` into a reusable helper, so the websocket stream resumes without creating a duplicate user turn or rebinding attachments away from the edited bubble.
+
+**Tech Stack:** Next.js App Router, React 19, TypeScript, better-sqlite3, Vitest, Testing Library, websocket conversation streaming
+
+---
+
+## File Map
+
+### Existing files to modify
+
+- `lib/conversations.ts`
+  Add a transactional helper that rewrites the selected user message, deletes the transcript tail, clears invalid compaction artifacts, and returns the retained conversation snapshot.
+- `lib/chat-turn.ts`
+  Extract a reusable assistant-only continuation helper that starts streaming from an existing retained user message.
+- `components/chat-view.tsx`
+  Replace the current user-message patch save flow with edit-and-restart behavior, reset local streaming state, trim later messages, and block concurrent sends while the restart request is running.
+- `components/message-bubble.tsx`
+  Keep the inline editor UI, but route save through a restart callback for user messages while leaving assistant bubbles immutable.
+- `tests/unit/conversations.test.ts`
+  Add data-layer regression coverage for in-place rewrite, tail deletion, attachment preservation, and compaction cleanup.
+- `tests/unit/chat-turn.test.ts`
+  Add coverage for assistant continuation from an existing edited user message without creating a duplicate user row.
+- `tests/unit/chat-view.test.ts`
+  Add restart interaction coverage for older-message edits, error handling, and assistant immutability.
+- `tests/unit/message-bubble.test.tsx`
+  Add rendering coverage for user edit controls and absence of assistant edit controls.
+
+### New files to create
+
+- `app/api/messages/[messageId]/edit-restart/route.ts`
+  Authenticated route that validates ownership and user role, rejects active turns, rewrites persisted history, then starts the new assistant turn from the existing edited message.
+- `tests/unit/message-edit-restart-route.test.ts`
+  Route coverage for success, assistant-message rejection, missing-message rejection, and active-turn conflict behavior.
+
+### Existing files to reference while implementing
+
+- `app/api/messages/[messageId]/route.ts`
+  Existing message patch route pattern and zod validation style.
+- `lib/chat-turn.ts`
+  Existing `startChatTurn` implementation whose assistant-side logic will be extracted and reused by the new route.
+- `lib/ws-singleton.ts`
+  Source of the shared conversation manager used by the new route.
+- `tests/unit/ws-handler.test.ts`
+  Existing websocket tests showing how conversation activity is exercised in unit tests.
+
+---
+
+### Task 1: Add failing data-layer tests for transcript rewrite
+
+**Files:**
+- Modify: `tests/unit/conversations.test.ts`
+- Modify: `lib/conversations.ts`
+- Reference: `lib/compaction.ts`
+
+- [ ] **Step 1: Write the failing data-layer tests**
+
+Add these tests near the other `conversation helpers` cases in `tests/unit/conversations.test.ts`:
+
+```ts
+import {
+  bindAttachmentsToMessage,
+  createConversation,
+  createMessage,
+  getConversationSnapshot,
+  rewriteConversationFromEditedUserMessage
+} from "@/lib/conversations";
+import { createAttachments } from "@/lib/attachments";
+import { getDb } from "@/lib/db";
+
+it("rewrites a user message, deletes later turns, and preserves the edited message attachment", () => {
+  const conversation = createConversation("Rewrite target");
+  const firstUser = createMessage({
+    conversationId: conversation.id,
+    role: "user",
+    content: "Original prompt"
+  });
+  const firstAssistant = createMessage({
+    conversationId: conversation.id,
+    role: "assistant",
+    content: "First answer"
+  });
+  const editedUser = createMessage({
+    conversationId: conversation.id,
+    role: "user",
+    content: "Need a deployment checklist"
+  });
+  const trailingAssistant = createMessage({
+    conversationId: conversation.id,
+    role: "assistant",
+    content: "Old checklist"
+  });
+
+  const [attachment] = createAttachments(conversation.id, [
+    {
+      filename: "context.txt",
+      mimeType: "text/plain",
+      buffer: Buffer.from("retain this attachment", "utf8")
+    }
+  ]);
+  bindAttachmentsToMessage(conversation.id, editedUser.id, [attachment.id]);
+
+  const rewritten = rewriteConversationFromEditedUserMessage(editedUser.id, {
+    content: "Need a deployment checklist with rollback steps"
+  });
+
+  expect(rewritten.messages.map((message) => message.content)).toEqual([
+    "Original prompt",
+    "First answer",
+    "Need a deployment checklist with rollback steps"
+  ]);
+  expect(rewritten.messages.at(-1)?.attachments?.map((item) => item.filename)).toEqual([
+    "context.txt"
+  ]);
+  expect(
+    rewritten.messages.some((message) => message.id === trailingAssistant.id)
+  ).toBe(false);
+  expect(getConversationSnapshot(conversation.id)?.messages).toHaveLength(3);
+});
+
+it("removes compaction artifacts that depend on deleted tail messages", () => {
+  const conversation = createConversation("Compaction cleanup");
+  const firstUser = createMessage({
+    conversationId: conversation.id,
+    role: "user",
+    content: "First request"
+  });
+  const editedUser = createMessage({
+    conversationId: conversation.id,
+    role: "user",
+    content: "Second request"
+  });
+  const tailAssistant = createMessage({
+    conversationId: conversation.id,
+    role: "assistant",
+    content: "Later answer"
+  });
+
+  const db = getDb();
+  db.prepare(
+    `INSERT INTO memory_nodes (
+      id, conversation_id, type, depth, content,
+      source_start_message_id, source_end_message_id,
+      source_token_count, summary_token_count, child_node_ids,
+      superseded_by_node_id, created_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+  ).run(
+    "mem_tail",
+    conversation.id,
+    "leaf_summary",
+    0,
+    "Summary reaching into deleted history",
+    firstUser.id,
+    tailAssistant.id,
+    90,
+    20,
+    "[]",
+    null,
+    new Date().toISOString()
+  );
+
+  db.prepare(
+    `INSERT INTO compaction_events (
+      id, conversation_id, node_id, source_start_message_id,
+      source_end_message_id, notice_message_id, created_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?)`
+  ).run(
+    "cmp_tail",
+    conversation.id,
+    "mem_tail",
+    firstUser.id,
+    tailAssistant.id,
+    null,
+    new Date().toISOString()
+  );
+
+  rewriteConversationFromEditedUserMessage(editedUser.id, {
+    content: "Edited second request"
+  });
+
+  expect(
+    db.prepare("SELECT COUNT(*) as count FROM memory_nodes WHERE conversation_id = ?").get(conversation.id)
+  ).toEqual({ count: 0 });
+  expect(
+    db.prepare("SELECT COUNT(*) as count FROM compaction_events WHERE conversation_id = ?").get(conversation.id)
+  ).toEqual({ count: 0 });
+});
+
+it("rejects rewriting a non-user message", () => {
+  const conversation = createConversation("Assistant immutable");
+  const assistant = createMessage({
+    conversationId: conversation.id,
+    role: "assistant",
+    content: "Cannot edit me"
+  });
+
+  expect(() =>
+    rewriteConversationFromEditedUserMessage(assistant.id, { content: "changed" })
+  ).toThrow("Only user messages can be edited");
+});
+```
+
+- [ ] **Step 2: Run the targeted data-layer tests to verify they fail**
+
+Run:
+
+```bash
+npx vitest run tests/unit/conversations.test.ts
+```
+
+Expected: FAIL with `rewriteConversationFromEditedUserMessage` missing.
+
+- [ ] **Step 3: Write the minimal transactional rewrite helper**
+
+Add this implementation shape in `lib/conversations.ts` near `forkConversationFromMessage`:
+
+```ts
+export function rewriteConversationFromEditedUserMessage(
+  messageId: string,
+  input: { content: string },
+  userId?: string
+) {
+  const transaction = getDb().transaction(() => {
+    const message = getMessage(messageId, userId);
+
+    if (!message) {
+      throw new Error("Message not found");
+    }
+
+    if (message.role !== "user") {
+      throw new Error("Only user messages can be edited");
+    }
+
+    const conversation = getConversation(message.conversationId, userId);
+    if (!conversation) {
+      throw new Error("Conversation not found");
+    }
+
+    const messages = listMessages(conversation.id);
+    const targetIndex = messages.findIndex((item) => item.id === message.id);
+    if (targetIndex === -1) {
+      throw new Error("Message not found");
+    }
+
+    const retainedMessages = messages.slice(0, targetIndex + 1);
+    const deletedMessages = messages.slice(targetIndex + 1);
+    const deletedIds = new Set(deletedMessages.map((item) => item.id));
+
+    updateMessage(message.id, {
+      content: input.content,
+      estimatedTokens: estimateTextTokens(input.content)
+    });
+
+    if (deletedMessages.length > 0) {
+      const deleteMessage = getDb().prepare("DELETE FROM messages WHERE id = ?");
+      deletedMessages.forEach((item) => deleteMessage.run(item.id));
+    }
+
+    getDb()
+      .prepare(
+        `DELETE FROM compaction_events
+         WHERE conversation_id = ?
+           AND (source_start_message_id IN (${Array.from(deletedIds).map(() => "?").join(", ")})
+             OR source_end_message_id IN (${Array.from(deletedIds).map(() => "?").join(", ")}))`
+      )
+      .run(conversation.id, ...deletedIds, ...deletedIds);
+
+    getDb()
+      .prepare(
+        `DELETE FROM memory_nodes
+         WHERE conversation_id = ?
+           AND (source_start_message_id IN (${Array.from(deletedIds).map(() => "?").join(", ")})
+             OR source_end_message_id IN (${Array.from(deletedIds).map(() => "?").join(", ")}))`
+      )
+      .run(conversation.id, ...deletedIds, ...deletedIds);
+
+    setConversationActive(conversation.id, false);
+
+    return getConversationSnapshot(conversation.id, userId);
+  });
+
+  const snapshot = transaction();
+  if (!snapshot) {
+    throw new Error("Conversation not found");
+  }
+  return snapshot;
+}
+```
+
+- [ ] **Step 4: Run the data-layer tests to verify they pass**
+
+Run:
+
+```bash
+npx vitest run tests/unit/conversations.test.ts
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Commit the data-layer rewrite helper**
+
+```bash
+git add lib/conversations.ts tests/unit/conversations.test.ts
+git commit -m "feat: add edit restart conversation rewrite"
+```
+
+---
+
+### Task 2: Add failing assistant-restart tests and implement the edit-restart backend
+
+**Files:**
+- Create: `tests/unit/message-edit-restart-route.test.ts`
+- Create: `app/api/messages/[messageId]/edit-restart/route.ts`
+- Modify: `tests/unit/chat-turn.test.ts`
+- Modify: `lib/chat-turn.ts`
+- Reference: `lib/chat-turn.ts`
+- Reference: `lib/ws-singleton.ts`
+
+- [ ] **Step 1: Write the failing route tests**
+
+Create `tests/unit/message-edit-restart-route.test.ts` with:
+
+```ts
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createConversation, createMessage, setConversationActive } from "@/lib/conversations";
+import { createLocalUser } from "@/lib/users";
+
+const { requireUserMock } = vi.hoisted(() => ({
+  requireUserMock: vi.fn()
+}));
+
+const { startAssistantTurnFromExistingUserMessageMock } = vi.hoisted(() => ({
+  startAssistantTurnFromExistingUserMessageMock: vi.fn()
+}));
+
+vi.mock("@/lib/auth", () => ({
+  requireUser: requireUserMock
+}));
+
+vi.mock("@/lib/chat-turn", () => ({
+  startAssistantTurnFromExistingUserMessage: startAssistantTurnFromExistingUserMessageMock
+}));
+
+describe("message edit restart route", () => {
+  beforeEach(() => {
+    requireUserMock.mockReset();
+    startAssistantTurnFromExistingUserMessageMock.mockReset();
+    startAssistantTurnFromExistingUserMessageMock.mockResolvedValue({ status: "completed" });
+  });
+
+  it("rewrites the message and starts a new assistant turn", async () => {
+    const user = await createLocalUser({
+      username: "edit-route-user",
+      password: "Password123!",
+      role: "user"
+    });
+    requireUserMock.mockResolvedValue(user);
+
+    const conversation = createConversation("Restart me", null, {}, user.id);
+    const message = createMessage({
+      conversationId: conversation.id,
+      role: "user",
+      content: "Old content"
+    });
+
+    const { POST } = await import("@/app/api/messages/[messageId]/edit-restart/route");
+    const response = await POST(
+      new Request(`http://localhost/api/messages/${message.id}/edit-restart`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ content: "New content" })
+      }),
+      { params: Promise.resolve({ messageId: message.id }) }
+    );
+
+    expect(response.status).toBe(200);
+    expect(startAssistantTurnFromExistingUserMessageMock).toHaveBeenCalledWith(
+      expect.anything(),
+      conversation.id,
+      message.id,
+      undefined
+    );
+  });
+
+  it("rejects assistant messages", async () => {
+    const user = await createLocalUser({
+      username: "edit-route-assistant",
+      password: "Password123!",
+      role: "user"
+    });
+    requireUserMock.mockResolvedValue(user);
+
+    const conversation = createConversation("No assistant edits", null, {}, user.id);
+    const assistant = createMessage({
+      conversationId: conversation.id,
+      role: "assistant",
+      content: "Immutable"
+    });
+
+    const { POST } = await import("@/app/api/messages/[messageId]/edit-restart/route");
+    const response = await POST(
+      new Request(`http://localhost/api/messages/${assistant.id}/edit-restart`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ content: "Changed" })
+      }),
+      { params: Promise.resolve({ messageId: assistant.id }) }
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Only user messages can be edited" });
+  });
+
+  it("rejects active conversations with 409", async () => {
+    const user = await createLocalUser({
+      username: "edit-route-active",
+      password: "Password123!",
+      role: "user"
+    });
+    requireUserMock.mockResolvedValue(user);
+
+    const conversation = createConversation("Busy conversation", null, {}, user.id);
+    const message = createMessage({
+      conversationId: conversation.id,
+      role: "user",
+      content: "Retry this"
+    });
+    setConversationActive(conversation.id, true);
+
+    const { POST } = await import("@/app/api/messages/[messageId]/edit-restart/route");
+    const response = await POST(
+      new Request(`http://localhost/api/messages/${message.id}/edit-restart`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ content: "Retry this with edits" })
+      }),
+      { params: Promise.resolve({ messageId: message.id }) }
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      error: "Wait for the current assistant response to finish before editing this conversation"
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Add the failing assistant-only chat-turn test**
+
+Append this case to `tests/unit/chat-turn.test.ts`:
+
+```ts
+it("continues from an existing user message without creating a duplicate user row", async () => {
+  const { createConversation, createMessage, listVisibleMessages } = await import("@/lib/conversations");
+  const { startAssistantTurnFromExistingUserMessage } = await import("@/lib/chat-turn");
+  const { getConversationManager } = await import("@/lib/ws-singleton");
+
+  const conversation = createConversation("Restart conversation");
+  const existingUser = createMessage({
+    conversationId: conversation.id,
+    role: "user",
+    content: "Edited prompt"
+  });
+
+  await startAssistantTurnFromExistingUserMessage(
+    getConversationManager(),
+    conversation.id,
+    existingUser.id
+  );
+
+  const messages = listVisibleMessages(conversation.id);
+  expect(messages.filter((message) => message.role === "user")).toHaveLength(1);
+  expect(messages[0]?.id).toBe(existingUser.id);
+  expect(messages.at(-1)?.role).toBe("assistant");
+});
+```
+
+- [ ] **Step 3: Run the route and chat-turn tests to verify they fail**
+
+Run:
+
+```bash
+npx vitest run tests/unit/chat-turn.test.ts tests/unit/message-edit-restart-route.test.ts
+```
+
+Expected: FAIL because the route file and assistant-only helper do not exist.
+
+- [ ] **Step 4: Extract assistant-only continuation from `lib/chat-turn.ts`**
+
+Refactor `lib/chat-turn.ts` so `startChatTurn` becomes a thin wrapper around a shared helper:
+
+```ts
+async function startAssistantTurn(
+  manager: ConversationManager,
+  conversationId: string,
+  existingUserMessage: Message,
+  personaId?: string
+): Promise<ChatTurnResult> {
+  const conversation = getConversation(conversationId);
+  if (!conversation) {
+    return { status: "skipped", errorMessage: "Conversation not found" };
+  }
+
+  const conversationOwnerId = getConversationOwnerId(conversationId);
+  const assistantMessage = createMessage({
+    conversationId,
+    role: "assistant",
+    content: "",
+    thinkingContent: "",
+    status: "streaming",
+    estimatedTokens: 0
+  });
+
+  manager.broadcast(conversationId, {
+    type: "delta",
+    conversationId,
+    event: { type: "message_start", messageId: assistantMessage.id }
+  });
+
+  // Reuse the rest of the existing assistant streaming body unchanged.
+}
+
+export async function startAssistantTurnFromExistingUserMessage(
+  manager: ConversationManager,
+  conversationId: string,
+  messageId: string,
+  personaId?: string
+) {
+  const message = getMessage(messageId);
+  if (!message || message.role !== "user" || message.conversationId !== conversationId) {
+    return { status: "skipped", errorMessage: "User message not found" };
+  }
+
+  return startAssistantTurn(manager, conversationId, message, personaId);
+}
+
+export async function startChatTurn(
+  manager: ConversationManager,
+  conversationId: string,
+  content: string,
+  attachmentIds: string[],
+  personaId?: string
+) {
+  const userMessage = createMessage({
+    conversationId,
+    role: "user",
+    content,
+    estimatedTokens: estimateTextTokens(content)
+  });
+
+  bindAttachmentsToMessage(conversationId, userMessage.id, attachmentIds);
+  void generateConversationTitleFromFirstUserMessage(conversationId, userMessage.id);
+
+  return startAssistantTurn(manager, conversationId, userMessage, personaId);
+}
+```
+
+- [ ] **Step 5: Implement the route using the assistant-only helper**
+
+Create `app/api/messages/[messageId]/edit-restart/route.ts`:
+
+```ts
+import { z } from "zod";
+
+import { requireUser } from "@/lib/auth";
+import { startAssistantTurnFromExistingUserMessage } from "@/lib/chat-turn";
+import { getConversationSnapshot, getMessage, rewriteConversationFromEditedUserMessage } from "@/lib/conversations";
+import { badRequest, ok } from "@/lib/http";
+import { getConversationManager } from "@/lib/ws-singleton";
+
+const paramsSchema = z.object({
+  messageId: z.string().min(1)
+});
+
+const bodySchema = z.object({
+  content: z.string().trim().min(1)
+});
+
+export async function POST(
+  request: Request,
+  context: { params: Promise<{ messageId: string }> }
+) {
+  const user = await requireUser();
+  const params = paramsSchema.safeParse(await context.params);
+  if (!params.success) {
+    return badRequest("Invalid message id");
+  }
+
+  const body = bodySchema.safeParse(await request.json());
+  if (!body.success) {
+    return badRequest("Invalid message update");
+  }
+
+  const message = getMessage(params.data.messageId, user.id);
+  if (!message) {
+    return badRequest("Message not found", 404);
+  }
+  if (message.role !== "user") {
+    return badRequest("Only user messages can be edited", 400);
+  }
+
+  const snapshot = getConversationSnapshot(message.conversationId, user.id);
+  if (!snapshot) {
+    return badRequest("Conversation not found", 404);
+  }
+  if (snapshot.conversation.isActive) {
+    return badRequest(
+      "Wait for the current assistant response to finish before editing this conversation",
+      409
+    );
+  }
+
+  const rewritten = rewriteConversationFromEditedUserMessage(message.id, {
+    content: body.data.content
+  }, user.id);
+
+  await startAssistantTurnFromExistingUserMessage(
+    getConversationManager(),
+    rewritten.conversation.id,
+    message.id,
+    undefined
+  );
+
+  return ok(rewritten);
+}
+```
+
+- [ ] **Step 6: Run the chat-turn and route tests to verify they pass**
+
+Run:
+
+```bash
+npx vitest run tests/unit/chat-turn.test.ts tests/unit/message-edit-restart-route.test.ts
+```
+
+Expected: PASS
+
+- [ ] **Step 7: Commit the assistant-only restart backend**
+
+```bash
+git add \
+  app/api/messages/[messageId]/edit-restart/route.ts \
+  lib/chat-turn.ts \
+  tests/unit/chat-turn.test.ts \
+  tests/unit/message-edit-restart-route.test.ts
+git commit -m "feat: add assistant restart backend"
+```
+
+---
+
+### Task 3: Add failing UI tests and wire the user-bubble edit restart flow
+
+**Files:**
+- Modify: `tests/unit/message-bubble.test.tsx`
+- Modify: `tests/unit/chat-view.test.ts`
+- Modify: `components/message-bubble.tsx`
+- Modify: `components/chat-view.tsx`
+
+- [ ] **Step 1: Add the user-bubble rendering test**
+
+Append this test to `tests/unit/message-bubble.test.tsx`:
+
+```ts
+import { render, screen } from "@testing-library/react";
+
+function createUserMessage(): Message {
+  return {
+    id: "msg_user",
+    conversationId: "conv_test",
+    role: "user",
+    content: "Editable prompt",
+    thinkingContent: "",
+    status: "completed",
+    estimatedTokens: 0,
+    systemKind: null,
+    compactedAt: null,
+    createdAt: new Date().toISOString(),
+    attachments: [],
+    actions: []
+  };
+}
+
+it("shows edit controls for user messages and not for assistant messages", () => {
+  const { rerender } = render(
+    React.createElement(MessageBubble, {
+      message: createUserMessage()
+    })
+  );
+
+  expect(screen.getByRole("button", { name: "Edit message" })).toBeInTheDocument();
+
+  rerender(
+    React.createElement(MessageBubble, {
+      message: createAssistantMessage()
+    })
+  );
+
+  expect(screen.queryByRole("button", { name: "Edit message" })).toBeNull();
+});
+```
+
+- [ ] **Step 2: Add the failing chat view interaction tests**
+
+Append these tests to `tests/unit/chat-view.test.ts`:
+
+```ts
+it("restarts the conversation when saving an older edited user message", async () => {
+  const olderUser = createMessage({
+    id: "msg_user_old",
+    role: "user",
+    content: "Old request"
+  });
+  const olderAssistant = createMessage({
+    id: "msg_assistant_old",
+    role: "assistant",
+    content: "Old answer"
+  });
+  const laterUser = createMessage({
+    id: "msg_user_later",
+    role: "user",
+    content: "Later request"
+  });
+
+  vi.mocked(global.fetch)
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ personas: [] })
+    } as Response)
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        conversation: createPayload().conversation,
+        messages: [olderUser, olderAssistant, { ...olderUser, content: "Edited request" }]
+      })
+    } as Response);
+
+  renderWithProvider(
+    React.createElement(ChatView, {
+      payload: createPayload({
+        messages: [olderUser, olderAssistant, laterUser]
+      })
+    })
+  );
+
+  fireEvent.click(screen.getAllByRole("button", { name: "Edit message" })[0]);
+  fireEvent.change(screen.getByDisplayValue("Old request"), {
+    target: { value: "Edited request" }
+  });
+  fireEvent.click(screen.getByRole("button", { name: "Save edit" }));
+
+  await waitFor(() => {
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/messages/msg_user_old/edit-restart",
+      expect.objectContaining({ method: "POST" })
+    );
+  });
+});
+
+it("keeps assistant messages immutable in the transcript controls", () => {
+  renderWithProvider(
+    React.createElement(ChatView, {
+      payload: createPayload({
+        messages: [
+          createMessage({ id: "msg_user", role: "user", content: "User prompt" }),
+          createMessage({ id: "msg_assistant", role: "assistant", content: "Assistant answer" })
+        ]
+      })
+    })
+  );
+
+  expect(screen.getAllByRole("button", { name: "Edit message" })).toHaveLength(1);
+});
+```
+
+- [ ] **Step 3: Run the UI tests to verify they fail**
+
+Run:
+
+```bash
+npx vitest run tests/unit/message-bubble.test.tsx tests/unit/chat-view.test.ts
+```
+
+Expected: FAIL because `ChatView` still calls `PATCH /api/messages/:id` and does not know about `/edit-restart`.
+
+- [ ] **Step 4: Replace the save callback with edit-and-restart behavior**
+
+In `components/chat-view.tsx`, replace the current `updateUserMessage` flow with a restart-aware handler:
+
+```ts
+const [editingRestartMessageId, setEditingRestartMessageId] = useState<string | null>(null);
+
+async function restartFromEditedUserMessage(messageId: string, content: string) {
+  const previousMessages = messages;
+  const targetIndex = previousMessages.findIndex((message) => message.id === messageId);
+  if (targetIndex === -1) {
+    return;
+  }
+
+  setError("");
+  setEditingRestartMessageId(messageId);
+  setIsSending(true);
+  setStreamMessageId(null);
+  updateStreamTimeline([]);
+  setStreamThinkingTarget("");
+  setStreamThinkingDisplay("");
+  setStreamAnswerTarget("");
+  setStreamAnswerDisplay("");
+
+  try {
+    const response = await fetch(`/api/messages/${messageId}/edit-restart`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({ content })
+    });
+
+    if (!response.ok) {
+      const failure = (await response.json()) as { error?: string };
+      throw new Error(failure.error ?? "Unable to restart conversation from edited message");
+    }
+
+    const result = (await response.json()) as {
+      conversation: Conversation;
+      messages: Message[];
+    };
+
+    setMessages(result.messages);
+    setConversationTitle(result.conversation.title);
+  } catch (caughtError) {
+    setMessages(previousMessages);
+    setError(
+      caughtError instanceof Error
+        ? caughtError.message
+        : "Unable to restart conversation from edited message"
+    );
+    throw caughtError;
+  } finally {
+    setEditingRestartMessageId((current) => (current === messageId ? null : current));
+    setIsSending(false);
+  }
+}
+```
+
+Update the render call so user bubbles use the new callback and pending state:
+
+```tsx
+<MessageBubble
+  message={message}
+  onUpdateUserMessage={restartFromEditedUserMessage}
+  isUpdating={editingRestartMessageId === message.id}
+  onForkAssistantMessage={forkAssistantMessage}
+  isForking={forkingMessageId === message.id}
+  onApproveMemoryProposal={approveMemoryProposal}
+  onDismissMemoryProposal={dismissMemoryProposal}
+/>
+```
+
+Keep `components/message-bubble.tsx` functionally the same for user bubbles, but make sure only the user branch renders the pencil icon and save path. Do not add any assistant edit affordance.
+
+- [ ] **Step 5: Run the UI tests to verify they pass**
+
+Run:
+
+```bash
+npx vitest run tests/unit/message-bubble.test.tsx tests/unit/chat-view.test.ts
+```
+
+Expected: PASS
+
+- [ ] **Step 6: Commit the UI restart flow**
+
+```bash
+git add components/chat-view.tsx components/message-bubble.tsx tests/unit/chat-view.test.ts tests/unit/message-bubble.test.tsx
+git commit -m "feat: restart chat from edited user message"
+```
+
+---
+
+### Task 4: Full verification, coverage, and browser validation
+
+**Files:**
+- Verify: `app/api/messages/[messageId]/edit-restart/route.ts`
+- Verify: `components/chat-view.tsx`
+- Verify: `components/message-bubble.tsx`
+- Verify: `lib/chat-turn.ts`
+- Verify: `tests/unit/conversations.test.ts`
+- Verify: `tests/unit/chat-turn.test.ts`
+- Verify: `tests/unit/message-edit-restart-route.test.ts`
+- Verify: `tests/unit/chat-view.test.ts`
+- Verify: `tests/unit/message-bubble.test.tsx`
+
+- [ ] **Step 1: Run the focused feature tests**
+
+Run:
+
+```bash
+npx vitest run \
+  tests/unit/conversations.test.ts \
+  tests/unit/chat-turn.test.ts \
+  tests/unit/message-edit-restart-route.test.ts \
+  tests/unit/chat-view.test.ts \
+  tests/unit/message-bubble.test.tsx
+```
+
+Expected: PASS
+
+- [ ] **Step 2: Run lint and typecheck**
+
+Run:
+
+```bash
+npm run lint
+npm run typecheck
+```
+
+Expected: both exit 0
+
+- [ ] **Step 3: Run the full test suite with coverage**
+
+Run:
+
+```bash
+npm test
+```
+
+Expected: PASS with coverage report emitted and no global coverage regression
+
+- [ ] **Step 4: Validate the UI in the browser with the required skill**
+
+Use `agent-browser` after starting or reusing the dev server from `.dev-server`:
+
+```bash
+if [ -f .dev-server ]; then
+  cat .dev-server
+else
+  npm run dev
+fi
+```
+
+Then validate:
+
+```bash
+agent-browser open http://localhost:<port>/chat/<conversationId>
+agent-browser wait --load networkidle
+agent-browser snapshot -i
+agent-browser screenshot --full
+```
+
+Manual checks:
+
+- A user bubble shows the pen icon under the bubble
+- An assistant bubble does not show a pen icon
+- Editing an older user message removes later turns after save
+- The regenerated assistant reply streams back into the same conversation
+
+- [ ] **Step 5: Commit the verified feature**
+
+```bash
+git add app/api/messages/[messageId]/edit-restart/route.ts \
+  components/chat-view.tsx \
+  components/message-bubble.tsx \
+  lib/chat-turn.ts \
+  lib/conversations.ts \
+  tests/unit/conversations.test.ts \
+  tests/unit/chat-turn.test.ts \
+  tests/unit/message-edit-restart-route.test.ts \
+  tests/unit/chat-view.test.ts \
+  tests/unit/message-bubble.test.tsx
+git commit -m "feat: add edit and restart chat flow"
+```

--- a/docs/superpowers/specs/2026-04-13-edit-chat-restart-design.md
+++ b/docs/superpowers/specs/2026-04-13-edit-chat-restart-design.md
@@ -1,0 +1,233 @@
+# Edit Chat Restart Design
+
+**Date:** 2026-04-13
+**Status:** Draft
+
+## Summary
+
+Allow users to edit one of their own previous chat messages directly in the transcript and restart the conversation from that exact point. When the user saves the edit, the app should update that user message in place, immediately remove every later message in the same conversation, and generate a fresh assistant reply from the edited turn.
+
+This is an in-place history rewrite, not a fork. Assistant messages remain immutable and never expose an edit affordance.
+
+## Goals
+
+- Let users correct or refine an earlier prompt without creating a new conversation
+- Make the edit affordance lightweight and directly attached to user bubbles
+- Preserve the edited message's existing attachments when restarting from history
+- Keep destructive history changes transactional and server-authored
+- Reuse the existing streaming chat path after the edit is accepted
+
+## Non-Goals
+
+- Editing assistant messages
+- Showing a confirmation dialog before deleting later turns
+- Inserting a second replacement user bubble
+- Creating a forked or hidden replacement conversation
+- Re-attaching files manually after an edit when the files already belong to the edited message
+- Redesigning the broader chat composer or transcript layout
+
+## Product Decisions
+
+### Editable scope
+
+- Only user messages are editable
+- Assistant messages never show a pen icon and cannot be modified
+- The edit affordance appears on completed user messages in the existing utility action row under the bubble
+
+### Restart semantics
+
+- Saving an edited historical user message rewrites that message in place
+- All later messages in the same conversation are deleted immediately with no confirmation step
+- The edited message stays in the same position in the transcript
+- A fresh assistant turn is generated from the retained prefix of the conversation
+
+### Attachment behavior
+
+- The edited message keeps its existing attachments automatically
+- The restart request reuses the attachment bindings already attached to that message
+- No later-message attachments are preserved unless they belong to the edited message itself
+
+### User experience
+
+- The user sees the edit inline inside the original bubble
+- Saving uses a busy state on the action row
+- Later bubbles disappear after the restart succeeds
+- The normal assistant streaming experience resumes from that point
+- There is no "edited" badge, no system notice, and no duplicate bubble
+
+## Recommended Approach
+
+Implement the feature as a dedicated server-side restart endpoint scoped to the selected user message:
+
+- `POST /api/messages/[messageId]/edit-restart`
+
+This endpoint should:
+
+1. Authenticate the user
+2. Load the target message and verify ownership through the parent conversation
+3. Reject non-user messages
+4. Update the message content and token estimate in place
+5. Delete every later message in the conversation inside the same transaction
+6. Remove dependent retained-context artifacts that reference deleted history
+7. Start a fresh assistant turn from the retained message prefix using the existing chat runtime
+8. Return enough state for the client to reconcile and display the restarted turn
+
+This keeps the destructive behavior authoritative on the server, avoids client-side transcript surgery as the source of truth, and fits the existing split where `ChatView` owns interaction and `lib/conversations.ts` owns persisted state.
+
+## UX Design
+
+### User message affordance
+
+The existing user bubble action row in [components/message-bubble.tsx](/Users/charles/conductor/workspaces/Eidon-AI/cairo/components/message-bubble.tsx) already supports inline editing. Keep that inline editing model and convert its save behavior into an edit-and-restart action for transcript rewrites.
+
+Behavior rules:
+
+- Show the pen icon only on user messages
+- Keep the pen icon visually aligned with the existing copy button
+- Do not render any edit action on assistant messages
+- Use the existing textarea editing experience inside the bubble
+- Disable save and cancel while the restart request is being submitted
+
+### Save behavior
+
+- Clicking save on an edited user message sends a single restart request
+- There is no confirmation modal
+- On success, the transcript should reflect the edited message and remove every later turn
+- The new assistant reply should appear through the normal streaming UI, not as a special-case layout
+
+### Failure behavior
+
+- If the restart request fails, the app stays in the current conversation
+- The user should see an error in the existing chat-level error area
+- The transcript should not be partially truncated on failure
+- The bubble should return to a coherent state, either staying editable or restoring the prior visible content, with no half-applied rewrite
+
+## Data Semantics
+
+The retained conversation after save is the original conversation with rewritten history, not a clone.
+
+### Edited message
+
+Update the selected user message in place, preserving:
+
+- `id`
+- `conversation_id`
+- `created_at`
+- attachment bindings on that message
+
+Update:
+
+- `content`
+- `estimated_tokens`
+
+Do not create a new message row for the edited user turn.
+
+### Tail deletion
+
+Delete every message in the same conversation that occurs after the edited user message. "After" should be determined using the conversation's chronological ordering, which is currently represented by message `created_at` and stable persisted IDs.
+
+Deleting later messages must also remove dependent rows tied to those messages:
+
+- `message_actions`
+- `message_text_segments`
+- `message_attachments` for deleted messages via cascade
+
+The edited message's attachments remain bound to the edited message and are not re-created.
+
+### Compaction state
+
+Any retained-context artifacts that depend on deleted history must be removed before the assistant is asked to continue. In practice:
+
+- delete `memory_nodes` whose summarized source range includes any deleted message
+- delete `compaction_events` whose source range includes any deleted message or whose node is deleted
+
+The retained conversation must not include summary state derived from discarded messages.
+
+## Implementation Shape
+
+### Server
+
+Primary implementation surfaces:
+
+- [app/api/messages/[messageId]/route.ts](/Users/charles/conductor/workspaces/Eidon-AI/cairo/app/api/messages/[messageId]/route.ts)
+- [app/api/conversations/[conversationId]/chat/route.ts](/Users/charles/conductor/workspaces/Eidon-AI/cairo/app/api/conversations/[conversationId]/chat/route.ts)
+- [lib/conversations.ts](/Users/charles/conductor/workspaces/Eidon-AI/cairo/lib/conversations.ts)
+
+Recommended structure:
+
+- keep `PATCH /api/messages/[messageId]` as the non-destructive content update route
+- add a new route at `app/api/messages/[messageId]/edit-restart/route.ts`
+- add a transactional helper in `lib/conversations.ts`, such as `rewriteConversationFromEditedUserMessage`
+- keep message rewriting, tail deletion, and context cleanup in the data layer rather than the route
+- reuse the existing assistant generation path after the rewrite rather than building a second streaming implementation
+
+One practical shape is to move the shared assistant-turn startup logic behind a helper callable from both the normal chat route and the edit-restart route.
+
+### Client
+
+Primary implementation surfaces:
+
+- [components/message-bubble.tsx](/Users/charles/conductor/workspaces/Eidon-AI/cairo/components/message-bubble.tsx)
+- [components/chat-view.tsx](/Users/charles/conductor/workspaces/Eidon-AI/cairo/components/chat-view.tsx)
+
+Recommended structure:
+
+- keep the inline bubble editor inside `MessageBubble`
+- add a dedicated callback for destructive restart saves instead of overloading the current simple update handler
+- let `ChatView` own request dispatch, optimistic transcript trimming, error presentation, and streaming reset
+- lock the composer while a restart request is in flight so a second user submission cannot race with the rewrite
+
+## Edge Cases
+
+- Reject editing a missing message
+- Reject editing a message owned by another user
+- Reject editing an assistant message
+- If the edited message is the latest user message, the flow still uses the same restart path; there is simply no transcript tail to delete
+- If the conversation currently has an active assistant turn, reject the edit-restart request with `409` rather than trying to interrupt and rewrite an in-flight turn
+- If cleanup of dependent history fails, roll back the rewrite and keep the original conversation intact
+
+## Testing
+
+### Data-layer coverage
+
+- Rewriting a user message updates only that row's editable fields
+- Later messages are deleted and earlier messages remain untouched
+- Attachments on the edited message are preserved
+- Attachments belonging only to deleted later messages are removed
+- Dependent `message_actions` and `message_text_segments` for deleted messages are removed
+- `memory_nodes` and `compaction_events` whose ranges cross into deleted history are removed
+- The transaction rolls back on failure
+
+### API coverage
+
+- Authorized user can restart from a valid user message
+- Requests for missing messages return `404`
+- Requests for assistant messages return `400`
+- Requests for messages owned by another user are rejected
+- Concurrent active-turn restart requests return `409`
+
+### UI coverage
+
+- User messages render the edit button
+- Assistant messages do not render the edit button
+- Saving an edited older message triggers the restart flow rather than the plain patch flow
+- Later transcript messages disappear after a successful restart
+- The assistant streaming state resets and resumes correctly after restart
+- Failed restart requests keep the prior transcript visible and surface an error
+
+### Manual validation
+
+- Edit a middle user message and confirm all later turns disappear
+- Confirm the edited user message keeps its original attachments
+- Confirm the assistant regenerates from the edited point
+- Confirm assistant messages never show a pen icon
+- Confirm saving does not show a confirmation dialog
+- Confirm the composer cannot submit another message during the restart request
+
+## Risks
+
+- The main correctness risk is incomplete cleanup of retained-context artifacts after tail deletion
+- A second risk is racing the rewrite against an already-active assistant stream
+- A UX risk is allowing the client to locally trim history before the server has accepted the transaction
+
+The mitigation is to keep the rewrite transactional in the data layer, make the restart contract explicit, and cover both transcript and context cleanup in tests.

--- a/lib/chat-turn-control.ts
+++ b/lib/chat-turn-control.ts
@@ -5,7 +5,9 @@ export class ChatTurnStoppedError extends Error {
   }
 }
 
-const activeTurns = new Map<string, ReturnType<typeof createChatTurnControl>>();
+export type ChatTurnControl = ReturnType<typeof createChatTurnControl>;
+
+const activeTurns = new Map<string, ChatTurnControl>();
 
 export function createChatTurnControl(conversationId: string, abortController = new AbortController()) {
   let stopped = false;
@@ -30,16 +32,42 @@ export function createChatTurnControl(conversationId: string, abortController = 
   };
 }
 
-export function registerChatTurn(conversationId: string) {
-  const control = createChatTurnControl(conversationId);
+export function claimChatTurnStart(conversationId: string, control = createChatTurnControl(conversationId)) {
+  if (activeTurns.has(conversationId)) {
+    return { ok: false as const };
+  }
+
   activeTurns.set(conversationId, control);
-  return control;
+  return {
+    ok: true as const,
+    control
+  };
+}
+
+export function registerChatTurn(conversationId: string) {
+  const claimed = claimChatTurnStart(conversationId);
+  if (!claimed.ok) {
+    throw new Error("Conversation already has an active assistant turn");
+  }
+
+  return claimed.control;
 }
 
 export function requestStop(conversationId: string) {
   activeTurns.get(conversationId)?.requestStop();
 }
 
+export function releaseChatTurnStart(conversationId: string, control?: ChatTurnControl) {
+  if (!control) {
+    activeTurns.delete(conversationId);
+    return;
+  }
+
+  if (activeTurns.get(conversationId) === control) {
+    activeTurns.delete(conversationId);
+  }
+}
+
 export function clearChatTurn(conversationId: string) {
-  activeTurns.delete(conversationId);
+  releaseChatTurnStart(conversationId);
 }

--- a/lib/chat-turn.ts
+++ b/lib/chat-turn.ts
@@ -1,5 +1,10 @@
 import { resolveAssistantTurn } from "@/lib/assistant-runtime";
-import { ChatTurnStoppedError, registerChatTurn, clearChatTurn } from "@/lib/chat-turn-control";
+import {
+  ChatTurnStoppedError,
+  claimChatTurnStart,
+  releaseChatTurnStart,
+  type ChatTurnControl
+} from "@/lib/chat-turn-control";
 import {
   bindAttachmentsToMessage,
   createMessage,
@@ -48,6 +53,8 @@ const globalEmitter = createEmitter<{
   delta: [string, unknown];
   status: [string, string];
 }>();
+
+const ACTIVE_TURN_ERROR_MESSAGE = "Conversation already has an active assistant turn";
 
 export function getChatEmitter(): ChatEmitter {
   return globalEmitter;
@@ -116,35 +123,12 @@ async function startAssistantTurn(
   conversationId: string,
   existingUserMessage: Message,
   preflight: AssistantTurnStartReady,
+  control: ChatTurnControl,
   personaId?: string
 ) : Promise<ChatTurnResult> {
   const { conversation, conversationOwnerId, settings, appSettings } = preflight;
-
-  const assistantMessage = createMessage({
-    conversationId: conversation.id,
-    role: "assistant",
-    content: "",
-    thinkingContent: "",
-    status: "streaming",
-    estimatedTokens: 0
-  });
-
-  manager.broadcast(conversationId, {
-    type: "delta",
-    conversationId,
-    event: { type: "message_start", messageId: assistantMessage.id }
-  });
-
-  manager.setActive(conversationId, true);
-  globalEmitter.emit("status", conversationId, "streaming");
-  setConversationActive(conversation.id, true);
-  manager.broadcastAll(
-    { type: "conversation_activity", conversationId, isActive: true },
-    conversationOwnerId ?? undefined
-  );
-
-  const control = registerChatTurn(conversationId);
-
+  let assistantMessage: Message | null = null;
+  let started = false;
   let timelineSortOrder = 0;
   let answerBuffer = "";
   let latestAnswer = "";
@@ -154,26 +138,50 @@ async function startAssistantTurn(
   let flushTimer: ReturnType<typeof setTimeout> | null = null;
   const runningActionHandles = new Set<string>();
 
-  function flushAnswerBuffer() {
-    if (!answerBuffer) return;
-    createMessageTextSegment({
-      messageId: assistantMessage.id,
-      content: answerBuffer,
-      sortOrder: timelineSortOrder++
-    });
-    answerBuffer = "";
-    lastFlush = Date.now();
-  }
-
-  function scheduleFlush() {
-    if (flushTimer) return;
-    flushTimer = setTimeout(() => {
-      flushTimer = null;
-      flushAnswerBuffer();
-    }, 100);
-  }
-
   try {
+    assistantMessage = createMessage({
+      conversationId: conversation.id,
+      role: "assistant",
+      content: "",
+      thinkingContent: "",
+      status: "streaming",
+      estimatedTokens: 0
+    });
+
+    manager.broadcast(conversationId, {
+      type: "delta",
+      conversationId,
+      event: { type: "message_start", messageId: assistantMessage.id }
+    });
+
+    manager.setActive(conversationId, true);
+    globalEmitter.emit("status", conversationId, "streaming");
+    setConversationActive(conversation.id, true);
+    manager.broadcastAll(
+      { type: "conversation_activity", conversationId, isActive: true },
+      conversationOwnerId ?? undefined
+    );
+    started = true;
+
+    function flushAnswerBuffer() {
+      if (!assistantMessage || !answerBuffer) return;
+      createMessageTextSegment({
+        messageId: assistantMessage.id,
+        content: answerBuffer,
+        sortOrder: timelineSortOrder++
+      });
+      answerBuffer = "";
+      lastFlush = Date.now();
+    }
+
+    function scheduleFlush() {
+      if (flushTimer) return;
+      flushTimer = setTimeout(() => {
+        flushTimer = null;
+        flushAnswerBuffer();
+      }, 100);
+    }
+
     const compacted = await ensureCompactedContext(conversation.id, settings, {
       onCompactionStart() {
         manager.broadcast(conversationId, {
@@ -336,9 +344,16 @@ async function startAssistantTurn(
     });
     return { status: "completed" };
   } catch (error) {
-    if (error instanceof ChatTurnStoppedError) {
+    if (error instanceof ChatTurnStoppedError && assistantMessage) {
       if (flushTimer) clearTimeout(flushTimer);
-      flushAnswerBuffer();
+      if (answerBuffer) {
+        createMessageTextSegment({
+          messageId: assistantMessage.id,
+          content: answerBuffer,
+          sortOrder: timelineSortOrder++
+        });
+        answerBuffer = "";
+      }
 
       updateMessage(assistantMessage.id, {
         content: latestAnswer,
@@ -361,11 +376,13 @@ async function startAssistantTurn(
       });
       return { status: "stopped" };
     } else {
-      updateMessage(assistantMessage.id, {
-        content: "",
-        thinkingContent: "",
-        status: "error"
-      });
+      if (assistantMessage) {
+        updateMessage(assistantMessage.id, {
+          content: "",
+          thinkingContent: "",
+          status: "error"
+        });
+      }
       manager.broadcast(conversationId, {
         type: "delta",
         conversationId,
@@ -380,14 +397,16 @@ async function startAssistantTurn(
       };
     }
   } finally {
-    clearChatTurn(conversationId);
-    setConversationActive(conversation.id, false);
-    manager.setActive(conversationId, false);
-    manager.broadcastAll(
-      { type: "conversation_activity", conversationId, isActive: false },
-      conversationOwnerId ?? undefined
-    );
-    globalEmitter.emit("status", conversationId, "completed");
+    releaseChatTurnStart(conversationId, control);
+    if (started) {
+      setConversationActive(conversation.id, false);
+      manager.setActive(conversationId, false);
+      manager.broadcastAll(
+        { type: "conversation_activity", conversationId, isActive: false },
+        conversationOwnerId ?? undefined
+      );
+      globalEmitter.emit("status", conversationId, "completed");
+    }
   }
 }
 
@@ -395,15 +414,25 @@ export async function startAssistantTurnFromExistingUserMessage(
   manager: ConversationManager,
   conversationId: string,
   messageId: string,
-  personaId?: string
+  personaId?: string,
+  options?: {
+    control?: ChatTurnControl;
+    preflight?: AssistantTurnStartReady;
+  }
 ): Promise<ChatTurnResult> {
   const message = getMessage(messageId);
   if (!message || message.role !== "user" || message.conversationId !== conversationId) {
+    if (options?.control) {
+      releaseChatTurnStart(conversationId, options.control);
+    }
     return { status: "skipped", errorMessage: "User message not found" };
   }
 
-  const preflight = getAssistantTurnStartPreflight(conversationId);
+  const preflight = options?.preflight ?? getAssistantTurnStartPreflight(conversationId);
   if (!preflight.ok) {
+    if (options?.control) {
+      releaseChatTurnStart(conversationId, options.control);
+    }
     if (preflight.status === "failed") {
       manager.broadcast(conversationId, {
         type: "error",
@@ -414,7 +443,18 @@ export async function startAssistantTurnFromExistingUserMessage(
     return { status: preflight.status, errorMessage: preflight.errorMessage };
   }
 
-  return startAssistantTurn(manager, conversationId, message, preflight, personaId);
+  const claimed = options?.control
+    ? { ok: true as const, control: options.control }
+    : claimChatTurnStart(conversationId);
+  if (!claimed.ok) {
+    manager.broadcast(conversationId, {
+      type: "error",
+      message: ACTIVE_TURN_ERROR_MESSAGE
+    });
+    return { status: "failed", errorMessage: ACTIVE_TURN_ERROR_MESSAGE };
+  }
+
+  return startAssistantTurn(manager, conversationId, message, preflight, claimed.control, personaId);
 }
 
 export async function startChatTurn(
@@ -436,15 +476,29 @@ export async function startChatTurn(
     return { status: preflight.status, errorMessage: preflight.errorMessage };
   }
 
-  const userMessage = createMessage({
-    conversationId,
-    role: "user",
-    content,
-    estimatedTokens: estimateTextTokens(content)
-  });
+  const claimed = claimChatTurnStart(conversationId);
+  if (!claimed.ok) {
+    manager.broadcast(conversationId, {
+      type: "error",
+      message: ACTIVE_TURN_ERROR_MESSAGE
+    });
+    return { status: "failed", errorMessage: ACTIVE_TURN_ERROR_MESSAGE };
+  }
 
-  bindAttachmentsToMessage(conversationId, userMessage.id, attachmentIds);
-  void generateConversationTitleFromFirstUserMessage(conversationId, userMessage.id);
+  try {
+    const userMessage = createMessage({
+      conversationId,
+      role: "user",
+      content,
+      estimatedTokens: estimateTextTokens(content)
+    });
 
-  return startAssistantTurn(manager, conversationId, userMessage, preflight, personaId);
+    bindAttachmentsToMessage(conversationId, userMessage.id, attachmentIds);
+    void generateConversationTitleFromFirstUserMessage(conversationId, userMessage.id);
+
+    return startAssistantTurn(manager, conversationId, userMessage, preflight, claimed.control, personaId);
+  } catch (error) {
+    releaseChatTurnStart(conversationId, claimed.control);
+    throw error;
+  }
 }

--- a/lib/chat-turn.ts
+++ b/lib/chat-turn.ts
@@ -106,17 +106,19 @@ export function getAssistantTurnStartPreflight(conversationId: string) {
   };
 }
 
+type AssistantTurnStartReady = Extract<
+  ReturnType<typeof getAssistantTurnStartPreflight>,
+  { ok: true }
+>;
+
 async function startAssistantTurn(
   manager: ConversationManager,
   conversationId: string,
   existingUserMessage: Message,
+  preflight: AssistantTurnStartReady,
   personaId?: string
 ) : Promise<ChatTurnResult> {
-  const conversation = getConversation(conversationId);
-  if (!conversation) {
-    return { status: "skipped", errorMessage: "Conversation not found" };
-  }
-  const conversationOwnerId = getConversationOwnerId(conversationId);
+  const { conversation, conversationOwnerId, settings, appSettings } = preflight;
 
   const assistantMessage = createMessage({
     conversationId: conversation.id,
@@ -132,21 +134,6 @@ async function startAssistantTurn(
     conversationId,
     event: { type: "message_start", messageId: assistantMessage.id }
   });
-
-  const preflight = getAssistantTurnStartPreflight(conversationId);
-  if (!preflight.ok) {
-    updateMessage(assistantMessage.id, {
-      status: "error"
-    });
-    if (preflight.status === "failed") {
-      manager.broadcast(conversationId, {
-        type: "error",
-        message: preflight.errorMessage
-      });
-    }
-    return { status: preflight.status, errorMessage: preflight.errorMessage };
-  }
-  const { settings, appSettings } = preflight;
 
   manager.setActive(conversationId, true);
   globalEmitter.emit("status", conversationId, "streaming");
@@ -415,7 +402,19 @@ export async function startAssistantTurnFromExistingUserMessage(
     return { status: "skipped", errorMessage: "User message not found" };
   }
 
-  return startAssistantTurn(manager, conversationId, message, personaId);
+  const preflight = getAssistantTurnStartPreflight(conversationId);
+  if (!preflight.ok) {
+    if (preflight.status === "failed") {
+      manager.broadcast(conversationId, {
+        type: "error",
+        message: preflight.errorMessage
+      });
+    }
+
+    return { status: preflight.status, errorMessage: preflight.errorMessage };
+  }
+
+  return startAssistantTurn(manager, conversationId, message, preflight, personaId);
 }
 
 export async function startChatTurn(
@@ -447,5 +446,5 @@ export async function startChatTurn(
   bindAttachmentsToMessage(conversationId, userMessage.id, attachmentIds);
   void generateConversationTitleFromFirstUserMessage(conversationId, userMessage.id);
 
-  return startAssistantTurn(manager, conversationId, userMessage, personaId);
+  return startAssistantTurn(manager, conversationId, userMessage, preflight, personaId);
 }

--- a/lib/chat-turn.ts
+++ b/lib/chat-turn.ts
@@ -53,6 +53,59 @@ export function getChatEmitter(): ChatEmitter {
   return globalEmitter;
 }
 
+export function getAssistantTurnStartPreflight(conversationId: string) {
+  const conversation = getConversation(conversationId);
+  if (!conversation) {
+    return {
+      ok: false as const,
+      status: "skipped" as const,
+      statusCode: 404,
+      errorMessage: "Conversation not found"
+    };
+  }
+
+  const settings =
+    (conversation.providerProfileId
+      ? getProviderProfileWithApiKey(conversation.providerProfileId)
+      : null) ?? getDefaultProviderProfileWithApiKey();
+  const appSettings = getSettings();
+
+  if (!settings) {
+    return {
+      ok: false as const,
+      status: "failed" as const,
+      statusCode: 400,
+      errorMessage: "No provider profile configured"
+    };
+  }
+
+  if (settings.providerKind !== "github_copilot" && !settings.apiKey) {
+    return {
+      ok: false as const,
+      status: "failed" as const,
+      statusCode: 400,
+      errorMessage: "Set an API key in settings before starting a chat"
+    };
+  }
+
+  if (settings.providerKind === "github_copilot" && !settings.githubUserAccessTokenEncrypted) {
+    return {
+      ok: false as const,
+      status: "failed" as const,
+      statusCode: 400,
+      errorMessage: "Connect a GitHub account in settings before starting a chat"
+    };
+  }
+
+  return {
+    ok: true as const,
+    conversation,
+    conversationOwnerId: getConversationOwnerId(conversationId),
+    settings,
+    appSettings
+  };
+}
+
 async function startAssistantTurn(
   manager: ConversationManager,
   conversationId: string,
@@ -80,44 +133,20 @@ async function startAssistantTurn(
     event: { type: "message_start", messageId: assistantMessage.id }
   });
 
-  const settings =
-    (conversation.providerProfileId
-      ? getProviderProfileWithApiKey(conversation.providerProfileId)
-      : null) ?? getDefaultProviderProfileWithApiKey();
-  const appSettings = getSettings();
-
-  if (!settings) {
+  const preflight = getAssistantTurnStartPreflight(conversationId);
+  if (!preflight.ok) {
     updateMessage(assistantMessage.id, {
       status: "error"
     });
-    manager.broadcast(conversationId, {
-      type: "error",
-      message: "No provider profile configured"
-    });
-    return { status: "failed", errorMessage: "No provider profile configured" };
+    if (preflight.status === "failed") {
+      manager.broadcast(conversationId, {
+        type: "error",
+        message: preflight.errorMessage
+      });
+    }
+    return { status: preflight.status, errorMessage: preflight.errorMessage };
   }
-
-  if (settings.providerKind !== "github_copilot" && !settings.apiKey) {
-    updateMessage(assistantMessage.id, {
-      status: "error"
-    });
-    manager.broadcast(conversationId, {
-      type: "error",
-      message: "Set an API key in settings before starting a chat"
-    });
-    return { status: "failed", errorMessage: "Set an API key in settings before starting a chat" };
-  }
-
-  if (settings.providerKind === "github_copilot" && !settings.githubUserAccessTokenEncrypted) {
-    updateMessage(assistantMessage.id, {
-      status: "error"
-    });
-    manager.broadcast(conversationId, {
-      type: "error",
-      message: "Connect a GitHub account in settings before starting a chat"
-    });
-    return { status: "failed", errorMessage: "Connect a GitHub account in settings before starting a chat" };
-  }
+  const { settings, appSettings } = preflight;
 
   manager.setActive(conversationId, true);
   globalEmitter.emit("status", conversationId, "streaming");

--- a/lib/chat-turn.ts
+++ b/lib/chat-turn.ts
@@ -28,7 +28,7 @@ import {
   getProviderProfileWithApiKey
 } from "@/lib/settings";
 import { createEmitter } from "@/lib/emitter";
-import type { ChatStreamEvent, Message } from "@/lib/types";
+import type { ChatStreamEvent } from "@/lib/types";
 import type { ConversationManager } from "@/lib/conversation-manager";
 
 export type ChatEmitter = ReturnType<typeof createEmitter<{
@@ -121,13 +121,12 @@ type AssistantTurnStartReady = Extract<
 async function startAssistantTurn(
   manager: ConversationManager,
   conversationId: string,
-  existingUserMessage: Message,
   preflight: AssistantTurnStartReady,
   control: ChatTurnControl,
   personaId?: string
 ) : Promise<ChatTurnResult> {
   const { conversation, conversationOwnerId, settings, appSettings } = preflight;
-  let assistantMessage: Message | null = null;
+  let assistantMessageId: string | null = null;
   let started = false;
   let timelineSortOrder = 0;
   let answerBuffer = "";
@@ -139,7 +138,7 @@ async function startAssistantTurn(
   const runningActionHandles = new Set<string>();
 
   try {
-    assistantMessage = createMessage({
+    const assistantMessage = createMessage({
       conversationId: conversation.id,
       role: "assistant",
       content: "",
@@ -147,6 +146,7 @@ async function startAssistantTurn(
       status: "streaming",
       estimatedTokens: 0
     });
+    assistantMessageId = assistantMessage.id;
 
     manager.broadcast(conversationId, {
       type: "delta",
@@ -164,9 +164,9 @@ async function startAssistantTurn(
     started = true;
 
     function flushAnswerBuffer() {
-      if (!assistantMessage || !answerBuffer) return;
+      if (!assistantMessageId || !answerBuffer) return;
       createMessageTextSegment({
-        messageId: assistantMessage.id,
+        messageId: assistantMessageId,
         content: answerBuffer,
         sortOrder: timelineSortOrder++
       });
@@ -253,9 +253,9 @@ async function startAssistantTurn(
       },
       onAnswerSegment(segment) {
         flushAnswerBuffer();
-        if (!sawStreamedAnswerSinceLastSegment && segment) {
+        if (!sawStreamedAnswerSinceLastSegment && segment && assistantMessageId) {
           createMessageTextSegment({
-            messageId: assistantMessage.id,
+            messageId: assistantMessageId,
             content: segment,
             sortOrder: timelineSortOrder++
           });
@@ -263,8 +263,11 @@ async function startAssistantTurn(
         sawStreamedAnswerSinceLastSegment = false;
       },
       onActionStart(action) {
+        if (!assistantMessageId) {
+          return "";
+        }
         const persisted = createMessageAction({
-          messageId: assistantMessage.id,
+          messageId: assistantMessageId,
           kind: action.kind,
           status: action.status,
           label: action.label,
@@ -327,7 +330,7 @@ async function startAssistantTurn(
     if (flushTimer) clearTimeout(flushTimer);
     flushAnswerBuffer();
 
-    updateMessage(assistantMessage.id, {
+    updateMessage(assistantMessageId, {
       content: providerResult.answer,
       thinkingContent: providerResult.thinking,
       status: "completed",
@@ -340,22 +343,22 @@ async function startAssistantTurn(
     manager.broadcast(conversationId, {
       type: "delta",
       conversationId,
-      event: { type: "done", messageId: assistantMessage.id }
+      event: { type: "done", messageId: assistantMessageId }
     });
     return { status: "completed" };
   } catch (error) {
-    if (error instanceof ChatTurnStoppedError && assistantMessage) {
+    if (error instanceof ChatTurnStoppedError && assistantMessageId) {
       if (flushTimer) clearTimeout(flushTimer);
       if (answerBuffer) {
         createMessageTextSegment({
-          messageId: assistantMessage.id,
+          messageId: assistantMessageId,
           content: answerBuffer,
           sortOrder: timelineSortOrder++
         });
         answerBuffer = "";
       }
 
-      updateMessage(assistantMessage.id, {
+      updateMessage(assistantMessageId, {
         content: latestAnswer,
         thinkingContent: latestThinking,
         status: "stopped",
@@ -372,12 +375,12 @@ async function startAssistantTurn(
       manager.broadcast(conversationId, {
         type: "delta",
         conversationId,
-        event: { type: "done", messageId: assistantMessage.id }
+        event: { type: "done", messageId: assistantMessageId }
       });
       return { status: "stopped" };
     } else {
-      if (assistantMessage) {
-        updateMessage(assistantMessage.id, {
+      if (assistantMessageId) {
+        updateMessage(assistantMessageId, {
           content: "",
           thinkingContent: "",
           status: "error"
@@ -454,7 +457,7 @@ export async function startAssistantTurnFromExistingUserMessage(
     return { status: "failed", errorMessage: ACTIVE_TURN_ERROR_MESSAGE };
   }
 
-  return startAssistantTurn(manager, conversationId, message, preflight, claimed.control, personaId);
+  return startAssistantTurn(manager, conversationId, preflight, claimed.control, personaId);
 }
 
 export async function startChatTurn(
@@ -496,7 +499,7 @@ export async function startChatTurn(
     bindAttachmentsToMessage(conversationId, userMessage.id, attachmentIds);
     void generateConversationTitleFromFirstUserMessage(conversationId, userMessage.id);
 
-    return startAssistantTurn(manager, conversationId, userMessage, preflight, claimed.control, personaId);
+    return startAssistantTurn(manager, conversationId, preflight, claimed.control, personaId);
   } catch (error) {
     releaseChatTurnStart(conversationId, claimed.control);
     throw error;

--- a/lib/chat-turn.ts
+++ b/lib/chat-turn.ts
@@ -7,6 +7,7 @@ import {
   createMessageAction,
   generateConversationTitleFromFirstUserMessage,
   getConversation,
+  getMessage,
   getConversationOwnerId,
   setConversationActive,
   updateMessage,
@@ -22,7 +23,7 @@ import {
   getProviderProfileWithApiKey
 } from "@/lib/settings";
 import { createEmitter } from "@/lib/emitter";
-import type { ChatStreamEvent } from "@/lib/types";
+import type { ChatStreamEvent, Message } from "@/lib/types";
 import type { ConversationManager } from "@/lib/conversation-manager";
 
 export type ChatEmitter = ReturnType<typeof createEmitter<{
@@ -52,11 +53,10 @@ export function getChatEmitter(): ChatEmitter {
   return globalEmitter;
 }
 
-export async function startChatTurn(
+async function startAssistantTurn(
   manager: ConversationManager,
   conversationId: string,
-  content: string,
-  attachmentIds: string[],
+  existingUserMessage: Message,
   personaId?: string
 ) : Promise<ChatTurnResult> {
   const conversation = getConversation(conversationId);
@@ -64,46 +64,6 @@ export async function startChatTurn(
     return { status: "skipped", errorMessage: "Conversation not found" };
   }
   const conversationOwnerId = getConversationOwnerId(conversationId);
-
-  const settings =
-    (conversation.providerProfileId
-      ? getProviderProfileWithApiKey(conversation.providerProfileId)
-      : null) ?? getDefaultProviderProfileWithApiKey();
-  const appSettings = getSettings();
-
-  if (!settings) {
-    manager.broadcast(conversationId, {
-      type: "error",
-      message: "No provider profile configured"
-    });
-    return { status: "failed", errorMessage: "No provider profile configured" };
-  }
-
-  if (settings.providerKind !== "github_copilot" && !settings.apiKey) {
-    manager.broadcast(conversationId, {
-      type: "error",
-      message: "Set an API key in settings before starting a chat"
-    });
-    return { status: "failed", errorMessage: "Set an API key in settings before starting a chat" };
-  }
-
-  if (settings.providerKind === "github_copilot" && !settings.githubUserAccessTokenEncrypted) {
-    manager.broadcast(conversationId, {
-      type: "error",
-      message: "Connect a GitHub account in settings before starting a chat"
-    });
-    return { status: "failed", errorMessage: "Connect a GitHub account in settings before starting a chat" };
-  }
-
-  const userMessage = createMessage({
-    conversationId: conversation.id,
-    role: "user",
-    content,
-    estimatedTokens: estimateTextTokens(content)
-  });
-
-  bindAttachmentsToMessage(conversation.id, userMessage.id, attachmentIds);
-  void generateConversationTitleFromFirstUserMessage(conversation.id, userMessage.id);
 
   const assistantMessage = createMessage({
     conversationId: conversation.id,
@@ -119,6 +79,45 @@ export async function startChatTurn(
     conversationId,
     event: { type: "message_start", messageId: assistantMessage.id }
   });
+
+  const settings =
+    (conversation.providerProfileId
+      ? getProviderProfileWithApiKey(conversation.providerProfileId)
+      : null) ?? getDefaultProviderProfileWithApiKey();
+  const appSettings = getSettings();
+
+  if (!settings) {
+    updateMessage(assistantMessage.id, {
+      status: "error"
+    });
+    manager.broadcast(conversationId, {
+      type: "error",
+      message: "No provider profile configured"
+    });
+    return { status: "failed", errorMessage: "No provider profile configured" };
+  }
+
+  if (settings.providerKind !== "github_copilot" && !settings.apiKey) {
+    updateMessage(assistantMessage.id, {
+      status: "error"
+    });
+    manager.broadcast(conversationId, {
+      type: "error",
+      message: "Set an API key in settings before starting a chat"
+    });
+    return { status: "failed", errorMessage: "Set an API key in settings before starting a chat" };
+  }
+
+  if (settings.providerKind === "github_copilot" && !settings.githubUserAccessTokenEncrypted) {
+    updateMessage(assistantMessage.id, {
+      status: "error"
+    });
+    manager.broadcast(conversationId, {
+      type: "error",
+      message: "Connect a GitHub account in settings before starting a chat"
+    });
+    return { status: "failed", errorMessage: "Connect a GitHub account in settings before starting a chat" };
+  }
 
   manager.setActive(conversationId, true);
   globalEmitter.emit("status", conversationId, "streaming");
@@ -374,4 +373,42 @@ export async function startChatTurn(
     );
     globalEmitter.emit("status", conversationId, "completed");
   }
+}
+
+export async function startAssistantTurnFromExistingUserMessage(
+  manager: ConversationManager,
+  conversationId: string,
+  messageId: string,
+  personaId?: string
+): Promise<ChatTurnResult> {
+  const message = getMessage(messageId);
+  if (!message || message.role !== "user" || message.conversationId !== conversationId) {
+    return { status: "skipped", errorMessage: "User message not found" };
+  }
+
+  return startAssistantTurn(manager, conversationId, message, personaId);
+}
+
+export async function startChatTurn(
+  manager: ConversationManager,
+  conversationId: string,
+  content: string,
+  attachmentIds: string[],
+  personaId?: string
+): Promise<ChatTurnResult> {
+  if (!getConversation(conversationId)) {
+    return { status: "skipped", errorMessage: "Conversation not found" };
+  }
+
+  const userMessage = createMessage({
+    conversationId,
+    role: "user",
+    content,
+    estimatedTokens: estimateTextTokens(content)
+  });
+
+  bindAttachmentsToMessage(conversationId, userMessage.id, attachmentIds);
+  void generateConversationTitleFromFirstUserMessage(conversationId, userMessage.id);
+
+  return startAssistantTurn(manager, conversationId, userMessage, personaId);
 }

--- a/lib/chat-turn.ts
+++ b/lib/chat-turn.ts
@@ -425,8 +425,16 @@ export async function startChatTurn(
   attachmentIds: string[],
   personaId?: string
 ): Promise<ChatTurnResult> {
-  if (!getConversation(conversationId)) {
-    return { status: "skipped", errorMessage: "Conversation not found" };
+  const preflight = getAssistantTurnStartPreflight(conversationId);
+  if (!preflight.ok) {
+    if (preflight.status === "failed") {
+      manager.broadcast(conversationId, {
+        type: "error",
+        message: preflight.errorMessage
+      });
+    }
+
+    return { status: preflight.status, errorMessage: preflight.errorMessage };
   }
 
   const userMessage = createMessage({

--- a/lib/conversations.ts
+++ b/lib/conversations.ts
@@ -1500,9 +1500,9 @@ export function rewriteConversationFromEditedUserMessage(
     const deletedIds = deletedMessages.map((item) => item.id);
 
     updateMessage(message.id, {
-      content: input.content,
-      estimatedTokens: estimateTextTokens(input.content)
+      content: input.content
     });
+    updateMessageEstimatedTokens(message.id);
 
     if (deletedIds.length > 0) {
       const deleteMessage = db.prepare("DELETE FROM messages WHERE id = ?");

--- a/lib/conversations.ts
+++ b/lib/conversations.ts
@@ -1043,6 +1043,24 @@ function recoverTextAttachmentFile(input: {
   };
 }
 
+function deleteAttachmentFilesForMessageIds(messageIds: string[]) {
+  if (!messageIds.length) {
+    return;
+  }
+
+  listAttachmentsForMessageIds(messageIds).forEach((attachment) => {
+    const absolutePath = path.resolve(getAttachmentsRoot(), attachment.relativePath);
+
+    try {
+      fs.unlinkSync(absolutePath);
+    } catch (error) {
+      if (!(error instanceof Error) || !("code" in error) || error.code !== "ENOENT") {
+        throw error;
+      }
+    }
+  });
+}
+
 export function forkConversationFromMessage(messageId: string, userId?: string) {
   const db = getDb();
   const copiedAttachmentPaths: string[] = [];
@@ -1496,6 +1514,7 @@ export function rewriteConversationFromEditedUserMessage(
       throw new Error("Message not found");
     }
 
+    const affectedIds = messages.slice(targetIndex).map((item) => item.id);
     const deletedMessages = messages.slice(targetIndex + 1);
     const deletedIds = deletedMessages.map((item) => item.id);
 
@@ -1504,25 +1523,27 @@ export function rewriteConversationFromEditedUserMessage(
     });
     updateMessageEstimatedTokens(message.id);
 
+    const affectedPlaceholders = affectedIds.map(() => "?").join(", ");
+
+    db.prepare(
+      `DELETE FROM compaction_events
+       WHERE conversation_id = ?
+         AND (source_start_message_id IN (${affectedPlaceholders})
+           OR source_end_message_id IN (${affectedPlaceholders}))`
+    ).run(conversation.id, ...affectedIds, ...affectedIds);
+
+    db.prepare(
+      `DELETE FROM memory_nodes
+       WHERE conversation_id = ?
+         AND (source_start_message_id IN (${affectedPlaceholders})
+           OR source_end_message_id IN (${affectedPlaceholders}))`
+    ).run(conversation.id, ...affectedIds, ...affectedIds);
+
     if (deletedIds.length > 0) {
       const deleteMessage = db.prepare("DELETE FROM messages WHERE id = ?");
-      const placeholders = deletedIds.map(() => "?").join(", ");
+      deleteAttachmentFilesForMessageIds(deletedIds);
 
       deletedMessages.forEach((item) => deleteMessage.run(item.id));
-
-      db.prepare(
-        `DELETE FROM compaction_events
-         WHERE conversation_id = ?
-           AND (source_start_message_id IN (${placeholders})
-             OR source_end_message_id IN (${placeholders}))`
-      ).run(conversation.id, ...deletedIds, ...deletedIds);
-
-      db.prepare(
-        `DELETE FROM memory_nodes
-         WHERE conversation_id = ?
-           AND (source_start_message_id IN (${placeholders})
-             OR source_end_message_id IN (${placeholders}))`
-      ).run(conversation.id, ...deletedIds, ...deletedIds);
     }
 
     setConversationActive(conversation.id, false);

--- a/lib/conversations.ts
+++ b/lib/conversations.ts
@@ -1521,45 +1521,75 @@ export function rewriteConversationFromEditedUserMessage(
     updateMessageEstimatedTokens(message.id);
 
     const affectedPlaceholders = affectedIds.map(() => "?").join(", ");
-    const deletedNodeRows = (
+    const allNodeRows = (
       db
         .prepare(
           `SELECT
              id,
              source_start_message_id,
-             source_end_message_id
+             source_end_message_id,
+             child_node_ids
            FROM memory_nodes
-           WHERE conversation_id = ?
-             AND (source_start_message_id IN (${affectedPlaceholders})
-               OR source_end_message_id IN (${affectedPlaceholders}))`
+           WHERE conversation_id = ?`
         )
-        .all(conversation.id, ...affectedIds, ...affectedIds) as Array<{
+        .all(conversation.id) as Array<{
         id: string;
         source_start_message_id: string;
         source_end_message_id: string;
+        child_node_ids: string;
       }>
     );
+    const invalidNodeIds = new Set(
+      allNodeRows
+        .filter(
+          (row) =>
+            affectedIds.includes(row.source_start_message_id) ||
+            affectedIds.includes(row.source_end_message_id)
+        )
+        .map((row) => row.id)
+    );
+
+    let changed = true;
+    while (changed) {
+      changed = false;
+
+      allNodeRows.forEach((row) => {
+        if (invalidNodeIds.has(row.id)) {
+          return;
+        }
+
+        const childNodeIds = JSON.parse(row.child_node_ids) as string[];
+        if (childNodeIds.some((childNodeId) => invalidNodeIds.has(childNodeId))) {
+          invalidNodeIds.add(row.id);
+          changed = true;
+        }
+      });
+    }
+
+    const deletedNodeRows = allNodeRows.filter((row) => invalidNodeIds.has(row.id));
     const deletedNodeIds = deletedNodeRows.map((row) => row.id);
-
-    db.prepare(
-      `DELETE FROM compaction_events
-       WHERE conversation_id = ?
-         AND (source_start_message_id IN (${affectedPlaceholders})
-           OR source_end_message_id IN (${affectedPlaceholders}))`
-    ).run(conversation.id, ...affectedIds, ...affectedIds);
-
-    db.prepare(
-      `DELETE FROM memory_nodes
-       WHERE conversation_id = ?
-         AND (source_start_message_id IN (${affectedPlaceholders})
-           OR source_end_message_id IN (${affectedPlaceholders}))`
-    ).run(conversation.id, ...affectedIds, ...affectedIds);
 
     if (deletedNodeIds.length > 0) {
       const deletedNodePlaceholders = deletedNodeIds.map(() => "?").join(", ");
       const deletedIdSet = new Set(deletedIds);
       const messageIndexById = new Map(messages.map((item, index) => [item.id, index]));
       const restoredCompactionIds = new Set<string>();
+
+      db.prepare(
+        `DELETE FROM compaction_events
+         WHERE conversation_id = ?
+           AND (
+             node_id IN (${deletedNodePlaceholders})
+             OR source_start_message_id IN (${affectedPlaceholders})
+             OR source_end_message_id IN (${affectedPlaceholders})
+           )`
+      ).run(conversation.id, ...deletedNodeIds, ...affectedIds, ...affectedIds);
+
+      db.prepare(
+        `DELETE FROM memory_nodes
+         WHERE conversation_id = ?
+           AND id IN (${deletedNodePlaceholders})`
+      ).run(conversation.id, ...deletedNodeIds);
 
       deletedNodeRows.forEach((row) => {
         const startIndex = messageIndexById.get(row.source_start_message_id);

--- a/lib/conversations.ts
+++ b/lib/conversations.ts
@@ -1466,6 +1466,79 @@ export function forkConversationFromMessage(messageId: string, userId?: string) 
   }
 }
 
+export function rewriteConversationFromEditedUserMessage(
+  messageId: string,
+  input: { content: string },
+  userId?: string
+) {
+  const db = getDb();
+  const transaction = db.transaction(() => {
+    const message = getMessage(messageId, userId);
+
+    if (!message) {
+      throw new Error("Message not found");
+    }
+
+    if (message.role !== "user") {
+      throw new Error("Only user messages can be edited");
+    }
+
+    const conversation = getConversation(message.conversationId, userId);
+
+    if (!conversation) {
+      throw new Error("Conversation not found");
+    }
+
+    const messages = listMessages(conversation.id);
+    const targetIndex = messages.findIndex((item) => item.id === message.id);
+
+    if (targetIndex === -1) {
+      throw new Error("Message not found");
+    }
+
+    const deletedMessages = messages.slice(targetIndex + 1);
+    const deletedIds = deletedMessages.map((item) => item.id);
+
+    updateMessage(message.id, {
+      content: input.content,
+      estimatedTokens: estimateTextTokens(input.content)
+    });
+
+    if (deletedIds.length > 0) {
+      const deleteMessage = db.prepare("DELETE FROM messages WHERE id = ?");
+      const placeholders = deletedIds.map(() => "?").join(", ");
+
+      deletedMessages.forEach((item) => deleteMessage.run(item.id));
+
+      db.prepare(
+        `DELETE FROM compaction_events
+         WHERE conversation_id = ?
+           AND (source_start_message_id IN (${placeholders})
+             OR source_end_message_id IN (${placeholders}))`
+      ).run(conversation.id, ...deletedIds, ...deletedIds);
+
+      db.prepare(
+        `DELETE FROM memory_nodes
+         WHERE conversation_id = ?
+           AND (source_start_message_id IN (${placeholders})
+             OR source_end_message_id IN (${placeholders}))`
+      ).run(conversation.id, ...deletedIds, ...deletedIds);
+    }
+
+    setConversationActive(conversation.id, false);
+
+    return getConversationSnapshot(conversation.id, userId);
+  });
+
+  const snapshot = transaction();
+
+  if (!snapshot) {
+    throw new Error("Conversation not found");
+  }
+
+  return snapshot;
+}
+
 export function createMessageAction(input: {
   messageId: string;
   kind: MessageActionKind;

--- a/lib/conversations.ts
+++ b/lib/conversations.ts
@@ -1043,13 +1043,9 @@ function recoverTextAttachmentFile(input: {
   };
 }
 
-function deleteAttachmentFilesForMessageIds(messageIds: string[]) {
-  if (!messageIds.length) {
-    return;
-  }
-
-  listAttachmentsForMessageIds(messageIds).forEach((attachment) => {
-    const absolutePath = path.resolve(getAttachmentsRoot(), attachment.relativePath);
+function deleteAttachmentFiles(relativePaths: string[]) {
+  relativePaths.forEach((relativePath) => {
+    const absolutePath = path.resolve(getAttachmentsRoot(), relativePath);
 
     try {
       fs.unlinkSync(absolutePath);
@@ -1490,6 +1486,7 @@ export function rewriteConversationFromEditedUserMessage(
   userId?: string
 ) {
   const db = getDb();
+  const deletedAttachmentPaths = new Set<string>();
   const transaction = db.transaction(() => {
     const message = getMessage(messageId, userId);
 
@@ -1524,6 +1521,17 @@ export function rewriteConversationFromEditedUserMessage(
     updateMessageEstimatedTokens(message.id);
 
     const affectedPlaceholders = affectedIds.map(() => "?").join(", ");
+    const deletedNodeIds = (
+      db
+        .prepare(
+          `SELECT id
+           FROM memory_nodes
+           WHERE conversation_id = ?
+             AND (source_start_message_id IN (${affectedPlaceholders})
+               OR source_end_message_id IN (${affectedPlaceholders}))`
+        )
+        .all(conversation.id, ...affectedIds, ...affectedIds) as Array<{ id: string }>
+    ).map((row) => row.id);
 
     db.prepare(
       `DELETE FROM compaction_events
@@ -1539,9 +1547,23 @@ export function rewriteConversationFromEditedUserMessage(
            OR source_end_message_id IN (${affectedPlaceholders}))`
     ).run(conversation.id, ...affectedIds, ...affectedIds);
 
+    if (deletedNodeIds.length > 0) {
+      const deletedNodePlaceholders = deletedNodeIds.map(() => "?").join(", ");
+
+      db.prepare(
+        `UPDATE memory_nodes
+         SET superseded_by_node_id = NULL
+         WHERE conversation_id = ?
+           AND superseded_by_node_id IN (${deletedNodePlaceholders})`
+      ).run(conversation.id, ...deletedNodeIds);
+    }
+
     if (deletedIds.length > 0) {
       const deleteMessage = db.prepare("DELETE FROM messages WHERE id = ?");
-      deleteAttachmentFilesForMessageIds(deletedIds);
+
+      listAttachmentsForMessageIds(deletedIds).forEach((attachment) => {
+        deletedAttachmentPaths.add(attachment.relativePath);
+      });
 
       deletedMessages.forEach((item) => deleteMessage.run(item.id));
     }
@@ -1552,6 +1574,7 @@ export function rewriteConversationFromEditedUserMessage(
   });
 
   const snapshot = transaction();
+  deleteAttachmentFiles([...deletedAttachmentPaths]);
 
   if (!snapshot) {
     throw new Error("Conversation not found");

--- a/lib/conversations.ts
+++ b/lib/conversations.ts
@@ -1521,17 +1521,25 @@ export function rewriteConversationFromEditedUserMessage(
     updateMessageEstimatedTokens(message.id);
 
     const affectedPlaceholders = affectedIds.map(() => "?").join(", ");
-    const deletedNodeIds = (
+    const deletedNodeRows = (
       db
         .prepare(
-          `SELECT id
+          `SELECT
+             id,
+             source_start_message_id,
+             source_end_message_id
            FROM memory_nodes
            WHERE conversation_id = ?
              AND (source_start_message_id IN (${affectedPlaceholders})
                OR source_end_message_id IN (${affectedPlaceholders}))`
         )
-        .all(conversation.id, ...affectedIds, ...affectedIds) as Array<{ id: string }>
-    ).map((row) => row.id);
+        .all(conversation.id, ...affectedIds, ...affectedIds) as Array<{
+        id: string;
+        source_start_message_id: string;
+        source_end_message_id: string;
+      }>
+    );
+    const deletedNodeIds = deletedNodeRows.map((row) => row.id);
 
     db.prepare(
       `DELETE FROM compaction_events
@@ -1549,6 +1557,27 @@ export function rewriteConversationFromEditedUserMessage(
 
     if (deletedNodeIds.length > 0) {
       const deletedNodePlaceholders = deletedNodeIds.map(() => "?").join(", ");
+      const deletedIdSet = new Set(deletedIds);
+      const messageIndexById = new Map(messages.map((item, index) => [item.id, index]));
+      const restoredCompactionIds = new Set<string>();
+
+      deletedNodeRows.forEach((row) => {
+        const startIndex = messageIndexById.get(row.source_start_message_id);
+        const endIndex = messageIndexById.get(row.source_end_message_id);
+
+        if (startIndex === undefined || endIndex === undefined) {
+          return;
+        }
+
+        const spanStart = Math.min(startIndex, endIndex);
+        const spanEnd = Math.max(startIndex, endIndex);
+
+        messages.slice(spanStart, spanEnd + 1).forEach((item) => {
+          if (!deletedIdSet.has(item.id)) {
+            restoredCompactionIds.add(item.id);
+          }
+        });
+      });
 
       db.prepare(
         `UPDATE memory_nodes
@@ -1556,6 +1585,16 @@ export function rewriteConversationFromEditedUserMessage(
          WHERE conversation_id = ?
            AND superseded_by_node_id IN (${deletedNodePlaceholders})`
       ).run(conversation.id, ...deletedNodeIds);
+
+      if (restoredCompactionIds.size > 0) {
+        const restoredPlaceholders = Array.from(restoredCompactionIds).map(() => "?").join(", ");
+
+        db.prepare(
+          `UPDATE messages
+           SET compacted_at = NULL
+           WHERE id IN (${restoredPlaceholders})`
+        ).run(...restoredCompactionIds);
+      }
     }
 
     if (deletedIds.length > 0) {

--- a/tests/unit/chat-turn.test.ts
+++ b/tests/unit/chat-turn.test.ts
@@ -360,4 +360,28 @@ describe("chat-turn", () => {
       })
     );
   });
+
+  it("continues from an existing user message without creating a duplicate user row", async () => {
+    const { createConversation, createMessage, listVisibleMessages } = await import("@/lib/conversations");
+    const { startAssistantTurnFromExistingUserMessage } = await import("@/lib/chat-turn");
+    const { getConversationManager } = await import("@/lib/ws-singleton");
+
+    const conversation = createConversation("Restart conversation");
+    const existingUser = createMessage({
+      conversationId: conversation.id,
+      role: "user",
+      content: "Edited prompt"
+    });
+
+    await startAssistantTurnFromExistingUserMessage(
+      getConversationManager(),
+      conversation.id,
+      existingUser.id
+    );
+
+    const messages = listVisibleMessages(conversation.id);
+    expect(messages.filter((message) => message.role === "user")).toHaveLength(1);
+    expect(messages[0]?.id).toBe(existingUser.id);
+    expect(messages.at(-1)?.role).toBe("assistant");
+  });
 });

--- a/tests/unit/chat-turn.test.ts
+++ b/tests/unit/chat-turn.test.ts
@@ -413,4 +413,33 @@ describe("chat-turn", () => {
     expect(messages.at(-1)?.status).toBe("completed");
     expect(messages.at(-1)?.content).toBe("Restarted answer");
   });
+
+  it("does not create an assistant placeholder when continuation preflight fails", async () => {
+    const { createConversation, createMessage, listVisibleMessages } = await import("@/lib/conversations");
+    const { startAssistantTurnFromExistingUserMessage } = await import("@/lib/chat-turn");
+    const { getConversationManager } = await import("@/lib/ws-singleton");
+
+    const conversation = createConversation("Restart conversation");
+    const existingUser = createMessage({
+      conversationId: conversation.id,
+      role: "user",
+      content: "Edited prompt"
+    });
+
+    await expect(
+      startAssistantTurnFromExistingUserMessage(
+        getConversationManager(),
+        conversation.id,
+        existingUser.id
+      )
+    ).resolves.toEqual({
+      status: "failed",
+      errorMessage: "Set an API key in settings before starting a chat"
+    });
+
+    const messages = listVisibleMessages(conversation.id);
+    expect(messages).toHaveLength(1);
+    expect(messages[0]?.id).toBe(existingUser.id);
+    expect(messages[0]?.role).toBe("user");
+  });
 });

--- a/tests/unit/chat-turn.test.ts
+++ b/tests/unit/chat-turn.test.ts
@@ -442,4 +442,52 @@ describe("chat-turn", () => {
     expect(messages[0]?.id).toBe(existingUser.id);
     expect(messages[0]?.role).toBe("user");
   });
+
+  it("rejects a concurrent chat start without persisting another user row", async () => {
+    const { streamProviderResponse } = await import("@/lib/provider");
+    const mockedStreamProviderResponse = vi.mocked(streamProviderResponse);
+    const { createConversation, listVisibleMessages } = await import("@/lib/conversations");
+    const { createConversationManager } = await import("@/lib/conversation-manager");
+    const { updateSettings } = await import("@/lib/settings");
+    const { startChatTurn } = await import("@/lib/chat-turn");
+
+    const { profileId, profile } = setupProviderProfile();
+    updateSettings({
+      defaultProviderProfileId: profileId,
+      skillsEnabled: false,
+      providerProfiles: [profile]
+    });
+
+    const manager = createConversationManager();
+    const conversation = createConversation("Concurrent start");
+
+    let release = () => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    mockedStreamProviderResponse.mockReturnValueOnce(
+      (async function* () {
+        yield { type: "answer_delta", text: "First answer" };
+        await gate;
+        return {
+          answer: "First answer",
+          thinking: "",
+          usage: { outputTokens: 2 }
+        };
+      })()
+    );
+
+    const firstStart = startChatTurn(manager, conversation.id, "First prompt", []);
+    const secondResult = await startChatTurn(manager, conversation.id, "Second prompt", []);
+
+    expect(secondResult).toEqual({
+      status: "failed",
+      errorMessage: "Conversation already has an active assistant turn"
+    });
+    expect(listVisibleMessages(conversation.id).filter((message) => message.role === "user")).toHaveLength(1);
+
+    release();
+    await expect(firstStart).resolves.toEqual({ status: "completed" });
+  });
 });

--- a/tests/unit/chat-turn.test.ts
+++ b/tests/unit/chat-turn.test.ts
@@ -190,10 +190,15 @@ describe("chat-turn", () => {
     manager.subscribe(conv.id, mockWs);
 
     const { startChatTurn } = await import("@/lib/chat-turn");
-    await startChatTurn(manager, conv.id, "Hi", []);
+    await expect(startChatTurn(manager, conv.id, "Hi", [])).resolves.toEqual({
+      status: "failed",
+      errorMessage: "Set an API key in settings before starting a chat"
+    });
 
     const errorMsg = sent.find((s: unknown) => (s as { type: string }).type === "error");
     expect(errorMsg).toBeDefined();
+    const { listVisibleMessages } = await import("@/lib/conversations");
+    expect(listVisibleMessages(conv.id)).toHaveLength(0);
   });
 
   it("persists a partial assistant message as stopped when the turn is cancelled", async () => {
@@ -362,9 +367,30 @@ describe("chat-turn", () => {
   });
 
   it("continues from an existing user message without creating a duplicate user row", async () => {
+    const { streamProviderResponse } = await import("@/lib/provider");
+    const mockedStreamProviderResponse = vi.mocked(streamProviderResponse);
+    const { updateSettings } = await import("@/lib/settings");
     const { createConversation, createMessage, listVisibleMessages } = await import("@/lib/conversations");
     const { startAssistantTurnFromExistingUserMessage } = await import("@/lib/chat-turn");
     const { getConversationManager } = await import("@/lib/ws-singleton");
+
+    const { profileId, profile } = setupProviderProfile();
+    updateSettings({
+      defaultProviderProfileId: profileId,
+      skillsEnabled: false,
+      providerProfiles: [profile]
+    });
+
+    mockedStreamProviderResponse.mockReturnValueOnce(
+      (async function* () {
+        yield { type: "answer_delta", text: "Restarted answer" };
+        return {
+          answer: "Restarted answer",
+          thinking: "",
+          usage: { outputTokens: 2 }
+        };
+      })()
+    );
 
     const conversation = createConversation("Restart conversation");
     const existingUser = createMessage({
@@ -373,15 +399,18 @@ describe("chat-turn", () => {
       content: "Edited prompt"
     });
 
-    await startAssistantTurnFromExistingUserMessage(
+    const result = await startAssistantTurnFromExistingUserMessage(
       getConversationManager(),
       conversation.id,
       existingUser.id
     );
 
+    expect(result).toEqual({ status: "completed" });
     const messages = listVisibleMessages(conversation.id);
     expect(messages.filter((message) => message.role === "user")).toHaveLength(1);
     expect(messages[0]?.id).toBe(existingUser.id);
     expect(messages.at(-1)?.role).toBe("assistant");
+    expect(messages.at(-1)?.status).toBe("completed");
+    expect(messages.at(-1)?.content).toBe("Restarted answer");
   });
 });

--- a/tests/unit/chat-view.test.ts
+++ b/tests/unit/chat-view.test.ts
@@ -1031,6 +1031,114 @@ describe("chat view", () => {
     });
   });
 
+  it("restarts the conversation from an edited user message and trims later turns", async () => {
+    vi.mocked(global.fetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ personas: [] })
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          conversation: {
+            ...createPayload().conversation,
+            id: "conv_1"
+          },
+          messages: [
+            createMessage({
+              id: "msg_user",
+              role: "user",
+              content: "Edited prompt"
+            })
+          ]
+        })
+      } as Response);
+
+    renderWithProvider(
+      React.createElement(ChatView, {
+        payload: {
+          ...createPayload(),
+          messages: [
+            createMessage({
+              id: "msg_user",
+              role: "user",
+              content: "Original prompt"
+            }),
+            createMessage({
+              id: "msg_assistant_old",
+              content: "Old answer"
+            })
+          ]
+        }
+      })
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit message" }));
+    fireEvent.change(screen.getByDisplayValue("Original prompt"), {
+      target: { value: "Edited prompt" }
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save edit" }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith("/api/messages/msg_user/edit-restart", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify({ content: "Edited prompt" })
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Edited prompt")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Old answer")).toBeNull();
+  });
+
+  it("keeps the existing transcript visible when edit restart fails", async () => {
+    vi.mocked(global.fetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ personas: [] })
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: false,
+        json: async () => ({ error: "Restart denied" })
+      } as Response);
+
+    renderWithProvider(
+      React.createElement(ChatView, {
+        payload: {
+          ...createPayload(),
+          messages: [
+            createMessage({
+              id: "msg_user",
+              role: "user",
+              content: "Original prompt"
+            }),
+            createMessage({
+              id: "msg_assistant_old",
+              content: "Old answer"
+            })
+          ]
+        }
+      })
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit message" }));
+    fireEvent.change(screen.getByDisplayValue("Original prompt"), {
+      target: { value: "Edited prompt" }
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save edit" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Restart denied")).toBeInTheDocument();
+    });
+
+    expect(screen.getByDisplayValue("Edited prompt")).toBeInTheDocument();
+    expect(screen.getByText("Old answer")).toBeInTheDocument();
+  });
+
   it("shows a local fork error and does not navigate when the fork request fails", async () => {
     vi.mocked(global.fetch)
       .mockResolvedValueOnce({

--- a/tests/unit/conversations.test.ts
+++ b/tests/unit/conversations.test.ts
@@ -20,6 +20,7 @@ import {
   getMessage,
   isVisibleMessage,
   forkConversationFromMessage,
+  rewriteConversationFromEditedUserMessage,
   listConversations,
   listConversationsPage,
   listMessages,
@@ -1143,6 +1144,137 @@ describe("conversation helpers", () => {
     expect(forkAttachment?.extractedText).toBe("source attachment");
     expect(fs.existsSync(forkAttachmentPath)).toBe(true);
     expect(fs.readFileSync(forkAttachmentPath, "utf8")).toBe("source attachment");
+  });
+
+  it("rewrites a user message, deletes later turns, and preserves the edited message attachment", () => {
+    const conversation = createConversation("Rewrite target");
+    createMessage({
+      conversationId: conversation.id,
+      role: "user",
+      content: "Original prompt"
+    });
+    createMessage({
+      conversationId: conversation.id,
+      role: "assistant",
+      content: "First answer"
+    });
+    const editedUser = createMessage({
+      conversationId: conversation.id,
+      role: "user",
+      content: "Need a deployment checklist"
+    });
+    const trailingAssistant = createMessage({
+      conversationId: conversation.id,
+      role: "assistant",
+      content: "Old checklist"
+    });
+
+    const [attachment] = createAttachments(conversation.id, [
+      {
+        filename: "context.txt",
+        mimeType: "text/plain",
+        bytes: Buffer.from("retain this attachment", "utf8")
+      }
+    ]);
+    bindAttachmentsToMessage(conversation.id, editedUser.id, [attachment.id]);
+
+    const rewritten = rewriteConversationFromEditedUserMessage(editedUser.id, {
+      content: "Need a deployment checklist with rollback steps"
+    });
+
+    expect(rewritten.messages.map((message) => message.content)).toEqual([
+      "Original prompt",
+      "First answer",
+      "Need a deployment checklist with rollback steps"
+    ]);
+    expect(rewritten.messages.at(-1)?.attachments?.map((item) => item.filename)).toEqual([
+      "context.txt"
+    ]);
+    expect(
+      rewritten.messages.some((message) => message.id === trailingAssistant.id)
+    ).toBe(false);
+    expect(getConversationSnapshot(conversation.id)?.messages).toHaveLength(3);
+  });
+
+  it("removes compaction artifacts that depend on deleted tail messages", () => {
+    const conversation = createConversation("Compaction cleanup");
+    const firstUser = createMessage({
+      conversationId: conversation.id,
+      role: "user",
+      content: "First request"
+    });
+    const editedUser = createMessage({
+      conversationId: conversation.id,
+      role: "user",
+      content: "Second request"
+    });
+    const tailAssistant = createMessage({
+      conversationId: conversation.id,
+      role: "assistant",
+      content: "Later answer"
+    });
+
+    const db = getDb();
+    db.prepare(
+      `INSERT INTO memory_nodes (
+        id, conversation_id, type, depth, content,
+        source_start_message_id, source_end_message_id,
+        source_token_count, summary_token_count, child_node_ids,
+        superseded_by_node_id, created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      "mem_tail",
+      conversation.id,
+      "leaf_summary",
+      0,
+      "Summary reaching into deleted history",
+      firstUser.id,
+      tailAssistant.id,
+      90,
+      20,
+      "[]",
+      null,
+      new Date().toISOString()
+    );
+
+    db.prepare(
+      `INSERT INTO compaction_events (
+        id, conversation_id, node_id, source_start_message_id,
+        source_end_message_id, notice_message_id, created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      "cmp_tail",
+      conversation.id,
+      "mem_tail",
+      firstUser.id,
+      tailAssistant.id,
+      null,
+      new Date().toISOString()
+    );
+
+    rewriteConversationFromEditedUserMessage(editedUser.id, {
+      content: "Edited second request"
+    });
+
+    expect(
+      db.prepare("SELECT COUNT(*) as count FROM memory_nodes WHERE conversation_id = ?").get(conversation.id)
+    ).toEqual({ count: 0 });
+    expect(
+      db.prepare("SELECT COUNT(*) as count FROM compaction_events WHERE conversation_id = ?").get(conversation.id)
+    ).toEqual({ count: 0 });
+  });
+
+  it("rejects rewriting a non-user message", () => {
+    const conversation = createConversation("Assistant immutable");
+    const assistant = createMessage({
+      conversationId: conversation.id,
+      role: "assistant",
+      content: "Cannot edit me"
+    });
+
+    expect(() =>
+      rewriteConversationFromEditedUserMessage(assistant.id, { content: "changed" })
+    ).toThrow("Only user messages can be edited");
   });
 
   it("rejects forking a missing message", () => {

--- a/tests/unit/conversations.test.ts
+++ b/tests/unit/conversations.test.ts
@@ -1344,6 +1344,27 @@ describe("conversation helpers", () => {
         superseded_by_node_id, created_at
       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     ).run(
+      "mem_merged_parent",
+      conversation.id,
+      "merged_summary",
+      1,
+      "Merged summary that depends on edited child",
+      firstUser.id,
+      firstAssistant.id,
+      50,
+      12,
+      JSON.stringify(["mem_edited"]),
+      null,
+      new Date().toISOString()
+    );
+    db.prepare(
+      `INSERT INTO memory_nodes (
+        id, conversation_id, type, depth, content,
+        source_start_message_id, source_end_message_id,
+        source_token_count, summary_token_count, child_node_ids,
+        superseded_by_node_id, created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(
       "mem_edited",
       conversation.id,
       "leaf_summary",
@@ -1383,6 +1404,20 @@ describe("conversation helpers", () => {
       "mem_edited",
       firstUser.id,
       editedUser.id,
+      null,
+      new Date().toISOString()
+    );
+    db.prepare(
+      `INSERT INTO compaction_events (
+        id, conversation_id, node_id, source_start_message_id,
+        source_end_message_id, notice_message_id, created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      "cmp_merged_parent",
+      conversation.id,
+      "mem_merged_parent",
+      firstUser.id,
+      firstAssistant.id,
       null,
       new Date().toISOString()
     );

--- a/tests/unit/conversations.test.ts
+++ b/tests/unit/conversations.test.ts
@@ -33,6 +33,7 @@ import {
 } from "@/lib/conversations";
 import { getDb } from "@/lib/db";
 import { getSettings, listProviderProfiles, updateSettings } from "@/lib/settings";
+import { estimateMessageTokens } from "@/lib/tokenization";
 import { createLocalUser } from "@/lib/users";
 
 const { generateConversationTitle } = vi.hoisted(() => ({
@@ -1190,6 +1191,9 @@ describe("conversation helpers", () => {
     expect(rewritten.messages.at(-1)?.attachments?.map((item) => item.filename)).toEqual([
       "context.txt"
     ]);
+    expect(rewritten.messages.at(-1)?.estimatedTokens).toBe(
+      estimateMessageTokens(rewritten.messages.at(-1)!)
+    );
     expect(
       rewritten.messages.some((message) => message.id === trailingAssistant.id)
     ).toBe(false);

--- a/tests/unit/conversations.test.ts
+++ b/tests/unit/conversations.test.ts
@@ -1249,7 +1249,7 @@ describe("conversation helpers", () => {
     const prepareSpy = vi.spyOn(db, "prepare");
 
     prepareSpy.mockImplementation(((sql: string) => {
-      if (sql === "UPDATE conversations SET is_active = ?, updated_at = ? WHERE id = ?") {
+      if (sql.includes("UPDATE conversations SET is_active =")) {
         throw new Error("force rollback");
       }
 
@@ -1406,6 +1406,80 @@ describe("conversation helpers", () => {
     expect(
       db.prepare("SELECT COUNT(*) as count FROM compaction_events WHERE conversation_id = ?").get(conversation.id)
     ).toEqual({ count: 0 });
+  });
+
+  it("restores compacted retained messages when rewrite invalidates their summaries", () => {
+    const conversation = createConversation("Compacted rewrite");
+    const firstUser = createMessage({
+      conversationId: conversation.id,
+      role: "user",
+      content: "First request"
+    });
+    const firstAssistant = createMessage({
+      conversationId: conversation.id,
+      role: "assistant",
+      content: "First answer"
+    });
+    const editedUser = createMessage({
+      conversationId: conversation.id,
+      role: "user",
+      content: "Second request"
+    });
+    createMessage({
+      conversationId: conversation.id,
+      role: "assistant",
+      content: "Later answer"
+    });
+
+    markMessagesCompacted([firstUser.id, firstAssistant.id, editedUser.id]);
+
+    const db = getDb();
+    db.prepare(
+      `INSERT INTO memory_nodes (
+        id, conversation_id, type, depth, content,
+        source_start_message_id, source_end_message_id,
+        source_token_count, summary_token_count, child_node_ids,
+        superseded_by_node_id, created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      "mem_compacted",
+      conversation.id,
+      "leaf_summary",
+      0,
+      "Summary covering retained messages",
+      firstUser.id,
+      editedUser.id,
+      75,
+      20,
+      "[]",
+      null,
+      new Date().toISOString()
+    );
+    db.prepare(
+      `INSERT INTO compaction_events (
+        id, conversation_id, node_id, source_start_message_id,
+        source_end_message_id, notice_message_id, created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      "cmp_compacted",
+      conversation.id,
+      "mem_compacted",
+      firstUser.id,
+      editedUser.id,
+      null,
+      new Date().toISOString()
+    );
+
+    rewriteConversationFromEditedUserMessage(editedUser.id, {
+      content: "Edited second request"
+    });
+
+    expect(getMessage(editedUser.id)?.compactedAt).toBeNull();
+    expect(listMessages(conversation.id).map((message) => message.compactedAt)).toEqual([
+      null,
+      null,
+      null
+    ]);
   });
 
   it("rejects rewriting a non-user message", () => {

--- a/tests/unit/conversations.test.ts
+++ b/tests/unit/conversations.test.ts
@@ -21,6 +21,7 @@ import {
   isVisibleMessage,
   forkConversationFromMessage,
   rewriteConversationFromEditedUserMessage,
+  setConversationActive,
   listConversations,
   listConversationsPage,
   listMessages,
@@ -1169,6 +1170,13 @@ describe("conversation helpers", () => {
       role: "assistant",
       content: "Old checklist"
     });
+    const [tailAttachment] = createAttachments(conversation.id, [
+      {
+        filename: "old-checklist.txt",
+        mimeType: "text/plain",
+        bytes: Buffer.from("delete this attachment file", "utf8")
+      }
+    ]);
 
     const [attachment] = createAttachments(conversation.id, [
       {
@@ -1178,6 +1186,14 @@ describe("conversation helpers", () => {
       }
     ]);
     bindAttachmentsToMessage(conversation.id, editedUser.id, [attachment.id]);
+    bindAttachmentsToMessage(conversation.id, trailingAssistant.id, [tailAttachment.id]);
+    setConversationActive(conversation.id, true);
+
+    const tailAttachmentPath = path.resolve(
+      process.env.EIDON_DATA_DIR!,
+      "attachments",
+      tailAttachment.relativePath
+    );
 
     const rewritten = rewriteConversationFromEditedUserMessage(editedUser.id, {
       content: "Need a deployment checklist with rollback steps"
@@ -1194,9 +1210,11 @@ describe("conversation helpers", () => {
     expect(rewritten.messages.at(-1)?.estimatedTokens).toBe(
       estimateMessageTokens(rewritten.messages.at(-1)!)
     );
+    expect(rewritten.conversation.isActive).toBe(false);
     expect(
       rewritten.messages.some((message) => message.id === trailingAssistant.id)
     ).toBe(false);
+    expect(fs.existsSync(tailAttachmentPath)).toBe(false);
     expect(getConversationSnapshot(conversation.id)?.messages).toHaveLength(3);
   });
 
@@ -1240,6 +1258,27 @@ describe("conversation helpers", () => {
       null,
       new Date().toISOString()
     );
+    db.prepare(
+      `INSERT INTO memory_nodes (
+        id, conversation_id, type, depth, content,
+        source_start_message_id, source_end_message_id,
+        source_token_count, summary_token_count, child_node_ids,
+        superseded_by_node_id, created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      "mem_edited",
+      conversation.id,
+      "leaf_summary",
+      0,
+      "Summary ending on edited message",
+      firstUser.id,
+      editedUser.id,
+      60,
+      15,
+      "[]",
+      null,
+      new Date().toISOString()
+    );
 
     db.prepare(
       `INSERT INTO compaction_events (
@@ -1252,6 +1291,20 @@ describe("conversation helpers", () => {
       "mem_tail",
       firstUser.id,
       tailAssistant.id,
+      null,
+      new Date().toISOString()
+    );
+    db.prepare(
+      `INSERT INTO compaction_events (
+        id, conversation_id, node_id, source_start_message_id,
+        source_end_message_id, notice_message_id, created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      "cmp_edited",
+      conversation.id,
+      "mem_edited",
+      firstUser.id,
+      editedUser.id,
       null,
       new Date().toISOString()
     );

--- a/tests/unit/conversations.test.ts
+++ b/tests/unit/conversations.test.ts
@@ -1218,12 +1218,69 @@ describe("conversation helpers", () => {
     expect(getConversationSnapshot(conversation.id)?.messages).toHaveLength(3);
   });
 
+  it("keeps tail attachment files and rows when rewrite rolls back", () => {
+    const conversation = createConversation("Rewrite rollback");
+    const editedUser = createMessage({
+      conversationId: conversation.id,
+      role: "user",
+      content: "Original prompt"
+    });
+    const trailingAssistant = createMessage({
+      conversationId: conversation.id,
+      role: "assistant",
+      content: "Tail answer"
+    });
+    const [tailAttachment] = createAttachments(conversation.id, [
+      {
+        filename: "tail.txt",
+        mimeType: "text/plain",
+        bytes: Buffer.from("rollback-safe file", "utf8")
+      }
+    ]);
+    bindAttachmentsToMessage(conversation.id, trailingAssistant.id, [tailAttachment.id]);
+
+    const tailAttachmentPath = path.resolve(
+      process.env.EIDON_DATA_DIR!,
+      "attachments",
+      tailAttachment.relativePath
+    );
+    const db = getDb();
+    const originalPrepare = db.prepare.bind(db);
+    const prepareSpy = vi.spyOn(db, "prepare");
+
+    prepareSpy.mockImplementation(((sql: string) => {
+      if (sql === "UPDATE conversations SET is_active = ?, updated_at = ? WHERE id = ?") {
+        throw new Error("force rollback");
+      }
+
+      return originalPrepare(sql);
+    }) as typeof db.prepare);
+
+    expect(() =>
+      rewriteConversationFromEditedUserMessage(editedUser.id, { content: "Edited prompt" })
+    ).toThrow("force rollback");
+
+    prepareSpy.mockRestore();
+
+    expect(fs.existsSync(tailAttachmentPath)).toBe(true);
+    expect(getMessage(editedUser.id)?.content).toBe("Original prompt");
+    expect(getMessage(trailingAssistant.id)).not.toBeNull();
+    expect(
+      db.prepare("SELECT COUNT(*) as count FROM message_attachments WHERE id = ?").get(tailAttachment.id)
+    ).toEqual({ count: 1 });
+  });
+
   it("removes compaction artifacts that depend on deleted tail messages", () => {
     const conversation = createConversation("Compaction cleanup");
     const firstUser = createMessage({
       conversationId: conversation.id,
       role: "user",
       content: "First request"
+    });
+    const firstAssistant = createMessage({
+      conversationId: conversation.id,
+      role: "assistant",
+      content: "First answer"
     });
     const editedUser = createMessage({
       conversationId: conversation.id,
@@ -1256,6 +1313,27 @@ describe("conversation helpers", () => {
       20,
       "[]",
       null,
+      new Date().toISOString()
+    );
+    db.prepare(
+      `INSERT INTO memory_nodes (
+        id, conversation_id, type, depth, content,
+        source_start_message_id, source_end_message_id,
+        source_token_count, summary_token_count, child_node_ids,
+        superseded_by_node_id, created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      "mem_retained",
+      conversation.id,
+      "leaf_summary",
+      0,
+      "Retained summary",
+      firstUser.id,
+      firstAssistant.id,
+      40,
+      10,
+      "[]",
+      "mem_edited",
       new Date().toISOString()
     );
     db.prepare(
@@ -1314,8 +1392,17 @@ describe("conversation helpers", () => {
     });
 
     expect(
-      db.prepare("SELECT COUNT(*) as count FROM memory_nodes WHERE conversation_id = ?").get(conversation.id)
-    ).toEqual({ count: 0 });
+      db
+        .prepare(
+          "SELECT id, superseded_by_node_id FROM memory_nodes WHERE conversation_id = ? ORDER BY id ASC"
+        )
+        .all(conversation.id)
+    ).toEqual([
+      {
+        id: "mem_retained",
+        superseded_by_node_id: null
+      }
+    ]);
     expect(
       db.prepare("SELECT COUNT(*) as count FROM compaction_events WHERE conversation_id = ?").get(conversation.id)
     ).toEqual({ count: 0 });

--- a/tests/unit/message-bubble.test.tsx
+++ b/tests/unit/message-bubble.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import React from "react";
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 
 import { MessageBubble } from "@/components/message-bubble";
 import type { Message } from "@/lib/types";
@@ -22,6 +22,22 @@ function createAssistantMessage(): Message {
   };
 }
 
+function createUserMessage(): Message {
+  return {
+    id: "msg_user",
+    conversationId: "conv_test",
+    role: "user",
+    content: "Edit me",
+    thinkingContent: "",
+    status: "completed",
+    estimatedTokens: 0,
+    systemKind: null,
+    compactedAt: null,
+    createdAt: new Date().toISOString(),
+    actions: []
+  };
+}
+
 describe("message bubble avatar", () => {
   it("renders the assistant avatar from agent-icon.png", () => {
     const { container } = render(
@@ -32,5 +48,23 @@ describe("message bubble avatar", () => {
 
     expect(container.querySelector('img[src="/agent-icon.png"]')).not.toBeNull();
     expect(container.querySelector('img[src="/chat-icon.png"]')).toBeNull();
+  });
+
+  it("shows the edit action for user messages only", () => {
+    const { rerender } = render(
+      React.createElement(MessageBubble, {
+        message: createUserMessage()
+      })
+    );
+
+    expect(screen.getByRole("button", { name: "Edit message" })).toBeInTheDocument();
+
+    rerender(
+      React.createElement(MessageBubble, {
+        message: createAssistantMessage()
+      })
+    );
+
+    expect(screen.queryByRole("button", { name: "Edit message" })).toBeNull();
   });
 });

--- a/tests/unit/message-edit-restart-route.test.ts
+++ b/tests/unit/message-edit-restart-route.test.ts
@@ -209,7 +209,7 @@ describe("message edit restart route", () => {
     expect(startAssistantTurnFromExistingUserMessageMock).not.toHaveBeenCalled();
   });
 
-  it("returns an error when assistant restart fails after rewrite", async () => {
+  it("returns the rewritten snapshot without waiting for assistant completion", async () => {
     const user = await createLocalUser({
       username: "edit-route-restart-fail",
       password: "Password123!",
@@ -238,8 +238,41 @@ describe("message edit restart route", () => {
       { params: Promise.resolve({ messageId: message.id }) }
     );
 
-    expect(response.status).toBe(500);
-    await expect(response.json()).resolves.toEqual({ error: "Chat stream failed" });
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({
+        conversation: expect.objectContaining({ id: conversation.id }),
+        messages: [
+          expect.objectContaining({
+            id: message.id,
+            role: "user",
+            content: "New content"
+          })
+        ]
+      })
+    );
     expect(getMessage(message.id)?.content).toBe("New content");
+  });
+
+  it("returns 404 when the message does not exist", async () => {
+    const user = await createLocalUser({
+      username: "edit-route-missing-message",
+      password: "Password123!",
+      role: "user"
+    });
+    requireUserMock.mockResolvedValue(user);
+
+    const { POST } = await import("@/app/api/messages/[messageId]/edit-restart/route");
+    const response = await POST(
+      new Request("http://localhost/api/messages/missing/edit-restart", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ content: "New content" })
+      }),
+      { params: Promise.resolve({ messageId: "missing" }) }
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({ error: "Message not found" });
   });
 });

--- a/tests/unit/message-edit-restart-route.test.ts
+++ b/tests/unit/message-edit-restart-route.test.ts
@@ -15,6 +15,13 @@ const { getAssistantTurnStartPreflightMock } = vi.hoisted(() => ({
   getAssistantTurnStartPreflightMock: vi.fn()
 }));
 
+const claimTurnControl = { id: "claim-control" };
+
+const { claimChatTurnStartMock, releaseChatTurnStartMock } = vi.hoisted(() => ({
+  claimChatTurnStartMock: vi.fn(),
+  releaseChatTurnStartMock: vi.fn()
+}));
+
 vi.mock("@/lib/auth", () => ({
   requireUser: requireUserMock
 }));
@@ -22,6 +29,11 @@ vi.mock("@/lib/auth", () => ({
 vi.mock("@/lib/chat-turn", () => ({
   startAssistantTurnFromExistingUserMessage: startAssistantTurnFromExistingUserMessageMock,
   getAssistantTurnStartPreflight: getAssistantTurnStartPreflightMock
+}));
+
+vi.mock("@/lib/chat-turn-control", () => ({
+  claimChatTurnStart: claimChatTurnStartMock,
+  releaseChatTurnStart: releaseChatTurnStartMock
 }));
 
 describe("message edit restart route", () => {
@@ -34,6 +46,12 @@ describe("message edit restart route", () => {
       ok: true,
       context: {}
     });
+    claimChatTurnStartMock.mockReset();
+    claimChatTurnStartMock.mockReturnValue({
+      ok: true,
+      control: claimTurnControl
+    });
+    releaseChatTurnStartMock.mockReset();
   });
 
   it("rewrites the message and starts a new assistant turn", async () => {
@@ -78,7 +96,14 @@ describe("message edit restart route", () => {
       expect.anything(),
       conversation.id,
       message.id,
-      undefined
+      undefined,
+      {
+        control: claimTurnControl,
+        preflight: {
+          ok: true,
+          context: {}
+        }
+      }
     );
   });
 
@@ -207,6 +232,7 @@ describe("message edit restart route", () => {
     await expect(response.json()).resolves.toEqual({ error: "No provider profile configured" });
     expect(getMessage(message.id)?.content).toBe("Old content");
     expect(startAssistantTurnFromExistingUserMessageMock).not.toHaveBeenCalled();
+    expect(claimChatTurnStartMock).not.toHaveBeenCalled();
   });
 
   it("returns the rewritten snapshot without waiting for assistant completion", async () => {
@@ -216,10 +242,9 @@ describe("message edit restart route", () => {
       role: "user"
     });
     requireUserMock.mockResolvedValue(user);
-    startAssistantTurnFromExistingUserMessageMock.mockResolvedValue({
-      status: "failed",
-      errorMessage: "Chat stream failed"
-    });
+    startAssistantTurnFromExistingUserMessageMock.mockRejectedValue(
+      new Error("Chat stream failed")
+    );
 
     const conversation = createConversation("Restart failure", null, {}, user.id);
     const message = createMessage({
@@ -252,6 +277,8 @@ describe("message edit restart route", () => {
       })
     );
     expect(getMessage(message.id)?.content).toBe("New content");
+    await Promise.resolve();
+    expect(releaseChatTurnStartMock).toHaveBeenCalledWith(conversation.id, claimTurnControl);
   });
 
   it("returns 404 when the message does not exist", async () => {
@@ -274,5 +301,41 @@ describe("message edit restart route", () => {
 
     expect(response.status).toBe(404);
     await expect(response.json()).resolves.toEqual({ error: "Message not found" });
+  });
+
+  it("returns 409 when the conversation is already claimed for another turn", async () => {
+    const user = await createLocalUser({
+      username: "edit-route-claimed",
+      password: "Password123!",
+      role: "user"
+    });
+    requireUserMock.mockResolvedValue(user);
+    claimChatTurnStartMock.mockReturnValue({
+      ok: false
+    });
+
+    const conversation = createConversation("Claimed conversation", null, {}, user.id);
+    const message = createMessage({
+      conversationId: conversation.id,
+      role: "user",
+      content: "Old content"
+    });
+
+    const { POST } = await import("@/app/api/messages/[messageId]/edit-restart/route");
+    const response = await POST(
+      new Request(`http://localhost/api/messages/${message.id}/edit-restart`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ content: "New content" })
+      }),
+      { params: Promise.resolve({ messageId: message.id }) }
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      error: "Wait for the current assistant response to finish before editing this conversation"
+    });
+    expect(getMessage(message.id)?.content).toBe("Old content");
+    expect(startAssistantTurnFromExistingUserMessageMock).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/message-edit-restart-route.test.ts
+++ b/tests/unit/message-edit-restart-route.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { createConversation, createMessage, setConversationActive } from "@/lib/conversations";
+import { createConversation, createMessage, getMessage, setConversationActive } from "@/lib/conversations";
 import { createLocalUser } from "@/lib/users";
 
 const { requireUserMock } = vi.hoisted(() => ({
@@ -11,12 +11,17 @@ const { startAssistantTurnFromExistingUserMessageMock } = vi.hoisted(() => ({
   startAssistantTurnFromExistingUserMessageMock: vi.fn()
 }));
 
+const { getAssistantTurnStartPreflightMock } = vi.hoisted(() => ({
+  getAssistantTurnStartPreflightMock: vi.fn()
+}));
+
 vi.mock("@/lib/auth", () => ({
   requireUser: requireUserMock
 }));
 
 vi.mock("@/lib/chat-turn", () => ({
-  startAssistantTurnFromExistingUserMessage: startAssistantTurnFromExistingUserMessageMock
+  startAssistantTurnFromExistingUserMessage: startAssistantTurnFromExistingUserMessageMock,
+  getAssistantTurnStartPreflight: getAssistantTurnStartPreflightMock
 }));
 
 describe("message edit restart route", () => {
@@ -24,6 +29,11 @@ describe("message edit restart route", () => {
     requireUserMock.mockReset();
     startAssistantTurnFromExistingUserMessageMock.mockReset();
     startAssistantTurnFromExistingUserMessageMock.mockResolvedValue({ status: "completed" });
+    getAssistantTurnStartPreflightMock.mockReset();
+    getAssistantTurnStartPreflightMock.mockReturnValue({
+      ok: true,
+      context: {}
+    });
   });
 
   it("rewrites the message and starts a new assistant turn", async () => {
@@ -52,6 +62,18 @@ describe("message edit restart route", () => {
     );
 
     expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({
+        conversation: expect.objectContaining({ id: conversation.id }),
+        messages: [
+          expect.objectContaining({
+            id: message.id,
+            role: "user",
+            content: "New content"
+          })
+        ]
+      })
+    );
     expect(startAssistantTurnFromExistingUserMessageMock).toHaveBeenCalledWith(
       expect.anything(),
       conversation.id,
@@ -119,5 +141,105 @@ describe("message edit restart route", () => {
     await expect(response.json()).resolves.toEqual({
       error: "Wait for the current assistant response to finish before editing this conversation"
     });
+  });
+
+  it("returns 400 for malformed json bodies", async () => {
+    const user = await createLocalUser({
+      username: "edit-route-bad-json",
+      password: "Password123!",
+      role: "user"
+    });
+    requireUserMock.mockResolvedValue(user);
+
+    const conversation = createConversation("Malformed body", null, {}, user.id);
+    const message = createMessage({
+      conversationId: conversation.id,
+      role: "user",
+      content: "Original"
+    });
+
+    const { POST } = await import("@/app/api/messages/[messageId]/edit-restart/route");
+    const response = await POST(
+      new Request(`http://localhost/api/messages/${message.id}/edit-restart`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{"
+      }),
+      { params: Promise.resolve({ messageId: message.id }) }
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Invalid message update" });
+  });
+
+  it("does not rewrite when assistant-start preflight fails", async () => {
+    const user = await createLocalUser({
+      username: "edit-route-preflight-fail",
+      password: "Password123!",
+      role: "user"
+    });
+    requireUserMock.mockResolvedValue(user);
+    getAssistantTurnStartPreflightMock.mockReturnValue({
+      ok: false,
+      status: "failed",
+      statusCode: 400,
+      errorMessage: "No provider profile configured"
+    });
+
+    const conversation = createConversation("Preflight failure", null, {}, user.id);
+    const message = createMessage({
+      conversationId: conversation.id,
+      role: "user",
+      content: "Old content"
+    });
+
+    const { POST } = await import("@/app/api/messages/[messageId]/edit-restart/route");
+    const response = await POST(
+      new Request(`http://localhost/api/messages/${message.id}/edit-restart`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ content: "New content" })
+      }),
+      { params: Promise.resolve({ messageId: message.id }) }
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "No provider profile configured" });
+    expect(getMessage(message.id)?.content).toBe("Old content");
+    expect(startAssistantTurnFromExistingUserMessageMock).not.toHaveBeenCalled();
+  });
+
+  it("returns an error when assistant restart fails after rewrite", async () => {
+    const user = await createLocalUser({
+      username: "edit-route-restart-fail",
+      password: "Password123!",
+      role: "user"
+    });
+    requireUserMock.mockResolvedValue(user);
+    startAssistantTurnFromExistingUserMessageMock.mockResolvedValue({
+      status: "failed",
+      errorMessage: "Chat stream failed"
+    });
+
+    const conversation = createConversation("Restart failure", null, {}, user.id);
+    const message = createMessage({
+      conversationId: conversation.id,
+      role: "user",
+      content: "Old content"
+    });
+
+    const { POST } = await import("@/app/api/messages/[messageId]/edit-restart/route");
+    const response = await POST(
+      new Request(`http://localhost/api/messages/${message.id}/edit-restart`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ content: "New content" })
+      }),
+      { params: Promise.resolve({ messageId: message.id }) }
+    );
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({ error: "Chat stream failed" });
+    expect(getMessage(message.id)?.content).toBe("New content");
   });
 });

--- a/tests/unit/message-edit-restart-route.test.ts
+++ b/tests/unit/message-edit-restart-route.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createConversation, createMessage, setConversationActive } from "@/lib/conversations";
+import { createLocalUser } from "@/lib/users";
+
+const { requireUserMock } = vi.hoisted(() => ({
+  requireUserMock: vi.fn()
+}));
+
+const { startAssistantTurnFromExistingUserMessageMock } = vi.hoisted(() => ({
+  startAssistantTurnFromExistingUserMessageMock: vi.fn()
+}));
+
+vi.mock("@/lib/auth", () => ({
+  requireUser: requireUserMock
+}));
+
+vi.mock("@/lib/chat-turn", () => ({
+  startAssistantTurnFromExistingUserMessage: startAssistantTurnFromExistingUserMessageMock
+}));
+
+describe("message edit restart route", () => {
+  beforeEach(() => {
+    requireUserMock.mockReset();
+    startAssistantTurnFromExistingUserMessageMock.mockReset();
+    startAssistantTurnFromExistingUserMessageMock.mockResolvedValue({ status: "completed" });
+  });
+
+  it("rewrites the message and starts a new assistant turn", async () => {
+    const user = await createLocalUser({
+      username: "edit-route-user",
+      password: "Password123!",
+      role: "user"
+    });
+    requireUserMock.mockResolvedValue(user);
+
+    const conversation = createConversation("Restart me", null, {}, user.id);
+    const message = createMessage({
+      conversationId: conversation.id,
+      role: "user",
+      content: "Old content"
+    });
+
+    const { POST } = await import("@/app/api/messages/[messageId]/edit-restart/route");
+    const response = await POST(
+      new Request(`http://localhost/api/messages/${message.id}/edit-restart`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ content: "New content" })
+      }),
+      { params: Promise.resolve({ messageId: message.id }) }
+    );
+
+    expect(response.status).toBe(200);
+    expect(startAssistantTurnFromExistingUserMessageMock).toHaveBeenCalledWith(
+      expect.anything(),
+      conversation.id,
+      message.id,
+      undefined
+    );
+  });
+
+  it("rejects assistant messages", async () => {
+    const user = await createLocalUser({
+      username: "edit-route-assistant",
+      password: "Password123!",
+      role: "user"
+    });
+    requireUserMock.mockResolvedValue(user);
+
+    const conversation = createConversation("No assistant edits", null, {}, user.id);
+    const assistant = createMessage({
+      conversationId: conversation.id,
+      role: "assistant",
+      content: "Immutable"
+    });
+
+    const { POST } = await import("@/app/api/messages/[messageId]/edit-restart/route");
+    const response = await POST(
+      new Request(`http://localhost/api/messages/${assistant.id}/edit-restart`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ content: "Changed" })
+      }),
+      { params: Promise.resolve({ messageId: assistant.id }) }
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Only user messages can be edited" });
+  });
+
+  it("rejects active conversations with 409", async () => {
+    const user = await createLocalUser({
+      username: "edit-route-active",
+      password: "Password123!",
+      role: "user"
+    });
+    requireUserMock.mockResolvedValue(user);
+
+    const conversation = createConversation("Busy conversation", null, {}, user.id);
+    const message = createMessage({
+      conversationId: conversation.id,
+      role: "user",
+      content: "Retry this"
+    });
+    setConversationActive(conversation.id, true);
+
+    const { POST } = await import("@/app/api/messages/[messageId]/edit-restart/route");
+    const response = await POST(
+      new Request(`http://localhost/api/messages/${message.id}/edit-restart`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ content: "Retry this with edits" })
+      }),
+      { params: Promise.resolve({ messageId: message.id }) }
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      error: "Wait for the current assistant response to finish before editing this conversation"
+    });
+  });
+});


### PR DESCRIPTION
Adds a server-side `edit-restart` flow for user messages that rewrites the conversation tail, invalidates dependent compaction artifacts, and restarts assistant generation from the edited prompt.

Updates chat UI state management so edited messages preserve attachments, trim later turns, serialize restart starts, and keep assistant messages immutable while failures leave the inline editor open.

Expands regression coverage across conversation rewrite, turn control, restart route, chat view, and user-only edit affordances, and includes the approved spec and implementation plan docs.

Verified with `npm test` (612 passed, 89.45% coverage), `npm run typecheck`, local browser validation, plus prior `npm run build` and `npm run lint`.