### PR TITLE
Add in-app attachment previews and fix chat duplication

### DIFF
--- a/app/api/attachments/[attachmentId]/route.ts
+++ b/app/api/attachments/[attachmentId]/route.ts
@@ -1,7 +1,6 @@
 import { z } from "zod";
 
 import {
-  AttachmentTextPreviewMissingFileError,
   AttachmentTextPreviewUnsupportedError,
   deleteAttachmentById,
   getAttachment,
@@ -50,10 +49,6 @@ export async function GET(
     } catch (error) {
       if (error instanceof AttachmentTextPreviewUnsupportedError) {
         return badRequest("Attachment cannot be previewed as text", 415);
-      }
-
-      if (error instanceof AttachmentTextPreviewMissingFileError) {
-        return badRequest("Attachment file not found", 404);
       }
 
       return badRequest("Internal server error", 500);

--- a/app/api/attachments/[attachmentId]/route.ts
+++ b/app/api/attachments/[attachmentId]/route.ts
@@ -1,6 +1,12 @@
 import { z } from "zod";
 
-import { deleteAttachmentById, getAttachment, readAttachmentBuffer } from "@/lib/attachments";
+import {
+  deleteAttachmentById,
+  getAttachment,
+  isInlineTextPreviewableAttachment,
+  readAttachmentBuffer,
+  readAttachmentText
+} from "@/lib/attachments";
 import { requireUser } from "@/lib/auth";
 import { badRequest } from "@/lib/http";
 
@@ -9,7 +15,7 @@ const paramsSchema = z.object({
 });
 
 export async function GET(
-  _request: Request,
+  request: Request,
   context: { params: Promise<{ attachmentId: string }> }
 ) {
   const user = await requireUser(false);
@@ -30,7 +36,22 @@ export async function GET(
     return badRequest("Attachment not found", 404);
   }
 
+  const format = new URL(request.url).searchParams.get("format");
+
   try {
+    if (format === "text") {
+      if (!isInlineTextPreviewableAttachment(attachment)) {
+        return badRequest("Attachment cannot be previewed as text", 415);
+      }
+
+      return Response.json({
+        id: attachment.id,
+        filename: attachment.filename,
+        mimeType: attachment.mimeType,
+        content: readAttachmentText(attachment)
+      });
+    }
+
     const buffer = readAttachmentBuffer(attachment);
 
     return new Response(buffer, {

--- a/app/api/attachments/[attachmentId]/route.ts
+++ b/app/api/attachments/[attachmentId]/route.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import {
+  AttachmentTextPreviewUnsupportedError,
   deleteAttachmentById,
   getAttachment,
   readAttachmentBuffer,
@@ -46,9 +47,11 @@ export async function GET(
         content: readAttachmentText(attachment)
       });
     } catch (error) {
-      if (error instanceof Error && error.message === "Attachment cannot be previewed as text") {
+      if (error instanceof AttachmentTextPreviewUnsupportedError) {
         return badRequest("Attachment cannot be previewed as text", 415);
       }
+
+      return badRequest("Attachment file not found", 404);
     }
   }
 

--- a/app/api/attachments/[attachmentId]/route.ts
+++ b/app/api/attachments/[attachmentId]/route.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import {
+  AttachmentTextPreviewMissingFileError,
   AttachmentTextPreviewUnsupportedError,
   deleteAttachmentById,
   getAttachment,
@@ -51,7 +52,11 @@ export async function GET(
         return badRequest("Attachment cannot be previewed as text", 415);
       }
 
-      return badRequest("Attachment file not found", 404);
+      if (error instanceof AttachmentTextPreviewMissingFileError) {
+        return badRequest("Attachment file not found", 404);
+      }
+
+      return badRequest("Internal server error", 500);
     }
   }
 

--- a/app/api/attachments/[attachmentId]/route.ts
+++ b/app/api/attachments/[attachmentId]/route.ts
@@ -3,7 +3,6 @@ import { z } from "zod";
 import {
   deleteAttachmentById,
   getAttachment,
-  isInlineTextPreviewableAttachment,
   readAttachmentBuffer,
   readAttachmentText
 } from "@/lib/attachments";
@@ -38,20 +37,22 @@ export async function GET(
 
   const format = new URL(request.url).searchParams.get("format");
 
-  try {
-    if (format === "text") {
-      if (!isInlineTextPreviewableAttachment(attachment)) {
-        return badRequest("Attachment cannot be previewed as text", 415);
-      }
-
+  if (format === "text") {
+    try {
       return Response.json({
         id: attachment.id,
         filename: attachment.filename,
         mimeType: attachment.mimeType,
         content: readAttachmentText(attachment)
       });
+    } catch (error) {
+      if (error instanceof Error && error.message === "Attachment cannot be previewed as text") {
+        return badRequest("Attachment cannot be previewed as text", 415);
+      }
     }
+  }
 
+  try {
     const buffer = readAttachmentBuffer(attachment);
 
     return new Response(buffer, {

--- a/components/attachment-preview-modal.tsx
+++ b/components/attachment-preview-modal.tsx
@@ -5,7 +5,7 @@ import { Download, FileText, X } from "lucide-react";
 
 import type { MessageAttachment } from "@/lib/types";
 
-type AttachmentPreviewState =
+export type AttachmentPreviewState =
   | { kind: "loading" }
   | { kind: "image" }
   | { kind: "text"; content: string }

--- a/components/attachment-preview-modal.tsx
+++ b/components/attachment-preview-modal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { Download, FileText, X } from "lucide-react";
 
 import type { MessageAttachment } from "@/lib/types";
@@ -42,85 +42,110 @@ export function useAttachmentPreviewController() {
     );
   }
 
-  async function openAttachmentPreview(attachment: MessageAttachment) {
-    const requestToken = previewRequestTokenRef.current + 1;
-    previewRequestTokenRef.current = requestToken;
-    previewAttachmentIdRef.current = attachment.id;
-    setPreviewAttachment(attachment);
-    setPreviewState({ kind: "loading" });
+  const closeAttachmentPreview = useCallback(() => {
+    previewRequestTokenRef.current += 1;
+    previewAttachmentIdRef.current = null;
+    setPreviewAttachment(null);
+    setPreviewState({ kind: "unsupported" });
+  }, []);
 
-    if (attachment.kind === "image") {
-      const image = new Image();
-      image.onload = () => {
+  const openAttachmentPreview = useCallback(
+    async (attachment: MessageAttachment) => {
+      const requestToken = previewRequestTokenRef.current + 1;
+      const seededText =
+        attachment.kind === "text" && attachment.extractedText.length > 0
+          ? attachment.extractedText
+          : null;
+
+      previewRequestTokenRef.current = requestToken;
+      previewAttachmentIdRef.current = attachment.id;
+      setPreviewAttachment(attachment);
+      setPreviewState(
+        seededText !== null
+          ? { kind: "text", content: seededText }
+          : { kind: "loading" }
+      );
+
+      if (attachment.kind === "image") {
+        const image = new Image();
+        image.onload = () => {
+          if (!isCurrentPreviewRequest(requestToken, attachment.id)) {
+            return;
+          }
+
+          setPreviewState({ kind: "image" });
+        };
+        image.onerror = () => {
+          if (!isCurrentPreviewRequest(requestToken, attachment.id)) {
+            return;
+          }
+
+          setPreviewState({
+            kind: "error",
+            message: "Unable to load attachment preview."
+          });
+        };
+        image.src = `/api/attachments/${attachment.id}`;
+        return;
+      }
+
+      if (Object.hasOwn(textPreviewCache, attachment.id)) {
+        const cached = textPreviewCache[attachment.id];
         if (!isCurrentPreviewRequest(requestToken, attachment.id)) {
           return;
         }
 
-        setPreviewState({ kind: "image" });
-      };
-      image.onerror = () => {
+        setPreviewState({ kind: "text", content: cached });
+        return;
+      }
+
+      try {
+        const response = await fetch(`/api/attachments/${attachment.id}?format=text`);
         if (!isCurrentPreviewRequest(requestToken, attachment.id)) {
+          return;
+        }
+
+        if (!response.ok) {
+          if (response.status === 415) {
+            if (seededText !== null) {
+              return;
+            }
+
+            setPreviewState({ kind: "unsupported" });
+            return;
+          }
+
+          if (seededText !== null) {
+            return;
+          }
+
+          throw new Error("Unable to load attachment preview.");
+        }
+
+        const payload = await response.json();
+        if (!isCurrentPreviewRequest(requestToken, attachment.id)) {
+          return;
+        }
+
+        setTextPreviewCache((current) => ({ ...current, [attachment.id]: payload.content }));
+        setPreviewState({ kind: "text", content: payload.content });
+      } catch (error) {
+        if (!isCurrentPreviewRequest(requestToken, attachment.id)) {
+          return;
+        }
+
+        if (seededText !== null) {
           return;
         }
 
         setPreviewState({
           kind: "error",
-          message: "Unable to load attachment preview."
+          message: error instanceof Error ? error.message : "Unable to load attachment preview."
         });
-      };
-      image.src = `/api/attachments/${attachment.id}`;
-      return;
-    }
-
-    if (Object.hasOwn(textPreviewCache, attachment.id)) {
-      const cached = textPreviewCache[attachment.id];
-      if (!isCurrentPreviewRequest(requestToken, attachment.id)) {
-        return;
       }
-
-      setPreviewState({ kind: "text", content: cached });
-      return;
-    }
-
-    try {
-      const response = await fetch(`/api/attachments/${attachment.id}?format=text`);
-      if (!isCurrentPreviewRequest(requestToken, attachment.id)) {
-        return;
-      }
-
-      if (!response.ok) {
-        if (response.status === 415) {
-          setPreviewState({ kind: "unsupported" });
-          return;
-        }
-        throw new Error("Unable to load attachment preview.");
-      }
-
-      const payload = await response.json();
-      if (!isCurrentPreviewRequest(requestToken, attachment.id)) {
-        return;
-      }
-
-      setTextPreviewCache((current) => ({ ...current, [attachment.id]: payload.content }));
-      setPreviewState({ kind: "text", content: payload.content });
-    } catch (error) {
-      if (!isCurrentPreviewRequest(requestToken, attachment.id)) {
-        return;
-      }
-
-      setPreviewState({
-        kind: "error",
-        message: error instanceof Error ? error.message : "Unable to load attachment preview."
-      });
-    }
-  }
-
-  function closeAttachmentPreview() {
-    previewRequestTokenRef.current += 1;
-    previewAttachmentIdRef.current = null;
-    setPreviewAttachment(null);
-    setPreviewState({ kind: "unsupported" });
-  }
+    },
+    [textPreviewCache]
+  );
 
   return {
     previewAttachment,

--- a/components/attachment-preview-modal.tsx
+++ b/components/attachment-preview-modal.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import React, { useEffect } from "react";
+import { Download, FileText, X } from "lucide-react";
+
+import type { MessageAttachment } from "@/lib/types";
+
+type AttachmentPreviewState =
+  | { kind: "loading" }
+  | { kind: "image" }
+  | { kind: "text"; content: string }
+  | { kind: "error"; message: string }
+  | { kind: "unsupported" };
+
+type AttachmentPreviewModalProps = {
+  attachment: MessageAttachment;
+  state: AttachmentPreviewState;
+  onClose: () => void;
+  onRetry?: () => void;
+};
+
+export function AttachmentPreviewModal({
+  attachment,
+  state,
+  onClose,
+  onRetry
+}: AttachmentPreviewModalProps) {
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 px-4 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Attachment preview"
+        className="flex max-h-[min(80vh,720px)] w-full max-w-4xl flex-col overflow-hidden rounded-2xl border border-white/10 bg-[#121317] shadow-2xl"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="flex items-center justify-between gap-4 border-b border-white/8 px-4 py-3">
+          <div className="flex min-w-0 items-center gap-3">
+            <button
+              type="button"
+              aria-label="Close attachment preview"
+              onClick={onClose}
+              className="flex h-9 w-9 items-center justify-center rounded-lg border border-white/10 bg-white/[0.03] text-white/75"
+            >
+              <X className="h-4 w-4" />
+            </button>
+            <div className="min-w-0">
+              <div className="truncate text-sm font-medium text-white">{attachment.filename}</div>
+              <div className="truncate text-xs text-white/50">{attachment.mimeType}</div>
+            </div>
+          </div>
+
+          <a
+            href={`/api/attachments/${attachment.id}`}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-2 rounded-lg border border-white/10 px-3 py-2 text-xs text-white/70"
+            aria-label="Open raw attachment"
+          >
+            <Download className="h-3.5 w-3.5" />
+            <span>Open raw</span>
+          </a>
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-auto p-4">
+          {state.kind === "image" ? (
+            <img
+              src={`/api/attachments/${attachment.id}`}
+              alt={attachment.filename}
+              className="mx-auto max-h-[60vh] w-auto max-w-full rounded-xl"
+            />
+          ) : null}
+
+          {state.kind === "loading" ? (
+            <div className="flex h-full min-h-64 items-center justify-center text-sm text-white/55">
+              Loading preview…
+            </div>
+          ) : null}
+
+          {state.kind === "text" ? (
+            <pre className="min-h-64 overflow-auto rounded-xl border border-white/8 bg-black/25 p-4 font-mono text-[13px] leading-6 text-white/85 whitespace-pre-wrap break-words">
+              {state.content}
+            </pre>
+          ) : null}
+
+          {state.kind === "unsupported" ? (
+            <div className="flex min-h-64 flex-col items-center justify-center gap-3 rounded-xl border border-dashed border-white/12 bg-black/20 px-6 text-center">
+              <FileText className="h-5 w-5 text-white/50" />
+              <p className="text-sm text-white/70">Preview unavailable for this attachment type.</p>
+            </div>
+          ) : null}
+
+          {state.kind === "error" ? (
+            <div className="flex min-h-64 flex-col items-center justify-center gap-4 rounded-xl border border-white/8 bg-black/20 px-6 text-center">
+              <p className="text-sm text-white/70">{state.message}</p>
+              <button
+                type="button"
+                onClick={onRetry}
+                className="rounded-lg border border-white/10 px-3 py-2 text-xs text-white/80"
+              >
+                Retry preview
+              </button>
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/attachment-preview-modal.tsx
+++ b/components/attachment-preview-modal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Download, FileText, X } from "lucide-react";
 
 import type { MessageAttachment } from "@/lib/types";
@@ -18,6 +18,117 @@ type AttachmentPreviewModalProps = {
   onClose: () => void;
   onRetry?: () => void;
 };
+
+export function useAttachmentPreviewController() {
+  const [previewAttachment, setPreviewAttachment] = useState<MessageAttachment | null>(null);
+  const [previewState, setPreviewState] = useState<AttachmentPreviewState>({
+    kind: "unsupported"
+  });
+  const [textPreviewCache, setTextPreviewCache] = useState<Record<string, string>>({});
+  const previewRequestTokenRef = useRef(0);
+  const previewAttachmentIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    return () => {
+      previewRequestTokenRef.current += 1;
+      previewAttachmentIdRef.current = null;
+    };
+  }, []);
+
+  function isCurrentPreviewRequest(requestToken: number, attachmentId: string) {
+    return (
+      previewRequestTokenRef.current === requestToken &&
+      previewAttachmentIdRef.current === attachmentId
+    );
+  }
+
+  async function openAttachmentPreview(attachment: MessageAttachment) {
+    const requestToken = previewRequestTokenRef.current + 1;
+    previewRequestTokenRef.current = requestToken;
+    previewAttachmentIdRef.current = attachment.id;
+    setPreviewAttachment(attachment);
+    setPreviewState({ kind: "loading" });
+
+    if (attachment.kind === "image") {
+      const image = new Image();
+      image.onload = () => {
+        if (!isCurrentPreviewRequest(requestToken, attachment.id)) {
+          return;
+        }
+
+        setPreviewState({ kind: "image" });
+      };
+      image.onerror = () => {
+        if (!isCurrentPreviewRequest(requestToken, attachment.id)) {
+          return;
+        }
+
+        setPreviewState({
+          kind: "error",
+          message: "Unable to load attachment preview."
+        });
+      };
+      image.src = `/api/attachments/${attachment.id}`;
+      return;
+    }
+
+    if (Object.hasOwn(textPreviewCache, attachment.id)) {
+      const cached = textPreviewCache[attachment.id];
+      if (!isCurrentPreviewRequest(requestToken, attachment.id)) {
+        return;
+      }
+
+      setPreviewState({ kind: "text", content: cached });
+      return;
+    }
+
+    try {
+      const response = await fetch(`/api/attachments/${attachment.id}?format=text`);
+      if (!isCurrentPreviewRequest(requestToken, attachment.id)) {
+        return;
+      }
+
+      if (!response.ok) {
+        if (response.status === 415) {
+          setPreviewState({ kind: "unsupported" });
+          return;
+        }
+        throw new Error("Unable to load attachment preview.");
+      }
+
+      const payload = await response.json();
+      if (!isCurrentPreviewRequest(requestToken, attachment.id)) {
+        return;
+      }
+
+      setTextPreviewCache((current) => ({ ...current, [attachment.id]: payload.content }));
+      setPreviewState({ kind: "text", content: payload.content });
+    } catch (error) {
+      if (!isCurrentPreviewRequest(requestToken, attachment.id)) {
+        return;
+      }
+
+      setPreviewState({
+        kind: "error",
+        message: error instanceof Error ? error.message : "Unable to load attachment preview."
+      });
+    }
+  }
+
+  function closeAttachmentPreview() {
+    previewRequestTokenRef.current += 1;
+    previewAttachmentIdRef.current = null;
+    setPreviewAttachment(null);
+    setPreviewState({ kind: "unsupported" });
+  }
+
+  return {
+    previewAttachment,
+    previewState,
+    openAttachmentPreview,
+    closeAttachmentPreview
+  };
+}
 
 export function AttachmentPreviewModal({
   attachment,

--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -50,13 +50,14 @@ const AUTO_SCROLL_THRESHOLD_PX = 32;
 
 type SnapshotReconciliation = {
   messages: Message[];
-  confirmedLocalMessageIds: string[];
+  pendingLocalSubmissions: PendingLocalSubmission[];
 };
 
 type PendingLocalSubmission = {
   localMessageId: string;
   content: string;
   attachments: MessageAttachment[];
+  serverMessageId: string | null;
 };
 
 function getActionSignature(action: Pick<MessageAction, "kind" | "label" | "detail" | "toolName">) {
@@ -82,6 +83,16 @@ function matchesPendingLocalSubmission(
     message.content === submission.content &&
     getAttachmentIdSignature(message.attachments) ===
       getAttachmentIdSignature(submission.attachments)
+  );
+}
+
+function attachmentsAreSubset(
+  candidateAttachments: MessageAttachment[] | undefined,
+  submissionAttachments: MessageAttachment[]
+) {
+  const submissionAttachmentIds = new Set(submissionAttachments.map((attachment) => attachment.id));
+  return (candidateAttachments ?? []).every((attachment) =>
+    submissionAttachmentIds.has(attachment.id)
   );
 }
 
@@ -172,7 +183,7 @@ function reconcileSnapshotMessages(
   if (sanitizedSnapshot.length === 0) {
     return {
       messages: current.filter((message) => !isLegacyCompactionNotice(message)),
-      confirmedLocalMessageIds: []
+      pendingLocalSubmissions
     };
   }
 
@@ -195,24 +206,55 @@ function reconcileSnapshotMessages(
     current.filter((m) => !m.id.startsWith("local_")).map((m) => m.id)
   );
   const confirmedLocalIds = new Set<string>();
-  const matchedServerUserMessageIds = new Set<string>();
+  const claimedServerUserMessageIds = new Set<string>();
   const newServerUserMessages = sanitizedSnapshot.filter(
     (message) => message.role === "user" && !currentNonLocalIds.has(message.id)
   );
+  const nextPendingLocalSubmissions = pendingLocalSubmissions.map((submission) => ({
+    ...submission
+  }));
 
-  for (const submission of pendingLocalSubmissions) {
-    const matchedServerMessage = newServerUserMessages.find(
-      (message) =>
-        !matchedServerUserMessageIds.has(message.id) &&
-        matchesPendingLocalSubmission(message, submission)
+  for (const submission of nextPendingLocalSubmissions) {
+    if (
+      submission.serverMessageId &&
+      !sanitizedSnapshot.some((message) => message.id === submission.serverMessageId)
+    ) {
+      submission.serverMessageId = null;
+    }
+
+    const candidateServerUserMessages =
+      submission.serverMessageId !== null
+        ? sanitizedSnapshot.filter((message) => message.id === submission.serverMessageId)
+        : newServerUserMessages.filter((message) => !claimedServerUserMessageIds.has(message.id));
+
+    const matchedServerMessage = candidateServerUserMessages.find(
+      (message) => matchesPendingLocalSubmission(message, submission)
     );
 
     if (!matchedServerMessage) {
+      if (submission.attachments.length === 0 || submission.serverMessageId !== null) {
+        continue;
+      }
+
+      const partialServerMessage = newServerUserMessages.find(
+        (message) =>
+          !claimedServerUserMessageIds.has(message.id) &&
+          message.role === "user" &&
+          message.content === submission.content &&
+          attachmentsAreSubset(message.attachments, submission.attachments)
+      );
+
+      if (partialServerMessage) {
+        submission.serverMessageId = partialServerMessage.id;
+        claimedServerUserMessageIds.add(partialServerMessage.id);
+      }
+
       continue;
     }
 
+    submission.serverMessageId = matchedServerMessage.id;
     confirmedLocalIds.add(submission.localMessageId);
-    matchedServerUserMessageIds.add(matchedServerMessage.id);
+    claimedServerUserMessageIds.add(matchedServerMessage.id);
   }
 
   const pendingLocalMessages = current.filter((m) => {
@@ -229,7 +271,9 @@ function reconcileSnapshotMessages(
 
   return {
     messages: [...merged, ...pendingLocalMessages],
-    confirmedLocalMessageIds: [...confirmedLocalIds]
+    pendingLocalSubmissions: nextPendingLocalSubmissions.filter(
+      (submission) => !confirmedLocalIds.has(submission.localMessageId)
+    )
   };
 }
 
@@ -315,6 +359,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
   const router = useRouter();
   const { getTokenUsage, setTokenUsage } = useContextTokens();
   const previewController = useAttachmentPreviewController();
+  const activeConversationIdRef = useRef(payload.conversation.id);
   const [messages, setMessages] = useState(() => sanitizeMessages(payload.messages));
   const [conversationTitle, setConversationTitle] = useState(payload.conversation.title);
   const [titleGenerationStatus, setTitleGenerationStatus] = useState(
@@ -344,6 +389,16 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
       }
     }
   }, [payload.conversation.id, getTokenUsage]);
+
+  useEffect(() => {
+    if (activeConversationIdRef.current === payload.conversation.id) {
+      return;
+    }
+
+    activeConversationIdRef.current = payload.conversation.id;
+    previewController.closeAttachmentPreview();
+  }, [payload.conversation.id, previewController.closeAttachmentPreview]);
+
   const compactionInProgressRef = useRef(false);
   const thinkingStartTimeRef = useRef<number | null>(null);
   const [thinkingDuration, setThinkingDuration] = useState<number | undefined>(undefined);
@@ -374,11 +429,6 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
       !(message.timeline?.length ?? 0) &&
       (message.status === "streaming" || message.status === "completed")
   );
-  const needsMessageSync =
-    isSending ||
-    streamMessageId !== null ||
-    messages.some((message) => message.role === "assistant" && message.status === "streaming") ||
-    hasEmptyAssistantShell;
   const queueRef = useRef<HTMLDivElement | null>(null);
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
   const dragDepthRef = useRef(0);
@@ -403,17 +453,48 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
   const submitRef = useRef<
     (nextInput?: string, nextPendingAttachments?: MessageAttachment[], nextPersonaId?: string) => Promise<void>
   >(async () => {});
+  const pendingLocalSubmissionsById = new Map(
+    pendingLocalSubmissionsRef.current.map((submission) => [
+      submission.localMessageId,
+      submission
+    ] as const)
+  );
+  const renderableMessages = messages.filter(
+    (message) => {
+      if (!message.id.startsWith("local_")) {
+        return true;
+      }
 
-  function removePendingLocalSubmissions(localMessageIds: string[]) {
-    if (localMessageIds.length === 0) {
-      return;
+      const pendingSubmission = pendingLocalSubmissionsById.get(message.id);
+
+      if (pendingSubmission) {
+        return pendingSubmission.serverMessageId === null;
+      }
+
+      if (message.role !== "user") {
+        return true;
+      }
+
+      return !messages.some(
+        (candidate) =>
+          !candidate.id.startsWith("local_") &&
+          candidate.role === "user" &&
+          candidate.content === message.content &&
+          getAttachmentIdSignature(candidate.attachments) ===
+            getAttachmentIdSignature(message.attachments)
+      );
     }
-
-    const confirmedIds = new Set(localMessageIds);
-    pendingLocalSubmissionsRef.current = pendingLocalSubmissionsRef.current.filter(
-      (submission) => !confirmedIds.has(submission.localMessageId)
-    );
-  }
+  );
+  const hasPendingLocalSubmission = pendingLocalSubmissionsRef.current.length > 0;
+  const hasOptimisticLocalMessage = renderableMessages.some((message) =>
+    message.id.startsWith("local_")
+  );
+  const needsMessageSync =
+    isSending ||
+    hasPendingLocalSubmission ||
+    streamMessageId !== null ||
+    messages.some((message) => message.role === "assistant" && message.status === "streaming") ||
+    hasEmptyAssistantShell;
 
   function updateStreamTimeline(
     nextTimeline:
@@ -758,7 +839,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
               streamMessageId,
               pendingLocalSubmissionsRef.current
             );
-            removePendingLocalSubmissions(reconciliation.confirmedLocalMessageIds);
+            pendingLocalSubmissionsRef.current = reconciliation.pendingLocalSubmissions;
             return reconciliation.messages;
           });
           break;
@@ -987,7 +1068,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
             activeStreamMessageId,
             pendingLocalSubmissionsRef.current
           );
-          removePendingLocalSubmissions(reconciliation.confirmedLocalMessageIds);
+          pendingLocalSubmissionsRef.current = reconciliation.pendingLocalSubmissions;
           return reconciliation.messages;
         });
         setConversationTitle(result.conversation.title);
@@ -1425,7 +1506,8 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
     pendingLocalSubmissionsRef.current.push({
       localMessageId: optimisticUserMessage.id,
       content: value,
-      attachments: nextPendingAttachments
+      attachments: nextPendingAttachments,
+      serverMessageId: null
     });
     setMessages((current) => [...current, optimisticUserMessage]);
 
@@ -1532,7 +1614,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
         }}
       >
         <div className="flex w-full flex-col gap-2.5 md:gap-4 px-2 md:px-0 pt-4 pb-[180px] md:pb-[200px]">
-          {messages.map((message) => (
+          {renderableMessages.map((message) => (
             <div
               key={message.id}
               className="animate-slide-up"

--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -1358,7 +1358,8 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
       estimatedTokens: 0,
       systemKind: null,
       compactedAt: null,
-      createdAt: new Date().toISOString()
+      createdAt: new Date().toISOString(),
+      attachments: nextPendingAttachments
     };
     pendingLocalMessageIdsRef.current.push(optimisticUserMessage.id);
     pendingLocalSubmissionsRef.current.push({

--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -3,6 +3,10 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 
+import {
+  AttachmentPreviewModal,
+  useAttachmentPreviewController
+} from "@/components/attachment-preview-modal";
 import { ChatComposer } from "@/components/chat-composer";
 import { MessageBubble } from "@/components/message-bubble";
 import { clearChatBootstrap, readChatBootstrap } from "@/lib/chat-bootstrap";
@@ -49,6 +53,12 @@ type SnapshotReconciliation = {
   confirmedLocalMessageIds: string[];
 };
 
+type PendingLocalSubmission = {
+  localMessageId: string;
+  content: string;
+  attachments: MessageAttachment[];
+};
+
 function getActionSignature(action: Pick<MessageAction, "kind" | "label" | "detail" | "toolName">) {
   return [action.kind, action.label, action.detail, action.toolName ?? ""].join("\u0000");
 }
@@ -57,6 +67,22 @@ function isNearQueueBottom(element: HTMLDivElement) {
   const distanceFromBottom =
     element.scrollHeight - element.clientHeight - element.scrollTop;
   return distanceFromBottom <= AUTO_SCROLL_THRESHOLD_PX;
+}
+
+function getAttachmentIdSignature(attachments: MessageAttachment[] | undefined) {
+  return [...(attachments ?? []).map((attachment) => attachment.id)].sort().join("\u0000");
+}
+
+function matchesPendingLocalSubmission(
+  message: Message,
+  submission: PendingLocalSubmission
+) {
+  return (
+    message.role === "user" &&
+    message.content === submission.content &&
+    getAttachmentIdSignature(message.attachments) ===
+      getAttachmentIdSignature(submission.attachments)
+  );
 }
 
 function findMatchingActionIndex(timeline: MessageTimelineItem[], action: MessageAction) {
@@ -139,7 +165,8 @@ function sanitizeMessages(messages: Message[] | undefined) {
 function reconcileSnapshotMessages(
   current: Message[],
   snapshot: Message[] | undefined,
-  activeStreamMessageId: string | null
+  activeStreamMessageId: string | null,
+  pendingLocalSubmissions: PendingLocalSubmission[]
 ): SnapshotReconciliation {
   const sanitizedSnapshot = sanitizeMessages(snapshot);
   if (sanitizedSnapshot.length === 0) {
@@ -167,17 +194,25 @@ function reconcileSnapshotMessages(
   const currentNonLocalIds = new Set(
     current.filter((m) => !m.id.startsWith("local_")).map((m) => m.id)
   );
+  const confirmedLocalIds = new Set<string>();
+  const matchedServerUserMessageIds = new Set<string>();
   const newServerUserMessages = sanitizedSnapshot.filter(
-    (m) => m.role === "user" && !currentNonLocalIds.has(m.id)
-  );
-  const pendingLocalUserMessages = current.filter(
-    (m) => m.id.startsWith("local_") && m.role === "user" && !snapshotMessageIds.has(m.id)
+    (message) => message.role === "user" && !currentNonLocalIds.has(message.id)
   );
 
-  const confirmCount = Math.min(pendingLocalUserMessages.length, newServerUserMessages.length);
-  const confirmedLocalIds = new Set<string>();
-  for (let i = 0; i < confirmCount; i++) {
-    confirmedLocalIds.add(pendingLocalUserMessages[i].id);
+  for (const submission of pendingLocalSubmissions) {
+    const matchedServerMessage = newServerUserMessages.find(
+      (message) =>
+        !matchedServerUserMessageIds.has(message.id) &&
+        matchesPendingLocalSubmission(message, submission)
+    );
+
+    if (!matchedServerMessage) {
+      continue;
+    }
+
+    confirmedLocalIds.add(submission.localMessageId);
+    matchedServerUserMessageIds.add(matchedServerMessage.id);
   }
 
   const pendingLocalMessages = current.filter((m) => {
@@ -279,6 +314,7 @@ function replaceMessageAction(
 export function ChatView({ payload }: { payload: ConversationPayload }) {
   const router = useRouter();
   const { getTokenUsage, setTokenUsage } = useContextTokens();
+  const previewController = useAttachmentPreviewController();
   const [messages, setMessages] = useState(() => sanitizeMessages(payload.messages));
   const [conversationTitle, setConversationTitle] = useState(payload.conversation.title);
   const [titleGenerationStatus, setTitleGenerationStatus] = useState(
@@ -356,11 +392,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
   const titlePollTimeoutRef = useRef<number | null>(null);
   const titlePollAttemptsRef = useRef(0);
   const messageSyncTimeoutRef = useRef<number | null>(null);
-  const pendingLocalMessageIdsRef = useRef<string[]>([]);
-  const pendingLocalSubmissionsRef = useRef<Array<{
-    content: string;
-    attachments: MessageAttachment[];
-  }>>([]);
+  const pendingLocalSubmissionsRef = useRef<PendingLocalSubmission[]>([]);
   const shouldAutoScrollRef = useRef(true);
   const bootstrapPayloadRef = useRef<{
     message: string;
@@ -378,26 +410,9 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
     }
 
     const confirmedIds = new Set(localMessageIds);
-    const nextPendingIds: string[] = [];
-    const nextPendingSubmissions: Array<{
-      content: string;
-      attachments: MessageAttachment[];
-    }> = [];
-
-    pendingLocalMessageIdsRef.current.forEach((messageId, index) => {
-      if (confirmedIds.has(messageId)) {
-        return;
-      }
-
-      nextPendingIds.push(messageId);
-      const submission = pendingLocalSubmissionsRef.current[index];
-      if (submission) {
-        nextPendingSubmissions.push(submission);
-      }
-    });
-
-    pendingLocalMessageIdsRef.current = nextPendingIds;
-    pendingLocalSubmissionsRef.current = nextPendingSubmissions;
+    pendingLocalSubmissionsRef.current = pendingLocalSubmissionsRef.current.filter(
+      (submission) => !confirmedIds.has(submission.localMessageId)
+    );
   }
 
   function updateStreamTimeline(
@@ -740,7 +755,8 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
             const reconciliation = reconcileSnapshotMessages(
               current,
               msg.messages as Message[],
-              streamMessageId
+              streamMessageId,
+              pendingLocalSubmissionsRef.current
             );
             removePendingLocalSubmissions(reconciliation.confirmedLocalMessageIds);
             return reconciliation.messages;
@@ -806,16 +822,18 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
       return;
     }
 
-    if (pendingLocalMessageIdsRef.current.length > 0) {
-      const failedIds = new Set(pendingLocalMessageIdsRef.current);
-      const latestSubmission = pendingLocalSubmissionsRef.current[pendingLocalSubmissionsRef.current.length - 1];
+    if (pendingLocalSubmissionsRef.current.length > 0) {
+      const failedIds = new Set(
+        pendingLocalSubmissionsRef.current.map((submission) => submission.localMessageId)
+      );
+      const latestSubmission =
+        pendingLocalSubmissionsRef.current[pendingLocalSubmissionsRef.current.length - 1];
 
       setMessages((current) => current.filter((message) => !failedIds.has(message.id)));
       setInput((current) => current || latestSubmission?.content || "");
       setPendingAttachments((current) =>
         current.length > 0 ? current : (latestSubmission?.attachments ?? [])
       );
-      pendingLocalMessageIdsRef.current = [];
       pendingLocalSubmissionsRef.current = [];
     }
 
@@ -966,7 +984,8 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
           const reconciliation = reconcileSnapshotMessages(
             current,
             result.messages,
-            activeStreamMessageId
+            activeStreamMessageId,
+            pendingLocalSubmissionsRef.current
           );
           removePendingLocalSubmissions(reconciliation.confirmedLocalMessageIds);
           return reconciliation.messages;
@@ -1403,8 +1422,8 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
       createdAt: new Date().toISOString(),
       attachments: nextPendingAttachments
     };
-    pendingLocalMessageIdsRef.current.push(optimisticUserMessage.id);
     pendingLocalSubmissionsRef.current.push({
+      localMessageId: optimisticUserMessage.id,
       content: value,
       attachments: nextPendingAttachments
     });
@@ -1521,6 +1540,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
             >
               <MessageBubble
                 message={message}
+                onPreviewAttachment={previewController.openAttachmentPreview}
                 streamingTimeline={message.id === streamMessageId ? streamTimeline : undefined}
                 streamingThinking={message.id === streamMessageId ? streamThinkingDisplay : undefined}
                 streamingAnswer={message.id === streamMessageId ? streamAnswerDisplay : undefined}
@@ -1603,6 +1623,18 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
           />
         </div>
       </div>
+      {previewController.previewAttachment ? (
+        <AttachmentPreviewModal
+          attachment={previewController.previewAttachment}
+          state={previewController.previewState}
+          onClose={previewController.closeAttachmentPreview}
+          onRetry={() =>
+            void previewController.openAttachmentPreview(
+              previewController.previewAttachment!
+            )
+          }
+        />
+      ) : null}
       </div>
     </div>
   );

--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -44,6 +44,11 @@ type ConversationPayload = {
 
 const AUTO_SCROLL_THRESHOLD_PX = 32;
 
+type SnapshotReconciliation = {
+  messages: Message[];
+  confirmedLocalMessageIds: string[];
+};
+
 function getActionSignature(action: Pick<MessageAction, "kind" | "label" | "detail" | "toolName">) {
   return [action.kind, action.label, action.detail, action.toolName ?? ""].join("\u0000");
 }
@@ -135,10 +140,13 @@ function reconcileSnapshotMessages(
   current: Message[],
   snapshot: Message[] | undefined,
   activeStreamMessageId: string | null
-) {
+): SnapshotReconciliation {
   const sanitizedSnapshot = sanitizeMessages(snapshot);
   if (sanitizedSnapshot.length === 0) {
-    return current.filter((message) => !isLegacyCompactionNotice(message));
+    return {
+      messages: current.filter((message) => !isLegacyCompactionNotice(message)),
+      confirmedLocalMessageIds: []
+    };
   }
 
   const merged = sanitizedSnapshot.map((snapshotMsg) => {
@@ -184,7 +192,10 @@ function reconcileSnapshotMessages(
     return !isLegacyCompactionNotice(m);
   });
 
-  return [...merged, ...pendingLocalMessages];
+  return {
+    messages: [...merged, ...pendingLocalMessages],
+    confirmedLocalMessageIds: [...confirmedLocalIds]
+  };
 }
 
 function adoptStreamingSnapshotState(timeline: MessageTimelineItem[] | undefined) {
@@ -361,6 +372,34 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
     (nextInput?: string, nextPendingAttachments?: MessageAttachment[], nextPersonaId?: string) => Promise<void>
   >(async () => {});
 
+  function removePendingLocalSubmissions(localMessageIds: string[]) {
+    if (localMessageIds.length === 0) {
+      return;
+    }
+
+    const confirmedIds = new Set(localMessageIds);
+    const nextPendingIds: string[] = [];
+    const nextPendingSubmissions: Array<{
+      content: string;
+      attachments: MessageAttachment[];
+    }> = [];
+
+    pendingLocalMessageIdsRef.current.forEach((messageId, index) => {
+      if (confirmedIds.has(messageId)) {
+        return;
+      }
+
+      nextPendingIds.push(messageId);
+      const submission = pendingLocalSubmissionsRef.current[index];
+      if (submission) {
+        nextPendingSubmissions.push(submission);
+      }
+    });
+
+    pendingLocalMessageIdsRef.current = nextPendingIds;
+    pendingLocalSubmissionsRef.current = nextPendingSubmissions;
+  }
+
   function updateStreamTimeline(
     nextTimeline:
       | MessageTimelineItem[]
@@ -471,23 +510,18 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
     }
 
     if (event.type === "message_start") {
-      const confirmedLocalId = pendingLocalMessageIdsRef.current.shift() ?? null;
-      pendingLocalSubmissionsRef.current.shift();
       setStreamMessageId(event.messageId);
       dispatchConversationActivityUpdated({
         conversationId: payload.conversation.id,
         isActive: true
       });
       setMessages((current) => {
-        const withoutLocal = confirmedLocalId
-          ? current.filter((m) => m.id !== confirmedLocalId)
-          : current;
-        if (withoutLocal.some((message) => message.id === event.messageId)) {
-          return withoutLocal;
+        if (current.some((message) => message.id === event.messageId)) {
+          return current;
         }
 
         return [
-          ...withoutLocal,
+          ...current,
           {
             id: event.messageId,
             conversationId: payload.conversation.id,
@@ -702,13 +736,15 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
             }
           }
 
-          setMessages((current) =>
-            reconcileSnapshotMessages(
+          setMessages((current) => {
+            const reconciliation = reconcileSnapshotMessages(
               current,
               msg.messages as Message[],
               streamMessageId
-            )
-          );
+            );
+            removePendingLocalSubmissions(reconciliation.confirmedLocalMessageIds);
+            return reconciliation.messages;
+          });
           break;
         case "error":
           clearCompactionIndicator();
@@ -926,9 +962,15 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
           Boolean(streamAnswerTargetRef.current) ||
           streamTimelineRef.current.length > 0;
 
-        setMessages((current) =>
-          reconcileSnapshotMessages(current, result.messages, activeStreamMessageId)
-        );
+        setMessages((current) => {
+          const reconciliation = reconcileSnapshotMessages(
+            current,
+            result.messages,
+            activeStreamMessageId
+          );
+          removePendingLocalSubmissions(reconciliation.confirmedLocalMessageIds);
+          return reconciliation.messages;
+        });
         setConversationTitle(result.conversation.title);
         setTitleGenerationStatus(result.conversation.titleGenerationStatus);
 

--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -8,7 +8,7 @@ import remarkGfm from "remark-gfm";
 
 import {
   AttachmentPreviewModal,
-  type AttachmentPreviewState
+  useAttachmentPreviewController
 } from "@/components/attachment-preview-modal";
 import { CompactionIndicator } from "@/components/compaction-indicator";
 import { Textarea } from "@/components/ui/textarea";
@@ -587,7 +587,8 @@ export function MessageBubble({
   onForkAssistantMessage,
   isForking = false,
   onApproveMemoryProposal,
-  onDismissMemoryProposal
+  onDismissMemoryProposal,
+  onPreviewAttachment
 }: {
   message: Message;
   streamingTimeline?: MessageTimelineItem[];
@@ -607,6 +608,7 @@ export function MessageBubble({
   isUpdating?: boolean;
   onForkAssistantMessage?: (messageId: string) => void;
   isForking?: boolean;
+  onPreviewAttachment?: (attachment: MessageAttachment) => void;
 }) {
   const rawContent = streamingAnswer ?? message.content;
   const rawThinking = streamingThinking ?? message.thinkingContent;
@@ -716,13 +718,7 @@ export function MessageBubble({
     .join("");
   const [thinkingOpen, setThinkingOpen] = useState(false);
   const [toolOpenItems, setToolOpenItems] = useState<Record<string, boolean>>({});
-  const [previewAttachment, setPreviewAttachment] = useState<MessageAttachment | null>(null);
-  const [previewState, setPreviewState] = useState<AttachmentPreviewState>({
-    kind: "unsupported"
-  });
-  const [textPreviewCache, setTextPreviewCache] = useState<Record<string, string>>({});
-  const previewRequestTokenRef = useRef(0);
-  const previewAttachmentIdRef = useRef<string | null>(null);
+  const previewController = useAttachmentPreviewController();
 
   function toggleToolItem(id: string) {
     setToolOpenItems((prev) => ({ ...prev, [id]: !prev[id] }));
@@ -757,13 +753,6 @@ export function MessageBubble({
       if (copyResetHandle.current) {
         window.clearTimeout(copyResetHandle.current);
       }
-    };
-  }, []);
-
-  useEffect(() => {
-    return () => {
-      previewRequestTokenRef.current += 1;
-      previewAttachmentIdRef.current = null;
     };
   }, []);
 
@@ -820,92 +809,7 @@ export function MessageBubble({
     setIsEditing(false);
   }
 
-  function isCurrentPreviewRequest(requestToken: number, attachmentId: string) {
-    return (
-      previewRequestTokenRef.current === requestToken &&
-      previewAttachmentIdRef.current === attachmentId
-    );
-  }
-
-  async function openAttachmentPreview(attachment: MessageAttachment) {
-    const requestToken = previewRequestTokenRef.current + 1;
-    previewRequestTokenRef.current = requestToken;
-    previewAttachmentIdRef.current = attachment.id;
-    setPreviewAttachment(attachment);
-    setPreviewState({ kind: "loading" });
-
-    if (attachment.kind === "image") {
-      const image = new Image();
-      image.onload = () => {
-        if (!isCurrentPreviewRequest(requestToken, attachment.id)) {
-          return;
-        }
-
-        setPreviewState({ kind: "image" });
-      };
-      image.onerror = () => {
-        if (!isCurrentPreviewRequest(requestToken, attachment.id)) {
-          return;
-        }
-
-        setPreviewState({
-          kind: "error",
-          message: "Unable to load attachment preview."
-        });
-      };
-      image.src = `/api/attachments/${attachment.id}`;
-      return;
-    }
-
-    if (Object.hasOwn(textPreviewCache, attachment.id)) {
-      const cached = textPreviewCache[attachment.id];
-      if (!isCurrentPreviewRequest(requestToken, attachment.id)) {
-        return;
-      }
-
-      setPreviewState({ kind: "text", content: cached });
-      return;
-    }
-
-    try {
-      const response = await fetch(`/api/attachments/${attachment.id}?format=text`);
-      if (!isCurrentPreviewRequest(requestToken, attachment.id)) {
-        return;
-      }
-
-      if (!response.ok) {
-        if (response.status === 415) {
-          setPreviewState({ kind: "unsupported" });
-          return;
-        }
-        throw new Error("Unable to load attachment preview.");
-      }
-
-      const payload = await response.json();
-      if (!isCurrentPreviewRequest(requestToken, attachment.id)) {
-        return;
-      }
-
-      setTextPreviewCache((current) => ({ ...current, [attachment.id]: payload.content }));
-      setPreviewState({ kind: "text", content: payload.content });
-    } catch (error) {
-      if (!isCurrentPreviewRequest(requestToken, attachment.id)) {
-        return;
-      }
-
-      setPreviewState({
-        kind: "error",
-        message: error instanceof Error ? error.message : "Unable to load attachment preview."
-      });
-    }
-  }
-
-  function closeAttachmentPreview() {
-    previewRequestTokenRef.current += 1;
-    previewAttachmentIdRef.current = null;
-    setPreviewAttachment(null);
-    setPreviewState({ kind: "unsupported" });
-  }
+  const handleAttachmentPreview = onPreviewAttachment ?? previewController.openAttachmentPreview;
 
   if (message.role === "system") {
     return (
@@ -949,7 +853,7 @@ export function MessageBubble({
                   <MessageAttachments
                     attachments={message.attachments}
                     compact
-                    onPreview={openAttachmentPreview}
+                    onPreview={handleAttachmentPreview}
                   />
                 </div>
               ) : null}
@@ -996,12 +900,12 @@ export function MessageBubble({
             ) : null}
           </div>
         </div>
-        {previewAttachment ? (
+        {!onPreviewAttachment && previewController.previewAttachment ? (
           <AttachmentPreviewModal
-            attachment={previewAttachment}
-            state={previewState}
-            onClose={closeAttachmentPreview}
-            onRetry={() => void openAttachmentPreview(previewAttachment)}
+            attachment={previewController.previewAttachment}
+            state={previewController.previewState}
+            onClose={previewController.closeAttachmentPreview}
+            onRetry={() => void previewController.openAttachmentPreview(previewController.previewAttachment!)}
           />
         ) : null}
       </>

--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -6,6 +6,7 @@ import ReactMarkdown from "react-markdown";
 import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
 
+import { AttachmentPreviewModal } from "@/components/attachment-preview-modal";
 import { CompactionIndicator } from "@/components/compaction-indicator";
 import { Textarea } from "@/components/ui/textarea";
 import type {
@@ -477,31 +478,38 @@ function ActionButton({
   );
 }
 
-function AttachmentTile({ attachment, compact = false }: { attachment: MessageAttachment; compact?: boolean }) {
-  const href = `/api/attachments/${attachment.id}`;
-
+function AttachmentTile({
+  attachment,
+  compact = false,
+  onPreview
+}: {
+  attachment: MessageAttachment;
+  compact?: boolean;
+  onPreview: (attachment: MessageAttachment) => void;
+}) {
   if (attachment.kind === "image") {
     return (
-      <a
-        href={href}
-        target="_blank"
-        rel="noreferrer"
+      <button
+        type="button"
+        aria-label={`Preview ${attachment.filename}`}
+        onClick={() => onPreview(attachment)}
         className={`overflow-hidden rounded-xl border border-white/10 bg-black/20 ${compact ? "w-16" : "w-28"}`}
       >
         <img
-          src={href}
-          alt={attachment.filename}
+          src={`/api/attachments/${attachment.id}`}
+          alt=""
+          aria-hidden="true"
           className={`w-full object-cover ${compact ? "h-16" : "h-28"}`}
         />
-      </a>
+      </button>
     );
   }
 
   return (
-    <a
-      href={href}
-      target="_blank"
-      rel="noreferrer"
+    <button
+      type="button"
+      aria-label={`Preview ${attachment.filename}`}
+      onClick={() => onPreview(attachment)}
       className="flex min-w-0 items-center gap-2 rounded-xl border border-white/10 bg-black/15 px-3 py-2 text-left"
     >
       <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-white/10 text-white/75">
@@ -511,16 +519,18 @@ function AttachmentTile({ attachment, compact = false }: { attachment: MessageAt
         <span className="block truncate text-sm font-medium text-white">{attachment.filename}</span>
         <span className="block truncate text-xs text-white/60">{attachment.mimeType}</span>
       </span>
-    </a>
+    </button>
   );
 }
 
 function MessageAttachments({
   attachments,
-  compact = false
+  compact = false,
+  onPreview
 }: {
   attachments: MessageAttachment[];
   compact?: boolean;
+  onPreview: (attachment: MessageAttachment) => void;
 }) {
   if (!attachments.length) {
     return null;
@@ -534,14 +544,24 @@ function MessageAttachments({
       {images.length ? (
         <div className="flex flex-wrap gap-2">
           {images.map((attachment) => (
-            <AttachmentTile key={attachment.id} attachment={attachment} compact={compact} />
+            <AttachmentTile
+              key={attachment.id}
+              attachment={attachment}
+              compact={compact}
+              onPreview={onPreview}
+            />
           ))}
         </div>
       ) : null}
       {files.length ? (
         <div className="space-y-2">
           {files.map((attachment) => (
-            <AttachmentTile key={attachment.id} attachment={attachment} compact={compact} />
+            <AttachmentTile
+              key={attachment.id}
+              attachment={attachment}
+              compact={compact}
+              onPreview={onPreview}
+            />
           ))}
         </div>
       ) : null}
@@ -693,6 +713,15 @@ export function MessageBubble({
     .join("");
   const [thinkingOpen, setThinkingOpen] = useState(false);
   const [toolOpenItems, setToolOpenItems] = useState<Record<string, boolean>>({});
+  const [previewAttachment, setPreviewAttachment] = useState<MessageAttachment | null>(null);
+  const [previewState, setPreviewState] = useState<
+    | { kind: "loading" }
+    | { kind: "image" }
+    | { kind: "text"; content: string }
+    | { kind: "error"; message: string }
+    | { kind: "unsupported" }
+  >({ kind: "unsupported" });
+  const [textPreviewCache, setTextPreviewCache] = useState<Record<string, string>>({});
 
   function toggleToolItem(id: string) {
     setToolOpenItems((prev) => ({ ...prev, [id]: !prev[id] }));
@@ -783,6 +812,48 @@ export function MessageBubble({
     setIsEditing(false);
   }
 
+  async function openAttachmentPreview(attachment: MessageAttachment) {
+    setPreviewAttachment(attachment);
+
+    if (attachment.kind === "image") {
+      setPreviewState({ kind: "image" });
+      return;
+    }
+
+    setPreviewState({ kind: "loading" });
+
+    const cached = textPreviewCache[attachment.id];
+    if (cached) {
+      setPreviewState({ kind: "text", content: cached });
+      return;
+    }
+
+    try {
+      const response = await fetch(`/api/attachments/${attachment.id}?format=text`);
+      if (!response.ok) {
+        if (response.status === 415) {
+          setPreviewState({ kind: "unsupported" });
+          return;
+        }
+        throw new Error("Unable to load attachment preview.");
+      }
+
+      const payload = await response.json();
+      setTextPreviewCache((current) => ({ ...current, [attachment.id]: payload.content }));
+      setPreviewState({ kind: "text", content: payload.content });
+    } catch (error) {
+      setPreviewState({
+        kind: "error",
+        message: error instanceof Error ? error.message : "Unable to load attachment preview."
+      });
+    }
+  }
+
+  function closeAttachmentPreview() {
+    setPreviewAttachment(null);
+    setPreviewState({ kind: "unsupported" });
+  }
+
   if (message.role === "system") {
     return (
       <div className="mx-auto max-w-lg rounded-full border border-white/6 bg-white/[0.03] px-5 py-2 text-center text-[11px] tracking-[0.12em] text-white/40 uppercase">
@@ -793,80 +864,94 @@ export function MessageBubble({
 
   if (message.role === "user") {
     return (
-      <div className="flex w-full justify-end">
-        <div className="group flex max-w-[96%] flex-col items-end md:max-w-[95%]">
-          <div className="w-full rounded-2xl border border-[var(--accent)]/10 bg-[var(--accent-soft)] px-4 py-3 text-[var(--text)]">
-            {isEditing ? (
-              <Textarea
-                ref={editRef}
-                value={draft}
-                onChange={(event) => setDraft(event.target.value)}
-                className="min-h-[88px] border-0 bg-transparent px-0 py-0 text-[14.5px] leading-7 text-[var(--text)] focus-visible:ring-0"
-                onKeyDown={(event) => {
-                  if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
-                    event.preventDefault();
-                    void handleSaveEdit();
-                  }
+      <>
+        <div className="flex w-full justify-end">
+          <div className="group flex max-w-[96%] flex-col items-end md:max-w-[95%]">
+            <div className="w-full rounded-2xl border border-[var(--accent)]/10 bg-[var(--accent-soft)] px-4 py-3 text-[var(--text)]">
+              {isEditing ? (
+                <Textarea
+                  ref={editRef}
+                  value={draft}
+                  onChange={(event) => setDraft(event.target.value)}
+                  className="min-h-[88px] border-0 bg-transparent px-0 py-0 text-[14.5px] leading-7 text-[var(--text)] focus-visible:ring-0"
+                  onKeyDown={(event) => {
+                    if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
+                      event.preventDefault();
+                      void handleSaveEdit();
+                    }
 
-                  if (event.key === "Escape") {
-                    event.preventDefault();
-                    handleCancelEdit();
-                  }
-                }}
-              />
-            ) : content ? (
-              <div ref={contentRef}>
-                <p className="whitespace-pre-wrap text-[14.5px] leading-7">{content}</p>
-              </div>
-            ) : null}
-            {message.attachments?.length ? (
-              <div className={content || isEditing ? "mt-3" : ""}>
-                <MessageAttachments attachments={message.attachments} compact />
+                    if (event.key === "Escape") {
+                      event.preventDefault();
+                      handleCancelEdit();
+                    }
+                  }}
+                />
+              ) : content ? (
+                <div ref={contentRef}>
+                  <p className="whitespace-pre-wrap text-[14.5px] leading-7">{content}</p>
+                </div>
+              ) : null}
+              {message.attachments?.length ? (
+                <div className={content || isEditing ? "mt-3" : ""}>
+                  <MessageAttachments
+                    attachments={message.attachments}
+                    compact
+                    onPreview={openAttachmentPreview}
+                  />
+                </div>
+              ) : null}
+            </div>
+
+            {showUserBubbleActions ? (
+              <div className="mt-2 flex items-center gap-1 opacity-100 transition md:pointer-events-none md:translate-y-1 md:opacity-0 md:group-hover:pointer-events-auto md:group-hover:translate-y-0 md:group-hover:opacity-100 md:group-focus-within:pointer-events-auto md:group-focus-within:translate-y-0 md:group-focus-within:opacity-100">
+                <ActionButton
+                  label={copyState === "copied" ? "Copied" : "Copy message"}
+                  onClick={() => void handleCopy()}
+                >
+                  {copyState === "copied" ? (
+                    <Check className="h-3.5 w-3.5 text-emerald-400" />
+                  ) : copyState === "error" ? (
+                    <X className="h-3.5 w-3.5 text-red-400" />
+                  ) : (
+                    <Copy className="h-3.5 w-3.5" />
+                  )}
+                </ActionButton>
+
+                {isEditing ? (
+                  <>
+                    <ActionButton
+                      label="Save edit"
+                      onClick={() => void handleSaveEdit()}
+                      disabled={isUpdating || !draft.trim()}
+                    >
+                      {isUpdating ? (
+                        <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
+                      ) : (
+                        <Check className="h-3.5 w-3.5" />
+                      )}
+                    </ActionButton>
+                    <ActionButton label="Cancel edit" onClick={handleCancelEdit} disabled={isUpdating}>
+                      <X className="h-3.5 w-3.5" />
+                    </ActionButton>
+                  </>
+                ) : (
+                  <ActionButton label="Edit message" onClick={() => setIsEditing(true)}>
+                    <Pencil className="h-3.5 w-3.5" />
+                  </ActionButton>
+                )}
               </div>
             ) : null}
           </div>
-
-          {showUserBubbleActions ? (
-            <div className="mt-2 flex items-center gap-1 opacity-100 transition md:pointer-events-none md:translate-y-1 md:opacity-0 md:group-hover:pointer-events-auto md:group-hover:translate-y-0 md:group-hover:opacity-100 md:group-focus-within:pointer-events-auto md:group-focus-within:translate-y-0 md:group-focus-within:opacity-100">
-              <ActionButton
-                label={copyState === "copied" ? "Copied" : "Copy message"}
-                onClick={() => void handleCopy()}
-              >
-                {copyState === "copied" ? (
-                  <Check className="h-3.5 w-3.5 text-emerald-400" />
-                ) : copyState === "error" ? (
-                  <X className="h-3.5 w-3.5 text-red-400" />
-                ) : (
-                  <Copy className="h-3.5 w-3.5" />
-                )}
-              </ActionButton>
-
-              {isEditing ? (
-                <>
-                  <ActionButton
-                    label="Save edit"
-                    onClick={() => void handleSaveEdit()}
-                    disabled={isUpdating || !draft.trim()}
-                  >
-                    {isUpdating ? (
-                      <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
-                    ) : (
-                      <Check className="h-3.5 w-3.5" />
-                    )}
-                  </ActionButton>
-                  <ActionButton label="Cancel edit" onClick={handleCancelEdit} disabled={isUpdating}>
-                    <X className="h-3.5 w-3.5" />
-                  </ActionButton>
-                </>
-              ) : (
-                <ActionButton label="Edit message" onClick={() => setIsEditing(true)}>
-                  <Pencil className="h-3.5 w-3.5" />
-                </ActionButton>
-              )}
-            </div>
-          ) : null}
         </div>
-      </div>
+        {previewAttachment ? (
+          <AttachmentPreviewModal
+            attachment={previewAttachment}
+            state={previewState}
+            onClose={closeAttachmentPreview}
+            onRetry={() => void openAttachmentPreview(previewAttachment)}
+          />
+        ) : null}
+      </>
     );
   }
 

--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -19,7 +19,7 @@ import type {
   MessageAttachment,
   MessageTimelineItem
 } from "@/lib/types";
-import { normalizeMarkdownLineBreaks } from "@/lib/utils";
+import { normalizeMarkdownLineBreaks } from "@/lib/text-utils";
 
 const MARKDOWN_PLUGINS = [remarkGfm, remarkBreaks];
 const COPY_RESET_DELAY_MS = 1600;

--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -6,7 +6,10 @@ import ReactMarkdown from "react-markdown";
 import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
 
-import { AttachmentPreviewModal } from "@/components/attachment-preview-modal";
+import {
+  AttachmentPreviewModal,
+  type AttachmentPreviewState
+} from "@/components/attachment-preview-modal";
 import { CompactionIndicator } from "@/components/compaction-indicator";
 import { Textarea } from "@/components/ui/textarea";
 import type {
@@ -714,14 +717,12 @@ export function MessageBubble({
   const [thinkingOpen, setThinkingOpen] = useState(false);
   const [toolOpenItems, setToolOpenItems] = useState<Record<string, boolean>>({});
   const [previewAttachment, setPreviewAttachment] = useState<MessageAttachment | null>(null);
-  const [previewState, setPreviewState] = useState<
-    | { kind: "loading" }
-    | { kind: "image" }
-    | { kind: "text"; content: string }
-    | { kind: "error"; message: string }
-    | { kind: "unsupported" }
-  >({ kind: "unsupported" });
+  const [previewState, setPreviewState] = useState<AttachmentPreviewState>({
+    kind: "unsupported"
+  });
   const [textPreviewCache, setTextPreviewCache] = useState<Record<string, string>>({});
+  const previewRequestTokenRef = useRef(0);
+  const previewAttachmentIdRef = useRef<string | null>(null);
 
   function toggleToolItem(id: string) {
     setToolOpenItems((prev) => ({ ...prev, [id]: !prev[id] }));
@@ -756,6 +757,13 @@ export function MessageBubble({
       if (copyResetHandle.current) {
         window.clearTimeout(copyResetHandle.current);
       }
+    };
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      previewRequestTokenRef.current += 1;
+      previewAttachmentIdRef.current = null;
     };
   }, []);
 
@@ -812,24 +820,59 @@ export function MessageBubble({
     setIsEditing(false);
   }
 
+  function isCurrentPreviewRequest(requestToken: number, attachmentId: string) {
+    return (
+      previewRequestTokenRef.current === requestToken &&
+      previewAttachmentIdRef.current === attachmentId
+    );
+  }
+
   async function openAttachmentPreview(attachment: MessageAttachment) {
+    const requestToken = previewRequestTokenRef.current + 1;
+    previewRequestTokenRef.current = requestToken;
+    previewAttachmentIdRef.current = attachment.id;
     setPreviewAttachment(attachment);
+    setPreviewState({ kind: "loading" });
 
     if (attachment.kind === "image") {
-      setPreviewState({ kind: "image" });
+      const image = new Image();
+      image.onload = () => {
+        if (!isCurrentPreviewRequest(requestToken, attachment.id)) {
+          return;
+        }
+
+        setPreviewState({ kind: "image" });
+      };
+      image.onerror = () => {
+        if (!isCurrentPreviewRequest(requestToken, attachment.id)) {
+          return;
+        }
+
+        setPreviewState({
+          kind: "error",
+          message: "Unable to load attachment preview."
+        });
+      };
+      image.src = `/api/attachments/${attachment.id}`;
       return;
     }
 
-    setPreviewState({ kind: "loading" });
-
     const cached = textPreviewCache[attachment.id];
     if (cached) {
+      if (!isCurrentPreviewRequest(requestToken, attachment.id)) {
+        return;
+      }
+
       setPreviewState({ kind: "text", content: cached });
       return;
     }
 
     try {
       const response = await fetch(`/api/attachments/${attachment.id}?format=text`);
+      if (!isCurrentPreviewRequest(requestToken, attachment.id)) {
+        return;
+      }
+
       if (!response.ok) {
         if (response.status === 415) {
           setPreviewState({ kind: "unsupported" });
@@ -839,9 +882,17 @@ export function MessageBubble({
       }
 
       const payload = await response.json();
+      if (!isCurrentPreviewRequest(requestToken, attachment.id)) {
+        return;
+      }
+
       setTextPreviewCache((current) => ({ ...current, [attachment.id]: payload.content }));
       setPreviewState({ kind: "text", content: payload.content });
     } catch (error) {
+      if (!isCurrentPreviewRequest(requestToken, attachment.id)) {
+        return;
+      }
+
       setPreviewState({
         kind: "error",
         message: error instanceof Error ? error.message : "Unable to load attachment preview."
@@ -850,6 +901,8 @@ export function MessageBubble({
   }
 
   function closeAttachmentPreview() {
+    previewRequestTokenRef.current += 1;
+    previewAttachmentIdRef.current = null;
     setPreviewAttachment(null);
     setPreviewState({ kind: "unsupported" });
   }

--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -857,8 +857,8 @@ export function MessageBubble({
       return;
     }
 
-    const cached = textPreviewCache[attachment.id];
-    if (cached) {
+    if (Object.hasOwn(textPreviewCache, attachment.id)) {
+      const cached = textPreviewCache[attachment.id];
       if (!isCurrentPreviewRequest(requestToken, attachment.id)) {
         return;
       }

--- a/docs/superpowers/plans/2026-04-13-attachment-preview-modal.md
+++ b/docs/superpowers/plans/2026-04-13-attachment-preview-modal.md
@@ -1,0 +1,928 @@
+# Attachment Preview Modal Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace transcript attachment links with a centered in-app preview modal that renders images inline, shows text-like files in a read-only viewer, and always provides an explicit close path across desktop, mobile, and PWA contexts.
+
+**Architecture:** Keep the modal flow local to transcript attachments. Add a narrow text-preview response mode to the existing attachment route, extract the preview shell into a focused component, and wire `components/message-bubble.tsx` to open that modal instead of navigating away. Cover the route, the modal behavior, and the transcript flow with focused unit tests plus chat attachment e2e coverage.
+
+**Tech Stack:** Next.js 15 App Router, React 19, TypeScript, lucide-react, Vitest, Testing Library, Playwright, agent-browser
+
+---
+
+## File Map
+
+- `lib/attachments.ts` — shared attachment preview helpers for inline text-preview eligibility and UTF-8 text reads
+- `app/api/attachments/[attachmentId]/route.ts` — existing authenticated attachment GET route, extended with a `format=text` preview mode while preserving raw inline responses
+- `tests/unit/attachment-preview-route.test.ts` — focused route coverage for text preview success, unsupported-preview rejection, and authentication
+- `components/attachment-preview-modal.tsx` — new centered modal shell that renders image, text, loading, error, and unsupported states
+- `components/message-bubble.tsx` — swap attachment tiles from direct navigation to modal-open behavior and keep raw-open/download access inside the modal
+- `tests/unit/message-bubble.test.ts` — transcript attachment modal regression coverage
+- `tests/e2e/features.spec.ts` — chat attachment transcript e2e coverage, including the modal open/close path and text preview rendering
+- `.dev-server` — local dev server discovery for browser validation when Playwright is done
+
+### Task 1: Add authenticated text-preview responses for supported attachments
+
+**Files:**
+- Modify: `lib/attachments.ts`
+- Modify: `app/api/attachments/[attachmentId]/route.ts`
+- Create: `tests/unit/attachment-preview-route.test.ts`
+
+- [ ] **Step 1: Write the failing route test**
+
+Create `tests/unit/attachment-preview-route.test.ts` with this content:
+
+```ts
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createAttachments } from "@/lib/attachments";
+import { createConversation } from "@/lib/conversations";
+import { createLocalUser } from "@/lib/users";
+
+const { requireUserMock } = vi.hoisted(() => ({
+  requireUserMock: vi.fn()
+}));
+
+vi.mock("@/lib/auth", () => ({
+  requireUser: requireUserMock
+}));
+
+describe("attachment preview route", () => {
+  beforeEach(() => {
+    requireUserMock.mockReset();
+  });
+
+  it("returns text preview JSON for supported text attachments", async () => {
+    const user = await createLocalUser({
+      username: "attachment-preview-user",
+      password: "Password123!",
+      role: "user"
+    });
+    const conversation = createConversation("Attachment preview", null, undefined, user.id);
+    const [attachment] = createAttachments(conversation.id, [
+      {
+        filename: "notes.md",
+        mimeType: "text/markdown",
+        bytes: Buffer.from("# Notes\nHello preview", "utf8")
+      }
+    ]);
+
+    requireUserMock.mockResolvedValue(user);
+
+    const { GET } = await import("@/app/api/attachments/[attachmentId]/route");
+    const response = await GET(
+      new Request(`http://localhost/api/attachments/${attachment.id}?format=text`),
+      { params: Promise.resolve({ attachmentId: attachment.id }) }
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      id: attachment.id,
+      filename: "notes.md",
+      mimeType: "text/markdown",
+      content: "# Notes\nHello preview"
+    });
+  });
+
+  it("rejects inline text preview for image attachments", async () => {
+    const user = await createLocalUser({
+      username: "attachment-preview-image-user",
+      password: "Password123!",
+      role: "user"
+    });
+    const conversation = createConversation("Image preview", null, undefined, user.id);
+    const [attachment] = createAttachments(conversation.id, [
+      {
+        filename: "photo.png",
+        mimeType: "image/png",
+        bytes: Buffer.from("png-binary", "utf8")
+      }
+    ]);
+
+    requireUserMock.mockResolvedValue(user);
+
+    const { GET } = await import("@/app/api/attachments/[attachmentId]/route");
+    const response = await GET(
+      new Request(`http://localhost/api/attachments/${attachment.id}?format=text`),
+      { params: Promise.resolve({ attachmentId: attachment.id }) }
+    );
+
+    expect(response.status).toBe(415);
+    await expect(response.text()).resolves.toContain("Attachment cannot be previewed as text");
+  });
+});
+```
+
+- [ ] **Step 2: Run the route test to verify it fails**
+
+Run:
+
+```bash
+npx vitest run tests/unit/attachment-preview-route.test.ts
+```
+
+Expected: FAIL because the current route always returns raw bytes and does not support `?format=text`.
+
+- [ ] **Step 3: Add shared preview helpers in `lib/attachments.ts`**
+
+Append these helpers near the existing read helpers in `lib/attachments.ts`:
+
+```ts
+const INLINE_TEXT_PREVIEW_MIME_TYPES = new Set([
+  "text/plain",
+  "text/markdown",
+  "application/json"
+]);
+
+export function isInlineTextPreviewableAttachment(
+  attachment: Pick<MessageAttachment, "kind" | "mimeType" | "filename">
+) {
+  if (attachment.kind !== "text") {
+    return false;
+  }
+
+  if (INLINE_TEXT_PREVIEW_MIME_TYPES.has(attachment.mimeType)) {
+    return true;
+  }
+
+  return /\.(txt|md|markdown|json)$/i.test(attachment.filename);
+}
+
+export function readAttachmentText(
+  attachment: Pick<MessageAttachment, "relativePath" | "kind" | "mimeType" | "filename">
+) {
+  if (!isInlineTextPreviewableAttachment(attachment)) {
+    throw new Error("Attachment cannot be previewed as text");
+  }
+
+  return readAttachmentBuffer(attachment).toString("utf8");
+}
+```
+
+- [ ] **Step 4: Extend the existing attachment GET route with `format=text`**
+
+Update `app/api/attachments/[attachmentId]/route.ts` like this:
+
+```ts
+import {
+  deleteAttachmentById,
+  getAttachment,
+  isInlineTextPreviewableAttachment,
+  readAttachmentBuffer,
+  readAttachmentText
+} from "@/lib/attachments";
+import { badRequest } from "@/lib/http";
+
+export async function GET(
+  request: Request,
+  context: { params: Promise<{ attachmentId: string }> }
+) {
+  const user = await requireUser(false);
+  // existing auth and param parsing stays the same
+
+  const attachment = getAttachment(params.data.attachmentId, user.id);
+  if (!attachment) {
+    return badRequest("Attachment not found", 404);
+  }
+
+  const format = new URL(request.url).searchParams.get("format");
+
+  try {
+    if (format === "text") {
+      if (!isInlineTextPreviewableAttachment(attachment)) {
+        return badRequest("Attachment cannot be previewed as text", 415);
+      }
+
+      return Response.json({
+        id: attachment.id,
+        filename: attachment.filename,
+        mimeType: attachment.mimeType,
+        content: readAttachmentText(attachment)
+      });
+    }
+
+    const buffer = readAttachmentBuffer(attachment);
+
+    return new Response(buffer, {
+      headers: {
+        "Content-Type": attachment.mimeType,
+        "Content-Length": String(buffer.length),
+        "Content-Disposition": `inline; filename="${attachment.filename}"`
+      }
+    });
+  } catch {
+    return badRequest("Attachment file not found", 404);
+  }
+}
+```
+
+- [ ] **Step 5: Run the focused route test to verify it passes**
+
+Run:
+
+```bash
+npx vitest run tests/unit/attachment-preview-route.test.ts tests/unit/attachments.test.ts
+```
+
+Expected: PASS with the new route test and the existing attachment helper tests both green.
+
+- [ ] **Step 6: Commit the route-preview change**
+
+Run:
+
+```bash
+git add lib/attachments.ts app/api/attachments/[attachmentId]/route.ts tests/unit/attachment-preview-route.test.ts
+git commit -m "feat: add attachment text preview responses"
+```
+
+Expected: a single commit covering the preview helper and route behavior only.
+
+### Task 2: Open transcript attachments in a centered preview modal
+
+**Files:**
+- Create: `components/attachment-preview-modal.tsx`
+- Modify: `components/message-bubble.tsx`
+- Modify: `tests/unit/message-bubble.test.ts`
+- Modify: `tests/e2e/features.spec.ts`
+
+- [ ] **Step 1: Write the failing transcript modal tests**
+
+Add these tests to `tests/unit/message-bubble.test.ts` near the existing attachment coverage:
+
+```tsx
+  it("opens image attachments in a centered modal and closes with the X button", async () => {
+    render(
+      React.createElement(MessageBubble, {
+        message: {
+          ...createUserMessage(),
+          content: "See attached",
+          attachments: [
+            {
+              id: "att_image",
+              conversationId: "conv_test",
+              messageId: "msg_user",
+              filename: "photo.png",
+              mimeType: "image/png",
+              byteSize: 10,
+              sha256: "hash",
+              relativePath: "conv_test/att_image_photo.png",
+              kind: "image",
+              extractedText: "",
+              createdAt: new Date().toISOString()
+            }
+          ]
+        }
+      })
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Preview photo.png" }));
+
+    expect(screen.getByRole("dialog", { name: "Attachment preview" })).toBeInTheDocument();
+    expect(screen.getByRole("img", { name: "photo.png" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Close attachment preview" }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Attachment preview" })).toBeNull();
+    });
+  });
+
+  it("loads text attachments into a read-only preview surface", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        id: "att_text",
+        filename: "notes.txt",
+        mimeType: "text/plain",
+        content: "hello from the preview route"
+      })
+    } as Response);
+
+    render(
+      React.createElement(MessageBubble, {
+        message: {
+          ...createUserMessage(),
+          content: "See attached",
+          attachments: [
+            {
+              id: "att_text",
+              conversationId: "conv_test",
+              messageId: "msg_user",
+              filename: "notes.txt",
+              mimeType: "text/plain",
+              byteSize: 10,
+              sha256: "hash2",
+              relativePath: "conv_test/att_text_notes.txt",
+              kind: "text",
+              extractedText: "hello",
+              createdAt: new Date().toISOString()
+            }
+          ]
+        }
+      })
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Preview notes.txt" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("hello from the preview route")).toBeInTheDocument();
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith("/api/attachments/att_text?format=text");
+    expect(screen.getByRole("link", { name: "Open raw attachment" })).toHaveAttribute(
+      "href",
+      "/api/attachments/att_text"
+    );
+  });
+
+  it("closes the attachment modal when Escape is pressed", async () => {
+    render(
+      React.createElement(MessageBubble, {
+        message: {
+          ...createUserMessage(),
+          content: "See attached",
+          attachments: [
+            {
+              id: "att_image",
+              conversationId: "conv_test",
+              messageId: "msg_user",
+              filename: "photo.png",
+              mimeType: "image/png",
+              byteSize: 10,
+              sha256: "hash",
+              relativePath: "conv_test/att_image_photo.png",
+              kind: "image",
+              extractedText: "",
+              createdAt: new Date().toISOString()
+            }
+          ]
+        }
+      })
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Preview photo.png" }));
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Attachment preview" })).toBeNull();
+    });
+  });
+```
+
+Add these e2e scenarios inside the `"Feature: Chat attachments"` block in `tests/e2e/features.spec.ts`:
+
+```ts
+  test("opens transcript image attachments in a modal and closes them", async ({ page }) => {
+    await signIn(page);
+    await mockChatResponse(page);
+    await mockAttachmentUpload(page, [
+      {
+        id: "att_photo",
+        filename: "photo.png",
+        mimeType: "image/png",
+        kind: "image"
+      }
+    ]);
+
+    await createNewChat(page);
+    await expect(page).toHaveURL(/\/chat\//, { timeout: 10000 });
+
+    const chooserPromise = page.waitForEvent("filechooser");
+    const uploadResponsePromise = page.waitForResponse(
+      (response) => response.url().includes("/api/attachments") && response.request().method() === "POST"
+    );
+    await page.getByRole("button", { name: "Attach files" }).click();
+    const chooser = await chooserPromise;
+    await chooser.setFiles({ name: "photo.png", mimeType: "image/png", buffer: TINY_PNG });
+    await uploadResponsePromise;
+
+    await page.getByPlaceholder(/Ask, create, or start a task/i).fill("Keep this image");
+    await page.getByRole("button", { name: "Send message" }).click();
+    await expect(page.getByRole("button", { name: "Preview photo.png" }).last()).toBeVisible({
+      timeout: 10000
+    });
+
+    await page.getByRole("button", { name: "Preview photo.png" }).last().click();
+    await expect(page.getByRole("dialog", { name: "Attachment preview" })).toBeVisible();
+    await expect(page.getByRole("img", { name: "photo.png" })).toBeVisible();
+
+    await page.getByRole("button", { name: "Close attachment preview" }).click();
+    await expect(page.getByRole("dialog", { name: "Attachment preview" })).toBeHidden();
+  });
+
+  test("opens transcript text attachments in a modal and renders preview content", async ({ page }) => {
+    await signIn(page);
+    await mockChatResponse(page);
+    await mockAttachmentUpload(page, [
+      {
+        id: "att_notes",
+        filename: "notes.txt",
+        mimeType: "text/plain",
+        kind: "text"
+      }
+    ]);
+
+    await createNewChat(page);
+    await expect(page).toHaveURL(/\/chat\//, { timeout: 10000 });
+
+    const chooserPromise = page.waitForEvent("filechooser");
+    const uploadResponsePromise = page.waitForResponse(
+      (response) => response.url().includes("/api/attachments") && response.request().method() === "POST"
+    );
+    await page.getByRole("button", { name: "Attach files" }).click();
+    const chooser = await chooserPromise;
+    await chooser.setFiles({ name: "notes.txt", mimeType: "text/plain", buffer: Buffer.from("hello") });
+    await uploadResponsePromise;
+
+    await page.getByPlaceholder(/Ask, create, or start a task/i).fill("Keep these notes");
+    await page.getByRole("button", { name: "Send message" }).click();
+    await expect(page.getByRole("button", { name: "Preview notes.txt" }).last()).toBeVisible({
+      timeout: 10000
+    });
+
+    await page.getByRole("button", { name: "Preview notes.txt" }).last().click();
+    await expect(page.getByRole("dialog", { name: "Attachment preview" })).toBeVisible();
+    await expect(page.getByText("hello")).toBeVisible();
+  });
+```
+
+- [ ] **Step 2: Run the modal-focused tests to verify they fail**
+
+Run:
+
+```bash
+npx vitest run tests/unit/message-bubble.test.ts
+npm run test:e2e -- --grep "Feature: Chat attachments"
+```
+
+Expected:
+
+- the unit suite fails because attachment tiles are still anchors, not preview buttons
+- the e2e suite fails because the transcript does not render an in-app modal yet
+
+- [ ] **Step 3: Create the centered modal component**
+
+Create `components/attachment-preview-modal.tsx` with this implementation:
+
+```tsx
+"use client";
+
+import React, { useEffect } from "react";
+import { Download, FileText, X } from "lucide-react";
+
+import type { MessageAttachment } from "@/lib/types";
+
+type AttachmentPreviewState =
+  | { kind: "loading" }
+  | { kind: "image" }
+  | { kind: "text"; content: string }
+  | { kind: "error"; message: string }
+  | { kind: "unsupported" };
+
+type AttachmentPreviewModalProps = {
+  attachment: MessageAttachment;
+  state: AttachmentPreviewState;
+  onClose: () => void;
+  onRetry?: () => void;
+};
+
+export function AttachmentPreviewModal({
+  attachment,
+  state,
+  onClose,
+  onRetry
+}: AttachmentPreviewModalProps) {
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 px-4 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Attachment preview"
+        className="flex max-h-[min(80vh,720px)] w-full max-w-4xl flex-col overflow-hidden rounded-2xl border border-white/10 bg-[#121317] shadow-2xl"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="flex items-center justify-between gap-4 border-b border-white/8 px-4 py-3">
+          <div className="flex items-center gap-3 min-w-0">
+            <button
+              type="button"
+              aria-label="Close attachment preview"
+              onClick={onClose}
+              className="flex h-9 w-9 items-center justify-center rounded-lg border border-white/10 bg-white/[0.03] text-white/75"
+            >
+              <X className="h-4 w-4" />
+            </button>
+            <div className="min-w-0">
+              <div className="truncate text-sm font-medium text-white">{attachment.filename}</div>
+              <div className="truncate text-xs text-white/50">{attachment.mimeType}</div>
+            </div>
+          </div>
+
+          <a
+            href={`/api/attachments/${attachment.id}`}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-2 rounded-lg border border-white/10 px-3 py-2 text-xs text-white/70"
+            aria-label="Open raw attachment"
+          >
+            <Download className="h-3.5 w-3.5" />
+            <span>Open raw</span>
+          </a>
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-auto p-4">
+          {state.kind === "image" ? (
+            <img
+              src={`/api/attachments/${attachment.id}`}
+              alt={attachment.filename}
+              className="mx-auto max-h-[60vh] w-auto max-w-full rounded-xl"
+            />
+          ) : null}
+
+          {state.kind === "loading" ? (
+            <div className="flex h-full min-h-64 items-center justify-center text-sm text-white/55">
+              Loading preview…
+            </div>
+          ) : null}
+
+          {state.kind === "text" ? (
+            <pre className="min-h-64 overflow-auto rounded-xl border border-white/8 bg-black/25 p-4 text-[13px] leading-6 text-white/85 whitespace-pre-wrap break-words font-mono">
+              {state.content}
+            </pre>
+          ) : null}
+
+          {state.kind === "unsupported" ? (
+            <div className="flex min-h-64 flex-col items-center justify-center gap-3 rounded-xl border border-dashed border-white/12 bg-black/20 px-6 text-center">
+              <FileText className="h-5 w-5 text-white/50" />
+              <p className="text-sm text-white/70">Preview unavailable for this attachment type.</p>
+            </div>
+          ) : null}
+
+          {state.kind === "error" ? (
+            <div className="flex min-h-64 flex-col items-center justify-center gap-4 rounded-xl border border-white/8 bg-black/20 px-6 text-center">
+              <p className="text-sm text-white/70">{state.message}</p>
+              <button
+                type="button"
+                onClick={onRetry}
+                className="rounded-lg border border-white/10 px-3 py-2 text-xs text-white/80"
+              >
+                Retry preview
+              </button>
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Wire transcript attachment tiles to open the modal**
+
+Update `components/message-bubble.tsx` with these changes:
+
+1. Add the new import near the top:
+
+```tsx
+import { AttachmentPreviewModal } from "@/components/attachment-preview-modal";
+```
+
+2. Replace `AttachmentTile` so it becomes a button instead of a direct link:
+
+```tsx
+function AttachmentTile({
+  attachment,
+  compact = false,
+  onPreview
+}: {
+  attachment: MessageAttachment;
+  compact?: boolean;
+  onPreview: (attachment: MessageAttachment) => void;
+}) {
+  if (attachment.kind === "image") {
+    return (
+      <button
+        type="button"
+        aria-label={`Preview ${attachment.filename}`}
+        onClick={() => onPreview(attachment)}
+        className={`overflow-hidden rounded-xl border border-white/10 bg-black/20 ${compact ? "w-16" : "w-28"}`}
+      >
+        <img
+          src={`/api/attachments/${attachment.id}`}
+          alt={attachment.filename}
+          className={`w-full object-cover ${compact ? "h-16" : "h-28"}`}
+        />
+      </button>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      aria-label={`Preview ${attachment.filename}`}
+      onClick={() => onPreview(attachment)}
+      className="flex min-w-0 items-center gap-2 rounded-xl border border-white/10 bg-black/15 px-3 py-2 text-left"
+    >
+      <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-white/10 text-white/75">
+        <FileText className="h-4 w-4" />
+      </span>
+      <span className="min-w-0">
+        <span className="block truncate text-sm font-medium text-white">{attachment.filename}</span>
+        <span className="block truncate text-xs text-white/60">{attachment.mimeType}</span>
+      </span>
+    </button>
+  );
+}
+```
+
+3. Pass the preview callback through `MessageAttachments`:
+
+```tsx
+function MessageAttachments({
+  attachments,
+  compact = false,
+  onPreview
+}: {
+  attachments: MessageAttachment[];
+  compact?: boolean;
+  onPreview: (attachment: MessageAttachment) => void;
+}) {
+  // existing image/file split remains the same
+  return (
+    <div className="space-y-2.5">
+      {images.length ? (
+        <div className="flex flex-wrap gap-2">
+          {images.map((attachment) => (
+            <AttachmentTile
+              key={attachment.id}
+              attachment={attachment}
+              compact={compact}
+              onPreview={onPreview}
+            />
+          ))}
+        </div>
+      ) : null}
+      {files.length ? (
+        <div className="space-y-2">
+          {files.map((attachment) => (
+            <AttachmentTile
+              key={attachment.id}
+              attachment={attachment}
+              compact={compact}
+              onPreview={onPreview}
+            />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+```
+
+4. Inside `MessageBubble`, add local preview state and lazy text loading:
+
+```tsx
+  const [previewAttachment, setPreviewAttachment] = useState<MessageAttachment | null>(null);
+  const [previewState, setPreviewState] = useState<
+    { kind: "loading" } | { kind: "image" } | { kind: "text"; content: string } | { kind: "error"; message: string } | { kind: "unsupported" }
+  >({ kind: "unsupported" });
+  const [textPreviewCache, setTextPreviewCache] = useState<Record<string, string>>({});
+
+  async function openAttachmentPreview(attachment: MessageAttachment) {
+    setPreviewAttachment(attachment);
+
+    if (attachment.kind === "image") {
+      setPreviewState({ kind: "image" });
+      return;
+    }
+
+    setPreviewState({ kind: "loading" });
+
+    const cached = textPreviewCache[attachment.id];
+    if (cached) {
+      setPreviewState({ kind: "text", content: cached });
+      return;
+    }
+
+    try {
+      const response = await fetch(`/api/attachments/${attachment.id}?format=text`);
+      if (!response.ok) {
+        if (response.status === 415) {
+          setPreviewState({ kind: "unsupported" });
+          return;
+        }
+        throw new Error("Unable to load attachment preview.");
+      }
+
+      const payload = await response.json();
+      setTextPreviewCache((current) => ({ ...current, [attachment.id]: payload.content }));
+      setPreviewState({ kind: "text", content: payload.content });
+    } catch (error) {
+      setPreviewState({
+        kind: "error",
+        message: error instanceof Error ? error.message : "Unable to load attachment preview."
+      });
+    }
+  }
+
+  function closeAttachmentPreview() {
+    setPreviewAttachment(null);
+    setPreviewState({ kind: "unsupported" });
+  }
+```
+
+5. Replace the existing attachment render call:
+
+```tsx
+                <MessageAttachments
+                  attachments={message.attachments}
+                  compact
+                  onPreview={openAttachmentPreview}
+                />
+```
+
+6. Render the modal near the bottom of `MessageBubble`:
+
+```tsx
+      {previewAttachment ? (
+        <AttachmentPreviewModal
+          attachment={previewAttachment}
+          state={previewState}
+          onClose={closeAttachmentPreview}
+          onRetry={() => void openAttachmentPreview(previewAttachment)}
+        />
+      ) : null}
+```
+
+- [ ] **Step 5: Update the e2e attachment mocks for text preview**
+
+Adjust `mockAttachmentUpload` in `tests/e2e/features.spec.ts` so preview requests can return text JSON:
+
+```ts
+  await page.route("**/api/attachments/*", async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.continue();
+      return;
+    }
+
+    const url = new URL(route.request().url());
+    const attachmentId = url.pathname.split("/").pop() ?? "";
+    const attachment = attachments.find((item) => item.id === attachmentId);
+
+    if (url.searchParams.get("format") === "text") {
+      await route.fulfill({
+        status: attachment?.kind === "text" ? 200 : 415,
+        contentType: "application/json",
+        body:
+          attachment?.kind === "text"
+            ? JSON.stringify({
+                id: attachment.id,
+                filename: attachment.filename,
+                mimeType: attachment.mimeType,
+                content: "hello"
+              })
+            : JSON.stringify({ error: "Attachment cannot be previewed as text" })
+      });
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: attachment?.mimeType ?? "image/png",
+      body: attachment?.kind === "image" ? TINY_PNG : Buffer.from("hello")
+    });
+  });
+```
+
+- [ ] **Step 6: Run the modal-focused suites to verify they pass**
+
+Run:
+
+```bash
+npx vitest run tests/unit/message-bubble.test.ts tests/unit/attachment-preview-route.test.ts
+npm run test:e2e -- --grep "Feature: Chat attachments"
+```
+
+Expected:
+
+- the focused unit suites pass
+- the chat attachments e2e scenarios pass, including transcript open/close behavior
+
+- [ ] **Step 7: Commit the modal-preview UI**
+
+Run:
+
+```bash
+git add components/attachment-preview-modal.tsx components/message-bubble.tsx tests/unit/message-bubble.test.ts tests/e2e/features.spec.ts
+git commit -m "feat: open attachments in preview modal"
+```
+
+Expected: a single commit covering the centered modal, transcript wiring, and matching tests.
+
+### Task 3: Run full verification and browser validation
+
+**Files:**
+- Review: `.dev-server`
+- Review: `playwright.config.ts`
+- Review: `.context/attachment-preview-modal-desktop.png`
+- Review: `.context/attachment-preview-modal-mobile.png`
+
+- [ ] **Step 1: Run the broader automated verification**
+
+Run:
+
+```bash
+npx vitest run
+npm run test:e2e -- --grep "Feature: Chat attachments|Feature: Create and delete conversations"
+```
+
+Expected:
+
+- `npx vitest run` passes without introducing regressions
+- the selected e2e coverage passes, including the attachment modal and baseline chat flow
+
+- [ ] **Step 2: Reuse or start the dev server using `.dev-server`**
+
+Run:
+
+```bash
+if [ -f .dev-server ]; then
+  URL="$(head -n 1 .dev-server)"
+  curl -sf "$URL" >/dev/null || rm .dev-server
+fi
+
+if [ ! -f .dev-server ]; then
+  npm run dev >/tmp/attachment-preview-dev.log 2>&1 &
+  until [ -f .dev-server ]; do sleep 1; done
+fi
+
+head -n 1 .dev-server
+```
+
+Expected: a reachable localhost URL on the first line of `.dev-server`.
+
+- [ ] **Step 3: Validate the desktop modal flow with agent-browser**
+
+Use the browser tooling against the URL from `.dev-server`:
+
+1. Open the app
+2. Sign in
+3. Create a chat with a text attachment
+4. Send the message
+5. Open the transcript attachment preview
+6. Confirm the centered modal, header controls, preview content, and explicit close path
+
+Save a screenshot to:
+
+```bash
+.context/attachment-preview-modal-desktop.png
+```
+
+Expected: a desktop screenshot showing the modal open over the transcript.
+
+- [ ] **Step 4: Validate the mobile-sized modal flow with agent-browser**
+
+In the same browser session:
+
+1. Switch to a narrow mobile viewport
+2. Re-open the same transcript attachment
+3. Confirm the modal still opens in-app
+4. Confirm the `X` close control remains visible and usable
+5. Confirm closing returns directly to the conversation view without navigation side effects
+
+Save a screenshot to:
+
+```bash
+.context/attachment-preview-modal-mobile.png
+```
+
+Expected: a mobile-sized screenshot showing the same centered modal pattern and visible close affordance.
+
+- [ ] **Step 5: Review the final diff and commit the verification-ready branch**
+
+Run:
+
+```bash
+git status --short
+git log --oneline --decorate -3
+```
+
+Expected:
+
+- no unexpected files beyond the planned source/test changes and `.context/` browser artifacts
+- the last two commits are:
+  - `feat: add attachment text preview responses`
+  - `feat: open attachments in preview modal`

--- a/docs/superpowers/specs/2026-04-13-attachment-preview-modal-design.md
+++ b/docs/superpowers/specs/2026-04-13-attachment-preview-modal-design.md
@@ -1,0 +1,175 @@
+# Attachment Preview Modal Design
+
+## Summary
+
+Replace the current attachment link behavior in chat bubbles with a centered in-app preview modal for all attachment clicks across desktop, mobile, and the PWA. The modal should open images inline, render text-like files such as `txt`, `md`, and `json` in a large read-only viewer, and provide a clear close path without relying on browser history or the system back gesture.
+
+This is a transcript attachment viewing change only. It does not introduce broader document management, pending-upload preview changes, or a new navigation pattern.
+
+## Goals
+
+- Eliminate the mobile/PWA dead-end caused by opening attachments inside the app without an obvious return path
+- Use one consistent attachment interaction model everywhere instead of splitting desktop and mobile behavior
+- Support inline preview for both image attachments and common text-like files
+- Keep the preview experience modal and explicit, with a visible close affordance
+
+## Non-Goals
+
+- Add browser-history integration or system-back handling for the preview state
+- Build a full document viewer platform for every file type
+- Add preview support to pending composer attachments before a message is sent
+- Redesign transcript attachment tiles beyond the click behavior needed to open the modal
+
+## Product Decisions
+
+### Interaction model
+
+- Clicking any persisted attachment tile in a chat bubble opens a centered modal inside the app
+- The modal uses the same interaction model on desktop, mobile browsers, and the installed PWA
+- Closing is modal-style only:
+  - `X` button
+  - backdrop click
+  - `Esc`
+- Closing is not tied to browser history, navigation state, or system back gestures
+
+### Content rendering
+
+- Image attachments render inline in the modal body using the existing authenticated attachment route
+- Text-like attachments render inline as plain read-only text in a large scrollable viewer
+- Initial inline text-preview support should explicitly cover:
+  - `text/plain`
+  - `text/markdown`
+  - `application/json`
+  - equivalent trusted text extensions already stored as text attachments
+- Unsupported file types still open the modal, but show a preview-unavailable fallback with raw-open/download actions
+
+### Header actions
+
+- The modal header includes:
+  - an explicit close control on the left
+  - filename and type metadata
+  - an action to open or download the raw attachment
+- The raw-open/download action remains available even when inline preview succeeds
+
+## UX Design
+
+### Modal shell
+
+Use a centered modal rather than a side sheet or full-bleed gallery. The centered shell is the simplest way to preserve one mental model across image and text attachments while staying compact enough for the existing chat experience.
+
+The body should prioritize the preview itself:
+
+- images scale to fit within the modal body without forcing navigation away from the transcript
+- text-like files render in a non-editable text surface with preserved whitespace, internal scrolling, and monospace styling suited for plain text, markdown, and JSON
+
+### Fallback states
+
+The preview surface must not trap the user when rendering fails or a file type is unsupported.
+
+Required fallback states:
+
+- **Loading:** visible while text content is being fetched
+- **Preview unavailable:** shown for unsupported file types
+- **Preview failed:** shown when inline fetching or rendering fails
+
+Each fallback should preserve:
+
+- the close control
+- the raw-open/download action
+- a retry affordance for fetch failures
+
+## Implementation Shape
+
+### Primary change surface
+
+The primary UI implementation surface is:
+
+- [components/message-bubble.tsx](/Users/charles/conductor/workspaces/Eidon-AI/buffalo/components/message-bubble.tsx)
+
+That component already owns transcript attachment rendering through `AttachmentTile` and `MessageAttachments`, so the modal state and click handling should stay close to that code instead of introducing a new global preview system.
+
+### State model
+
+Introduce a small attachment-preview state local to the message-bubble attachment rendering flow:
+
+- selected attachment metadata
+- whether the modal is open
+- text preview loading state
+- text preview content or error state
+
+This can stay local to the transcript attachment tree unless reuse becomes necessary later.
+
+### Data loading
+
+The app already has enough metadata to decide how to render the selected attachment. Only text-like previews need client-side body loading.
+
+Implementation direction:
+
+- images keep using `/api/attachments/[attachmentId]` directly as the preview source
+- text-like files fetch attachment body on demand when the modal opens
+- fetched text should be cached in-memory for the active client session so reopening the same file does not immediately refetch
+
+If the existing attachment route proves awkward for text-body fetching in the client, the implementation may add a narrowly-scoped text-preview response path or companion endpoint. That should remain limited to the preview feature and not broaden into generalized attachment APIs.
+
+### Attachment type handling
+
+Do not infer previewability from arbitrary MIME strings alone. Use a conservative allowlist based on the app’s current attachment model:
+
+- image attachments: inline image preview
+- known text-like attachments: inline text preview
+- everything else: preview-unavailable fallback
+
+This keeps the first iteration predictable and avoids malformed binary data being treated as readable text.
+
+## States And Edge Cases
+
+- Opening an attachment should no longer navigate to a new tab or new in-app document view
+- The modal must handle repeated open/close cycles cleanly
+- Very large text attachments should remain scrollable within the viewer rather than expanding the modal indefinitely
+- Failed preview fetches must not leave the modal blank or uncloseable
+- Unsupported attachment types should still expose a useful action path through raw open/download
+- The feature is scoped to persisted message attachments only, not pending composer uploads
+
+## Testing
+
+Add regression coverage for both rendering and interaction.
+
+### Unit coverage
+
+- Verify clicking an image attachment opens the modal
+- Verify clicking a text attachment opens the modal
+- Verify image attachments render an image preview body
+- Verify text-like attachments render a read-only text viewer after loading
+- Verify the modal closes via:
+  - `X`
+  - backdrop click
+  - `Esc`
+- Verify unsupported files render the preview-unavailable fallback
+- Verify preview failures render an error state with retry support
+
+### End-to-end coverage
+
+Extend the chat attachments feature coverage in:
+
+- [tests/e2e/features.spec.ts](/Users/charles/conductor/workspaces/Eidon-AI/buffalo/tests/e2e/features.spec.ts)
+
+Scenarios to validate:
+
+- send a chat with an image attachment, open it from the transcript, verify the modal appears, then close it
+- send a chat with a text attachment, open it from the transcript, verify inline content appears, then close it
+
+### Browser validation
+
+Because the original bug is specific to mobile/PWA behavior, manual browser validation should explicitly include:
+
+- desktop browser viewport
+- narrow mobile viewport
+- installed or standalone-oriented PWA flow if available in local testing
+
+Confirm that the preview always opens in-app and always exposes a visible close path.
+
+## Risks
+
+- The main implementation risk is client-side text preview loading if the existing attachment response shape is not convenient for inline text reading
+- A secondary risk is overextending support to too many file types too early; the first version should stay conservative
+- Another risk is introducing a modal shell that visually diverges from the rest of the app; implementation should follow existing overlay conventions where possible without broad redesign

--- a/lib/attachments.ts
+++ b/lib/attachments.ts
@@ -74,13 +74,6 @@ export class AttachmentTextPreviewUnsupportedError extends Error {
   }
 }
 
-export class AttachmentTextPreviewMissingFileError extends Error {
-  constructor() {
-    super("Attachment file not found");
-    this.name = "AttachmentTextPreviewMissingFileError";
-  }
-}
-
 function nowIso() {
   return new Date().toISOString();
 }
@@ -506,9 +499,7 @@ export function isInlineTextPreviewableAttachment(
 }
 
 export function readAttachmentText(
-  attachment: Pick<MessageAttachment, "relativePath" | "kind" | "mimeType" | "filename"> & {
-    extractedText?: string | null;
-  }
+  attachment: Pick<MessageAttachment, "relativePath" | "kind" | "mimeType" | "filename" | "extractedText">
 ) {
   if (!isInlineTextPreviewableAttachment(attachment)) {
     throw new AttachmentTextPreviewUnsupportedError();
@@ -518,11 +509,7 @@ export function readAttachmentText(
     return readAttachmentBuffer(attachment).toString("utf8");
   } catch (error) {
     if (error instanceof Error && "code" in error && error.code === "ENOENT") {
-      if (attachment.extractedText !== undefined && attachment.extractedText !== null) {
-        return attachment.extractedText;
-      }
-
-      throw new AttachmentTextPreviewMissingFileError();
+      return attachment.extractedText;
     }
 
     throw error;

--- a/lib/attachments.ts
+++ b/lib/attachments.ts
@@ -74,6 +74,13 @@ export class AttachmentTextPreviewUnsupportedError extends Error {
   }
 }
 
+export class AttachmentTextPreviewMissingFileError extends Error {
+  constructor() {
+    super("Attachment file not found");
+    this.name = "AttachmentTextPreviewMissingFileError";
+  }
+}
+
 function nowIso() {
   return new Date().toISOString();
 }
@@ -509,7 +516,11 @@ export function readAttachmentText(
     return readAttachmentBuffer(attachment).toString("utf8");
   } catch (error) {
     if (error instanceof Error && "code" in error && error.code === "ENOENT") {
-      return attachment.extractedText;
+      if (attachment.extractedText.length > 0) {
+        return attachment.extractedText;
+      }
+
+      throw new AttachmentTextPreviewMissingFileError();
     }
 
     throw error;

--- a/lib/attachments.ts
+++ b/lib/attachments.ts
@@ -477,8 +477,6 @@ export function readAttachmentBuffer(attachment: Pick<MessageAttachment, "relati
   return fs.readFileSync(resolveAttachmentAbsolutePath(attachment.relativePath));
 }
 
-const INLINE_TEXT_PREVIEW_MIME_TYPES = new Set(["text/plain", "text/markdown", "application/json"]);
-
 export function isInlineTextPreviewableAttachment(
   attachment: Pick<MessageAttachment, "kind" | "mimeType" | "filename">
 ) {
@@ -486,11 +484,11 @@ export function isInlineTextPreviewableAttachment(
     return false;
   }
 
-  if (INLINE_TEXT_PREVIEW_MIME_TYPES.has(attachment.mimeType)) {
-    return true;
+  try {
+    return normalizeAttachmentKind(attachment.filename, attachment.mimeType).kind === "text";
+  } catch {
+    return false;
   }
-
-  return /\.(txt|md|markdown|json)$/i.test(attachment.filename);
 }
 
 export function readAttachmentText(

--- a/lib/attachments.ts
+++ b/lib/attachments.ts
@@ -492,13 +492,21 @@ export function isInlineTextPreviewableAttachment(
 }
 
 export function readAttachmentText(
-  attachment: Pick<MessageAttachment, "relativePath" | "kind" | "mimeType" | "filename">
+  attachment: Pick<MessageAttachment, "relativePath" | "kind" | "mimeType" | "filename" | "extractedText">
 ) {
   if (!isInlineTextPreviewableAttachment(attachment)) {
     throw new Error("Attachment cannot be previewed as text");
   }
 
-  return readAttachmentBuffer(attachment).toString("utf8");
+  try {
+    return readAttachmentBuffer(attachment).toString("utf8");
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      return attachment.extractedText;
+    }
+
+    throw error;
+  }
 }
 
 export function getAttachmentDataUrl(attachment: Pick<MessageAttachment, "relativePath" | "mimeType">) {

--- a/lib/attachments.ts
+++ b/lib/attachments.ts
@@ -67,6 +67,13 @@ type CreateAttachmentInput = {
   bytes: Buffer;
 };
 
+export class AttachmentTextPreviewUnsupportedError extends Error {
+  constructor() {
+    super("Attachment cannot be previewed as text");
+    this.name = "AttachmentTextPreviewUnsupportedError";
+  }
+}
+
 function nowIso() {
   return new Date().toISOString();
 }
@@ -495,7 +502,7 @@ export function readAttachmentText(
   attachment: Pick<MessageAttachment, "relativePath" | "kind" | "mimeType" | "filename" | "extractedText">
 ) {
   if (!isInlineTextPreviewableAttachment(attachment)) {
-    throw new Error("Attachment cannot be previewed as text");
+    throw new AttachmentTextPreviewUnsupportedError();
   }
 
   try {

--- a/lib/attachments.ts
+++ b/lib/attachments.ts
@@ -477,6 +477,32 @@ export function readAttachmentBuffer(attachment: Pick<MessageAttachment, "relati
   return fs.readFileSync(resolveAttachmentAbsolutePath(attachment.relativePath));
 }
 
+const INLINE_TEXT_PREVIEW_MIME_TYPES = new Set(["text/plain", "text/markdown", "application/json"]);
+
+export function isInlineTextPreviewableAttachment(
+  attachment: Pick<MessageAttachment, "kind" | "mimeType" | "filename">
+) {
+  if (attachment.kind !== "text") {
+    return false;
+  }
+
+  if (INLINE_TEXT_PREVIEW_MIME_TYPES.has(attachment.mimeType)) {
+    return true;
+  }
+
+  return /\.(txt|md|markdown|json)$/i.test(attachment.filename);
+}
+
+export function readAttachmentText(
+  attachment: Pick<MessageAttachment, "relativePath" | "kind" | "mimeType" | "filename">
+) {
+  if (!isInlineTextPreviewableAttachment(attachment)) {
+    throw new Error("Attachment cannot be previewed as text");
+  }
+
+  return readAttachmentBuffer(attachment).toString("utf8");
+}
+
 export function getAttachmentDataUrl(attachment: Pick<MessageAttachment, "relativePath" | "mimeType">) {
   const buffer = readAttachmentBuffer(attachment);
   return `data:${attachment.mimeType};base64,${buffer.toString("base64")}`;

--- a/lib/attachments.ts
+++ b/lib/attachments.ts
@@ -506,7 +506,9 @@ export function isInlineTextPreviewableAttachment(
 }
 
 export function readAttachmentText(
-  attachment: Pick<MessageAttachment, "relativePath" | "kind" | "mimeType" | "filename" | "extractedText">
+  attachment: Pick<MessageAttachment, "relativePath" | "kind" | "mimeType" | "filename"> & {
+    extractedText?: string | null;
+  }
 ) {
   if (!isInlineTextPreviewableAttachment(attachment)) {
     throw new AttachmentTextPreviewUnsupportedError();
@@ -516,7 +518,7 @@ export function readAttachmentText(
     return readAttachmentBuffer(attachment).toString("utf8");
   } catch (error) {
     if (error instanceof Error && "code" in error && error.code === "ENOENT") {
-      if (attachment.extractedText.length > 0) {
+      if (attachment.extractedText !== undefined && attachment.extractedText !== null) {
         return attachment.extractedText;
       }
 

--- a/lib/attachments.ts
+++ b/lib/attachments.ts
@@ -6,7 +6,7 @@ import { MAX_ATTACHMENT_BYTES } from "@/lib/constants";
 import { getDb } from "@/lib/db";
 import { env } from "@/lib/env";
 import { createId } from "@/lib/ids";
-import { normalizeLineBreaks } from "@/lib/utils";
+import { normalizeLineBreaks } from "@/lib/text-utils";
 import type { AttachmentKind, MessageAttachment } from "@/lib/types";
 
 const IMAGE_EXTENSION_TO_MIME = new Map<string, string>([

--- a/lib/provider.ts
+++ b/lib/provider.ts
@@ -5,7 +5,7 @@ import { ensureFreshGithubAccessToken, runGithubCopilotChat, streamGithubCopilot
 import { buildCopilotTools, type CopilotToolContext } from "@/lib/copilot-tools";
 import { supportsVisibleReasoning } from "@/lib/model-capabilities";
 import { estimatePromptTokens, setActiveTokenizer } from "@/lib/tokenization";
-import { normalizeLineBreaks } from "@/lib/utils";
+import { normalizeLineBreaks } from "@/lib/text-utils";
 import type {
   ChatStreamEvent,
   MessageActionKind,

--- a/lib/text-utils.ts
+++ b/lib/text-utils.ts
@@ -1,0 +1,26 @@
+export function normalizeLineBreaks(text: string) {
+  return text
+    .replace(/\r\n?/g, "\n")
+    .replace(/(?:\\\\)+r(?:\\\\)+n/g, "\n")
+    .replace(/(?:\\\\)+n/g, "\n")
+    .replace(/(?:\\\\)+r/g, "\n")
+    .replace(/\\r\\n/g, "\n")
+    .replace(/\\n/g, "\n")
+    .replace(/\\r/g, "\n");
+}
+
+export function normalizeMarkdownLineBreaks(text: string) {
+  return normalizeLineBreaks(text).replace(/\n{3,}/g, (match) => {
+    const extras = match.length - 2;
+    return "\n\n" + "\u00A0\n\n".repeat(extras);
+  });
+}
+
+export function formatTimestamp(value: string) {
+  return new Intl.DateTimeFormat("en", {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit"
+  }).format(new Date(value));
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -5,33 +5,6 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
-export function normalizeLineBreaks(text: string) {
-  return text
-    .replace(/\r\n?/g, "\n")
-    .replace(/(?:\\\\)+r(?:\\\\)+n/g, "\n")
-    .replace(/(?:\\\\)+n/g, "\n")
-    .replace(/(?:\\\\)+r/g, "\n")
-    .replace(/\\r\\n/g, "\n")
-    .replace(/\\n/g, "\n")
-    .replace(/\\r/g, "\n");
-}
-
-export function normalizeMarkdownLineBreaks(text: string) {
-  return normalizeLineBreaks(text).replace(/\n{3,}/g, (match) => {
-    const extras = match.length - 2;
-    return "\n\n" + "\u00A0\n\n".repeat(extras);
-  });
-}
-
-export function formatTimestamp(value: string) {
-  return new Intl.DateTimeFormat("en", {
-    month: "short",
-    day: "numeric",
-    hour: "numeric",
-    minute: "2-digit"
-  }).format(new Date(value));
-}
-
 export function shouldAutofocusTextInput() {
   if (typeof window === "undefined") {
     return false;

--- a/tests/e2e/features.spec.ts
+++ b/tests/e2e/features.spec.ts
@@ -709,6 +709,10 @@ test.describe("Feature: Chat attachments", () => {
     await page.getByPlaceholder(/Ask, create, or start a task/i).fill("Keep this image");
     await page.getByRole("button", { name: "Send message" }).click();
     await expect(page.getByRole("button", { name: "Preview photo.png" }).last()).toBeVisible({
+      timeout: 1000
+    });
+    await page.waitForTimeout(250);
+    await expect(page.getByRole("button", { name: "Preview photo.png" }).last()).toBeVisible({
       timeout: 10000
     });
 
@@ -746,6 +750,10 @@ test.describe("Feature: Chat attachments", () => {
 
     await page.getByPlaceholder(/Ask, create, or start a task/i).fill("Keep these notes");
     await page.getByRole("button", { name: "Send message" }).click();
+    await expect(page.getByRole("button", { name: "Preview notes.txt" }).last()).toBeVisible({
+      timeout: 1000
+    });
+    await page.waitForTimeout(250);
     await expect(page.getByRole("button", { name: "Preview notes.txt" }).last()).toBeVisible({
       timeout: 10000
     });

--- a/tests/e2e/features.spec.ts
+++ b/tests/e2e/features.spec.ts
@@ -54,12 +54,25 @@ async function mockChatResponse(page: import("@playwright/test").Page) {
 }
 
 async function createNewChat(page: import("@playwright/test").Page) {
-  const newChatButton = page.getByRole("button", { name: "New chat", exact: true });
-  await expect(newChatButton).toBeVisible({ timeout: 10000 });
-  await expect(newChatButton).toBeEnabled({ timeout: 10000 });
+  const newChatButtons = page.getByRole("button", { name: "New chat", exact: true });
+  await expect(newChatButtons.first()).toBeVisible({ timeout: 10000 });
+
+  let newChatButton: import("@playwright/test").Locator | null = null;
+  const buttonCount = await newChatButtons.count();
+
+  for (let index = 0; index < buttonCount; index += 1) {
+    const candidate = newChatButtons.nth(index);
+
+    if ((await candidate.isVisible()) && (await candidate.isEnabled())) {
+      newChatButton = candidate;
+      break;
+    }
+  }
+
+  expect(newChatButton).not.toBeNull();
 
   for (let attempt = 0; attempt < 3; attempt += 1) {
-    await newChatButton.click();
+    await newChatButton!.click();
 
     try {
       await expect(page).toHaveURL(/\/chat\//, { timeout: 4000 });
@@ -680,6 +693,50 @@ test.describe("Feature: Chat attachments", () => {
     await expect(page.getByRole("button", { name: "Send message" })).toBeEnabled({
       timeout: 5000
     });
+  });
+
+  test("keeps a single user bubble when sending one prompt with two attachments", async ({ page }) => {
+    await signIn(page);
+    await mockChatResponse(page);
+    await mockAttachmentUpload(page, [
+      {
+        id: "att_photo",
+        filename: "photo.png",
+        mimeType: "image/png",
+        kind: "image"
+      },
+      {
+        id: "att_notes",
+        filename: "notes.txt",
+        mimeType: "text/plain",
+        kind: "text"
+      }
+    ]);
+
+    await createNewChat(page);
+    await expect(page).toHaveURL(/\/chat\//, { timeout: 10000 });
+
+    const chooserPromise = page.waitForEvent("filechooser");
+    const uploadResponsePromise = page.waitForResponse(
+      (response) =>
+        response.url().includes("/api/attachments") && response.request().method() === "POST"
+    );
+    await page.getByRole("button", { name: "Attach files" }).click();
+    const chooser = await chooserPromise;
+    await chooser.setFiles([
+      { name: "photo.png", mimeType: "image/png", buffer: TINY_PNG },
+      { name: "notes.txt", mimeType: "text/plain", buffer: Buffer.from("hello") }
+    ]);
+    await uploadResponsePromise;
+
+    await page.getByPlaceholder(/Ask, create, or start a task/i).fill("hello");
+    await page.getByRole("button", { name: "Send message" }).click();
+
+    await expect(page.getByText("hello", { exact: true })).toHaveCount(1, {
+      timeout: 10000
+    });
+    await expect(page.getByRole("button", { name: "Preview photo.png" })).toHaveCount(1);
+    await expect(page.getByRole("button", { name: "Preview notes.txt" })).toHaveCount(1);
   });
 
   test("opens transcript image attachments in a modal and closes them", async ({ page }) => {

--- a/tests/e2e/features.spec.ts
+++ b/tests/e2e/features.spec.ts
@@ -120,11 +120,51 @@ async function mockAttachmentUpload(
       return;
     }
 
-    await route.fulfill({
-      status: 200,
-      contentType: "image/png",
-      body: TINY_PNG
-    });
+    const requestUrl = new URL(route.request().url());
+    const attachmentId = requestUrl.pathname.split("/").pop();
+    const attachment = attachments.find((item) => item.id === attachmentId);
+
+    if (!attachment) {
+      await route.fulfill({ status: 404 });
+      return;
+    }
+
+    if (requestUrl.searchParams.get("format") === "text") {
+      if (attachment.kind !== "text") {
+        await route.fulfill({
+          status: 415,
+          contentType: "application/json",
+          body: JSON.stringify({ error: "Preview unavailable for this attachment type." })
+        });
+        return;
+      }
+
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: attachment.id,
+          filename: attachment.filename,
+          mimeType: attachment.mimeType,
+          content: "hello"
+        })
+      });
+      return;
+    }
+
+    await route.fulfill(
+      attachment.kind === "image"
+        ? {
+            status: 200,
+            contentType: "image/png",
+            body: TINY_PNG
+          }
+        : {
+            status: 200,
+            contentType: attachment.mimeType,
+            body: "hello"
+          }
+    );
   });
 }
 
@@ -640,5 +680,78 @@ test.describe("Feature: Chat attachments", () => {
     await expect(page.getByRole("button", { name: "Send message" })).toBeEnabled({
       timeout: 5000
     });
+  });
+
+  test("opens transcript image attachments in a modal and closes them", async ({ page }) => {
+    await signIn(page);
+    await mockChatResponse(page);
+    await mockAttachmentUpload(page, [
+      {
+        id: "att_photo",
+        filename: "photo.png",
+        mimeType: "image/png",
+        kind: "image"
+      }
+    ]);
+
+    await createNewChat(page);
+    await expect(page).toHaveURL(/\/chat\//, { timeout: 10000 });
+
+    const chooserPromise = page.waitForEvent("filechooser");
+    const uploadResponsePromise = page.waitForResponse(
+      (response) => response.url().includes("/api/attachments") && response.request().method() === "POST"
+    );
+    await page.getByRole("button", { name: "Attach files" }).click();
+    const chooser = await chooserPromise;
+    await chooser.setFiles({ name: "photo.png", mimeType: "image/png", buffer: TINY_PNG });
+    await uploadResponsePromise;
+
+    await page.getByPlaceholder(/Ask, create, or start a task/i).fill("Keep this image");
+    await page.getByRole("button", { name: "Send message" }).click();
+    await expect(page.getByRole("button", { name: "Preview photo.png" }).last()).toBeVisible({
+      timeout: 10000
+    });
+
+    await page.getByRole("button", { name: "Preview photo.png" }).last().click();
+    await expect(page.getByRole("dialog", { name: "Attachment preview" })).toBeVisible();
+    await expect(page.getByRole("img", { name: "photo.png" })).toBeVisible();
+
+    await page.getByRole("button", { name: "Close attachment preview" }).click();
+    await expect(page.getByRole("dialog", { name: "Attachment preview" })).toBeHidden();
+  });
+
+  test("opens transcript text attachments in a modal and renders preview content", async ({ page }) => {
+    await signIn(page);
+    await mockChatResponse(page);
+    await mockAttachmentUpload(page, [
+      {
+        id: "att_notes",
+        filename: "notes.txt",
+        mimeType: "text/plain",
+        kind: "text"
+      }
+    ]);
+
+    await createNewChat(page);
+    await expect(page).toHaveURL(/\/chat\//, { timeout: 10000 });
+
+    const chooserPromise = page.waitForEvent("filechooser");
+    const uploadResponsePromise = page.waitForResponse(
+      (response) => response.url().includes("/api/attachments") && response.request().method() === "POST"
+    );
+    await page.getByRole("button", { name: "Attach files" }).click();
+    const chooser = await chooserPromise;
+    await chooser.setFiles({ name: "notes.txt", mimeType: "text/plain", buffer: Buffer.from("hello") });
+    await uploadResponsePromise;
+
+    await page.getByPlaceholder(/Ask, create, or start a task/i).fill("Keep these notes");
+    await page.getByRole("button", { name: "Send message" }).click();
+    await expect(page.getByRole("button", { name: "Preview notes.txt" }).last()).toBeVisible({
+      timeout: 10000
+    });
+
+    await page.getByRole("button", { name: "Preview notes.txt" }).last().click();
+    await expect(page.getByRole("dialog", { name: "Attachment preview" })).toBeVisible();
+    await expect(page.getByText("hello")).toBeVisible();
   });
 });

--- a/tests/unit/attachment-preview-route.test.ts
+++ b/tests/unit/attachment-preview-route.test.ts
@@ -145,9 +145,9 @@ describe("attachment preview route", () => {
       { params: Promise.resolve({ attachmentId: attachment.id }) }
     );
 
-    expect(response.status).toBe(404);
+    expect(response.status).toBe(500);
     expect(response.headers.get("Content-Type")).not.toBe("text/markdown");
-    await expect(response.text()).resolves.toContain("Attachment file not found");
+    await expect(response.text()).resolves.toContain("Internal server error");
   });
 
   it("rejects inline text preview for image attachments", async () => {

--- a/tests/unit/attachment-preview-route.test.ts
+++ b/tests/unit/attachment-preview-route.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs";
+import path from "node:path";
+
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createAttachments } from "@/lib/attachments";
@@ -78,6 +81,44 @@ describe("attachment preview route", () => {
       filename: "notes.md",
       mimeType: "text/markdown",
       content: "# Notes\nHello preview"
+    });
+  });
+
+  it("falls back to stored extracted text when the text attachment file is missing", async () => {
+    const user = await createLocalUser({
+      username: "attachment-preview-missing-file-user",
+      password: "Password123!",
+      role: "user"
+    });
+    const conversation = createConversation("Missing attachment file preview", null, undefined, user.id);
+    const [attachment] = createAttachments(conversation.id, [
+      {
+        filename: "fallback.md",
+        mimeType: "text/markdown",
+        bytes: Buffer.from("# Missing file\nRecovered from extracted text", "utf8")
+      }
+    ]);
+    const absolutePath = path.resolve(
+      process.env.EIDON_DATA_DIR!,
+      "attachments",
+      attachment.relativePath
+    );
+
+    fs.unlinkSync(absolutePath);
+    requireUserMock.mockResolvedValue(user);
+
+    const { GET } = await import("@/app/api/attachments/[attachmentId]/route");
+    const response = await GET(
+      new Request(`http://localhost/api/attachments/${attachment.id}?format=text`),
+      { params: Promise.resolve({ attachmentId: attachment.id }) }
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      id: attachment.id,
+      filename: "fallback.md",
+      mimeType: "text/markdown",
+      content: "# Missing file\nRecovered from extracted text"
     });
   });
 

--- a/tests/unit/attachment-preview-route.test.ts
+++ b/tests/unit/attachment-preview-route.test.ts
@@ -2,11 +2,7 @@ import fs from "node:fs";
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import {
-  AttachmentTextPreviewMissingFileError,
-  createAttachments,
-  resolveAttachmentPath
-} from "@/lib/attachments";
+import { createAttachments, resolveAttachmentPath } from "@/lib/attachments";
 import { createConversation } from "@/lib/conversations";
 import { createLocalUser } from "@/lib/users";
 
@@ -153,37 +149,6 @@ describe("attachment preview route", () => {
       mimeType: "text/markdown",
       content: ""
     });
-  });
-
-  it("returns 404 for known missing-file preview failures without usable fallback", async () => {
-    const user = await createLocalUser({
-      username: "attachment-preview-known-missing-user",
-      password: "Password123!",
-      role: "user"
-    });
-    const conversation = createConversation("Known missing preview", null, undefined, user.id);
-    const [attachment] = createAttachments(conversation.id, [
-      {
-        filename: "missing.md",
-        mimeType: "text/markdown",
-        bytes: Buffer.from("# Missing\nNo fallback", "utf8")
-      }
-    ]);
-
-    requireUserMock.mockResolvedValue(user);
-    const attachmentsModule = await import("@/lib/attachments");
-    vi.spyOn(attachmentsModule, "readAttachmentText").mockImplementation(() => {
-      throw new AttachmentTextPreviewMissingFileError();
-    });
-
-    const { GET } = await import("@/app/api/attachments/[attachmentId]/route");
-    const response = await GET(
-      new Request(`http://localhost/api/attachments/${attachment.id}?format=text`),
-      { params: Promise.resolve({ attachmentId: attachment.id }) }
-    );
-
-    expect(response.status).toBe(404);
-    await expect(response.text()).resolves.toContain("Attachment file not found");
   });
 
   it("keeps text preview requests in text mode when preview reading fails unexpectedly", async () => {

--- a/tests/unit/attachment-preview-route.test.ts
+++ b/tests/unit/attachment-preview-route.test.ts
@@ -17,6 +17,38 @@ describe("attachment preview route", () => {
     requireUserMock.mockReset();
   });
 
+  it("returns text preview JSON for supported text attachment types accepted by uploads", async () => {
+    const user = await createLocalUser({
+      username: "attachment-preview-csv-user",
+      password: "Password123!",
+      role: "user"
+    });
+    const conversation = createConversation("Attachment csv preview", null, undefined, user.id);
+    const [attachment] = createAttachments(conversation.id, [
+      {
+        filename: "data.csv",
+        mimeType: "text/csv",
+        bytes: Buffer.from("name,value\npreview,1", "utf8")
+      }
+    ]);
+
+    requireUserMock.mockResolvedValue(user);
+
+    const { GET } = await import("@/app/api/attachments/[attachmentId]/route");
+    const response = await GET(
+      new Request(`http://localhost/api/attachments/${attachment.id}?format=text`),
+      { params: Promise.resolve({ attachmentId: attachment.id }) }
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      id: attachment.id,
+      filename: "data.csv",
+      mimeType: "text/csv",
+      content: "name,value\npreview,1"
+    });
+  });
+
   it("returns text preview JSON for supported text attachments", async () => {
     const user = await createLocalUser({
       username: "attachment-preview-user",
@@ -74,5 +106,46 @@ describe("attachment preview route", () => {
 
     expect(response.status).toBe(415);
     await expect(response.text()).resolves.toContain("Attachment cannot be previewed as text");
+  });
+
+  it("keeps the default response path as raw attachment bytes", async () => {
+    const user = await createLocalUser({
+      username: "attachment-raw-response-user",
+      password: "Password123!",
+      role: "user"
+    });
+    const conversation = createConversation("Raw attachment response", null, undefined, user.id);
+    const [attachment] = createAttachments(conversation.id, [
+      {
+        filename: "notes.md",
+        mimeType: "text/markdown",
+        bytes: Buffer.from("# Notes\nRaw body", "utf8")
+      }
+    ]);
+
+    requireUserMock.mockResolvedValue(user);
+
+    const { GET } = await import("@/app/api/attachments/[attachmentId]/route");
+    const response = await GET(
+      new Request(`http://localhost/api/attachments/${attachment.id}`),
+      { params: Promise.resolve({ attachmentId: attachment.id }) }
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("text/markdown");
+    expect(response.headers.get("Content-Disposition")).toBe('inline; filename="notes.md"');
+    await expect(response.text()).resolves.toBe("# Notes\nRaw body");
+  });
+
+  it("requires authentication for text preview access", async () => {
+    requireUserMock.mockResolvedValue(null);
+
+    const { GET } = await import("@/app/api/attachments/[attachmentId]/route");
+    const response = await GET(new Request("http://localhost/api/attachments/att_missing?format=text"), {
+      params: Promise.resolve({ attachmentId: "att_missing" })
+    });
+
+    expect(response.status).toBe(401);
+    await expect(response.text()).resolves.toContain("Authentication required");
   });
 });

--- a/tests/unit/attachment-preview-route.test.ts
+++ b/tests/unit/attachment-preview-route.test.ts
@@ -1,9 +1,8 @@
 import fs from "node:fs";
-import path from "node:path";
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { createAttachments } from "@/lib/attachments";
+import { createAttachments, resolveAttachmentPath } from "@/lib/attachments";
 import { createConversation } from "@/lib/conversations";
 import { createLocalUser } from "@/lib/users";
 
@@ -18,6 +17,7 @@ vi.mock("@/lib/auth", () => ({
 describe("attachment preview route", () => {
   beforeEach(() => {
     requireUserMock.mockReset();
+    vi.restoreAllMocks();
   });
 
   it("returns text preview JSON for supported text attachment types accepted by uploads", async () => {
@@ -98,11 +98,7 @@ describe("attachment preview route", () => {
         bytes: Buffer.from("# Missing file\nRecovered from extracted text", "utf8")
       }
     ]);
-    const absolutePath = path.resolve(
-      process.env.EIDON_DATA_DIR!,
-      "attachments",
-      attachment.relativePath
-    );
+    const absolutePath = resolveAttachmentPath(attachment);
 
     fs.unlinkSync(absolutePath);
     requireUserMock.mockResolvedValue(user);
@@ -120,6 +116,38 @@ describe("attachment preview route", () => {
       mimeType: "text/markdown",
       content: "# Missing file\nRecovered from extracted text"
     });
+  });
+
+  it("keeps text preview requests in text mode when preview reading fails unexpectedly", async () => {
+    const user = await createLocalUser({
+      username: "attachment-preview-read-error-user",
+      password: "Password123!",
+      role: "user"
+    });
+    const conversation = createConversation("Attachment preview read error", null, undefined, user.id);
+    const [attachment] = createAttachments(conversation.id, [
+      {
+        filename: "read-error.md",
+        mimeType: "text/markdown",
+        bytes: Buffer.from("# Read error\nStill text", "utf8")
+      }
+    ]);
+
+    requireUserMock.mockResolvedValue(user);
+    const attachmentsModule = await import("@/lib/attachments");
+    vi.spyOn(attachmentsModule, "readAttachmentText").mockImplementation(() => {
+      throw new Error("unexpected preview failure");
+    });
+
+    const { GET } = await import("@/app/api/attachments/[attachmentId]/route");
+    const response = await GET(
+      new Request(`http://localhost/api/attachments/${attachment.id}?format=text`),
+      { params: Promise.resolve({ attachmentId: attachment.id }) }
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get("Content-Type")).not.toBe("text/markdown");
+    await expect(response.text()).resolves.toContain("Attachment file not found");
   });
 
   it("rejects inline text preview for image attachments", async () => {

--- a/tests/unit/attachment-preview-route.test.ts
+++ b/tests/unit/attachment-preview-route.test.ts
@@ -2,7 +2,11 @@ import fs from "node:fs";
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { createAttachments, resolveAttachmentPath } from "@/lib/attachments";
+import {
+  AttachmentTextPreviewMissingFileError,
+  createAttachments,
+  resolveAttachmentPath
+} from "@/lib/attachments";
 import { createConversation } from "@/lib/conversations";
 import { createLocalUser } from "@/lib/users";
 
@@ -116,6 +120,70 @@ describe("attachment preview route", () => {
       mimeType: "text/markdown",
       content: "# Missing file\nRecovered from extracted text"
     });
+  });
+
+  it("returns empty text preview content when the stored fallback is empty and the file is missing", async () => {
+    const user = await createLocalUser({
+      username: "attachment-preview-empty-fallback-user",
+      password: "Password123!",
+      role: "user"
+    });
+    const conversation = createConversation("Empty fallback preview", null, undefined, user.id);
+    const [attachment] = createAttachments(conversation.id, [
+      {
+        filename: "blank.md",
+        mimeType: "text/markdown",
+        bytes: Buffer.from(" \n\t", "utf8")
+      }
+    ]);
+
+    fs.unlinkSync(resolveAttachmentPath(attachment));
+    requireUserMock.mockResolvedValue(user);
+
+    const { GET } = await import("@/app/api/attachments/[attachmentId]/route");
+    const response = await GET(
+      new Request(`http://localhost/api/attachments/${attachment.id}?format=text`),
+      { params: Promise.resolve({ attachmentId: attachment.id }) }
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      id: attachment.id,
+      filename: "blank.md",
+      mimeType: "text/markdown",
+      content: ""
+    });
+  });
+
+  it("returns 404 for known missing-file preview failures without usable fallback", async () => {
+    const user = await createLocalUser({
+      username: "attachment-preview-known-missing-user",
+      password: "Password123!",
+      role: "user"
+    });
+    const conversation = createConversation("Known missing preview", null, undefined, user.id);
+    const [attachment] = createAttachments(conversation.id, [
+      {
+        filename: "missing.md",
+        mimeType: "text/markdown",
+        bytes: Buffer.from("# Missing\nNo fallback", "utf8")
+      }
+    ]);
+
+    requireUserMock.mockResolvedValue(user);
+    const attachmentsModule = await import("@/lib/attachments");
+    vi.spyOn(attachmentsModule, "readAttachmentText").mockImplementation(() => {
+      throw new AttachmentTextPreviewMissingFileError();
+    });
+
+    const { GET } = await import("@/app/api/attachments/[attachmentId]/route");
+    const response = await GET(
+      new Request(`http://localhost/api/attachments/${attachment.id}?format=text`),
+      { params: Promise.resolve({ attachmentId: attachment.id }) }
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.text()).resolves.toContain("Attachment file not found");
   });
 
   it("keeps text preview requests in text mode when preview reading fails unexpectedly", async () => {

--- a/tests/unit/attachment-preview-route.test.ts
+++ b/tests/unit/attachment-preview-route.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createAttachments } from "@/lib/attachments";
+import { createConversation } from "@/lib/conversations";
+import { createLocalUser } from "@/lib/users";
+
+const { requireUserMock } = vi.hoisted(() => ({
+  requireUserMock: vi.fn()
+}));
+
+vi.mock("@/lib/auth", () => ({
+  requireUser: requireUserMock
+}));
+
+describe("attachment preview route", () => {
+  beforeEach(() => {
+    requireUserMock.mockReset();
+  });
+
+  it("returns text preview JSON for supported text attachments", async () => {
+    const user = await createLocalUser({
+      username: "attachment-preview-user",
+      password: "Password123!",
+      role: "user"
+    });
+    const conversation = createConversation("Attachment preview", null, undefined, user.id);
+    const [attachment] = createAttachments(conversation.id, [
+      {
+        filename: "notes.md",
+        mimeType: "text/markdown",
+        bytes: Buffer.from("# Notes\nHello preview", "utf8")
+      }
+    ]);
+
+    requireUserMock.mockResolvedValue(user);
+
+    const { GET } = await import("@/app/api/attachments/[attachmentId]/route");
+    const response = await GET(
+      new Request(`http://localhost/api/attachments/${attachment.id}?format=text`),
+      { params: Promise.resolve({ attachmentId: attachment.id }) }
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      id: attachment.id,
+      filename: "notes.md",
+      mimeType: "text/markdown",
+      content: "# Notes\nHello preview"
+    });
+  });
+
+  it("rejects inline text preview for image attachments", async () => {
+    const user = await createLocalUser({
+      username: "attachment-preview-image-user",
+      password: "Password123!",
+      role: "user"
+    });
+    const conversation = createConversation("Image preview", null, undefined, user.id);
+    const [attachment] = createAttachments(conversation.id, [
+      {
+        filename: "photo.png",
+        mimeType: "image/png",
+        bytes: Buffer.from("png-binary", "utf8")
+      }
+    ]);
+
+    requireUserMock.mockResolvedValue(user);
+
+    const { GET } = await import("@/app/api/attachments/[attachmentId]/route");
+    const response = await GET(
+      new Request(`http://localhost/api/attachments/${attachment.id}?format=text`),
+      { params: Promise.resolve({ attachmentId: attachment.id }) }
+    );
+
+    expect(response.status).toBe(415);
+    await expect(response.text()).resolves.toContain("Attachment cannot be previewed as text");
+  });
+});

--- a/tests/unit/chat-view.test.ts
+++ b/tests/unit/chat-view.test.ts
@@ -403,6 +403,16 @@ describe("chat view", () => {
     return render(React.createElement(ContextTokensProvider, null, ui));
   }
 
+  function renderWithProviderStrict(ui: React.ReactElement) {
+    return render(
+      React.createElement(
+        React.StrictMode,
+        null,
+        React.createElement(ContextTokensProvider, null, ui)
+      )
+    );
+  }
+
   it("uploads an attachment from the file input and removes it from the pending list", async () => {
     const attachment = createAttachment();
     vi.mocked(global.fetch)
@@ -930,6 +940,182 @@ describe("chat view", () => {
     expect(bootstrapMock.clearChatBootstrap).toHaveBeenCalledWith("conv_1");
   });
 
+  it("reconciles a bootstrapped home submission with attachments from polling", async () => {
+    const imageAttachment = createAttachment({
+      id: "att_image",
+      filename: "photo.png",
+      mimeType: "image/png",
+      kind: "image"
+    });
+    const textAttachment = createAttachment({
+      id: "att_text",
+      filename: "notes.txt",
+      mimeType: "text/plain",
+      kind: "text",
+      extractedText: "hello"
+    });
+    let conversationFetchCount = 0;
+
+    bootstrapMock.readChatBootstrap.mockReturnValue({
+      message: "Bootstrapped prompt",
+      attachments: [imageAttachment, textAttachment]
+    });
+
+    vi.mocked(global.fetch).mockImplementation((input) => {
+      if (input === "/api/personas") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ personas: [] })
+        } as Response);
+      }
+
+      if (input === "/api/conversations/conv_1") {
+        conversationFetchCount += 1;
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            conversation: {
+              ...createPayload().conversation,
+              isActive: false
+            },
+            messages: [
+              createMessage({
+                id: "msg_user_server",
+                role: "user",
+                content: "Bootstrapped prompt",
+                attachments: [imageAttachment, textAttachment]
+              }),
+              createMessage({
+                id: "msg_assistant",
+                role: "assistant",
+                content: "Attachment received",
+                status: "completed"
+              })
+            ]
+          })
+        } as Response);
+      }
+
+      return Promise.reject(new Error(`Unexpected fetch: ${String(input)}`));
+    });
+
+    renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
+
+    await waitFor(() => {
+      expect(wsMock.send).toHaveBeenCalledWith({
+        type: "message",
+        conversationId: "conv_1",
+        content: "Bootstrapped prompt",
+        attachmentIds: ["att_image", "att_text"]
+      });
+    });
+
+    await waitFor(() => {
+      expect(conversationFetchCount).toBeGreaterThan(0);
+    });
+
+    await waitFor(
+      () => {
+        expect(screen.getAllByText("Bootstrapped prompt")).toHaveLength(1);
+        expect(screen.getAllByRole("button", { name: "Preview photo.png" })).toHaveLength(1);
+        expect(screen.getAllByRole("button", { name: "Preview notes.txt" })).toHaveLength(1);
+      },
+      { timeout: 2500 }
+    );
+  });
+
+  it("removes an orphaned local duplicate when polling confirms the server user message", async () => {
+    const imageAttachment = createAttachment({
+      id: "att_image",
+      filename: "photo.png",
+      mimeType: "image/png",
+      kind: "image"
+    });
+    const textAttachment = createAttachment({
+      id: "att_text",
+      filename: "notes.txt",
+      mimeType: "text/plain",
+      kind: "text",
+      extractedText: "hello"
+    });
+    const serverUserMessage = createMessage({
+      id: "msg_user_server",
+      role: "user",
+      content: "Bootstrapped prompt",
+      attachments: [imageAttachment, textAttachment]
+    });
+    const orphanedLocalMessage = createMessage({
+      id: "local_orphan",
+      role: "user",
+      content: "Bootstrapped prompt",
+      attachments: [imageAttachment, textAttachment]
+    });
+    const assistantStreamingMessage = createMessage({
+      id: "msg_assistant",
+      role: "assistant",
+      content: "",
+      status: "streaming"
+    });
+    let conversationFetchCount = 0;
+
+    vi.mocked(global.fetch).mockImplementation((input) => {
+      if (input === "/api/personas") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ personas: [] })
+        } as Response);
+      }
+
+      if (input === "/api/conversations/conv_1") {
+        conversationFetchCount += 1;
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            conversation: {
+              ...createPayload().conversation,
+              isActive: false
+            },
+            messages: [
+              serverUserMessage,
+              {
+                ...assistantStreamingMessage,
+                content: "Attachment received",
+                status: "completed"
+              }
+            ]
+          })
+        } as Response);
+      }
+
+      return Promise.reject(new Error(`Unexpected fetch: ${String(input)}`));
+    });
+
+    renderWithProvider(
+      React.createElement(ChatView, {
+        payload: createPayload({
+          conversation: {
+            ...createPayload().conversation,
+            isActive: true
+          },
+          messages: [serverUserMessage, assistantStreamingMessage, orphanedLocalMessage]
+        })
+      })
+    );
+
+    await waitFor(() => {
+      expect(conversationFetchCount).toBeGreaterThan(0);
+    });
+
+    await waitFor(
+      () => {
+        expect(screen.getAllByText("Bootstrapped prompt")).toHaveLength(1);
+        expect(screen.getAllByRole("button", { name: "Preview photo.png" })).toHaveLength(1);
+        expect(screen.getAllByRole("button", { name: "Preview notes.txt" })).toHaveLength(1);
+      },
+      { timeout: 2500 }
+    );
+  });
+
   it("deletes an empty conversation when navigating away before sending a message", async () => {
     const { deleteConversationIfStillEmpty } = await import("@/lib/conversation-drafts");
 
@@ -1212,7 +1398,696 @@ describe("chat view", () => {
     });
   });
 
+  it("reconciles a multi-attachment optimistic message after partial then complete server snapshots", async () => {
+    const imageAttachment = createAttachment({
+      id: "att_image",
+      filename: "photo.png",
+      mimeType: "image/png",
+      kind: "image"
+    });
+    const textAttachment = createAttachment({
+      id: "att_text",
+      filename: "notes.txt",
+      mimeType: "text/plain",
+      kind: "text",
+      extractedText: "hello"
+    });
+
+    vi.mocked(global.fetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ personas: [] })
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ attachments: [imageAttachment, textAttachment] })
+      } as Response);
+
+    const { container } = renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const textarea = screen.getByPlaceholderText(
+      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
+    );
+
+    fireEvent.change(input, {
+      target: {
+        files: [
+          new File(["binary"], "photo.png", { type: "image/png" }),
+          new File(["hello"], "notes.txt", { type: "text/plain" })
+        ]
+      }
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Remove photo.png" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Remove notes.txt" })).toBeInTheDocument();
+    });
+
+    fireEvent.change(textarea, { target: { value: "hello" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(wsMock.send).toHaveBeenCalledWith({
+        type: "message",
+        conversationId: "conv_1",
+        content: "hello",
+        attachmentIds: ["att_image", "att_text"]
+      });
+    });
+
+    act(() => {
+      wsMock.onMessage!({
+        type: "snapshot",
+        conversationId: "conv_1",
+        messages: [
+          createMessage({
+            id: "msg_user_server",
+            role: "user",
+            content: "hello",
+            attachments: [imageAttachment]
+          })
+        ]
+      });
+    });
+
+    act(() => {
+      wsMock.onMessage!({
+        type: "snapshot",
+        conversationId: "conv_1",
+        messages: [
+          createMessage({
+            id: "msg_user_server",
+            role: "user",
+            content: "hello",
+            attachments: [imageAttachment, textAttachment]
+          })
+        ]
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByText("hello")).toHaveLength(1);
+      expect(screen.getAllByRole("button", { name: "Preview photo.png" })).toHaveLength(1);
+      expect(screen.getAllByRole("button", { name: "Preview notes.txt" })).toHaveLength(1);
+    });
+  });
+
+  it("reconciles a multi-attachment optimistic message after an empty then complete server snapshot", async () => {
+    const imageAttachment = createAttachment({
+      id: "att_image",
+      filename: "photo.png",
+      mimeType: "image/png",
+      kind: "image"
+    });
+    const textAttachment = createAttachment({
+      id: "att_text",
+      filename: "notes.txt",
+      mimeType: "text/plain",
+      kind: "text",
+      extractedText: "hello"
+    });
+
+    vi.mocked(global.fetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ personas: [] })
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ attachments: [imageAttachment, textAttachment] })
+      } as Response);
+
+    const { container } = renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const textarea = screen.getByPlaceholderText(
+      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
+    );
+
+    fireEvent.change(input, {
+      target: {
+        files: [
+          new File(["binary"], "photo.png", { type: "image/png" }),
+          new File(["hello"], "notes.txt", { type: "text/plain" })
+        ]
+      }
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("photo.png")).toBeInTheDocument();
+      expect(screen.getByText("notes.txt")).toBeInTheDocument();
+    });
+
+    fireEvent.change(textarea, { target: { value: "hello" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(wsMock.send).toHaveBeenCalledWith({
+        type: "message",
+        conversationId: "conv_1",
+        content: "hello",
+        attachmentIds: ["att_image", "att_text"]
+      });
+    });
+
+    act(() => {
+      wsMock.onMessage!({
+        type: "snapshot",
+        conversationId: "conv_1",
+        messages: [
+          createMessage({
+            id: "msg_user_server",
+            role: "user",
+            content: "hello",
+            attachments: []
+          })
+        ]
+      });
+    });
+
+    act(() => {
+      wsMock.onMessage!({
+        type: "snapshot",
+        conversationId: "conv_1",
+        messages: [
+          createMessage({
+            id: "msg_user_server",
+            role: "user",
+            content: "hello",
+            attachments: [imageAttachment, textAttachment]
+          })
+        ]
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByText("hello")).toHaveLength(1);
+      expect(screen.getAllByRole("button", { name: "Preview photo.png" })).toHaveLength(1);
+      expect(screen.getAllByRole("button", { name: "Preview notes.txt" })).toHaveLength(1);
+    });
+  });
+
+  it("keeps polling after assistant done until a pending optimistic user message reconciles", async () => {
+    const imageAttachment = createAttachment({
+      id: "att_image",
+      filename: "photo.png",
+      mimeType: "image/png",
+      kind: "image"
+    });
+    const textAttachment = createAttachment({
+      id: "att_text",
+      filename: "notes.txt",
+      mimeType: "text/plain",
+      kind: "text",
+      extractedText: "hello"
+    });
+    const baseConversation = createPayload().conversation;
+    let conversationFetchCount = 0;
+
+    vi.mocked(global.fetch).mockImplementation((input) => {
+      if (input === "/api/personas") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ personas: [] })
+        } as Response);
+      }
+
+      if (input === "/api/attachments") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ attachments: [imageAttachment, textAttachment] })
+        } as Response);
+      }
+
+      if (input === "/api/conversations/conv_1") {
+        conversationFetchCount += 1;
+
+        if (conversationFetchCount === 1) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              conversation: {
+                ...baseConversation,
+                isActive: true
+              },
+              messages: [
+                createMessage({
+                  id: "msg_user_server",
+                  role: "user",
+                  content: "hello",
+                  attachments: []
+                }),
+                createMessage({
+                  id: "msg_assistant",
+                  role: "assistant",
+                  content: "",
+                  status: "streaming"
+                })
+              ]
+            })
+          } as Response);
+        }
+
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            conversation: {
+              ...baseConversation,
+              isActive: false
+            },
+            messages: [
+              createMessage({
+                id: "msg_user_server",
+                role: "user",
+                content: "hello",
+                attachments: [imageAttachment, textAttachment]
+              }),
+              createMessage({
+                id: "msg_assistant",
+                role: "assistant",
+                content: "Attachment received",
+                status: "completed"
+              })
+            ]
+          })
+        } as Response);
+      }
+
+      return Promise.reject(new Error(`Unexpected fetch: ${String(input)}`));
+    });
+
+    const { container } = renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const textarea = screen.getByPlaceholderText(
+      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
+    );
+
+    fireEvent.change(input, {
+      target: {
+        files: [
+          new File(["binary"], "photo.png", { type: "image/png" }),
+          new File(["hello"], "notes.txt", { type: "text/plain" })
+        ]
+      }
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("photo.png")).toBeInTheDocument();
+      expect(screen.getByText("notes.txt")).toBeInTheDocument();
+    });
+
+    fireEvent.change(textarea, { target: { value: "hello" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(conversationFetchCount).toBe(1);
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByText("hello")).toHaveLength(1);
+    });
+
+    act(() => {
+      wsMock.onMessage!({
+        type: "delta",
+        conversationId: "conv_1",
+        event: { type: "answer_delta", text: "Attachment received" }
+      });
+    });
+
+    act(() => {
+      wsMock.onMessage!({
+        type: "delta",
+        conversationId: "conv_1",
+        event: { type: "done", messageId: "msg_assistant" }
+      });
+    });
+
+    await waitFor(
+      () => {
+        expect(conversationFetchCount).toBe(1);
+        expect(screen.getAllByText("hello")).toHaveLength(1);
+        expect(screen.queryByRole("button", { name: "Preview photo.png" })).toBeNull();
+        expect(screen.queryByRole("button", { name: "Preview notes.txt" })).toBeNull();
+      },
+      { timeout: 2500 }
+    );
+
+    await waitFor(
+      () => {
+        expect(conversationFetchCount).toBe(2);
+        expect(screen.getAllByText("hello")).toHaveLength(1);
+        expect(screen.getAllByRole("button", { name: "Preview photo.png" })).toHaveLength(1);
+        expect(screen.getAllByRole("button", { name: "Preview notes.txt" })).toHaveLength(1);
+      },
+      { timeout: 2500 }
+    );
+  });
+
+  it("does not replay a retired optimistic attachment message in strict mode", async () => {
+    const imageAttachment = createAttachment({
+      id: "att_image",
+      filename: "photo.png",
+      mimeType: "image/png",
+      kind: "image"
+    });
+    const textAttachment = createAttachment({
+      id: "att_text",
+      filename: "notes.txt",
+      mimeType: "text/plain",
+      kind: "text",
+      extractedText: "hello"
+    });
+    const baseConversation = createPayload().conversation;
+    let conversationFetchCount = 0;
+
+    vi.mocked(global.fetch).mockImplementation((input) => {
+      if (input === "/api/personas") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ personas: [] })
+        } as Response);
+      }
+
+      if (input === "/api/attachments") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ attachments: [imageAttachment, textAttachment] })
+        } as Response);
+      }
+
+      if (input === "/api/conversations/conv_1") {
+        conversationFetchCount += 1;
+
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            conversation: {
+              ...baseConversation,
+              isActive: true
+            },
+            messages: [
+              createMessage({
+                id: "msg_user_server",
+                role: "user",
+                content: "hello",
+                attachments: [imageAttachment, textAttachment]
+              }),
+              createMessage({
+                id: "msg_assistant",
+                role: "assistant",
+                content: "",
+                status: "streaming"
+              })
+            ]
+          })
+        } as Response);
+      }
+
+      return Promise.reject(new Error(`Unexpected fetch: ${String(input)}`));
+    });
+
+    const { container } = renderWithProviderStrict(
+      React.createElement(ChatView, { payload: createPayload() })
+    );
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const textarea = screen.getByPlaceholderText(
+      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
+    );
+
+    fireEvent.change(input, {
+      target: {
+        files: [
+          new File(["binary"], "photo.png", { type: "image/png" }),
+          new File(["hello"], "notes.txt", { type: "text/plain" })
+        ]
+      }
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("photo.png")).toBeInTheDocument();
+      expect(screen.getByText("notes.txt")).toBeInTheDocument();
+    });
+
+    fireEvent.change(textarea, { target: { value: "hello" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(conversationFetchCount).toBeGreaterThan(0);
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByText("hello")).toHaveLength(1);
+      expect(screen.getAllByRole("button", { name: "Preview photo.png" })).toHaveLength(1);
+      expect(screen.getAllByRole("button", { name: "Preview notes.txt" })).toHaveLength(1);
+    });
+  });
+
+  it("keeps a later identical submission optimistic until its own server message arrives", async () => {
+    const imageAttachment = createAttachment({
+      id: "att_image",
+      filename: "photo.png",
+      mimeType: "image/png",
+      kind: "image"
+    });
+    const textAttachment = createAttachment({
+      id: "att_text",
+      filename: "notes.txt",
+      mimeType: "text/plain",
+      kind: "text",
+      extractedText: "hello"
+    });
+
+    vi.mocked(global.fetch).mockImplementation((input) => {
+      if (input === "/api/personas") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ personas: [] })
+        } as Response);
+      }
+
+      if (typeof input === "string" && input === "/api/attachments") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ attachments: [imageAttachment, textAttachment] })
+        } as Response);
+      }
+
+      return Promise.reject(new Error(`Unexpected fetch: ${String(input)}`));
+    });
+
+    const { container } = renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const textarea = screen.getByPlaceholderText(
+      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
+    );
+
+    fireEvent.change(input, {
+      target: {
+        files: [
+          new File(["binary"], "photo.png", { type: "image/png" }),
+          new File(["hello"], "notes.txt", { type: "text/plain" })
+        ]
+      }
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Remove photo.png" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Remove notes.txt" })).toBeInTheDocument();
+    });
+
+    fireEvent.change(textarea, { target: { value: "hello" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(wsMock.send).toHaveBeenCalledWith({
+        type: "message",
+        conversationId: "conv_1",
+        content: "hello",
+        attachmentIds: ["att_image", "att_text"]
+      });
+    });
+
+    act(() => {
+      wsMock.onMessage!({
+        type: "delta",
+        conversationId: "conv_1",
+        event: { type: "message_start", messageId: "msg_assistant_first" }
+      });
+    });
+
+    act(() => {
+      wsMock.onMessage!({
+        type: "delta",
+        conversationId: "conv_1",
+        event: { type: "done", messageId: "msg_assistant_first" }
+      });
+    });
+
+    fireEvent.change(input, {
+      target: {
+        files: [
+          new File(["binary"], "photo.png", { type: "image/png" }),
+          new File(["hello"], "notes.txt", { type: "text/plain" })
+        ]
+      }
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Remove photo.png" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Remove notes.txt" })).toBeInTheDocument();
+    });
+
+    fireEvent.change(textarea, { target: { value: "hello" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(wsMock.send).toHaveBeenNthCalledWith(2, {
+        type: "message",
+        conversationId: "conv_1",
+        content: "hello",
+        attachmentIds: ["att_image", "att_text"]
+      });
+    });
+
+    act(() => {
+      wsMock.onMessage!({
+        type: "snapshot",
+        conversationId: "conv_1",
+        messages: [
+          createMessage({
+            id: "msg_user_server_first",
+            role: "user",
+            content: "hello",
+            attachments: [imageAttachment]
+          })
+        ]
+      });
+    });
+
+    act(() => {
+      wsMock.onMessage!({
+        type: "snapshot",
+        conversationId: "conv_1",
+        messages: [
+          createMessage({
+            id: "msg_user_server_first",
+            role: "user",
+            content: "hello",
+            attachments: [imageAttachment, textAttachment]
+          })
+        ]
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByText("hello")).toHaveLength(2);
+      expect(screen.getAllByRole("button", { name: "Preview photo.png" })).toHaveLength(2);
+      expect(screen.getAllByRole("button", { name: "Preview notes.txt" })).toHaveLength(2);
+    });
+  });
+
   it("keeps the attachment preview open when a local message is replaced by the persisted server message", async () => {
+    const attachment = createAttachment({
+      id: "att_text",
+      filename: "notes.txt",
+      mimeType: "text/plain",
+      kind: "text",
+      extractedText: "preview content"
+    });
+
+    vi.mocked(global.fetch).mockImplementation((input) => {
+      if (input === "/api/personas") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ personas: [] })
+        } as Response);
+      }
+
+      if (input === "/api/attachments") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ attachments: [attachment] })
+        } as Response);
+      }
+
+      if (input === "/api/attachments/att_text?format=text") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            id: "att_text",
+            filename: "notes.txt",
+            mimeType: "text/plain",
+            content: "preview content"
+          })
+        } as Response);
+      }
+
+      return Promise.reject(new Error(`Unexpected fetch: ${String(input)}`));
+    });
+
+    const { container } = renderWithProvider(
+      React.createElement(ChatView, { payload: createPayload() })
+    );
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const textarea = screen.getByPlaceholderText(
+      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
+    );
+
+    fireEvent.change(input, {
+      target: {
+        files: [new File(["preview content"], "notes.txt", { type: "text/plain" })]
+      }
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Remove notes.txt" })).toBeInTheDocument();
+    });
+
+    fireEvent.change(textarea, { target: { value: "Keep these notes" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(wsMock.send).toHaveBeenCalledWith({
+        type: "message",
+        conversationId: "conv_1",
+        content: "Keep these notes",
+        attachmentIds: ["att_text"]
+      });
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Preview notes.txt" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog", { name: "Attachment preview" })).toBeInTheDocument();
+      expect(screen.getByText("preview content")).toBeInTheDocument();
+    });
+
+    const persistedPayload = createPayload({
+      messages: [
+        createMessage({
+          id: "msg_user",
+          role: "user",
+          content: "Keep these notes",
+          attachments: [attachment]
+        })
+      ]
+    });
+
+    act(() => {
+      wsMock.onMessage!({
+        type: "snapshot",
+        conversationId: "conv_1",
+        messages: persistedPayload.messages
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog", { name: "Attachment preview" })).toBeInTheDocument();
+      expect(screen.getByText("preview content")).toBeInTheDocument();
+    });
+  });
+
+  it("closes the attachment preview when the active conversation changes", async () => {
     vi.mocked(global.fetch).mockImplementation((input) => {
       if (input === "/api/personas") {
         return Promise.resolve({
@@ -1243,26 +2118,8 @@ describe("chat view", () => {
       kind: "text",
       extractedText: "preview content"
     });
-    const localPayload = createPayload({
-      messages: [
-        createMessage({
-          id: "local_1",
-          role: "user",
-          content: "Keep these notes",
-          attachments: [attachment]
-        })
-      ]
-    });
-    const view = renderWithProvider(React.createElement(ChatView, { payload: localPayload }));
 
-    fireEvent.click(screen.getByRole("button", { name: "Preview notes.txt" }));
-
-    await waitFor(() => {
-      expect(screen.getByRole("dialog", { name: "Attachment preview" })).toBeInTheDocument();
-      expect(screen.getByText("preview content")).toBeInTheDocument();
-    });
-
-    const persistedPayload = createPayload({
+    const firstPayload = createPayload({
       messages: [
         createMessage({
           id: "msg_user",
@@ -1273,17 +2130,34 @@ describe("chat view", () => {
       ]
     });
 
-    view.rerender(
-      React.createElement(
-        ContextTokensProvider,
-        null,
-        React.createElement(ChatView, { payload: persistedPayload })
-      )
-    );
+    const view = renderWithProvider(React.createElement(ChatView, { payload: firstPayload }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Preview notes.txt" }));
 
     await waitFor(() => {
       expect(screen.getByRole("dialog", { name: "Attachment preview" })).toBeInTheDocument();
       expect(screen.getByText("preview content")).toBeInTheDocument();
+    });
+
+    const secondPayload = createPayload({
+      conversation: {
+        ...firstPayload.conversation,
+        id: "conv_2",
+        title: "Another conversation"
+      },
+      messages: []
+    });
+
+    view.rerender(
+      React.createElement(
+        ContextTokensProvider,
+        null,
+        React.createElement(ChatView, { payload: secondPayload })
+      )
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Attachment preview" })).toBeNull();
     });
   });
 

--- a/tests/unit/chat-view.test.ts
+++ b/tests/unit/chat-view.test.ts
@@ -1178,6 +1178,115 @@ describe("chat view", () => {
     });
   });
 
+  it("keeps an optimistic user message visible when an unrelated server user message arrives first", async () => {
+    renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
+
+    const textarea = screen.getByPlaceholderText(
+      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
+    );
+
+    fireEvent.change(textarea, { target: { value: "keep this attachment" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(screen.getByText("keep this attachment")).toBeInTheDocument();
+    });
+
+    act(() => {
+      wsMock.onMessage!({
+        type: "snapshot",
+        conversationId: "conv_1",
+        messages: [
+          createMessage({
+            id: "msg_other_user",
+            role: "user",
+            content: "server-side note"
+          })
+        ]
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("keep this attachment")).toBeInTheDocument();
+      expect(screen.getByText("server-side note")).toBeInTheDocument();
+    });
+  });
+
+  it("keeps the attachment preview open when a local message is replaced by the persisted server message", async () => {
+    vi.mocked(global.fetch).mockImplementation((input) => {
+      if (input === "/api/personas") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ personas: [] })
+        } as Response);
+      }
+
+      if (input === "/api/attachments/att_text?format=text") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            id: "att_text",
+            filename: "notes.txt",
+            mimeType: "text/plain",
+            content: "preview content"
+          })
+        } as Response);
+      }
+
+      return Promise.reject(new Error(`Unexpected fetch: ${String(input)}`));
+    });
+
+    const attachment = createAttachment({
+      id: "att_text",
+      filename: "notes.txt",
+      mimeType: "text/plain",
+      kind: "text",
+      extractedText: "preview content"
+    });
+    const localPayload = createPayload({
+      messages: [
+        createMessage({
+          id: "local_1",
+          role: "user",
+          content: "Keep these notes",
+          attachments: [attachment]
+        })
+      ]
+    });
+    const view = renderWithProvider(React.createElement(ChatView, { payload: localPayload }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Preview notes.txt" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog", { name: "Attachment preview" })).toBeInTheDocument();
+      expect(screen.getByText("preview content")).toBeInTheDocument();
+    });
+
+    const persistedPayload = createPayload({
+      messages: [
+        createMessage({
+          id: "msg_user",
+          role: "user",
+          content: "Keep these notes",
+          attachments: [attachment]
+        })
+      ]
+    });
+
+    view.rerender(
+      React.createElement(
+        ContextTokensProvider,
+        null,
+        React.createElement(ChatView, { payload: persistedPayload })
+      )
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog", { name: "Attachment preview" })).toBeInTheDocument();
+      expect(screen.getByText("preview content")).toBeInTheDocument();
+    });
+  });
+
   it("does not append duplicate assistant placeholders for the same stream message", async () => {
     const { container } = renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
 

--- a/tests/unit/message-bubble.test.ts
+++ b/tests/unit/message-bubble.test.ts
@@ -930,8 +930,126 @@ describe("message bubble", () => {
       })
     );
 
-    expect(screen.getByAltText("photo.png")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Preview photo.png" })).toBeInTheDocument();
     expect(screen.getByText("notes.txt")).toBeInTheDocument();
+  });
+
+  it("opens image attachments in a centered modal and closes with the X button", async () => {
+    render(
+      React.createElement(MessageBubble, {
+        message: {
+          ...createUserMessage(),
+          content: "See attached",
+          attachments: [
+            {
+              id: "att_image",
+              conversationId: "conv_test",
+              messageId: "msg_user",
+              filename: "photo.png",
+              mimeType: "image/png",
+              byteSize: 10,
+              sha256: "hash",
+              relativePath: "conv_test/att_image_photo.png",
+              kind: "image",
+              extractedText: "",
+              createdAt: new Date().toISOString()
+            }
+          ]
+        }
+      })
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Preview photo.png" }));
+
+    expect(screen.getByRole("dialog", { name: "Attachment preview" })).toBeInTheDocument();
+    expect(screen.getByRole("img", { name: "photo.png" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Close attachment preview" }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Attachment preview" })).toBeNull();
+    });
+  });
+
+  it("loads text attachments into a read-only preview surface", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        id: "att_text",
+        filename: "notes.txt",
+        mimeType: "text/plain",
+        content: "hello from the preview route"
+      })
+    } as Response);
+
+    render(
+      React.createElement(MessageBubble, {
+        message: {
+          ...createUserMessage(),
+          content: "See attached",
+          attachments: [
+            {
+              id: "att_text",
+              conversationId: "conv_test",
+              messageId: "msg_user",
+              filename: "notes.txt",
+              mimeType: "text/plain",
+              byteSize: 10,
+              sha256: "hash2",
+              relativePath: "conv_test/att_text_notes.txt",
+              kind: "text",
+              extractedText: "hello",
+              createdAt: new Date().toISOString()
+            }
+          ]
+        }
+      })
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Preview notes.txt" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("hello from the preview route")).toBeInTheDocument();
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith("/api/attachments/att_text?format=text");
+    expect(screen.getByRole("link", { name: "Open raw attachment" })).toHaveAttribute(
+      "href",
+      "/api/attachments/att_text"
+    );
+  });
+
+  it("closes the attachment modal when Escape is pressed", async () => {
+    render(
+      React.createElement(MessageBubble, {
+        message: {
+          ...createUserMessage(),
+          content: "See attached",
+          attachments: [
+            {
+              id: "att_image",
+              conversationId: "conv_test",
+              messageId: "msg_user",
+              filename: "photo.png",
+              mimeType: "image/png",
+              byteSize: 10,
+              sha256: "hash",
+              relativePath: "conv_test/att_image_photo.png",
+              kind: "image",
+              extractedText: "",
+              createdAt: new Date().toISOString()
+            }
+          ]
+        }
+      })
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Preview photo.png" }));
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Attachment preview" })).toBeNull();
+    });
   });
 
   it("renders streaming actions before the streaming answer text", () => {

--- a/tests/unit/message-bubble.test.ts
+++ b/tests/unit/message-bubble.test.ts
@@ -1054,6 +1054,62 @@ describe("message bubble", () => {
     );
   });
 
+  it("reuses cached text previews when the content is an empty string", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        id: "att_text",
+        filename: "notes.txt",
+        mimeType: "text/plain",
+        content: ""
+      })
+    } as Response);
+
+    render(
+      React.createElement(MessageBubble, {
+        message: {
+          ...createUserMessage(),
+          content: "See attached",
+          attachments: [
+            {
+              id: "att_text",
+              conversationId: "conv_test",
+              messageId: "msg_user",
+              filename: "notes.txt",
+              mimeType: "text/plain",
+              byteSize: 10,
+              sha256: "hash2",
+              relativePath: "conv_test/att_text_notes.txt",
+              kind: "text",
+              extractedText: "",
+              createdAt: new Date().toISOString()
+            }
+          ]
+        }
+      })
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Preview notes.txt" }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(screen.getByRole("dialog", { name: "Attachment preview" })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Close attachment preview" }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Attachment preview" })).toBeNull();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Preview notes.txt" }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(screen.getByRole("dialog", { name: "Attachment preview" })).toBeInTheDocument();
+    });
+  });
+
   it("closes the attachment modal when Escape is pressed", async () => {
     installMockImage();
 

--- a/tests/unit/message-bubble.test.ts
+++ b/tests/unit/message-bubble.test.ts
@@ -6,6 +6,9 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MessageBubble, StreamingPlaceholder } from "@/components/message-bubble";
 import type { Message, MessageAction, MessageTimelineItem } from "@/lib/types";
 
+const originalFetch = global.fetch;
+const OriginalImage = global.Image;
+
 function createAssistantMessage(): Message {
   return {
     id: "msg_assistant",
@@ -106,6 +109,32 @@ function createMemoryProposalMessage(
     ...overrides
   };
 }
+
+function installMockImage({ fail = false }: { fail?: boolean } = {}) {
+  class MockImage {
+    onload: null | (() => void) = null;
+    onerror: null | (() => void) = null;
+
+    set src(_value: string) {
+      window.setTimeout(() => {
+        if (fail) {
+          this.onerror?.();
+          return;
+        }
+
+        this.onload?.();
+      }, 0);
+    }
+  }
+
+  global.Image = MockImage as unknown as typeof Image;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  global.fetch = originalFetch;
+  global.Image = OriginalImage;
+});
 
 describe("message bubble", () => {
   it("renders running tool actions with a spinner while streaming", () => {
@@ -935,6 +964,8 @@ describe("message bubble", () => {
   });
 
   it("opens image attachments in a centered modal and closes with the X button", async () => {
+    installMockImage();
+
     render(
       React.createElement(MessageBubble, {
         message: {
@@ -962,7 +993,11 @@ describe("message bubble", () => {
     fireEvent.click(screen.getByRole("button", { name: "Preview photo.png" }));
 
     expect(screen.getByRole("dialog", { name: "Attachment preview" })).toBeInTheDocument();
-    expect(screen.getByRole("img", { name: "photo.png" })).toBeInTheDocument();
+    expect(screen.getByText("Loading preview…")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByRole("img", { name: "photo.png" })).toBeInTheDocument();
+    });
 
     fireEvent.click(screen.getByRole("button", { name: "Close attachment preview" }));
 
@@ -1020,6 +1055,8 @@ describe("message bubble", () => {
   });
 
   it("closes the attachment modal when Escape is pressed", async () => {
+    installMockImage();
+
     render(
       React.createElement(MessageBubble, {
         message: {
@@ -1050,6 +1087,136 @@ describe("message bubble", () => {
     await waitFor(() => {
       expect(screen.queryByRole("dialog", { name: "Attachment preview" })).toBeNull();
     });
+  });
+
+  it("ignores stale text preview responses when a newer attachment is selected", async () => {
+    let resolveFirst:
+      | ((value: Response | PromiseLike<Response>) => void)
+      | undefined;
+    let resolveSecond:
+      | ((value: Response | PromiseLike<Response>) => void)
+      | undefined;
+
+    global.fetch = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise<Response>((resolve) => {
+            resolveFirst = resolve;
+          })
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise<Response>((resolve) => {
+            resolveSecond = resolve;
+          })
+      );
+
+    render(
+      React.createElement(MessageBubble, {
+        message: {
+          ...createUserMessage(),
+          content: "See attached",
+          attachments: [
+            {
+              id: "att_first",
+              conversationId: "conv_test",
+              messageId: "msg_user",
+              filename: "first.txt",
+              mimeType: "text/plain",
+              byteSize: 10,
+              sha256: "hash-first",
+              relativePath: "conv_test/att_first_first.txt",
+              kind: "text",
+              extractedText: "first",
+              createdAt: new Date().toISOString()
+            },
+            {
+              id: "att_second",
+              conversationId: "conv_test",
+              messageId: "msg_user",
+              filename: "second.txt",
+              mimeType: "text/plain",
+              byteSize: 10,
+              sha256: "hash-second",
+              relativePath: "conv_test/att_second_second.txt",
+              kind: "text",
+              extractedText: "second",
+              createdAt: new Date().toISOString()
+            }
+          ]
+        }
+      })
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Preview first.txt" }));
+    fireEvent.click(screen.getByRole("button", { name: "Preview second.txt" }));
+
+    resolveSecond?.({
+      ok: true,
+      json: async () => ({
+        id: "att_second",
+        filename: "second.txt",
+        mimeType: "text/plain",
+        content: "second attachment content"
+      })
+    } as Response);
+
+    await waitFor(() => {
+      expect(screen.getByText("second attachment content")).toBeInTheDocument();
+    });
+
+    resolveFirst?.({
+      ok: true,
+      json: async () => ({
+        id: "att_first",
+        filename: "first.txt",
+        mimeType: "text/plain",
+        content: "stale attachment content"
+      })
+    } as Response);
+
+    await waitFor(() => {
+      expect(screen.getByText("second attachment content")).toBeInTheDocument();
+      expect(screen.queryByText("stale attachment content")).toBeNull();
+    });
+  });
+
+  it("shows an error state when an image preview fails to load", async () => {
+    installMockImage({ fail: true });
+
+    render(
+      React.createElement(MessageBubble, {
+        message: {
+          ...createUserMessage(),
+          content: "See attached",
+          attachments: [
+            {
+              id: "att_image",
+              conversationId: "conv_test",
+              messageId: "msg_user",
+              filename: "photo.png",
+              mimeType: "image/png",
+              byteSize: 10,
+              sha256: "hash",
+              relativePath: "conv_test/att_image_photo.png",
+              kind: "image",
+              extractedText: "",
+              createdAt: new Date().toISOString()
+            }
+          ]
+        }
+      })
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Preview photo.png" }));
+
+    expect(screen.getByText("Loading preview…")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText("Unable to load attachment preview.")).toBeInTheDocument();
+    });
+    expect(screen.getByRole("button", { name: "Retry preview" })).toBeInTheDocument();
   });
 
   it("renders streaming actions before the streaming answer text", () => {

--- a/tests/unit/message-bubble.test.ts
+++ b/tests/unit/message-bubble.test.ts
@@ -1145,6 +1145,162 @@ describe("message bubble", () => {
     });
   });
 
+  it("closes the attachment modal when the backdrop is clicked", async () => {
+    installMockImage();
+
+    render(
+      React.createElement(MessageBubble, {
+        message: {
+          ...createUserMessage(),
+          content: "See attached",
+          attachments: [
+            {
+              id: "att_image",
+              conversationId: "conv_test",
+              messageId: "msg_user",
+              filename: "photo.png",
+              mimeType: "image/png",
+              byteSize: 10,
+              sha256: "hash",
+              relativePath: "conv_test/att_image_photo.png",
+              kind: "image",
+              extractedText: "",
+              createdAt: new Date().toISOString()
+            }
+          ]
+        }
+      })
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Preview photo.png" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog", { name: "Attachment preview" })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("dialog", { name: "Attachment preview" }).parentElement!);
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Attachment preview" })).toBeNull();
+    });
+  });
+
+  it("shows the unsupported preview fallback when the route rejects inline text preview", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 415
+    } as Response);
+
+    render(
+      React.createElement(MessageBubble, {
+        message: {
+          ...createUserMessage(),
+          content: "See attached",
+          attachments: [
+            {
+              id: "att_binary",
+              conversationId: "conv_test",
+              messageId: "msg_user",
+              filename: "archive.bin",
+              mimeType: "application/octet-stream",
+              byteSize: 10,
+              sha256: "hash-binary",
+              relativePath: "conv_test/att_binary_archive.bin",
+              kind: "text",
+              extractedText: "",
+              createdAt: new Date().toISOString()
+            }
+          ]
+        }
+      })
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Preview archive.bin" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Preview unavailable for this attachment type.")
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("keeps seeded extracted text visible when the refresh route responds with unsupported", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 415
+    } as Response);
+
+    render(
+      React.createElement(MessageBubble, {
+        message: {
+          ...createUserMessage(),
+          content: "See attached",
+          attachments: [
+            {
+              id: "att_text",
+              conversationId: "conv_test",
+              messageId: "msg_user",
+              filename: "notes.txt",
+              mimeType: "text/plain",
+              byteSize: 10,
+              sha256: "hash2",
+              relativePath: "conv_test/att_text_notes.txt",
+              kind: "text",
+              extractedText: "seeded preview content",
+              createdAt: new Date().toISOString()
+            }
+          ]
+        }
+      })
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Preview notes.txt" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("seeded preview content")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByText("Preview unavailable for this attachment type.")
+    ).toBeNull();
+  });
+
+  it("uses stored extracted text when refreshing a text preview fails", async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error("Network down"));
+
+    render(
+      React.createElement(MessageBubble, {
+        message: {
+          ...createUserMessage(),
+          content: "See attached",
+          attachments: [
+            {
+              id: "att_text",
+              conversationId: "conv_test",
+              messageId: "msg_user",
+              filename: "notes.txt",
+              mimeType: "text/plain",
+              byteSize: 10,
+              sha256: "hash2",
+              relativePath: "conv_test/att_text_notes.txt",
+              kind: "text",
+              extractedText: "hello from extracted text",
+              createdAt: new Date().toISOString()
+            }
+          ]
+        }
+      })
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Preview notes.txt" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("hello from extracted text")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText("Network down")).toBeNull();
+  });
+
   it("ignores stale text preview responses when a newer attachment is selected", async () => {
     let resolveFirst:
       | ((value: Response | PromiseLike<Response>) => void)

--- a/tests/unit/transport-utils.test.ts
+++ b/tests/unit/transport-utils.test.ts
@@ -2,7 +2,8 @@ import { NextResponse } from "next/server";
 
 import { badRequest, ok } from "@/lib/http";
 import { encodeSseEvent, encodeSseFlushMarker, encodeSsePrelude } from "@/lib/sse";
-import { cn, formatTimestamp, normalizeLineBreaks, normalizeMarkdownLineBreaks } from "@/lib/utils";
+import { formatTimestamp, normalizeLineBreaks, normalizeMarkdownLineBreaks } from "@/lib/text-utils";
+import { cn } from "@/lib/utils";
 
 describe("transport helpers", () => {
   it("creates json responses for success and failure", async () => {


### PR DESCRIPTION
This PR replaces transcript attachment links with an in-app preview modal for images and text files, with seeded extracted-text fallbacks and server-safe text utilities.

It also hardens optimistic message reconciliation so multi-attachment sends do not leave duplicate user bubbles while partial snapshots are still resolving.

The branch includes the attachment preview spec and execution plan plus unit and e2e coverage for modal behavior, polling, strict-mode replay, and the two-attachment duplicate regression.

Verification: `npm test`, `npm run typecheck`, `npm run test:e2e -- --grep "keeps a single user bubble when sending one prompt with two attachments"`, and live `agent-browser` validation of a text prompt with two attachments.