### PR TITLE
Persist provider default when Set Default clicked

### DIFF
--- a/components/settings/sections/providers-section.tsx
+++ b/components/settings/sections/providers-section.tsx
@@ -220,10 +220,12 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
     }
   }
 
-  async function buildSettingsPayload() {
+  async function buildSettingsPayload(defaultProviderProfileIdOverride?: string) {
+    const nextDefaultProviderProfileId = defaultProviderProfileIdOverride ?? defaultProviderProfileId;
+
     return {
       ...settings,
-      defaultProviderProfileId,
+      defaultProviderProfileId: nextDefaultProviderProfileId,
       skillsEnabled,
       providerProfiles: providerProfiles.map((profile) => ({
         id: profile.id,
@@ -258,10 +260,14 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
   }
 
   async function saveSettings() {
+    return saveSettingsWithDefault(defaultProviderProfileId);
+  }
+
+  async function saveSettingsWithDefault(nextDefaultProviderProfileId: string) {
     const response = await fetch("/api/settings/providers", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(await buildSettingsPayload())
+      body: JSON.stringify(await buildSettingsPayload(nextDefaultProviderProfileId))
     });
 
     const result = (await response.json()) as { error?: string };
@@ -383,7 +389,15 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
                     <Button
                       type="button"
                       variant="secondary"
-                      onClick={() => setDefaultProviderProfileId(activeProviderProfile.id)}
+                      onClick={async () => {
+                        setError("");
+                        setSuccess("");
+                        const nextDefaultProfileId = activeProviderProfile.id;
+
+                        if (await saveSettingsWithDefault(nextDefaultProfileId)) {
+                          setDefaultProviderProfileId(nextDefaultProfileId);
+                        }
+                      }}
                       disabled={activeProviderProfile.id === defaultProviderProfileId}
                       className="gap-1.5 px-3 py-1.5 text-xs"
                     >

--- a/tests/unit/providers-section.test.tsx
+++ b/tests/unit/providers-section.test.tsx
@@ -419,4 +419,124 @@ describe("providers section", () => {
 
     expect(body.providerProfiles[0].compactionThreshold).toBe(0.76);
   });
+
+  it("persists the default profile when clicking Set Default", async () => {
+    const fetchMock = vi.mocked(global.fetch);
+    const settings = makeSettings({
+      providerProfiles: [
+        {
+          id: "profile_primary",
+          providerKind: "openai_compatible",
+          name: "Primary",
+          apiBaseUrl: "https://api.example.com/v1",
+          model: "gpt-test",
+          apiMode: "responses",
+          systemPrompt: "Be exact.",
+          temperature: 0.4,
+          maxOutputTokens: 512,
+          reasoningEffort: "medium",
+          reasoningSummaryEnabled: true,
+          modelContextLimit: 16384,
+          compactionThreshold: 0.8,
+          freshTailCount: 12,
+          tokenizerModel: "gpt-tokenizer",
+          safetyMarginTokens: 1200,
+          leafSourceTokenLimit: 12000,
+          leafMinMessageCount: 6,
+          mergedMinNodeCount: 4,
+          mergedTargetTokens: 1600,
+          visionMode: "native",
+          visionMcpServerId: null,
+          githubTokenExpiresAt: null,
+          githubRefreshTokenExpiresAt: null,
+          githubAccountLogin: null,
+          githubAccountName: null,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+          hasApiKey: false,
+          githubConnectionStatus: "disconnected"
+        },
+        {
+          id: "profile_backup",
+          providerKind: "openai_compatible",
+          name: "Backup",
+          apiBaseUrl: "https://api.example.com/v1",
+          model: "gpt-backup",
+          apiMode: "responses",
+          systemPrompt: "Be exact.",
+          temperature: 0.4,
+          maxOutputTokens: 512,
+          reasoningEffort: "medium",
+          reasoningSummaryEnabled: true,
+          modelContextLimit: 16384,
+          compactionThreshold: 0.8,
+          freshTailCount: 12,
+          tokenizerModel: "gpt-tokenizer",
+          safetyMarginTokens: 1200,
+          leafSourceTokenLimit: 12000,
+          leafMinMessageCount: 6,
+          mergedMinNodeCount: 4,
+          mergedTargetTokens: 1600,
+          visionMode: "native",
+          visionMcpServerId: null,
+          githubTokenExpiresAt: null,
+          githubRefreshTokenExpiresAt: null,
+          githubAccountLogin: null,
+          githubAccountName: null,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+          hasApiKey: false,
+          githubConnectionStatus: "disconnected"
+        }
+      ],
+      defaultProviderProfileId: "profile_primary"
+    });
+
+    fetchMock.mockImplementation((input, init) => {
+      const url = String(input);
+
+      if (url === "/api/mcp-servers") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ servers: [], models: [] })
+        } as Response);
+      }
+
+      if (url === "/api/settings/providers" && init?.method === "PUT") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ settings })
+        } as Response);
+      }
+
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({})
+      } as Response);
+    });
+
+    render(React.createElement(ProvidersSection, { settings }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/mcp-servers");
+    });
+
+    fireEvent.click(screen.getByText("Backup"));
+    fireEvent.click(screen.getByRole("button", { name: "Set Default" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/settings/providers",
+        expect.objectContaining({ method: "PUT" })
+      );
+    });
+
+    const putCall = fetchMock.mock.calls.find(
+      ([url, init]) => url === "/api/settings/providers" && init?.method === "PUT"
+    );
+    const body = JSON.parse(String(putCall?.[1]?.body));
+
+    expect(body.defaultProviderProfileId).toBe("profile_backup");
+    expect(screen.getByRole("button", { name: "Is Default" })).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Fixes provider default behavior so clicking Set Default in settings persists the selection immediately by saving provider settings during that click, instead of requiring the bottom Save button. It retains existing Save behavior, which still saves current in-memory state using the current default value when no override is specified. Added a regression test that selects Backup, clicks Set Default, asserts PUT to /api/settings/providers with defaultProviderProfileId set to profile_backup, and verifies the Is Default state updates in the UI. Verification shows unit tests including the new case pass and full-suite coverage remains within required thresholds.
