### PR TITLE
Add durable queued follow-ups for chat

### DIFF
--- a/app/api/conversations/[conversationId]/route.ts
+++ b/app/api/conversations/[conversationId]/route.ts
@@ -5,6 +5,7 @@ import {
   deleteConversation,
   deleteConversationIfEmpty,
   getConversation,
+  listQueuedMessages,
   listVisibleMessages,
   moveConversationToFolder,
   setConversationActive,
@@ -40,6 +41,7 @@ export async function GET(
   return ok({
     conversation,
     messages: listVisibleMessages(conversation.id),
+    queuedMessages: listQueuedMessages(conversation.id),
     debug: getConversationDebugStats(conversation.id)
   });
 }

--- a/app/automations/[automationId]/runs/[runId]/page.tsx
+++ b/app/automations/[automationId]/runs/[runId]/page.tsx
@@ -4,7 +4,7 @@ import { ChatView } from "@/components/chat-view";
 import { Shell } from "@/components/shell";
 import { requireUser } from "@/lib/auth";
 import { getAutomationRun, listAutomations } from "@/lib/automations";
-import { getConversation, listConversationsPage, listVisibleMessages } from "@/lib/conversations";
+import { getConversation, listConversationsPage, listQueuedMessages, listVisibleMessages } from "@/lib/conversations";
 import { getConversationDebugStats } from "@/lib/compaction";
 import { isPasswordLoginEnabled } from "@/lib/env";
 import { listFolders } from "@/lib/folders";
@@ -44,6 +44,7 @@ export default async function AutomationRunPage({
         payload={{
           conversation,
           messages: listVisibleMessages(conversation.id),
+          queuedMessages: listQueuedMessages(conversation.id),
           settings: {
             sttEngine: settings.sttEngine,
             sttLanguage: settings.sttLanguage

--- a/app/chat/[conversationId]/page.tsx
+++ b/app/chat/[conversationId]/page.tsx
@@ -3,7 +3,7 @@ import { notFound, redirect } from "next/navigation";
 import { ChatView } from "@/components/chat-view";
 import { Shell } from "@/components/shell";
 import { requireUser } from "@/lib/auth";
-import { getConversation, listConversationsPage, listVisibleMessages } from "@/lib/conversations";
+import { getConversation, listConversationsPage, listQueuedMessages, listVisibleMessages } from "@/lib/conversations";
 import { getConversationDebugStats } from "@/lib/compaction";
 import { isPasswordLoginEnabled } from "@/lib/env";
 import { listFolders } from "@/lib/folders";
@@ -64,6 +64,7 @@ export default async function ConversationPage({
         payload={{
           conversation,
           messages: listVisibleMessages(conversation.id),
+          queuedMessages: listQueuedMessages(conversation.id),
           settings: {
             sttEngine: settings.sttEngine,
             sttLanguage: settings.sttLanguage

--- a/components/chat-composer.tsx
+++ b/components/chat-composer.tsx
@@ -56,6 +56,7 @@ type ChatComposerProps = {
   speechError: string | null;
   onStartSpeech: () => void | Promise<void>;
   onStopSpeech: () => void | Promise<void>;
+  queueingEnabled?: boolean;
 };
 
 function CustomDropdown<T extends { id: string; name: string }>({
@@ -211,7 +212,8 @@ export function ChatComposer({
   speechLevel,
   speechError,
   onStartSpeech,
-  onStopSpeech
+  onStopSpeech,
+  queueingEnabled = false
 }: ChatComposerProps) {
   const fileInputRef = React.useRef<HTMLInputElement | null>(null);
   const [mounted, setMounted] = useState(false);
@@ -220,14 +222,17 @@ export function ChatComposer({
     setMounted(true);
   }, []);
 
+  const hasTextDraft = input.trim().length > 0;
+  const canQueueDraft = queueingEnabled && hasTextDraft;
+  const canImmediateDraft = !queueingEnabled && (hasTextDraft || pendingAttachments.length > 0);
+  const showStopButton = canStop && !isUploadingAttachments && !canQueueDraft;
   const isSubmitDisabled =
     !mounted ||
-    isSending ||
     isUploadingAttachments ||
     speechPhase === "listening" ||
     speechPhase === "transcribing" ||
-    (!input.trim() && pendingAttachments.length === 0);
-  const showStopButton = canStop && !isUploadingAttachments;
+    (!showStopButton && !canQueueDraft && !canImmediateDraft) ||
+    (!queueingEnabled && isSending);
   const showContextUsage = hasMessages && usedTokens !== null;
   const isSpeechActive = speechPhase === "listening" || speechPhase === "transcribing";
   const speechLevelWidth = Math.max(8, Math.round(speechLevel * 100));
@@ -410,7 +415,7 @@ export function ChatComposer({
                   ? "bg-[var(--accent)] text-white shadow-[0_0_20px_var(--accent-glow)]"
                   : "bg-white/5 text-white/20"
             )}
-            aria-label={showStopButton ? "Stop response" : "Send message"}
+            aria-label={showStopButton ? "Stop response" : canQueueDraft ? "Queue follow-up" : "Send message"}
           >
             {showStopButton ? (
               <Square className="h-4 w-4 fill-current" />

--- a/components/chat-composer.tsx
+++ b/components/chat-composer.tsx
@@ -226,18 +226,20 @@ export function ChatComposer({
   const canQueueDraft = queueingEnabled && hasTextDraft;
   const canImmediateDraft = !queueingEnabled && (hasTextDraft || pendingAttachments.length > 0);
   const showStopButton = canStop && !isUploadingAttachments;
-  const showPrimaryStopButton = showStopButton && !canQueueDraft;
+  const busyButtonQueues = showStopButton && canQueueDraft;
+  const busyButtonStops = showStopButton && !canQueueDraft;
   const isSubmitDisabled =
     !mounted ||
     isUploadingAttachments ||
     speechPhase === "listening" ||
     speechPhase === "transcribing" ||
-    (!showPrimaryStopButton && !canQueueDraft && !canImmediateDraft) ||
+    (!showStopButton && !canQueueDraft && !canImmediateDraft) ||
     (!queueingEnabled && isSending);
   const showContextUsage = hasMessages && usedTokens !== null;
   const isSpeechActive = speechPhase === "listening" || speechPhase === "transcribing";
   const speechLevelWidth = Math.max(8, Math.round(speechLevel * 100));
   const speechControlsDisabled = !mounted || isSending || isUploadingAttachments || isSpeechActive;
+  const showBusyQueueHint = showStopButton;
 
   // For the model selector, we want to show the profile name prominently
   const displayModels = providerProfiles.map(p => ({
@@ -321,7 +323,7 @@ export function ChatComposer({
         ) : null}
       </AnimatePresence>
 
-      <div className="flex w-full items-end gap-2 pb-1 pr-1.5">
+      <div className="flex w-full items-center gap-2 pb-1 pr-1.5">
         <div className="flex-1 min-w-0">
           <Textarea
             ref={textareaRef}
@@ -401,41 +403,29 @@ export function ChatComposer({
             )}
           </AnimatePresence>
 
-          {showStopButton && canQueueDraft ? (
-            <button
-              type="button"
-              onClick={() => void onStop()}
-              disabled={isStopPending}
-              className={cn(
-                "flex h-10 w-10 items-center justify-center rounded-full transition-all duration-300 shrink-0",
-                isStopPending
-                  ? "bg-white/5 text-white/20"
-                  : "bg-red-500 text-white shadow-[0_0_15px_rgba(239,68,68,0.4)]"
-              )}
-              aria-label="Stop response"
-            >
-              <Square className="h-4 w-4 fill-current" />
-            </button>
-          ) : null}
-
           <motion.button
             whileHover={{ scale: 1.05 }}
             whileTap={{ scale: 0.95 }}
-            onClick={() => void (showPrimaryStopButton ? onStop() : onSubmit())}
-            disabled={showPrimaryStopButton ? isStopPending : isSubmitDisabled}
+            onClick={() =>
+              void (busyButtonStops ? onStop() : onSubmit())
+            }
+            disabled={busyButtonStops ? isStopPending : isSubmitDisabled}
             className={cn(
-              "flex h-10 w-10 items-center justify-center rounded-full transition-all duration-300 shrink-0",
-              showPrimaryStopButton
+              "relative flex h-10 w-10 items-center justify-center rounded-full transition-all duration-300 shrink-0",
+              showStopButton
                 ? isStopPending
                   ? "bg-white/5 text-white/20"
-                  : "bg-red-500 text-white shadow-[0_0_15px_rgba(239,68,68,0.4)]"
+                  : "border border-white/12 bg-zinc-900 text-white shadow-[0_0_15px_rgba(167,139,250,0.18)]"
                 : !isSubmitDisabled
                   ? "bg-[var(--accent)] text-white shadow-[0_0_20px_var(--accent-glow)]"
                   : "bg-white/5 text-white/20"
             )}
-            aria-label={showPrimaryStopButton ? "Stop response" : canQueueDraft ? "Queue follow-up" : "Send message"}
+            aria-label={busyButtonStops ? "Stop response" : canQueueDraft ? "Queue follow-up" : "Send message"}
           >
-            {showPrimaryStopButton ? (
+            {showStopButton && !isStopPending ? (
+              <span className="pointer-events-none absolute inset-[-3px] rounded-full border-2 border-white/10 border-t-violet-400 animate-spin" />
+            ) : null}
+            {showStopButton ? (
               <Square className="h-4 w-4 fill-current" />
             ) : isSending || isUploadingAttachments ? (
               <LoaderCircle className="h-5 w-5 animate-spin" />
@@ -446,6 +436,15 @@ export function ChatComposer({
         </div>
       </div>
 
+      {showBusyQueueHint ? (
+        <motion.div
+          initial={{ opacity: 0, y: 4 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="px-4 pb-2 text-[11px] font-medium text-white/45"
+        >
+          Agent working - send still queues
+        </motion.div>
+      ) : null}
 
       {showVisionWarning ? (
         <motion.div 

--- a/components/chat-composer.tsx
+++ b/components/chat-composer.tsx
@@ -225,13 +225,14 @@ export function ChatComposer({
   const hasTextDraft = input.trim().length > 0;
   const canQueueDraft = queueingEnabled && hasTextDraft;
   const canImmediateDraft = !queueingEnabled && (hasTextDraft || pendingAttachments.length > 0);
-  const showStopButton = canStop && !isUploadingAttachments && !canQueueDraft;
+  const showStopButton = canStop && !isUploadingAttachments;
+  const showPrimaryStopButton = showStopButton && !canQueueDraft;
   const isSubmitDisabled =
     !mounted ||
     isUploadingAttachments ||
     speechPhase === "listening" ||
     speechPhase === "transcribing" ||
-    (!showStopButton && !canQueueDraft && !canImmediateDraft) ||
+    (!showPrimaryStopButton && !canQueueDraft && !canImmediateDraft) ||
     (!queueingEnabled && isSending);
   const showContextUsage = hasMessages && usedTokens !== null;
   const isSpeechActive = speechPhase === "listening" || speechPhase === "transcribing";
@@ -400,14 +401,31 @@ export function ChatComposer({
             )}
           </AnimatePresence>
 
+          {showStopButton && canQueueDraft ? (
+            <button
+              type="button"
+              onClick={() => void onStop()}
+              disabled={isStopPending}
+              className={cn(
+                "flex h-10 w-10 items-center justify-center rounded-full transition-all duration-300 shrink-0",
+                isStopPending
+                  ? "bg-white/5 text-white/20"
+                  : "bg-red-500 text-white shadow-[0_0_15px_rgba(239,68,68,0.4)]"
+              )}
+              aria-label="Stop response"
+            >
+              <Square className="h-4 w-4 fill-current" />
+            </button>
+          ) : null}
+
           <motion.button
             whileHover={{ scale: 1.05 }}
             whileTap={{ scale: 0.95 }}
-            onClick={() => void (showStopButton ? onStop() : onSubmit())}
-            disabled={showStopButton ? isStopPending : isSubmitDisabled}
+            onClick={() => void (showPrimaryStopButton ? onStop() : onSubmit())}
+            disabled={showPrimaryStopButton ? isStopPending : isSubmitDisabled}
             className={cn(
               "flex h-10 w-10 items-center justify-center rounded-full transition-all duration-300 shrink-0",
-              showStopButton
+              showPrimaryStopButton
                 ? isStopPending
                   ? "bg-white/5 text-white/20"
                   : "bg-red-500 text-white shadow-[0_0_15px_rgba(239,68,68,0.4)]"
@@ -415,9 +433,9 @@ export function ChatComposer({
                   ? "bg-[var(--accent)] text-white shadow-[0_0_20px_var(--accent-glow)]"
                   : "bg-white/5 text-white/20"
             )}
-            aria-label={showStopButton ? "Stop response" : canQueueDraft ? "Queue follow-up" : "Send message"}
+            aria-label={showPrimaryStopButton ? "Stop response" : canQueueDraft ? "Queue follow-up" : "Send message"}
           >
-            {showStopButton ? (
+            {showPrimaryStopButton ? (
               <Square className="h-4 w-4 fill-current" />
             ) : isSending || isUploadingAttachments ? (
               <LoaderCircle className="h-5 w-5 animate-spin" />

--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -26,12 +26,14 @@ import type {
   MessageAction,
   MessageAttachment,
   MessageTimelineItem,
+  QueuedMessage,
   ProviderProfileSummary
 } from "@/lib/types";
 
 type ConversationPayload = {
   conversation: Conversation;
   messages: Message[];
+  queuedMessages: QueuedMessage[];
   settings: Pick<AppSettings, "sttEngine" | "sttLanguage">;
   providerProfiles: ProviderProfileSummary[];
   defaultProviderProfileId: string | null;

--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -268,6 +268,10 @@ function replaceMessageAction(
   });
 }
 
+function isQueuedMessageOperationError(message: string) {
+  return message === "Queued message not found";
+}
+
 export function ChatView({ payload }: { payload: ConversationPayload }) {
   const router = useRouter();
   const { getTokenUsage, setTokenUsage } = useContextTokens();
@@ -743,6 +747,11 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
           setQueuedMessages((msg.queuedMessages as QueuedMessage[] | undefined) ?? []);
           break;
         case "error":
+          if (isQueuedMessageOperationError(msg.message)) {
+            setError(msg.message);
+            break;
+          }
+
           clearCompactionIndicator();
           setIsConversationActive(false);
           dispatchConversationActivityUpdated({

--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 
 import { ChatComposer } from "@/components/chat-composer";
+import { QueuedMessageBanner } from "@/components/queued-message-banner";
 import { MessageBubble } from "@/components/message-bubble";
 import { clearChatBootstrap, readChatBootstrap } from "@/lib/chat-bootstrap";
 import { useContextTokens } from "@/lib/context-tokens-context";
@@ -271,6 +272,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
   const router = useRouter();
   const { getTokenUsage, setTokenUsage } = useContextTokens();
   const [messages, setMessages] = useState(() => sanitizeMessages(payload.messages));
+  const [queuedMessages, setQueuedMessages] = useState(() => payload.queuedMessages);
   const [conversationTitle, setConversationTitle] = useState(payload.conversation.title);
   const [titleGenerationStatus, setTitleGenerationStatus] = useState(
     payload.conversation.titleGenerationStatus
@@ -288,6 +290,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
   const [hasReceivedFirstToken, setHasReceivedFirstToken] = useState(false);
   const [compactionInProgress, setCompactionInProgress] = useState(false);
   const [usedTokens, setUsedTokens] = useState<number | null>(null);
+  const [isConversationActive, setIsConversationActive] = useState(payload.conversation.isActive);
   const hasInitializedTokensRef = useRef(false);
 
   useEffect(() => {
@@ -381,6 +384,10 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
   }, [payload.messages]);
 
   useEffect(() => {
+    setQueuedMessages(payload.queuedMessages);
+  }, [payload.queuedMessages]);
+
+  useEffect(() => {
     messagesRef.current = messages;
   }, [messages]);
 
@@ -405,6 +412,10 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
   useEffect(() => {
     setConversationTitle(payload.conversation.title);
   }, [payload.conversation.title]);
+
+  useEffect(() => {
+    setIsConversationActive(payload.conversation.isActive);
+  }, [payload.conversation.isActive]);
 
   useEffect(() => {
     setTitleGenerationStatus(payload.conversation.titleGenerationStatus);
@@ -473,6 +484,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
     }
 
     if (event.type === "message_start") {
+      setIsConversationActive(true);
       const confirmedLocalId = pendingLocalMessageIdsRef.current.shift() ?? null;
       pendingLocalSubmissionsRef.current.shift();
       setStreamMessageId(event.messageId);
@@ -593,6 +605,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
 
     if (event.type === "done") {
       clearCompactionIndicator();
+      setIsConversationActive(false);
       const wasStopped = isStopPending;
       setIsStopPending(false);
       const finalAnswer = streamAnswerTargetRef.current;
@@ -629,6 +642,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
 
     if (event.type === "error") {
       clearCompactionIndicator();
+      setIsConversationActive(false);
       setIsStopPending(false);
       const activeStreamMessageId = streamMessageIdRef.current;
       dispatchConversationActivityUpdated({
@@ -657,6 +671,13 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
     onMessage(msg) {
       switch (msg.type) {
         case "ready":
+          setIsConversationActive(
+            msg.activeConversations.some(
+              (conversation) =>
+                conversation.id === payload.conversation.id &&
+                conversation.status === "streaming"
+            )
+          );
           dispatchConversationActivityUpdated({
             conversationId: payload.conversation.id,
             isActive: msg.activeConversations.some(
@@ -667,6 +688,12 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
           });
           break;
         case "snapshot":
+          setQueuedMessages((msg.queuedMessages as QueuedMessage[] | undefined) ?? []);
+          setIsConversationActive(
+            (msg.messages as Message[]).some(
+              (message) => message.role === "assistant" && message.status === "streaming"
+            )
+          );
           if (streamMessageId) {
             const activeSnapshotMessage = (msg.messages as Message[]).find(
               (message) => message.id === streamMessageId
@@ -712,8 +739,12 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
             )
           );
           break;
+        case "queue_updated":
+          setQueuedMessages((msg.queuedMessages as QueuedMessage[] | undefined) ?? []);
+          break;
         case "error":
           clearCompactionIndicator();
+          setIsConversationActive(false);
           dispatchConversationActivityUpdated({
             conversationId: payload.conversation.id,
             isActive: false
@@ -1316,12 +1347,16 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
   ) {
     const value = nextInput.trim();
     const effectivePersonaId = nextPersonaId ?? personaId;
+    const hasActiveTurn =
+      isConversationActive ||
+      Boolean(streamMessageIdRef.current) ||
+      messagesRef.current.some(
+        (message) => message.role === "assistant" && message.status === "streaming"
+      );
 
     if (
       speechSnapshot.phase === "listening" ||
       speechSnapshot.phase === "transcribing" ||
-      (!value && nextPendingAttachments.length === 0) ||
-      isSending ||
       isUploadingAttachments
     ) {
       return;
@@ -1331,6 +1366,25 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
       setError(
         "Realtime chat connection is unavailable. Restart Eidon with the websocket server enabled."
       );
+      return;
+    }
+
+    if (hasActiveTurn) {
+      if (!value) {
+        return;
+      }
+
+      setError("");
+      setInput("");
+      wsSend({
+        type: "queue_message",
+        conversationId: payload.conversation.id,
+        content: value
+      });
+      return;
+    }
+
+    if ((!value && nextPendingAttachments.length === 0) || isSending) {
       return;
     }
 
@@ -1376,6 +1430,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
       attachmentIds: nextPendingAttachments.map((attachment) => attachment.id),
       personaId: effectivePersonaId ?? undefined
     });
+    setIsConversationActive(true);
 
     if (titleGenerationStatus === "pending") {
       startTitlePolling();
@@ -1395,6 +1450,57 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
   }
 
   submitRef.current = submit;
+
+  function ensureRealtimeConnection() {
+    if (!wsFailed) {
+      return true;
+    }
+
+    setError(
+      "Realtime chat connection is unavailable. Restart Eidon with the websocket server enabled."
+    );
+    return false;
+  }
+
+  async function updateQueuedMessage(queuedMessageId: string, content: string) {
+    if (!ensureRealtimeConnection()) {
+      return;
+    }
+
+    setError("");
+    wsSend({
+      type: "update_queued_message",
+      conversationId: payload.conversation.id,
+      queuedMessageId,
+      content
+    });
+  }
+
+  async function deleteQueuedMessage(queuedMessageId: string) {
+    if (!ensureRealtimeConnection()) {
+      return;
+    }
+
+    setError("");
+    wsSend({
+      type: "delete_queued_message",
+      conversationId: payload.conversation.id,
+      queuedMessageId
+    });
+  }
+
+  async function sendQueuedMessageNow(queuedMessageId: string) {
+    if (!ensureRealtimeConnection()) {
+      return;
+    }
+
+    setError("");
+    wsSend({
+      type: "send_queued_message_now",
+      conversationId: payload.conversation.id,
+      queuedMessageId
+    });
+  }
 
   return (
     <div
@@ -1519,6 +1625,12 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
 
       <div className="fixed inset-x-0 bottom-0 z-10 pointer-events-none">
         <div className="mx-auto w-full px-4 md:px-8 pointer-events-auto max-w-[980px]">
+          <QueuedMessageBanner
+            items={queuedMessages}
+            onEdit={updateQueuedMessage}
+            onDelete={deleteQueuedMessage}
+            onSendNow={sendQueuedMessageNow}
+          />
           <ChatComposer
             input={input}
             onInputChange={setInput}
@@ -1546,6 +1658,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
             speechPhase={speechSnapshot.phase}
             speechLevel={speechSnapshot.level}
             speechError={speechSnapshot.error}
+            queueingEnabled={isConversationActive}
             onStartSpeech={() => {
               setError("");
               void startSpeech();

--- a/components/queued-message-banner.tsx
+++ b/components/queued-message-banner.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import React, { useEffect, useMemo, useState } from "react";
+import { AlertCircle, LoaderCircle, Pencil, Send, Trash2 } from "lucide-react";
+
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+import type { QueuedMessage } from "@/lib/types";
+
+type QueuedMessageBannerProps = {
+  items: QueuedMessage[];
+  onEdit: (queuedMessageId: string, content: string) => void | Promise<void>;
+  onDelete: (queuedMessageId: string) => void | Promise<void>;
+  onSendNow: (queuedMessageId: string) => void | Promise<void>;
+  className?: string;
+};
+
+const STATUS_COPY: Record<QueuedMessage["status"], string> = {
+  pending: "Pending",
+  processing: "Processing",
+  failed: "Failed",
+  cancelled: "Cancelled"
+};
+
+export function QueuedMessageBanner({
+  items,
+  onEdit,
+  onDelete,
+  onSendNow,
+  className
+}: QueuedMessageBannerProps) {
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [draftContent, setDraftContent] = useState("");
+  const [isSaving, setIsSaving] = useState(false);
+
+  const sortedItems = useMemo(
+    () => [...items].sort((left, right) => left.sortOrder - right.sortOrder),
+    [items]
+  );
+
+  useEffect(() => {
+    if (!editingId) {
+      return;
+    }
+
+    const activeItem = sortedItems.find((item) => item.id === editingId);
+
+    if (!activeItem || activeItem.status !== "pending") {
+      setEditingId(null);
+      setDraftContent("");
+      setIsSaving(false);
+    }
+  }, [editingId, sortedItems]);
+
+  if (sortedItems.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      className={cn(
+        "mb-2 rounded-xl border border-white/8 bg-zinc-950/80 shadow-[0_8px_24px_rgba(0,0,0,0.24)]",
+        className
+      )}
+    >
+      <div className="border-b border-white/6 px-3 py-2 text-sm text-white/55">
+        {sortedItems.length === 1 ? "1 queued follow-up" : `${sortedItems.length} queued follow-ups`}
+      </div>
+      <div className="max-h-56 overflow-y-auto">
+        {sortedItems.map((item, index) => {
+          const isPending = item.status === "pending";
+          const isEditing = editingId === item.id;
+
+          return (
+            <div
+              key={item.id}
+              className={cn("px-3 py-3", index > 0 && "border-t border-white/6")}
+            >
+              <div className="mb-2 flex items-center justify-between gap-3">
+                <div className="flex min-w-0 items-center gap-2 text-sm text-white/60">
+                  <span className="font-medium text-white/80">{index === 0 ? "Next" : `Then ${index}`}</span>
+                  <span className="text-white/35">•</span>
+                  <span>{STATUS_COPY[item.status]}</span>
+                </div>
+
+                {isPending ? (
+                  <div className="flex items-center gap-2">
+                    {isEditing ? (
+                      <>
+                        <button
+                          type="button"
+                          className="rounded-md border border-white/10 px-2 py-1 text-xs font-medium text-white/70 transition-colors hover:border-white/20 hover:text-white"
+                          onClick={() => {
+                            setEditingId(null);
+                            setDraftContent("");
+                          }}
+                          disabled={isSaving}
+                        >
+                          Cancel
+                        </button>
+                        <button
+                          type="button"
+                          className="rounded-md bg-white/10 px-2 py-1 text-xs font-medium text-white transition-colors hover:bg-white/15 disabled:cursor-not-allowed disabled:opacity-50"
+                          onClick={async () => {
+                            const nextContent = draftContent.trim();
+                            if (!nextContent || isSaving) {
+                              return;
+                            }
+
+                            setIsSaving(true);
+
+                            try {
+                              await onEdit(item.id, nextContent);
+                              setEditingId(null);
+                              setDraftContent("");
+                            } finally {
+                              setIsSaving(false);
+                            }
+                          }}
+                          disabled={isSaving || !draftContent.trim()}
+                        >
+                          Save
+                        </button>
+                      </>
+                    ) : (
+                      <>
+                        <button
+                          type="button"
+                          className="inline-flex items-center gap-1 rounded-md border border-white/10 px-2 py-1 text-xs font-medium text-white/70 transition-colors hover:border-white/20 hover:text-white"
+                          onClick={() => {
+                            setEditingId(item.id);
+                            setDraftContent(item.content);
+                          }}
+                        >
+                          <Pencil className="h-3 w-3" />
+                          Edit
+                        </button>
+                        <button
+                          type="button"
+                          className="inline-flex items-center gap-1 rounded-md border border-white/10 px-2 py-1 text-xs font-medium text-white/70 transition-colors hover:border-white/20 hover:text-white"
+                          onClick={() => void onDelete(item.id)}
+                        >
+                          <Trash2 className="h-3 w-3" />
+                          Delete
+                        </button>
+                        <button
+                          type="button"
+                          className="inline-flex items-center gap-1 rounded-md bg-white/10 px-2 py-1 text-xs font-medium text-white transition-colors hover:bg-white/15"
+                          onClick={() => void onSendNow(item.id)}
+                        >
+                          <Send className="h-3 w-3" />
+                          Send now
+                        </button>
+                      </>
+                    )}
+                  </div>
+                ) : item.status === "processing" ? (
+                  <div className="flex items-center gap-1 text-xs text-white/50">
+                    <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
+                    Running
+                  </div>
+                ) : item.status === "failed" ? (
+                  <div className="flex items-center gap-1 text-xs text-red-300/80">
+                    <AlertCircle className="h-3.5 w-3.5" />
+                    Needs review
+                  </div>
+                ) : null}
+              </div>
+
+              {isEditing ? (
+                <Textarea
+                  value={draftContent}
+                  onChange={(event) => setDraftContent(event.target.value)}
+                  className="min-h-[76px] resize-none border-white/10 bg-white/5 px-3 py-2 text-sm text-[var(--text)] focus-visible:ring-0"
+                />
+              ) : (
+                <div className="whitespace-pre-wrap text-sm leading-6 text-[var(--text)]">
+                  {item.content}
+                </div>
+              )}
+
+              {item.status === "failed" && item.failureMessage ? (
+                <div className="mt-2 text-xs text-red-300/80">{item.failureMessage}</div>
+              ) : null}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/components/queued-message-banner.tsx
+++ b/components/queued-message-banner.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useEffect, useMemo, useState } from "react";
-import { AlertCircle, LoaderCircle, Pencil, Send, Trash2 } from "lucide-react";
+import { AlertCircle, ChevronDown, LoaderCircle, Pencil, Send, Trash2 } from "lucide-react";
 
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
@@ -32,6 +32,8 @@ export function QueuedMessageBanner({
   const [editingId, setEditingId] = useState<string | null>(null);
   const [draftContent, setDraftContent] = useState("");
   const [isSaving, setIsSaving] = useState(false);
+  const [isMobileViewport, setIsMobileViewport] = useState(false);
+  const [isCollapsedOnMobile, setIsCollapsedOnMobile] = useState(false);
 
   const sortedItems = useMemo(
     () => [...items].sort((left, right) => left.sortOrder - right.sortOrder),
@@ -52,21 +54,69 @@ export function QueuedMessageBanner({
     }
   }, [editingId, sortedItems]);
 
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia("(max-width: 639px)");
+    const syncViewport = () => {
+      setIsMobileViewport(mediaQuery.matches);
+      setIsCollapsedOnMobile(mediaQuery.matches);
+    };
+
+    syncViewport();
+
+    if (typeof mediaQuery.addEventListener === "function") {
+      mediaQuery.addEventListener("change", syncViewport);
+
+      return () => mediaQuery.removeEventListener("change", syncViewport);
+    }
+
+    mediaQuery.addListener(syncViewport);
+
+    return () => mediaQuery.removeListener(syncViewport);
+  }, []);
+
   if (sortedItems.length === 0) {
     return null;
   }
 
+  const isExpanded = !isMobileViewport || !isCollapsedOnMobile;
+
   return (
     <div
       className={cn(
-        "mb-2 rounded-xl border border-white/8 bg-zinc-950/80 shadow-[0_8px_24px_rgba(0,0,0,0.24)]",
+        "mb-2 rounded-xl border border-white/8 bg-zinc-950 shadow-[0_8px_24px_rgba(0,0,0,0.24)]",
         className
       )}
     >
-      <div className="border-b border-white/6 px-3 py-2 text-sm text-white/55">
-        {sortedItems.length === 1 ? "1 queued follow-up" : `${sortedItems.length} queued follow-ups`}
-      </div>
-      <div className="max-h-56 overflow-y-auto">
+      <button
+        type="button"
+        className={cn(
+          "flex w-full items-center justify-between gap-3 px-3 py-2 text-left text-sm text-white/55",
+          isExpanded && "border-b border-white/6"
+        )}
+        aria-expanded={isExpanded}
+        onClick={() => {
+          if (!isMobileViewport) {
+            return;
+          }
+
+          setIsCollapsedOnMobile((current) => !current);
+        }}
+      >
+        <span>
+          {sortedItems.length === 1 ? "1 queued follow-up" : `${sortedItems.length} queued follow-ups`}
+        </span>
+        <ChevronDown
+          className={cn(
+            "h-4 w-4 text-white/35 transition-transform sm:hidden",
+            isExpanded && "rotate-180"
+          )}
+        />
+      </button>
+      {isExpanded ? <div className="max-h-56 overflow-y-auto">
         {sortedItems.map((item, index) => {
           const isPending = item.status === "pending";
           const isEditing = editingId === item.id;
@@ -76,15 +126,57 @@ export function QueuedMessageBanner({
               key={item.id}
               className={cn("px-3 py-3", index > 0 && "border-t border-white/6")}
             >
-              <div className="mb-2 flex items-center justify-between gap-3">
-                <div className="flex min-w-0 items-center gap-2 text-sm text-white/60">
-                  <span className="font-medium text-white/80">{index === 0 ? "Next" : `Then ${index}`}</span>
-                  <span className="text-white/35">•</span>
-                  <span>{STATUS_COPY[item.status]}</span>
+              {item.status !== "pending" ? (
+                <div className="mb-2 flex items-center justify-between gap-3">
+                  <div className="flex min-w-0 items-center gap-2 text-sm text-white/60">
+                    <span>{STATUS_COPY[item.status]}</span>
+                  </div>
+                  {item.status === "processing" ? (
+                    <div className="flex items-center gap-1 text-xs text-white/50">
+                      <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
+                      Running
+                    </div>
+                  ) : item.status === "failed" ? (
+                    <div className="flex items-center gap-1 text-xs text-red-300/80">
+                      <AlertCircle className="h-3.5 w-3.5" />
+                      Needs review
+                    </div>
+                  ) : null}
                 </div>
+              ) : null}
 
+              <div
+                data-testid={`queued-message-body-${item.id}`}
+                className={cn(
+                  "grid items-start gap-3",
+                  isPending ? "grid-cols-[auto_minmax(0,1fr)_auto]" : "grid-cols-[auto_minmax(0,1fr)]"
+                )}
+              >
+                <span className="inline-flex h-6 min-w-6 shrink-0 items-center justify-center rounded-full border border-white/10 px-1.5 text-[11px] font-semibold leading-none text-white/75">
+                  {index + 1}
+                </span>
+                <div className="min-w-0">
+                  {isEditing ? (
+                    <Textarea
+                      value={draftContent}
+                      onChange={(event) => setDraftContent(event.target.value)}
+                      className="min-h-[76px] resize-none border-white/10 bg-white/5 px-3 py-2 text-sm text-[var(--text)] focus-visible:ring-0"
+                    />
+                  ) : (
+                    <div className="whitespace-pre-wrap pt-0.5 text-sm leading-6 text-[var(--text)]">
+                      {item.content}
+                    </div>
+                  )}
+
+                  {item.status === "failed" && item.failureMessage ? (
+                    <div className="mt-2 text-xs text-red-300/80">{item.failureMessage}</div>
+                  ) : null}
+                </div>
                 {isPending ? (
-                  <div className="flex items-center gap-2">
+                  <div
+                    data-testid={`queued-message-actions-${item.id}`}
+                    className="flex shrink-0 items-start gap-1 self-start pl-2"
+                  >
                     {isEditing ? (
                       <>
                         <button
@@ -126,66 +218,43 @@ export function QueuedMessageBanner({
                       <>
                         <button
                           type="button"
-                          className="inline-flex items-center gap-1 rounded-md border border-white/10 px-2 py-1 text-xs font-medium text-white/70 transition-colors hover:border-white/20 hover:text-white"
+                          aria-label="Edit"
+                          title="Edit"
+                          className="inline-flex h-7 w-7 items-center justify-center rounded-lg p-1 text-white/25 transition-colors duration-200 hover:bg-white/5 hover:text-white"
                           onClick={() => {
                             setEditingId(item.id);
                             setDraftContent(item.content);
                           }}
                         >
-                          <Pencil className="h-3 w-3" />
-                          Edit
+                          <Pencil className="h-3.5 w-3.5" />
                         </button>
                         <button
                           type="button"
-                          className="inline-flex items-center gap-1 rounded-md border border-white/10 px-2 py-1 text-xs font-medium text-white/70 transition-colors hover:border-white/20 hover:text-white"
+                          aria-label="Delete"
+                          title="Delete"
+                          className="inline-flex h-7 w-7 items-center justify-center rounded-lg p-1 text-white/25 transition-colors duration-200 hover:bg-white/5 hover:text-white"
                           onClick={() => void onDelete(item.id)}
                         >
-                          <Trash2 className="h-3 w-3" />
-                          Delete
+                          <Trash2 className="h-3.5 w-3.5" />
                         </button>
                         <button
                           type="button"
-                          className="inline-flex items-center gap-1 rounded-md bg-white/10 px-2 py-1 text-xs font-medium text-white transition-colors hover:bg-white/15"
+                          aria-label="Send now"
+                          title="Send now"
+                          className="inline-flex h-7 w-7 items-center justify-center rounded-lg p-1 text-white/25 transition-colors duration-200 hover:bg-white/5 hover:text-white"
                           onClick={() => void onSendNow(item.id)}
                         >
-                          <Send className="h-3 w-3" />
-                          Send now
+                          <Send className="h-3.5 w-3.5" />
                         </button>
                       </>
                     )}
                   </div>
-                ) : item.status === "processing" ? (
-                  <div className="flex items-center gap-1 text-xs text-white/50">
-                    <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
-                    Running
-                  </div>
-                ) : item.status === "failed" ? (
-                  <div className="flex items-center gap-1 text-xs text-red-300/80">
-                    <AlertCircle className="h-3.5 w-3.5" />
-                    Needs review
-                  </div>
                 ) : null}
               </div>
-
-              {isEditing ? (
-                <Textarea
-                  value={draftContent}
-                  onChange={(event) => setDraftContent(event.target.value)}
-                  className="min-h-[76px] resize-none border-white/10 bg-white/5 px-3 py-2 text-sm text-[var(--text)] focus-visible:ring-0"
-                />
-              ) : (
-                <div className="whitespace-pre-wrap text-sm leading-6 text-[var(--text)]">
-                  {item.content}
-                </div>
-              )}
-
-              {item.status === "failed" && item.failureMessage ? (
-                <div className="mt-2 text-xs text-red-300/80">{item.failureMessage}</div>
-              ) : null}
             </div>
           );
         })}
-      </div>
+      </div> : null}
     </div>
   );
 }

--- a/docs/superpowers/plans/2026-04-13-queued-chat-followups.md
+++ b/docs/superpowers/plans/2026-04-13-queued-chat-followups.md
@@ -1,0 +1,1013 @@
+# Queued Chat Follow-Ups Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users queue multiple follow-up prompts during an active chat turn, edit or delete pending items, and force any pending item to send next via `Send now`, with the queue persisted server-side per conversation.
+
+**Architecture:** Add a dedicated `queued_messages` persistence layer and a conversation-scoped dispatcher that claims one pending queue item at a time and feeds it into the existing `startChatTurn(...)` pipeline. Extend websocket snapshots and chat page payloads to include queue state, then render a banner stack above the composer that manages pending items without polluting the transcript.
+
+**Tech Stack:** TypeScript, Next.js 15 App Router, React 19, `better-sqlite3`, `ws`, Vitest, Testing Library, Playwright
+
+**Spec:** `docs/superpowers/specs/2026-04-13-queued-chat-followups-design.md`
+
+---
+
+## File Structure
+
+### New files
+
+| File | Responsibility |
+|------|---------------|
+| `lib/queued-chat-dispatcher.ts` | Conversation-scoped queue dispatcher, in-memory dispatch locks, and helper to kick off pending follow-ups once a conversation becomes idle |
+| `components/queued-message-banner.tsx` | Banner stack UI for pending, processing, and failed queued follow-ups |
+| `tests/unit/queued-chat-dispatcher.test.ts` | Unit coverage for claim/dispatch/lock/recovery behavior |
+| `tests/unit/queued-message-banner.test.tsx` | UI coverage for banner rendering, edit/delete, and `Send now` actions |
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `lib/db.ts:185-292,647-655` | Add `queued_messages` table, indexes, and migration/recovery glue |
+| `lib/types.ts:34-120` | Add `QueuedMessageStatus`, `QueuedMessage`, and snapshot payload types |
+| `lib/conversations.ts:910-920` plus new queue helpers nearby | Add queue CRUD, reorder, claim, fail, and snapshot hydration support |
+| `lib/ws-protocol.ts:3-29` | Add queue-specific client messages and `queue_updated` server message support |
+| `lib/ws-handler.ts:1-137` | Route queue operations and broadcast queue state updates |
+| `lib/chat-turn.ts:1-260` | Add dispatch hook so queue rows are deleted when real messages are created, and trigger queue dispatch on turn finalization |
+| `app/chat/[conversationId]/page.tsx:1-78` | Include queued messages in initial payload |
+| `app/automations/[automationId]/runs/[runId]/page.tsx:1-56` | Include queued messages in automation chat payload |
+| `app/api/conversations/[conversationId]/route.ts:1-43` | Return queued messages in polling/snapshot payload |
+| `components/chat-view.tsx:32-43,268-281,656-724,915-951,1310-1560` | Track queue state, branch submit behavior, reconcile queue snapshots, and wire queue mutations |
+| `components/chat-composer.tsx:29-59,223-234,318-340` | Keep composer submit and stop affordances coherent while queued follow-ups leave attachments composer-local |
+| `tests/unit/conversations.test.ts` | Cover queue persistence, reorder, claim, and snapshot hydration |
+| `tests/unit/ws-protocol.test.ts` | Cover queue message parsing/serialization |
+| `tests/unit/ws-handler.test.ts` | Cover queue create/edit/delete/send-now routing and snapshot payload shape |
+| `tests/unit/chat-turn.test.ts` | Cover queue deletion on dispatch and finalizer-triggered follow-up dispatch |
+| `tests/unit/chat-view.test.ts` | Cover queueing during streaming, queue hydration, edit/delete, and `Send now` |
+| `tests/e2e/features.spec.ts` | Exercise real UI behavior for queueing, `Send now`, and persistence across refresh |
+
+---
+
+## Task 1: Add queued-message schema, types, and conversation helpers
+
+**Files:**
+- Modify: `lib/db.ts:185-292,647-655`
+- Modify: `lib/types.ts:34-120`
+- Modify: `lib/conversations.ts:906-920` and add queue helpers near other conversation persistence functions
+- Test: `tests/unit/conversations.test.ts`
+
+- [ ] **Step 1: Write the failing queue persistence tests**
+
+Add these tests to `tests/unit/conversations.test.ts`:
+
+```typescript
+it("creates, reorders, and claims queued messages for a conversation", async () => {
+  const { createConversation, createQueuedMessage, listQueuedMessages, moveQueuedMessageToFront, claimNextQueuedMessageForDispatch } =
+    await import("@/lib/conversations");
+
+  const conversation = createConversation();
+  const first = createQueuedMessage({ conversationId: conversation.id, content: "First queued follow-up" });
+  const second = createQueuedMessage({ conversationId: conversation.id, content: "Second queued follow-up" });
+
+  moveQueuedMessageToFront({ conversationId: conversation.id, queuedMessageId: second.id });
+
+  expect(listQueuedMessages(conversation.id).map((item) => item.id)).toEqual([second.id, first.id]);
+
+  const claimed = claimNextQueuedMessageForDispatch(conversation.id);
+  expect(claimed?.id).toBe(second.id);
+  expect(listQueuedMessages(conversation.id)[0]).toMatchObject({
+    id: second.id,
+    status: "processing"
+  });
+});
+
+it("includes queued messages in conversation snapshots", async () => {
+  const { createConversation, createQueuedMessage, getConversationSnapshot } = await import("@/lib/conversations");
+
+  const conversation = createConversation();
+  createQueuedMessage({ conversationId: conversation.id, content: "Queued while busy" });
+
+  expect(getConversationSnapshot(conversation.id)?.queuedMessages).toEqual([
+    expect.objectContaining({
+      content: "Queued while busy",
+      status: "pending"
+    })
+  ]);
+});
+```
+
+- [ ] **Step 2: Run the queue persistence test to verify it fails**
+
+Run: `npx vitest run tests/unit/conversations.test.ts`
+
+Expected: FAIL with missing queue helper exports and `queuedMessages` absent from `ConversationSnapshot`.
+
+- [ ] **Step 3: Add the queue table, types, and persistence helpers**
+
+Update `lib/types.ts` with the new queue types:
+
+```typescript
+export type QueuedMessageStatus = "pending" | "processing" | "failed" | "cancelled";
+
+export type QueuedMessage = {
+  id: string;
+  conversationId: string;
+  content: string;
+  status: QueuedMessageStatus;
+  sortOrder: number;
+  failureMessage: string | null;
+  createdAt: string;
+  updatedAt: string;
+  processingStartedAt: string | null;
+};
+
+export type ConversationSnapshot = {
+  conversation: Conversation;
+  messages: Message[];
+  queuedMessages: QueuedMessage[];
+};
+```
+
+Add the new table and index in `lib/db.ts`:
+
+```typescript
+CREATE TABLE IF NOT EXISTS queued_messages (
+  id TEXT PRIMARY KEY,
+  conversation_id TEXT NOT NULL,
+  content TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending',
+  sort_order INTEGER NOT NULL,
+  failure_message TEXT,
+  processing_started_at TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  FOREIGN KEY (conversation_id) REFERENCES conversations(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_queued_messages_conversation_status_sort
+  ON queued_messages(conversation_id, status, sort_order, created_at);
+```
+
+Add these helpers in `lib/conversations.ts`:
+
+```typescript
+export function createQueuedMessage(input: { conversationId: string; content: string }) {
+  const db = getDb();
+  const now = nowIso();
+  const nextSortOrder =
+    ((db.prepare("SELECT COALESCE(MAX(sort_order), 0) AS max_sort_order FROM queued_messages WHERE conversation_id = ?")
+      .get(input.conversationId) as { max_sort_order: number | null }).max_sort_order ?? 0) + 1;
+
+  const row = {
+    id: createId("queued"),
+    conversation_id: input.conversationId,
+    content: input.content,
+    status: "pending" as const,
+    sort_order: nextSortOrder,
+    failure_message: null,
+    processing_started_at: null,
+    created_at: now,
+    updated_at: now
+  };
+
+  db.prepare(`
+    INSERT INTO queued_messages (
+      id, conversation_id, content, status, sort_order, failure_message, processing_started_at, created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    row.id,
+    row.conversation_id,
+    row.content,
+    row.status,
+    row.sort_order,
+    row.failure_message,
+    row.processing_started_at,
+    row.created_at,
+    row.updated_at
+  );
+
+  return rowToQueuedMessage(row);
+}
+
+export function claimNextQueuedMessageForDispatch(conversationId: string) {
+  const db = getDb();
+  return db.transaction(() => {
+    const next = db.prepare(`
+      SELECT *
+      FROM queued_messages
+      WHERE conversation_id = ? AND status = 'pending'
+      ORDER BY sort_order ASC, created_at ASC
+      LIMIT 1
+    `).get(conversationId) as QueuedMessageRow | undefined;
+
+    if (!next) return null;
+
+    const now = nowIso();
+    const result = db.prepare(`
+      UPDATE queued_messages
+      SET status = 'processing',
+          processing_started_at = ?,
+          updated_at = ?,
+          failure_message = NULL
+      WHERE id = ? AND status = 'pending'
+    `).run(now, now, next.id);
+
+    if (result.changes === 0) return null;
+
+    return rowToQueuedMessage({ ...next, status: "processing", processing_started_at: now, updated_at: now, failure_message: null });
+  })();
+}
+```
+
+Also update `getConversationSnapshot(...)` to return `queuedMessages: listQueuedMessages(conversationId)`.
+
+- [ ] **Step 4: Run the conversation tests again**
+
+Run: `npx vitest run tests/unit/conversations.test.ts`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/db.ts lib/types.ts lib/conversations.ts tests/unit/conversations.test.ts
+git commit -m "feat: add queued message persistence"
+```
+
+---
+
+## Task 2: Expose queue state through snapshots and websocket queue actions
+
+**Files:**
+- Modify: `lib/ws-protocol.ts:3-29`
+- Modify: `lib/ws-handler.ts:1-137`
+- Modify: `app/api/conversations/[conversationId]/route.ts:1-43`
+- Modify: `app/chat/[conversationId]/page.tsx:1-78`
+- Modify: `app/automations/[automationId]/runs/[runId]/page.tsx:1-56`
+- Test: `tests/unit/ws-protocol.test.ts`
+- Test: `tests/unit/ws-handler.test.ts`
+
+- [ ] **Step 1: Write the failing protocol and handler tests**
+
+Add this protocol test to `tests/unit/ws-protocol.test.ts`:
+
+```typescript
+it("serializes and parses queue client messages", async () => {
+  const { serializeClientMessage, parseClientMessage } = await import("@/lib/ws-protocol");
+  const message = { type: "queue_message", conversationId: "conv-1", content: "Queued follow-up" } as const;
+
+  expect(parseClientMessage(serializeClientMessage(message))).toEqual(message);
+});
+```
+
+Add this handler test to `tests/unit/ws-handler.test.ts`:
+
+```typescript
+it("creates a queued message and broadcasts queue state", async () => {
+  const queuedMessage = {
+    id: "queued_1",
+    conversationId: "conv-1",
+    content: "Queued follow-up",
+    status: "pending",
+    sortOrder: 1,
+    failureMessage: null,
+    processingStartedAt: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString()
+  };
+  const createQueuedMessage = vi.fn().mockReturnValue({
+    ...queuedMessage
+  });
+  const listQueuedMessages = vi.fn().mockReturnValue([queuedMessage]);
+
+  vi.doMock("@/lib/conversations", () => ({
+    getConversationSnapshot: vi.fn().mockReturnValue({
+      conversation: { id: "conv-1", title: "Test", isActive: true },
+      messages: [],
+      queuedMessages: []
+    }),
+    listActiveConversations: vi.fn().mockReturnValue([]),
+    createQueuedMessage,
+    listQueuedMessages
+  }));
+
+  const { handleConnection } = await import("@/lib/ws-handler");
+  const sent: string[] = [];
+  const handlers: Array<(raw: string) => void> = [];
+  const ws = {
+    readyState: 1,
+    send: vi.fn((data: string) => sent.push(data)),
+    close: vi.fn(),
+    on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      if (event === "message") handlers.push((raw: string) => handler(raw));
+    })
+  } as unknown as WebSocket;
+
+  await handleConnection(ws, "session=valid-token");
+  handlers.forEach((handler) =>
+    handler(JSON.stringify({ type: "queue_message", conversationId: "conv-1", content: "Queued follow-up" }))
+  );
+
+  expect(createQueuedMessage).toHaveBeenCalledWith({
+    conversationId: "conv-1",
+    content: "Queued follow-up"
+  });
+  expect(sent.some((entry) => JSON.parse(entry).type === "queue_updated")).toBe(true);
+});
+```
+
+- [ ] **Step 2: Run the websocket tests to verify they fail**
+
+Run: `npx vitest run tests/unit/ws-protocol.test.ts tests/unit/ws-handler.test.ts`
+
+Expected: FAIL because `queue_message` is not a recognized client message and the handler has no queue routing.
+
+- [ ] **Step 3: Add queue protocol messages and initial snapshot payloads**
+
+Update `lib/ws-protocol.ts`:
+
+```typescript
+export type ClientMessage =
+  | { type: "subscribe"; conversationId: string }
+  | { type: "unsubscribe"; conversationId: string }
+  | { type: "message"; conversationId: string; content: string; attachmentIds?: string[]; personaId?: string }
+  | { type: "queue_message"; conversationId: string; content: string }
+  | { type: "update_queued_message"; conversationId: string; queuedMessageId: string; content: string }
+  | { type: "delete_queued_message"; conversationId: string; queuedMessageId: string }
+  | { type: "send_queued_message_now"; conversationId: string; queuedMessageId: string }
+  | { type: "stop"; conversationId: string }
+  | { type: "edit"; messageId: string; content: string };
+
+export type ServerMessage =
+  | { type: "ready"; activeConversations: { id: string; title: string; status: string }[] }
+  | { type: "snapshot"; conversationId: string; messages: unknown[]; queuedMessages: unknown[]; actions: unknown[]; segments: unknown[] }
+  | { type: "queue_updated"; conversationId: string; queuedMessages: unknown[] }
+  | { type: "delta"; conversationId: string; event: ChatStreamEvent }
+  | { type: "error"; message: string };
+
+const CLIENT_MESSAGE_TYPES = new Set([
+  "subscribe",
+  "unsubscribe",
+  "message",
+  "queue_message",
+  "update_queued_message",
+  "delete_queued_message",
+  "send_queued_message_now",
+  "stop",
+  "edit"
+]);
+```
+
+Update the page and API payloads so they all include `queuedMessages`:
+
+```typescript
+payload={{
+  conversation,
+  messages: listVisibleMessages(conversation.id),
+  queuedMessages: listQueuedMessages(conversation.id),
+  settings: {
+    sttEngine: settings.sttEngine,
+    sttLanguage: settings.sttLanguage
+  },
+  providerProfiles: settings.providerProfiles,
+  defaultProviderProfileId: settings.defaultProviderProfileId,
+  debug: getConversationDebugStats(conversation.id)
+}}
+```
+
+Also update `app/api/conversations/[conversationId]/route.ts`:
+
+```typescript
+return ok({
+  conversation,
+  messages: listVisibleMessages(conversation.id),
+  queuedMessages: listQueuedMessages(conversation.id),
+  debug: getConversationDebugStats(conversation.id)
+});
+```
+
+- [ ] **Step 4: Route queue websocket actions and broadcast queue updates**
+
+Add a shared helper in `lib/ws-handler.ts`:
+
+```typescript
+function broadcastQueuedMessages(mgr: ConversationManager, conversationId: string) {
+  mgr.broadcast(conversationId, {
+    type: "queue_updated",
+    conversationId,
+    queuedMessages: listQueuedMessages(conversationId)
+  });
+}
+```
+
+Handle the new message types:
+
+```typescript
+case "queue_message": {
+  createQueuedMessage({ conversationId: msg.conversationId, content: msg.content });
+  broadcastQueuedMessages(mgr, msg.conversationId);
+  void ensureQueuedDispatch({ manager: mgr, conversationId: msg.conversationId });
+  break;
+}
+case "update_queued_message": {
+  updateQueuedMessage({ conversationId: msg.conversationId, queuedMessageId: msg.queuedMessageId, content: msg.content });
+  broadcastQueuedMessages(mgr, msg.conversationId);
+  break;
+}
+case "delete_queued_message": {
+  deleteQueuedMessage({ conversationId: msg.conversationId, queuedMessageId: msg.queuedMessageId });
+  broadcastQueuedMessages(mgr, msg.conversationId);
+  break;
+}
+case "send_queued_message_now": {
+  moveQueuedMessageToFront({ conversationId: msg.conversationId, queuedMessageId: msg.queuedMessageId });
+  requestStop(msg.conversationId);
+  broadcastQueuedMessages(mgr, msg.conversationId);
+  void ensureQueuedDispatch({ manager: mgr, conversationId: msg.conversationId });
+  break;
+}
+```
+
+Make the subscribe snapshot include `queuedMessages`.
+
+- [ ] **Step 5: Run the websocket tests again**
+
+Run: `npx vitest run tests/unit/ws-protocol.test.ts tests/unit/ws-handler.test.ts`
+
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/ws-protocol.ts lib/ws-handler.ts app/api/conversations/[conversationId]/route.ts app/chat/[conversationId]/page.tsx app/automations/[automationId]/runs/[runId]/page.tsx tests/unit/ws-protocol.test.ts tests/unit/ws-handler.test.ts
+git commit -m "feat: expose queued message snapshots and ws actions"
+```
+
+---
+
+## Task 3: Add the queue dispatcher and hook it into chat-turn lifecycle
+
+**Files:**
+- Create: `lib/queued-chat-dispatcher.ts`
+- Modify: `lib/conversations.ts`
+- Modify: `lib/chat-turn.ts:24-31,47-60,88-111,250-259`
+- Test: `tests/unit/queued-chat-dispatcher.test.ts`
+- Test: `tests/unit/chat-turn.test.ts`
+
+- [ ] **Step 1: Write the failing dispatcher and chat-turn tests**
+
+Create `tests/unit/queued-chat-dispatcher.test.ts`:
+
+```typescript
+import { describe, it, expect, vi } from "vitest";
+
+describe("queued-chat-dispatcher", () => {
+  it("claims only one queued message per conversation at a time", async () => {
+    const { createConversation, createQueuedMessage, listQueuedMessages } = await import("@/lib/conversations");
+    const { ensureQueuedDispatch } = await import("@/lib/queued-chat-dispatcher");
+
+    const conversation = createConversation();
+    createQueuedMessage({ conversationId: conversation.id, content: "First" });
+    createQueuedMessage({ conversationId: conversation.id, content: "Second" });
+
+    const startChatTurn = vi.fn().mockResolvedValue({ status: "completed" });
+    await Promise.all([
+      ensureQueuedDispatch({ manager: {} as never, conversationId: conversation.id, startChatTurn }),
+      ensureQueuedDispatch({ manager: {} as never, conversationId: conversation.id, startChatTurn })
+    ]);
+
+    expect(startChatTurn).toHaveBeenCalledTimes(1);
+    expect(listQueuedMessages(conversation.id).map((item) => item.content)).toEqual(["Second"]);
+  });
+});
+```
+
+Add this test to `tests/unit/chat-turn.test.ts`:
+
+```typescript
+it("triggers queued dispatch after a turn finalizes", async () => {
+  const ensureQueuedDispatch = vi.fn().mockResolvedValue(undefined);
+  vi.doMock("@/lib/queued-chat-dispatcher", () => ({ ensureQueuedDispatch }));
+
+  const { createConversation } = await import("@/lib/conversations");
+  const { createConversationManager } = await import("@/lib/conversation-manager");
+  const { startChatTurn } = await import("@/lib/chat-turn");
+
+  const manager = createConversationManager();
+  const conversation = createConversation();
+
+  await startChatTurn(manager, conversation.id, "Hello", []);
+
+  expect(ensureQueuedDispatch).toHaveBeenCalledWith({
+    manager,
+    conversationId: conversation.id,
+    startChatTurn
+  });
+});
+```
+
+- [ ] **Step 2: Run the dispatcher tests to verify they fail**
+
+Run: `npx vitest run tests/unit/queued-chat-dispatcher.test.ts tests/unit/chat-turn.test.ts`
+
+Expected: FAIL because the dispatcher module does not exist and `chat-turn.ts` does not trigger queue dispatch.
+
+- [ ] **Step 3: Implement queue claiming, deletion-on-dispatch, and idle dispatch**
+
+Create `lib/queued-chat-dispatcher.ts`:
+
+```typescript
+import { claimNextQueuedMessageForDispatch, deleteQueuedMessage, failQueuedMessage, getConversation, listQueuedMessages, markOrphanedQueuedMessagesFailed } from "@/lib/conversations";
+import type { ConversationManager } from "@/lib/conversation-manager";
+import type { StartChatTurn } from "@/lib/chat-turn";
+
+const dispatchLocks = new Set<string>();
+
+export async function ensureQueuedDispatch(input: {
+  manager: ConversationManager;
+  conversationId: string;
+  startChatTurn: StartChatTurn;
+}) {
+  if (dispatchLocks.has(input.conversationId)) {
+    return;
+  }
+
+  const conversation = getConversation(input.conversationId);
+  if (!conversation || conversation.isActive) {
+    return;
+  }
+
+  dispatchLocks.add(input.conversationId);
+
+  try {
+    markOrphanedQueuedMessagesFailed(input.conversationId);
+    const queued = claimNextQueuedMessageForDispatch(input.conversationId);
+    if (!queued) {
+      return;
+    }
+
+    const result = await input.startChatTurn(
+      input.manager,
+      input.conversationId,
+      queued.content,
+      [],
+      undefined,
+      {
+        onMessagesCreated() {
+          deleteQueuedMessage({ conversationId: input.conversationId, queuedMessageId: queued.id });
+        },
+        source: "queue"
+      }
+    );
+
+    if (result.status === "failed" || result.status === "skipped") {
+      failQueuedMessage({
+        conversationId: input.conversationId,
+        queuedMessageId: queued.id,
+        failureMessage: result.errorMessage ?? "Unable to dispatch queued follow-up"
+      });
+    }
+  } finally {
+    dispatchLocks.delete(input.conversationId);
+  }
+}
+```
+
+Extend `startChatTurn` in `lib/chat-turn.ts` so it accepts an optional fifth parameter:
+
+```typescript
+export type StartChatTurn = (
+  manager: ConversationManager,
+  conversationId: string,
+  content: string,
+  attachmentIds: string[],
+  personaId?: string,
+  options?: {
+    source?: "live" | "queue";
+    onMessagesCreated?: (payload: { userMessageId: string; assistantMessageId: string }) => void;
+  }
+) => Promise<ChatTurnResult>;
+```
+
+Call the hook immediately after creating the real user/assistant messages:
+
+```typescript
+options?.onMessagesCreated?.({
+  userMessageId: userMessage.id,
+  assistantMessageId: assistantMessage.id
+});
+```
+
+In the `finally` block, trigger the dispatcher:
+
+```typescript
+const { ensureQueuedDispatch } = await import("@/lib/queued-chat-dispatcher");
+await ensureQueuedDispatch({
+  manager,
+  conversationId,
+  startChatTurn
+});
+```
+
+- [ ] **Step 4: Run the dispatcher and chat-turn tests again**
+
+Run: `npx vitest run tests/unit/queued-chat-dispatcher.test.ts tests/unit/chat-turn.test.ts`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/queued-chat-dispatcher.ts lib/chat-turn.ts lib/conversations.ts tests/unit/queued-chat-dispatcher.test.ts tests/unit/chat-turn.test.ts
+git commit -m "feat: dispatch queued follow-ups through chat turn lifecycle"
+```
+
+---
+
+## Task 4: Build the banner stack UI and branch composer submits into queue creation
+
+**Files:**
+- Create: `components/queued-message-banner.tsx`
+- Modify: `components/chat-view.tsx:32-43,268-281,656-724,915-951,1310-1560`
+- Modify: `components/chat-composer.tsx:29-59,223-234,318-340`
+- Test: `tests/unit/queued-message-banner.test.tsx`
+- Test: `tests/unit/chat-view.test.ts`
+
+- [ ] **Step 1: Write the failing UI tests**
+
+Create `tests/unit/queued-message-banner.test.tsx`:
+
+```typescript
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { QueuedMessageBanner } from "@/components/queued-message-banner";
+
+describe("queued-message-banner", () => {
+  it("renders pending items and exposes edit/delete/send-now actions", () => {
+    const onEdit = vi.fn();
+    const onDelete = vi.fn();
+    const onSendNow = vi.fn();
+
+    render(
+      <QueuedMessageBanner
+        items={[
+          {
+            id: "queued_1",
+            conversationId: "conv_1",
+            content: "Queued follow-up",
+            status: "pending",
+            sortOrder: 1,
+            failureMessage: null,
+            processingStartedAt: null,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString()
+          }
+        ]}
+        onEdit={onEdit}
+        onDelete={onDelete}
+        onSendNow={onSendNow}
+      />
+    );
+
+    expect(screen.getByText("Queued follow-up")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Send queued follow-up now" }));
+    expect(onSendNow).toHaveBeenCalledWith("queued_1");
+  });
+});
+```
+
+Add these tests to `tests/unit/chat-view.test.ts`:
+
+```typescript
+it("queues a message instead of sending immediately when a turn is active", async () => {
+  renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
+
+  await act(async () => {
+    wsMock.onMessage?.({
+      type: "delta",
+      conversationId: "conv_1",
+      event: { type: "message_start", messageId: "msg_assistant_1" }
+    });
+  });
+
+  fireEvent.change(screen.getByPlaceholderText("Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."), {
+    target: { value: "Queue this follow-up" }
+  });
+  fireEvent.keyDown(screen.getByPlaceholderText("Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."), {
+    key: "Enter"
+  });
+
+  await waitFor(() => {
+    expect(wsMock.send).toHaveBeenCalledWith({
+      type: "queue_message",
+      conversationId: "conv_1",
+      content: "Queue this follow-up"
+    });
+  });
+});
+
+it("hydrates queued messages from websocket snapshots", async () => {
+  renderWithProvider(React.createElement(ChatView, {
+    payload: createPayload({
+      queuedMessages: []
+    })
+  }));
+
+  wsMock.onMessage?.({
+    type: "queue_updated",
+    conversationId: "conv_1",
+    queuedMessages: [
+      {
+        id: "queued_1",
+        conversationId: "conv_1",
+        content: "Queued follow-up",
+        status: "pending",
+        sortOrder: 1,
+        failureMessage: null,
+        processingStartedAt: null,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString()
+      }
+    ]
+  });
+
+  expect(screen.getByText("Queued follow-up")).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run the UI tests to verify they fail**
+
+Run: `npx vitest run tests/unit/queued-message-banner.test.tsx tests/unit/chat-view.test.ts`
+
+Expected: FAIL because the banner component does not exist and `ChatView` only sends immediate websocket messages.
+
+- [ ] **Step 3: Implement the queue banner component**
+
+Create `components/queued-message-banner.tsx`:
+
+```tsx
+"use client";
+
+import React, { useState } from "react";
+import { Pencil, Play, Trash2 } from "lucide-react";
+import type { QueuedMessage } from "@/lib/types";
+import { cn } from "@/lib/utils";
+
+export function QueuedMessageBanner(input: {
+  items: QueuedMessage[];
+  onEdit: (queuedMessageId: string, content: string) => void | Promise<void>;
+  onDelete: (queuedMessageId: string) => void | Promise<void>;
+  onSendNow: (queuedMessageId: string) => void | Promise<void>;
+}) {
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [draft, setDraft] = useState("");
+
+  if (!input.items.length) {
+    return null;
+  }
+
+  return (
+    <div className="rounded-[22px] border border-white/10 bg-zinc-950/88 p-3 shadow-[0_18px_50px_rgba(0,0,0,0.28)] backdrop-blur-xl">
+      <div className="mb-2 flex items-center justify-between">
+        <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/45">
+          Queued follow-ups · {input.items.length}
+        </div>
+      </div>
+      <div className="max-h-48 space-y-2 overflow-y-auto pr-1">
+        {input.items.map((item, index) => {
+          const editable = item.status === "pending";
+          const isEditing = editingId === item.id;
+          return (
+            <div
+              key={item.id}
+              className={cn(
+                "rounded-2xl border px-3 py-3",
+                index === 0 ? "border-white/16 bg-white/8" : "border-white/8 bg-white/[0.04]"
+              )}
+            >
+              <div className="mb-2 flex items-center justify-between gap-3">
+                <div className="text-[11px] font-medium uppercase tracking-[0.16em] text-white/35">
+                  {index === 0 ? "Next" : `Then ${index + 1}`}
+                </div>
+                <div className="text-[11px] text-white/40">{item.status}</div>
+              </div>
+              {isEditing ? (
+                <textarea
+                  value={draft}
+                  onChange={(event) => setDraft(event.target.value)}
+                  className="min-h-[72px] w-full resize-none rounded-xl border border-white/10 bg-black/20 px-3 py-2 text-sm text-white"
+                />
+              ) : (
+                <div className="text-sm text-white/88">{item.content}</div>
+              )}
+              <div className="mt-3 flex items-center justify-end gap-2">
+                {editable && isEditing ? (
+                  <button type="button" className="rounded-full bg-white px-3 py-1.5 text-xs font-medium text-zinc-950" onClick={() => { void input.onEdit(item.id, draft); setEditingId(null); }}>
+                    Save
+                  </button>
+                ) : null}
+                {editable && !isEditing ? (
+                  <button type="button" aria-label="Edit queued follow-up" className="rounded-full border border-white/10 p-2 text-white/70" onClick={() => { setEditingId(item.id); setDraft(item.content); }}>
+                    <Pencil className="h-3.5 w-3.5" />
+                  </button>
+                ) : null}
+                {editable ? (
+                  <button type="button" aria-label="Delete queued follow-up" className="rounded-full border border-white/10 p-2 text-white/70" onClick={() => void input.onDelete(item.id)}>
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </button>
+                ) : null}
+                {editable ? (
+                  <button type="button" aria-label="Send queued follow-up now" className="rounded-full bg-cyan-300 px-3 py-1.5 text-xs font-semibold text-zinc-950" onClick={() => void input.onSendNow(item.id)}>
+                    <Play className="mr-1 inline h-3.5 w-3.5" />
+                    Send now
+                  </button>
+                ) : null}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Branch `ChatView` submit logic into live-send vs queue-send and render the banner**
+
+Update the payload and state setup in `components/chat-view.tsx`:
+
+```tsx
+type ConversationPayload = {
+  conversation: Conversation;
+  messages: Message[];
+  queuedMessages: QueuedMessage[];
+  settings: Pick<AppSettings, "sttEngine" | "sttLanguage">;
+  providerProfiles: ProviderProfileSummary[];
+  defaultProviderProfileId: string | null;
+  debug: { rawTurnCount: number; memoryNodeCount: number; latestCompactionAt: string | null };
+};
+
+const [queuedMessages, setQueuedMessages] = useState(payload.queuedMessages);
+```
+
+Handle queue snapshot updates:
+
+```tsx
+case "snapshot":
+  setQueuedMessages(msg.queuedMessages as QueuedMessage[]);
+  setMessages((current) => reconcileSnapshotMessages(current, msg.messages as Message[], streamMessageId));
+  break;
+case "queue_updated":
+  setQueuedMessages(msg.queuedMessages as QueuedMessage[]);
+  break;
+```
+
+Branch submit behavior:
+
+```tsx
+const hasActiveTurn = Boolean(streamMessageIdRef.current) || payload.conversation.isActive;
+
+if (hasActiveTurn) {
+  setError("");
+  setInput("");
+  setQueuedMessages((current) => [
+    ...current,
+    {
+      id: `local_queue_${Date.now()}`,
+      conversationId: payload.conversation.id,
+      content: value,
+      status: "pending",
+      sortOrder: current.length + 1,
+      failureMessage: null,
+      processingStartedAt: null,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString()
+    }
+  ]);
+  wsSend({
+    type: "queue_message",
+    conversationId: payload.conversation.id,
+    content: value
+  });
+  return;
+}
+```
+
+Wire the banner above the composer:
+
+```tsx
+<div className="fixed inset-x-0 bottom-0 z-10 pointer-events-none">
+  <div className="mx-auto w-full max-w-[980px] px-4 md:px-8 pointer-events-auto">
+    <div className="mb-3">
+      <QueuedMessageBanner
+        items={queuedMessages}
+        onEdit={(queuedMessageId, content) => wsSend({ type: "update_queued_message", conversationId: payload.conversation.id, queuedMessageId, content })}
+        onDelete={(queuedMessageId) => wsSend({ type: "delete_queued_message", conversationId: payload.conversation.id, queuedMessageId })}
+        onSendNow={(queuedMessageId) => wsSend({ type: "send_queued_message_now", conversationId: payload.conversation.id, queuedMessageId })}
+      />
+    </div>
+    <ChatComposer /* existing props */ />
+  </div>
+</div>
+```
+
+Leave attachments composer-local while queueing: do not include `attachmentIds` in queue messages and do not clear `pendingAttachments` inside the queue branch.
+
+- [ ] **Step 5: Run the UI tests again**
+
+Run: `npx vitest run tests/unit/queued-message-banner.test.tsx tests/unit/chat-view.test.ts`
+
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add components/queued-message-banner.tsx components/chat-view.tsx components/chat-composer.tsx tests/unit/queued-message-banner.test.tsx tests/unit/chat-view.test.ts
+git commit -m "feat: add queued follow-up banner and chat view flow"
+```
+
+---
+
+## Task 5: Add end-to-end coverage and run full verification
+
+**Files:**
+- Modify: `tests/e2e/features.spec.ts`
+- Verify: full test, typecheck, lint, and browser validation
+
+- [ ] **Step 1: Write the failing end-to-end spec**
+
+Add this Playwright scenario to `tests/e2e/features.spec.ts`:
+
+```typescript
+test("queues follow-ups during streaming and sends a selected item next", async ({ page }) => {
+  let requestCount = 0;
+
+  await page.route("**/api/conversations/*/chat", async (route) => {
+    requestCount += 1;
+    await route.fulfill({
+      status: 200,
+      contentType: "text/event-stream",
+      body: [
+        'data: {"type":"message_start","messageId":"msg_assistant"}',
+        'data: {"type":"answer_delta","text":"Working..."}',
+        'data: {"type":"done","messageId":"msg_assistant"}'
+      ].join("\\n\\n")
+    });
+  });
+
+  await page.getByRole("button", { name: "New chat", exact: true }).click();
+  await expect(page).toHaveURL(/\\/chat\\//);
+
+  await page.getByPlaceholder("Ask, create, or start a task. Press ⌘ ⏎ to insert a line break...").fill("Initial question");
+  await page.keyboard.press("Enter");
+
+  await page.getByPlaceholder("Ask, create, or start a task. Press ⌘ ⏎ to insert a line break...").fill("Queued follow-up one");
+  await page.keyboard.press("Enter");
+
+  await expect(page.getByText("Queued follow-up one")).toBeVisible();
+  await page.getByRole("button", { name: "Send queued follow-up now" }).click();
+
+  await expect.poll(() => requestCount).toBeGreaterThan(1);
+});
+```
+
+- [ ] **Step 2: Run the e2e spec to verify it fails**
+
+Run: `npm run test:e2e -- tests/e2e/features.spec.ts`
+
+Expected: FAIL because the queue banner and queue actions do not exist yet.
+
+- [ ] **Step 3: Run the targeted unit tests, then the full verification suite**
+
+Run:
+
+```bash
+npx vitest run tests/unit/conversations.test.ts tests/unit/ws-protocol.test.ts tests/unit/ws-handler.test.ts tests/unit/queued-chat-dispatcher.test.ts tests/unit/chat-turn.test.ts tests/unit/queued-message-banner.test.tsx tests/unit/chat-view.test.ts
+npm run lint
+npm run typecheck
+npm test
+npm run test:e2e -- tests/e2e/features.spec.ts
+```
+
+Expected:
+
+- all targeted queue-related unit suites PASS
+- `npm run lint` exits 0
+- `npm run typecheck` exits 0
+- `npm test` exits 0 with coverage still meeting the repo threshold
+- the Playwright scenario PASSes
+
+- [ ] **Step 4: Validate the UI in the browser**
+
+1. Check for `.dev-server` in the repo root. If it exists, use its URL; if the server is dead, delete the file and start fresh with `npm run dev`.
+2. Open the chat page with the `agent-browser` skill.
+3. Start a message, queue two follow-ups, edit one, delete one, and use `Send now`.
+4. Refresh the page and confirm the queue banner persists.
+5. Capture a screenshot of the banner stack above the composer.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/e2e/features.spec.ts
+git commit -m "test: cover queued chat follow-ups"
+```

--- a/docs/superpowers/specs/2026-04-13-queued-chat-followups-design.md
+++ b/docs/superpowers/specs/2026-04-13-queued-chat-followups-design.md
@@ -1,0 +1,323 @@
+# Queued Chat Follow-Ups Design
+
+## Overview
+
+Add a durable per-conversation follow-up queue so users can submit additional prompts while the assistant is still streaming or executing tools. Queued items are not real transcript messages yet. They are deferred user intents that wait for the active turn to finish, then automatically dispatch through the existing chat turn pipeline.
+
+The queue must be server-side so it survives reloads, reconnects, and app restarts. The user can edit or delete pending queue items before they send, and can force any pending item to send next with a `Send now` action that stops the active turn and promotes the chosen item to the front of the queue.
+
+## Goals
+
+- Let users queue multiple follow-up prompts during an active assistant turn.
+- Persist the queue on the server per conversation.
+- Keep queued items out of the transcript until they are actually dispatched.
+- Reuse the existing `startChatTurn(...)` flow so queued sends behave like normal user messages at dispatch time.
+- Support inline edit, delete, and `Send now` actions on pending queue items.
+
+## Non-Goals
+
+- Queuing attachments together with follow-up items.
+- Freezing the current provider profile, persona, tool set, or transcript state at queue time.
+- Turning queued follow-ups into a generic automation system.
+- Supporting multiple simultaneously active assistant turns within one conversation.
+
+## Product Behavior
+
+### Queue creation
+
+If the conversation is idle, composer submission behaves exactly as it does today and starts a chat turn immediately.
+
+If the conversation already has an active turn, composer submission creates a queued follow-up item instead of sending a websocket `message` event. The new queue item is appended to the end of the conversation queue.
+
+Queued items store only:
+
+- conversation id
+- queued text
+- queue order
+- queue state
+- timestamps
+- optional failure metadata for recoverable dispatch failures
+
+Queued items do not snapshot:
+
+- the current transcript
+- attachments
+- persona selection
+- provider profile
+- tool call state
+- any other runtime inputs
+
+At dispatch time, the queued item is treated as if the user had just submitted that text at that moment.
+
+### Queue presentation
+
+The queue is rendered as a banner stack above the composer and below the transcript. It is visually separate from transcript messages so pending follow-ups do not read like already-sent conversation history.
+
+Behavioral requirements:
+
+- The first pending item is visually emphasized as the next item to send.
+- Additional pending items remain visible in stack order.
+- The banner uses a capped height with internal scrolling once the stack grows beyond the available vertical space.
+- Pending items support inline edit.
+- Pending items support delete.
+- Pending items support `Send now`.
+- Processing items are visible in the banner but are not editable.
+- Failed items stay visible with a recoverable error state.
+
+### Automatic dispatch
+
+Each conversation may have:
+
+- zero or one active assistant turn
+- zero or more queued follow-up items
+
+When the active turn finishes with status `completed`, `stopped`, or `failed`, the server checks whether the conversation has a pending queued item. If so, it promotes the oldest pending item to `processing` and dispatches it through the same `startChatTurn(...)` path used for immediate sends.
+
+Only one queue item can be `processing` for a conversation at a time.
+
+### Send now
+
+`Send now` is available for pending queue items only.
+
+When invoked during an active turn:
+
+1. The server requests stop for the active turn.
+2. The chosen queue item is promoted to the front of the pending queue.
+3. The rest of the queue keeps its relative order behind it.
+4. Once the active turn fully resolves, the promoted queue item dispatches next through the normal queue dispatcher.
+
+When invoked while the conversation is idle:
+
+1. The chosen queue item is promoted to the front.
+2. The dispatcher starts it immediately.
+
+`Send now` does not bypass the existing stop/finalize flow. It changes queue order, then waits for the conversation to become idle before dispatching.
+
+### Edit and delete
+
+Only queue items in the `pending` state are editable or deletable.
+
+Once a queue item enters `processing`, it is no longer editable because it has already crossed into the real chat pipeline. After `startChatTurn(...)` successfully creates the real user message and assistant placeholder, the queue row is deleted. From that point onward, the actual user message and assistant turn live in the transcript.
+
+### Failures
+
+There are two failure classes:
+
+1. Queue dispatch failure before a real user message is created.
+   The queue item moves to `failed`, keeps its banner row, and exposes retry behavior through existing queue actions.
+
+2. Chat turn failure after dispatch has already created the real user message.
+   This is no longer a queue failure. The queue item is considered consumed, and the failure appears as the normal chat turn failure inside the transcript.
+
+## Architecture
+
+### Data model
+
+Add a new conversation-scoped queue table instead of overloading `messages`.
+
+Proposed shape:
+
+```ts
+type QueuedMessageStatus = "pending" | "processing" | "failed" | "cancelled";
+
+type QueuedMessage = {
+  id: string;
+  conversationId: string;
+  content: string;
+  status: QueuedMessageStatus;
+  sortOrder: number;
+  failureMessage: string | null;
+  createdAt: string;
+  updatedAt: string;
+  processingStartedAt: string | null;
+};
+```
+
+Database responsibilities:
+
+- durable storage of queue items
+- stable FIFO ordering
+- single-item processing state
+- reorder support for `Send now`
+- recovery after server restart
+
+`messages` remains reserved for actual transcript history only.
+
+### Server dispatcher
+
+Add a small queue dispatcher responsible for deciding when a queued follow-up should start. The dispatcher is conversation-scoped and must enforce single dispatch per conversation even if multiple websocket clients are subscribed.
+
+Responsibilities:
+
+- check whether the conversation is idle
+- pick the next pending item
+- atomically move it to `processing`
+- call `startChatTurn(...)` with the queued content
+- remove or finalize the queue item once dispatch succeeds
+- mark the queue item `failed` if dispatch fails before the user message is created
+- kick off the next pending item when the active turn clears
+
+The dispatcher is invoked from:
+
+- websocket queue creation
+- queue edit/delete/send-now actions when relevant
+- chat turn completion/finalization
+- startup or reconnect recovery paths when a conversation has pending queue items and no active turn
+
+### Chat turn integration
+
+Queued dispatch must use the same `startChatTurn(...)` entry point used by live user sends. That preserves:
+
+- prompt construction
+- compaction behavior
+- skill/tool availability
+- current provider/profile lookup
+- current persona handling
+- streaming events
+- stop semantics
+
+This avoids introducing a second execution path for queued sends.
+
+### Transport and snapshot model
+
+Conversation snapshots include queue state in addition to transcript messages so reconnecting clients can rehydrate the banner stack.
+
+Queue operations are exposed through the transport layer:
+
+- create queued item
+- edit queued item
+- delete queued item
+- send queued item now
+- snapshot queue contents
+
+The websocket `message` event should remain reserved for immediate sends only. When the conversation is busy, the client should call a queue-specific operation instead of pretending an immediate send occurred.
+
+## UI Design
+
+### Chat view
+
+`components/chat-view.tsx` becomes responsible for two adjacent but separate states:
+
+- real transcript messages
+- queued follow-up banner state
+
+The transcript remains unchanged except for existing stop behavior continuing to work with queue promotion.
+
+Queue-specific requirements:
+
+- fetch queue state from the conversation snapshot
+- optimistically reflect queue edits where safe
+- preserve queue state across reconnects via snapshot reconciliation
+- keep queue UI independent from transcript reconciliation
+
+### Composer
+
+The composer keeps its current drafting behavior, but submit logic branches:
+
+- idle conversation: immediate send
+- active conversation: create queue item
+
+The composer does not need to freeze current attachments or runtime metadata into queue rows. If attachments are currently pending in the composer, they remain composer-local and are not bundled into queued follow-ups.
+
+### Banner stack
+
+The banner stack sits above the composer and contains:
+
+- queue count
+- ordered queue rows
+- inline edit affordance
+- delete affordance
+- `Send now` affordance
+- error rendering for failed queue items
+
+The UI must communicate clearly that these rows are scheduled next steps, not already-sent messages.
+
+## Ordering and concurrency rules
+
+- FIFO is the default order.
+- `Send now` promotes a chosen pending item to the front.
+- Only one queue item may be `processing` per conversation.
+- Only one active assistant turn may exist per conversation.
+- Queue dispatch must be idempotent against reconnects and duplicate client actions.
+- Multi-client viewing of the same conversation must converge on the same server-owned queue order.
+
+## Recovery behavior
+
+Because the queue is server-owned, recovery must not depend on the browser tab surviving.
+
+On startup or conversation rehydration:
+
+- if the conversation is active, do not dispatch a queued item yet
+- if the conversation is idle and has pending queue items, dispatch the next item
+- if a queue row is stuck in `processing` with no active conversation turn, downgrade it to `failed` or back to `pending` according to the chosen recovery policy
+
+Recommended recovery policy:
+
+- mark orphaned `processing` rows as `failed` with a recovery message
+
+This is safer than silently retrying after an unexpected crash because it avoids accidental duplicate sends.
+
+## File changes
+
+Expected primary files:
+
+- `lib/db.ts`
+  Add queue table migration and indexes.
+- `lib/types.ts`
+  Add queue row types and statuses.
+- `lib/conversations.ts`
+  Add CRUD and reorder helpers for queued follow-ups.
+- `lib/chat-turn.ts`
+  Trigger dispatcher checks when a turn finalizes.
+- `lib/ws-protocol.ts`
+  Add queue message shapes to the client/server protocol.
+- `lib/ws-handler.ts`
+  Handle queue create/edit/delete/send-now websocket events.
+- `components/chat-view.tsx`
+  Render and reconcile the queue banner stack.
+- `components/chat-composer.tsx`
+  Support branch between immediate send and queueing behavior.
+- `tests/unit/chat-view.test.ts`
+  Add queue UI and client-flow coverage.
+- `tests/unit/ws-handler.test.ts`
+  Add queue transport coverage.
+- `tests/unit/conversations.test.ts` or a new queue-focused unit test file
+  Cover queue persistence/order helpers.
+
+If queue actions are easier to expose through REST rather than websocket-only mutations, add dedicated conversation queue routes under `app/api/conversations/[conversationId]/...`.
+
+## Testing
+
+### Automated
+
+Required coverage:
+
+1. Submitting during an active turn creates a queue item instead of sending immediately.
+2. Multiple queued items preserve FIFO order.
+3. Pending queue items can be edited.
+4. Pending queue items can be deleted.
+5. `Send now` stops the active turn, promotes the selected item, and dispatches it next.
+6. Queue rows survive snapshot refresh and page reload.
+7. Completed, stopped, and failed turns all trigger next-item dispatch when appropriate.
+8. Only one queued item dispatches at a time even with repeated reconnect or duplicate triggers.
+9. Orphaned `processing` rows recover safely after restart.
+10. Failed queue items remain editable or retryable according to the selected action design.
+
+### Manual validation
+
+1. Start a long assistant response and submit three follow-ups.
+2. Confirm the follow-ups appear in the banner stack, not in the transcript.
+3. Edit the second queued item and delete the third.
+4. Use `Send now` on the second queued item and confirm the current turn stops and that item dispatches next.
+5. Reload the page during an active turn with pending queue items and confirm the queue rehydrates.
+6. Quit and relaunch the app, then confirm the queue still exists and continues from server state.
+7. Let queued items dispatch automatically and confirm they appear as ordinary user messages only when actually sent.
+
+## Open decisions resolved
+
+- Queue scope: multiple queued items per conversation
+- Queue ordering: FIFO with `Send now` promotion
+- Queue editing: pending items are editable and deletable
+- Queue payload semantics: deferred user intent only, no snapshot of current runtime state
+- Queue persistence: server-side and durable across reloads/app restarts
+- Queue UI placement: banner stack above the composer

--- a/lib/chat-turn.ts
+++ b/lib/chat-turn.ts
@@ -40,7 +40,11 @@ export type StartChatTurn = (
   conversationId: string,
   content: string,
   attachmentIds: string[],
-  personaId?: string
+  personaId?: string,
+  options?: {
+    source?: "live" | "queue";
+    onMessagesCreated?: (payload: { userMessageId: string; assistantMessageId: string }) => void;
+  }
 ) => Promise<ChatTurnResult>;
 
 const globalEmitter = createEmitter<{
@@ -57,7 +61,11 @@ export async function startChatTurn(
   conversationId: string,
   content: string,
   attachmentIds: string[],
-  personaId?: string
+  personaId?: string,
+  options?: {
+    source?: "live" | "queue";
+    onMessagesCreated?: (payload: { userMessageId: string; assistantMessageId: string }) => void;
+  }
 ) : Promise<ChatTurnResult> {
   const conversation = getConversation(conversationId);
   if (!conversation) {
@@ -112,6 +120,11 @@ export async function startChatTurn(
     thinkingContent: "",
     status: "streaming",
     estimatedTokens: 0
+  });
+
+  options?.onMessagesCreated?.({
+    userMessageId: userMessage.id,
+    assistantMessageId: assistantMessage.id
   });
 
   manager.broadcast(conversationId, {
@@ -373,5 +386,11 @@ export async function startChatTurn(
       conversationOwnerId ?? undefined
     );
     globalEmitter.emit("status", conversationId, "completed");
+    const { ensureQueuedDispatch } = await import("@/lib/queued-chat-dispatcher");
+    await ensureQueuedDispatch({
+      manager,
+      conversationId,
+      startChatTurn
+    });
   }
 }

--- a/lib/chat-turn.ts
+++ b/lib/chat-turn.ts
@@ -386,11 +386,16 @@ export async function startChatTurn(
       conversationOwnerId ?? undefined
     );
     globalEmitter.emit("status", conversationId, "completed");
-    const { ensureQueuedDispatch } = await import("@/lib/queued-chat-dispatcher");
-    await ensureQueuedDispatch({
-      manager,
-      conversationId,
-      startChatTurn
-    });
+    void import("@/lib/queued-chat-dispatcher")
+      .then(({ ensureQueuedDispatch }) =>
+        ensureQueuedDispatch({
+          manager,
+          conversationId,
+          startChatTurn
+        })
+      )
+      .catch((error) => {
+        console.error("Queued chat dispatch failed", error);
+      });
   }
 }

--- a/lib/chat-turn.ts
+++ b/lib/chat-turn.ts
@@ -122,11 +122,6 @@ export async function startChatTurn(
     estimatedTokens: 0
   });
 
-  options?.onMessagesCreated?.({
-    userMessageId: userMessage.id,
-    assistantMessageId: assistantMessage.id
-  });
-
   manager.broadcast(conversationId, {
     type: "delta",
     conversationId,
@@ -172,6 +167,11 @@ export async function startChatTurn(
   }
 
   try {
+    options?.onMessagesCreated?.({
+      userMessageId: userMessage.id,
+      assistantMessageId: assistantMessage.id
+    });
+
     const compacted = await ensureCompactedContext(conversation.id, settings, {
       onCompactionStart() {
         manager.broadcast(conversationId, {

--- a/lib/conversations.ts
+++ b/lib/conversations.ts
@@ -1085,6 +1085,13 @@ export function moveQueuedMessageToFront({
 
 export function claimNextQueuedMessageForDispatch(conversationId: string) {
   const db = getDb();
+  const selectProcessing = db.prepare(
+    `SELECT id
+     FROM queued_messages
+     WHERE conversation_id = ?
+       AND status = 'processing'
+     LIMIT 1`
+  );
   const selectNextPending = db.prepare(
     `SELECT
       id,
@@ -1113,6 +1120,12 @@ export function claimNextQueuedMessageForDispatch(conversationId: string) {
   );
 
   const transaction = db.transaction((targetConversationId: string) => {
+    const processingRow = selectProcessing.get(targetConversationId) as { id: string } | undefined;
+
+    if (processingRow) {
+      return null;
+    }
+
     const row = selectNextPending.get(targetConversationId) as
       | {
           id: string;

--- a/lib/conversations.ts
+++ b/lib/conversations.ts
@@ -973,28 +973,11 @@ export function createQueuedMessage({
   conversationId: string;
   content: string;
 }) {
-  const timestamp = nowIso();
   const db = getDb();
-  const nextSortOrder =
-    ((db
-      .prepare(
-        "SELECT COALESCE(MAX(sort_order), -1) AS max_sort_order FROM queued_messages WHERE conversation_id = ?"
-      )
-      .get(conversationId) as { max_sort_order: number | null }).max_sort_order ?? -1) + 1;
-
-  const queuedMessage: QueuedMessage = {
-    id: createId("queue"),
-    conversationId,
-    content,
-    status: "pending",
-    sortOrder: nextSortOrder,
-    failureMessage: null,
-    createdAt: timestamp,
-    updatedAt: timestamp,
-    processingStartedAt: null
-  };
-
-  db.prepare(
+  const selectMaxSortOrder = db.prepare(
+    "SELECT COALESCE(MAX(sort_order), -1) AS max_sort_order FROM queued_messages WHERE conversation_id = ?"
+  );
+  const insertQueuedMessage = db.prepare(
     `INSERT INTO queued_messages (
       id,
       conversation_id,
@@ -1006,19 +989,41 @@ export function createQueuedMessage({
       created_at,
       updated_at
     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
-  ).run(
-    queuedMessage.id,
-    queuedMessage.conversationId,
-    queuedMessage.content,
-    queuedMessage.status,
-    queuedMessage.sortOrder,
-    queuedMessage.failureMessage,
-    queuedMessage.processingStartedAt,
-    queuedMessage.createdAt,
-    queuedMessage.updatedAt
   );
 
-  return queuedMessage;
+  const transaction = db.transaction((targetConversationId: string, queuedContent: string) => {
+    const timestamp = nowIso();
+    const nextSortOrder =
+      ((selectMaxSortOrder.get(targetConversationId) as { max_sort_order: number | null }).max_sort_order ?? -1) + 1;
+
+    const queuedMessage: QueuedMessage = {
+      id: createId("queue"),
+      conversationId: targetConversationId,
+      content: queuedContent,
+      status: "pending",
+      sortOrder: nextSortOrder,
+      failureMessage: null,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      processingStartedAt: null
+    };
+
+    insertQueuedMessage.run(
+      queuedMessage.id,
+      queuedMessage.conversationId,
+      queuedMessage.content,
+      queuedMessage.status,
+      queuedMessage.sortOrder,
+      queuedMessage.failureMessage,
+      queuedMessage.processingStartedAt,
+      queuedMessage.createdAt,
+      queuedMessage.updatedAt
+    );
+
+    return queuedMessage;
+  });
+
+  return transaction(conversationId, content);
 }
 
 export function moveQueuedMessageToFront({

--- a/lib/conversations.ts
+++ b/lib/conversations.ts
@@ -27,6 +27,7 @@ import type {
   ConversationListPage,
   ConversationOrigin,
   ConversationSearchResult,
+  ConversationSnapshot,
   ConversationTitleGenerationStatus,
   Message,
   MessageAttachment,
@@ -39,6 +40,8 @@ import type {
   MessageStatus,
   MemoryProposalPayload,
   MemoryProposalState,
+  QueuedMessage,
+  QueuedMessageStatus,
   SystemMessageKind
 } from "@/lib/types";
 
@@ -199,6 +202,30 @@ function rowToMessageTextSegment(row: {
     content: row.content,
     sortOrder: row.sort_order,
     createdAt: row.created_at
+  };
+}
+
+function rowToQueuedMessage(row: {
+  id: string;
+  conversation_id: string;
+  content: string;
+  status: QueuedMessageStatus;
+  sort_order: number;
+  failure_message: string | null;
+  created_at: string;
+  updated_at: string;
+  processing_started_at: string | null;
+}): QueuedMessage {
+  return {
+    id: row.id,
+    conversationId: row.conversation_id,
+    content: row.content,
+    status: row.status,
+    sortOrder: row.sort_order,
+    failureMessage: row.failure_message,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    processingStartedAt: row.processing_started_at
   };
 }
 
@@ -907,16 +934,221 @@ export function listVisibleMessages(conversationId: string) {
   return listMessages(conversationId).filter(isVisibleMessage);
 }
 
-export type ConversationSnapshot = {
-  conversation: Conversation;
-  messages: Message[];
-};
+export function listQueuedMessages(conversationId: string) {
+  const rows = getDb()
+    .prepare(
+      `SELECT
+        id,
+        conversation_id,
+        content,
+        status,
+        sort_order,
+        failure_message,
+        created_at,
+        updated_at,
+        processing_started_at
+       FROM queued_messages
+       WHERE conversation_id = ?
+       ORDER BY sort_order ASC, created_at ASC, rowid ASC`
+    )
+    .all(conversationId) as Array<{
+    id: string;
+    conversation_id: string;
+    content: string;
+    status: QueuedMessageStatus;
+    sort_order: number;
+    failure_message: string | null;
+    created_at: string;
+    updated_at: string;
+    processing_started_at: string | null;
+  }>;
+
+  return rows.map(rowToQueuedMessage);
+}
+
+export function createQueuedMessage({
+  conversationId,
+  content
+}: {
+  conversationId: string;
+  content: string;
+}) {
+  const timestamp = nowIso();
+  const db = getDb();
+  const nextSortOrder =
+    ((db
+      .prepare(
+        "SELECT COALESCE(MAX(sort_order), -1) AS max_sort_order FROM queued_messages WHERE conversation_id = ?"
+      )
+      .get(conversationId) as { max_sort_order: number | null }).max_sort_order ?? -1) + 1;
+
+  const queuedMessage: QueuedMessage = {
+    id: createId("queue"),
+    conversationId,
+    content,
+    status: "pending",
+    sortOrder: nextSortOrder,
+    failureMessage: null,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    processingStartedAt: null
+  };
+
+  db.prepare(
+    `INSERT INTO queued_messages (
+      id,
+      conversation_id,
+      content,
+      status,
+      sort_order,
+      failure_message,
+      processing_started_at,
+      created_at,
+      updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+  ).run(
+    queuedMessage.id,
+    queuedMessage.conversationId,
+    queuedMessage.content,
+    queuedMessage.status,
+    queuedMessage.sortOrder,
+    queuedMessage.failureMessage,
+    queuedMessage.processingStartedAt,
+    queuedMessage.createdAt,
+    queuedMessage.updatedAt
+  );
+
+  return queuedMessage;
+}
+
+export function moveQueuedMessageToFront({
+  conversationId,
+  queuedMessageId
+}: {
+  conversationId: string;
+  queuedMessageId: string;
+}) {
+  const db = getDb();
+  const selectRows = db.prepare(
+    `SELECT
+      id,
+      conversation_id,
+      content,
+      status,
+      sort_order,
+      failure_message,
+      created_at,
+      updated_at,
+      processing_started_at
+     FROM queued_messages
+     WHERE conversation_id = ?
+     ORDER BY sort_order ASC, created_at ASC, rowid ASC`
+  );
+  const updateSortOrder = db.prepare(
+    "UPDATE queued_messages SET sort_order = ?, updated_at = ? WHERE id = ? AND conversation_id = ?"
+  );
+
+  const transaction = db.transaction((targetConversationId: string, targetQueuedMessageId: string) => {
+    const rows = selectRows.all(targetConversationId) as Array<{
+      id: string;
+      conversation_id: string;
+      content: string;
+      status: QueuedMessageStatus;
+      sort_order: number;
+      failure_message: string | null;
+      created_at: string;
+      updated_at: string;
+      processing_started_at: string | null;
+    }>;
+    const targetIndex = rows.findIndex((row) => row.id === targetQueuedMessageId);
+
+    if (targetIndex <= 0) {
+      return targetIndex === 0;
+    }
+
+    const reorderedRows = [rows[targetIndex], ...rows.slice(0, targetIndex), ...rows.slice(targetIndex + 1)];
+    const timestamp = nowIso();
+    reorderedRows.forEach((row, index) => {
+      updateSortOrder.run(index, timestamp, row.id, targetConversationId);
+    });
+
+    return true;
+  });
+
+  return transaction(conversationId, queuedMessageId);
+}
+
+export function claimNextQueuedMessageForDispatch(conversationId: string) {
+  const db = getDb();
+  const selectNextPending = db.prepare(
+    `SELECT
+      id,
+      conversation_id,
+      content,
+      status,
+      sort_order,
+      failure_message,
+      created_at,
+      updated_at,
+      processing_started_at
+     FROM queued_messages
+     WHERE conversation_id = ?
+       AND status = 'pending'
+     ORDER BY sort_order ASC, created_at ASC, rowid ASC
+     LIMIT 1`
+  );
+  const claimQueuedMessage = db.prepare(
+    `UPDATE queued_messages
+     SET status = 'processing',
+         processing_started_at = ?,
+         updated_at = ?
+     WHERE id = ?
+       AND status = 'pending'`
+  );
+
+  const transaction = db.transaction((targetConversationId: string) => {
+    const row = selectNextPending.get(targetConversationId) as
+      | {
+          id: string;
+          conversation_id: string;
+          content: string;
+          status: QueuedMessageStatus;
+          sort_order: number;
+          failure_message: string | null;
+          created_at: string;
+          updated_at: string;
+          processing_started_at: string | null;
+        }
+      | undefined;
+
+    if (!row) {
+      return null;
+    }
+
+    const timestamp = nowIso();
+    const result = claimQueuedMessage.run(timestamp, timestamp, row.id);
+
+    if (result.changes === 0) {
+      return null;
+    }
+
+    return rowToQueuedMessage({
+      ...row,
+      status: "processing",
+      updated_at: timestamp,
+      processing_started_at: timestamp
+    });
+  });
+
+  return transaction(conversationId);
+}
 
 export function getConversationSnapshot(conversationId: string, userId?: string): ConversationSnapshot | null {
   const conversation = getConversation(conversationId, userId);
   if (!conversation) return null;
   const messages = listVisibleMessages(conversationId);
-  return { conversation, messages };
+  const queuedMessages = listQueuedMessages(conversationId);
+  return { conversation, messages, queuedMessages };
 }
 
 export function listActiveConversations(userId?: string): Array<{ id: string; title: string; isActive: boolean }> {

--- a/lib/conversations.ts
+++ b/lib/conversations.ts
@@ -1026,6 +1026,85 @@ export function createQueuedMessage({
   return transaction(conversationId, content);
 }
 
+export function updateQueuedMessage({
+  conversationId,
+  queuedMessageId,
+  content
+}: {
+  conversationId: string;
+  queuedMessageId: string;
+  content: string;
+}) {
+  const db = getDb();
+  const updateQueuedMessageRow = db.prepare(
+    `UPDATE queued_messages
+     SET content = ?,
+         updated_at = ?
+     WHERE id = ?
+       AND conversation_id = ?`
+  );
+  const selectQueuedMessageRow = db.prepare(
+    `SELECT
+      id,
+      conversation_id,
+      content,
+      status,
+      sort_order,
+      failure_message,
+      created_at,
+      updated_at,
+      processing_started_at
+     FROM queued_messages
+     WHERE id = ?
+       AND conversation_id = ?`
+  );
+
+  const transaction = db.transaction((targetConversationId: string, targetQueuedMessageId: string, nextContent: string) => {
+    const timestamp = nowIso();
+    const result = updateQueuedMessageRow.run(nextContent, timestamp, targetQueuedMessageId, targetConversationId);
+
+    if (result.changes === 0) {
+      return null;
+    }
+
+    const row = selectQueuedMessageRow.get(targetQueuedMessageId, targetConversationId) as
+      | {
+          id: string;
+          conversation_id: string;
+          content: string;
+          status: QueuedMessageStatus;
+          sort_order: number;
+          failure_message: string | null;
+          created_at: string;
+          updated_at: string;
+          processing_started_at: string | null;
+        }
+      | undefined;
+
+    return row ? rowToQueuedMessage(row) : null;
+  });
+
+  return transaction(conversationId, queuedMessageId, content);
+}
+
+export function deleteQueuedMessage({
+  conversationId,
+  queuedMessageId
+}: {
+  conversationId: string;
+  queuedMessageId: string;
+}) {
+  const result = getDb()
+    .prepare(
+      `DELETE FROM queued_messages
+       WHERE id = ?
+         AND conversation_id = ?`
+    )
+    .run(queuedMessageId, conversationId);
+
+  return result.changes > 0;
+}
+
 export function moveQueuedMessageToFront({
   conversationId,
   queuedMessageId

--- a/lib/conversations.ts
+++ b/lib/conversations.ts
@@ -1105,6 +1105,7 @@ export function claimNextQueuedMessageForDispatch(conversationId: string) {
   const claimQueuedMessage = db.prepare(
     `UPDATE queued_messages
      SET status = 'processing',
+         failure_message = NULL,
          processing_started_at = ?,
          updated_at = ?
      WHERE id = ?
@@ -1140,6 +1141,7 @@ export function claimNextQueuedMessageForDispatch(conversationId: string) {
     return rowToQueuedMessage({
       ...row,
       status: "processing",
+      failure_message: null,
       updated_at: timestamp,
       processing_started_at: timestamp
     });

--- a/lib/conversations.ts
+++ b/lib/conversations.ts
@@ -1105,6 +1105,52 @@ export function deleteQueuedMessage({
   return result.changes > 0;
 }
 
+export function failQueuedMessage({
+  conversationId,
+  queuedMessageId,
+  failureMessage
+}: {
+  conversationId: string;
+  queuedMessageId: string;
+  failureMessage: string;
+}) {
+  const timestamp = nowIso();
+  const result = getDb()
+    .prepare(
+      `UPDATE queued_messages
+       SET status = 'failed',
+           failure_message = ?,
+           processing_started_at = NULL,
+           updated_at = ?
+       WHERE id = ?
+         AND conversation_id = ?
+         AND status = 'processing'`
+    )
+    .run(failureMessage, timestamp, queuedMessageId, conversationId);
+
+  return result.changes > 0;
+}
+
+export function markOrphanedQueuedMessagesFailed(
+  conversationId: string,
+  failureMessage = "Queued follow-up was abandoned before dispatch completed"
+) {
+  const timestamp = nowIso();
+  const result = getDb()
+    .prepare(
+      `UPDATE queued_messages
+       SET status = 'failed',
+           failure_message = ?,
+           processing_started_at = NULL,
+           updated_at = ?
+       WHERE conversation_id = ?
+         AND status = 'processing'`
+    )
+    .run(failureMessage, timestamp, conversationId);
+
+  return result.changes;
+}
+
 export function moveQueuedMessageToFront({
   conversationId,
   queuedMessageId

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -210,6 +210,18 @@ function migrate(db: Database.Database) {
       created_at TEXT NOT NULL,
       FOREIGN KEY (conversation_id) REFERENCES conversations(id) ON DELETE CASCADE
     );
+    CREATE TABLE IF NOT EXISTS queued_messages (
+      id TEXT PRIMARY KEY,
+      conversation_id TEXT NOT NULL,
+      content TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'pending',
+      sort_order INTEGER NOT NULL,
+      failure_message TEXT,
+      processing_started_at TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      FOREIGN KEY (conversation_id) REFERENCES conversations(id) ON DELETE CASCADE
+    );
     CREATE TABLE IF NOT EXISTS memory_nodes (
       id TEXT PRIMARY KEY,
       conversation_id TEXT NOT NULL,
@@ -651,6 +663,8 @@ function migrate(db: Database.Database) {
     CREATE INDEX IF NOT EXISTS idx_automation_runs_status_scheduled_for ON automation_runs(status, scheduled_for);
     CREATE INDEX IF NOT EXISTS idx_message_actions_message_sort_order ON message_actions(message_id, sort_order, started_at);
     CREATE INDEX IF NOT EXISTS idx_message_text_segments_message_sort_order ON message_text_segments(message_id, sort_order, created_at);
+    CREATE INDEX IF NOT EXISTS idx_queued_messages_conversation_status_sort
+      ON queued_messages(conversation_id, status, sort_order, created_at);
     CREATE INDEX IF NOT EXISTS idx_message_attachments_message_created_at ON message_attachments(message_id, created_at ASC);
     CREATE INDEX IF NOT EXISTS idx_message_attachments_conversation_created_at ON message_attachments(conversation_id, created_at ASC);
     CREATE INDEX IF NOT EXISTS idx_memory_nodes_conversation_depth ON memory_nodes(conversation_id, depth, created_at);

--- a/lib/queued-chat-dispatcher.ts
+++ b/lib/queued-chat-dispatcher.ts
@@ -1,0 +1,72 @@
+import {
+  claimNextQueuedMessageForDispatch,
+  deleteQueuedMessage,
+  failQueuedMessage,
+  getConversation,
+  markOrphanedQueuedMessagesFailed
+} from "@/lib/conversations";
+import type { ConversationManager } from "@/lib/conversation-manager";
+import type { StartChatTurn } from "@/lib/chat-turn";
+
+const dispatchLocks = new Set<string>();
+
+export async function ensureQueuedDispatch({
+  manager,
+  conversationId,
+  startChatTurn
+}: {
+  manager: ConversationManager;
+  conversationId: string;
+  startChatTurn: StartChatTurn;
+}) {
+  if (dispatchLocks.has(conversationId)) {
+    return;
+  }
+
+  const conversation = getConversation(conversationId);
+  if (!conversation || conversation.isActive) {
+    return;
+  }
+
+  dispatchLocks.add(conversationId);
+
+  try {
+    if (!manager.isActive(conversationId)) {
+      markOrphanedQueuedMessagesFailed(conversationId);
+    }
+
+    const queued = claimNextQueuedMessageForDispatch(conversationId);
+    if (!queued) {
+      return;
+    }
+
+    let messagesCreated = false;
+    const result = await startChatTurn(
+      manager,
+      conversationId,
+      queued.content,
+      [],
+      undefined,
+      {
+        source: "queue",
+        onMessagesCreated() {
+          messagesCreated = true;
+          deleteQueuedMessage({
+            conversationId,
+            queuedMessageId: queued.id
+          });
+        }
+      }
+    );
+
+    if ((result.status === "failed" || result.status === "skipped") && !messagesCreated) {
+      failQueuedMessage({
+        conversationId,
+        queuedMessageId: queued.id,
+        failureMessage: result.errorMessage ?? "Unable to dispatch queued follow-up"
+      });
+    }
+  } finally {
+    dispatchLocks.delete(conversationId);
+  }
+}

--- a/lib/queued-chat-dispatcher.ts
+++ b/lib/queued-chat-dispatcher.ts
@@ -31,40 +31,47 @@ export async function ensureQueuedDispatch({
   dispatchLocks.add(conversationId);
 
   try {
-    if (!manager.isActive(conversationId)) {
-      markOrphanedQueuedMessagesFailed(conversationId);
-    }
-
-    const queued = claimNextQueuedMessageForDispatch(conversationId);
-    if (!queued) {
-      return;
-    }
-
-    let messagesCreated = false;
-    const result = await startChatTurn(
-      manager,
-      conversationId,
-      queued.content,
-      [],
-      undefined,
-      {
-        source: "queue",
-        onMessagesCreated() {
-          messagesCreated = true;
-          deleteQueuedMessage({
-            conversationId,
-            queuedMessageId: queued.id
-          });
-        }
+    while (true) {
+      const currentConversation = getConversation(conversationId);
+      if (!currentConversation || currentConversation.isActive) {
+        return;
       }
-    );
 
-    if ((result.status === "failed" || result.status === "skipped") && !messagesCreated) {
-      failQueuedMessage({
+      if (!manager.isActive(conversationId)) {
+        markOrphanedQueuedMessagesFailed(conversationId);
+      }
+
+      const queued = claimNextQueuedMessageForDispatch(conversationId);
+      if (!queued) {
+        return;
+      }
+
+      let messagesCreated = false;
+      const result = await startChatTurn(
+        manager,
         conversationId,
-        queuedMessageId: queued.id,
-        failureMessage: result.errorMessage ?? "Unable to dispatch queued follow-up"
-      });
+        queued.content,
+        [],
+        undefined,
+        {
+          source: "queue",
+          onMessagesCreated() {
+            messagesCreated = true;
+            deleteQueuedMessage({
+              conversationId,
+              queuedMessageId: queued.id
+            });
+          }
+        }
+      );
+
+      if ((result.status === "failed" || result.status === "skipped") && !messagesCreated) {
+        failQueuedMessage({
+          conversationId,
+          queuedMessageId: queued.id,
+          failureMessage: result.errorMessage ?? "Unable to dispatch queued follow-up"
+        });
+      }
     }
   } finally {
     dispatchLocks.delete(conversationId);

--- a/lib/queued-chat-dispatcher.ts
+++ b/lib/queued-chat-dispatcher.ts
@@ -3,12 +3,21 @@ import {
   deleteQueuedMessage,
   failQueuedMessage,
   getConversation,
+  listQueuedMessages,
   markOrphanedQueuedMessagesFailed
 } from "@/lib/conversations";
 import type { ConversationManager } from "@/lib/conversation-manager";
 import type { StartChatTurn } from "@/lib/chat-turn";
 
 const dispatchLocks = new Set<string>();
+
+function broadcastQueueUpdated(manager: ConversationManager, conversationId: string) {
+  manager.broadcast(conversationId, {
+    type: "queue_updated",
+    conversationId,
+    queuedMessages: listQueuedMessages(conversationId)
+  });
+}
 
 export async function ensureQueuedDispatch({
   manager,
@@ -38,13 +47,17 @@ export async function ensureQueuedDispatch({
       }
 
       if (!manager.isActive(conversationId)) {
-        markOrphanedQueuedMessagesFailed(conversationId);
+        const recoveredCount = markOrphanedQueuedMessagesFailed(conversationId);
+        if (recoveredCount > 0) {
+          broadcastQueueUpdated(manager, conversationId);
+        }
       }
 
       const queued = claimNextQueuedMessageForDispatch(conversationId);
       if (!queued) {
         return;
       }
+      broadcastQueueUpdated(manager, conversationId);
 
       let messagesCreated = false;
       const result = await startChatTurn(
@@ -61,6 +74,7 @@ export async function ensureQueuedDispatch({
               conversationId,
               queuedMessageId: queued.id
             });
+            broadcastQueueUpdated(manager, conversationId);
           }
         }
       );
@@ -71,6 +85,7 @@ export async function ensureQueuedDispatch({
           queuedMessageId: queued.id,
           failureMessage: result.errorMessage ?? "Unable to dispatch queued follow-up"
         });
+        broadcastQueueUpdated(manager, conversationId);
       }
     }
   } finally {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -38,6 +38,8 @@ export type MessageRole = "user" | "assistant" | "system";
 
 export type MessageStatus = "idle" | "streaming" | "completed" | "error" | "stopped";
 
+export type QueuedMessageStatus = "pending" | "processing" | "failed" | "cancelled";
+
 export type ConversationTitleGenerationStatus =
   | "pending"
   | "running"
@@ -171,6 +173,18 @@ export type ConversationListPage = {
   hasMore: boolean;
 };
 
+export type QueuedMessage = {
+  id: string;
+  conversationId: string;
+  content: string;
+  status: QueuedMessageStatus;
+  sortOrder: number;
+  failureMessage: string | null;
+  createdAt: string;
+  updatedAt: string;
+  processingStartedAt: string | null;
+};
+
 export type Folder = {
   id: string;
   name: string;
@@ -294,6 +308,12 @@ export type Message = {
   textSegments?: MessageTextSegment[];
   timeline?: MessageTimelineItem[];
   attachments?: MessageAttachment[];
+};
+
+export type ConversationSnapshot = {
+  conversation: Conversation;
+  messages: Message[];
+  queuedMessages: QueuedMessage[];
 };
 
 export type MessageAttachment = {

--- a/lib/ws-handler.ts
+++ b/lib/ws-handler.ts
@@ -4,7 +4,15 @@ import { verifySessionToken } from "@/lib/auth";
 import { createAutomationScheduler as createAutomationSchedulerBase } from "@/lib/automation-scheduler";
 import { startChatTurn } from "@/lib/chat-turn";
 import { SESSION_COOKIE_NAME } from "@/lib/constants";
-import { getConversationSnapshot, listActiveConversations } from "@/lib/conversations";
+import {
+  createQueuedMessage,
+  deleteQueuedMessage,
+  getConversationSnapshot,
+  listActiveConversations,
+  listQueuedMessages,
+  moveQueuedMessageToFront,
+  updateQueuedMessage
+} from "@/lib/conversations";
 import { type ConversationManager } from "@/lib/conversation-manager";
 import { isPasswordLoginEnabled } from "@/lib/env";
 import { requestStop } from "@/lib/chat-turn-control";
@@ -104,7 +112,8 @@ function handleMessage(
         conversationId: msg.conversationId,
         messages: snapshot.messages,
         actions: snapshot.messages.flatMap(m => m.actions ?? []),
-        segments: snapshot.messages.flatMap(m => m.textSegments ?? [])
+        segments: snapshot.messages.flatMap(m => m.textSegments ?? []),
+        queuedMessages: snapshot.queuedMessages
       }));
       break;
     }
@@ -134,7 +143,78 @@ function handleMessage(
       requestStop(msg.conversationId);
       break;
     }
+    case "queue_message": {
+      if (!ensureConversationAccess(ws, msg.conversationId, currentUserId)) {
+        break;
+      }
+
+      createQueuedMessage({
+        conversationId: msg.conversationId,
+        content: msg.content
+      });
+      broadcastQueueUpdated(mgr, msg.conversationId);
+      break;
+    }
+    case "update_queued_message": {
+      if (!ensureConversationAccess(ws, msg.conversationId, currentUserId)) {
+        break;
+      }
+
+      updateQueuedMessage({
+        conversationId: msg.conversationId,
+        queuedMessageId: msg.queuedMessageId,
+        content: msg.content
+      });
+      broadcastQueueUpdated(mgr, msg.conversationId);
+      break;
+    }
+    case "delete_queued_message": {
+      if (!ensureConversationAccess(ws, msg.conversationId, currentUserId)) {
+        break;
+      }
+
+      deleteQueuedMessage({
+        conversationId: msg.conversationId,
+        queuedMessageId: msg.queuedMessageId
+      });
+      broadcastQueueUpdated(mgr, msg.conversationId);
+      break;
+    }
+    case "send_queued_message_now": {
+      if (!ensureConversationAccess(ws, msg.conversationId, currentUserId)) {
+        break;
+      }
+
+      moveQueuedMessageToFront({
+        conversationId: msg.conversationId,
+        queuedMessageId: msg.queuedMessageId
+      });
+      requestStop(msg.conversationId);
+      broadcastQueueUpdated(mgr, msg.conversationId);
+      break;
+    }
   }
+}
+
+function ensureConversationAccess(
+  ws: WebSocket,
+  conversationId: string,
+  currentUserId: string | null
+) {
+  if (!getConversationSnapshot(conversationId, currentUserId ?? undefined)) {
+    ws.send(serializeServerMessage({ type: "error", message: "Conversation not found" }));
+    return false;
+  }
+
+  return true;
+}
+
+function broadcastQueueUpdated(mgr: ConversationManager, conversationId: string) {
+  mgr.broadcast(conversationId, {
+    type: "queue_updated",
+    conversationId,
+    queuedMessages: listQueuedMessages(conversationId)
+  });
 }
 
 async function handleUserMessage(

--- a/lib/ws-handler.ts
+++ b/lib/ws-handler.ts
@@ -160,11 +160,17 @@ function handleMessage(
         break;
       }
 
-      updateQueuedMessage({
+      const updated = updateQueuedMessage({
         conversationId: msg.conversationId,
         queuedMessageId: msg.queuedMessageId,
         content: msg.content
       });
+
+      if (!updated) {
+        sendError(ws, "Queued message not found");
+        break;
+      }
+
       broadcastQueueUpdated(mgr, msg.conversationId);
       break;
     }
@@ -173,10 +179,16 @@ function handleMessage(
         break;
       }
 
-      deleteQueuedMessage({
+      const deleted = deleteQueuedMessage({
         conversationId: msg.conversationId,
         queuedMessageId: msg.queuedMessageId
       });
+
+      if (!deleted) {
+        sendError(ws, "Queued message not found");
+        break;
+      }
+
       broadcastQueueUpdated(mgr, msg.conversationId);
       break;
     }
@@ -185,10 +197,16 @@ function handleMessage(
         break;
       }
 
-      moveQueuedMessageToFront({
+      const moved = moveQueuedMessageToFront({
         conversationId: msg.conversationId,
         queuedMessageId: msg.queuedMessageId
       });
+
+      if (!moved) {
+        sendError(ws, "Queued message not found");
+        break;
+      }
+
       requestStop(msg.conversationId);
       broadcastQueueUpdated(mgr, msg.conversationId);
       break;
@@ -202,11 +220,15 @@ function ensureConversationAccess(
   currentUserId: string | null
 ) {
   if (!getConversationSnapshot(conversationId, currentUserId ?? undefined)) {
-    ws.send(serializeServerMessage({ type: "error", message: "Conversation not found" }));
+    sendError(ws, "Conversation not found");
     return false;
   }
 
   return true;
+}
+
+function sendError(ws: WebSocket, message: string) {
+  ws.send(serializeServerMessage({ type: "error", message }));
 }
 
 function broadcastQueueUpdated(mgr: ConversationManager, conversationId: string) {

--- a/lib/ws-protocol.ts
+++ b/lib/ws-protocol.ts
@@ -1,15 +1,20 @@
-import type { ChatStreamEvent } from "@/lib/types";
+import type { ChatStreamEvent, QueuedMessage } from "@/lib/types";
 
 export type ClientMessage =
   | { type: "subscribe"; conversationId: string }
   | { type: "unsubscribe"; conversationId: string }
   | { type: "message"; conversationId: string; content: string; attachmentIds?: string[]; personaId?: string }
   | { type: "stop"; conversationId: string }
-  | { type: "edit"; messageId: string; content: string };
+  | { type: "edit"; messageId: string; content: string }
+  | { type: "queue_message"; conversationId: string; content: string }
+  | { type: "update_queued_message"; conversationId: string; queuedMessageId: string; content: string }
+  | { type: "delete_queued_message"; conversationId: string; queuedMessageId: string }
+  | { type: "send_queued_message_now"; conversationId: string; queuedMessageId: string };
 
 export type ServerMessage =
   | { type: "ready"; activeConversations: { id: string; title: string; status: string }[] }
-  | { type: "snapshot"; conversationId: string; messages: unknown[]; actions: unknown[]; segments: unknown[] }
+  | { type: "snapshot"; conversationId: string; messages: unknown[]; actions: unknown[]; segments: unknown[]; queuedMessages: QueuedMessage[] }
+  | { type: "queue_updated"; conversationId: string; queuedMessages: QueuedMessage[] }
   | { type: "delta"; conversationId: string; event: ChatStreamEvent }
   | { type: "error"; message: string }
   | { type: "conversation_created"; conversation: { id: string; title: string; folderId: string | null; createdAt: string; updatedAt: string; isActive: boolean } }
@@ -26,7 +31,17 @@ export function serializeServerMessage(msg: ServerMessage): string {
   return JSON.stringify(msg);
 }
 
-const CLIENT_MESSAGE_TYPES = new Set(["subscribe", "unsubscribe", "message", "stop", "edit"]);
+const CLIENT_MESSAGE_TYPES = new Set([
+  "subscribe",
+  "unsubscribe",
+  "message",
+  "stop",
+  "edit",
+  "queue_message",
+  "update_queued_message",
+  "delete_queued_message",
+  "send_queued_message_now"
+]);
 
 export function parseClientMessage(raw: string): ClientMessage | null {
   try {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,6 +2,7 @@ import { defineConfig, devices } from "@playwright/test";
 
 export default defineConfig({
   testDir: "./tests/e2e",
+  workers: 1,
   use: {
     baseURL: "http://localhost:3117",
     trace: "on-first-retry"

--- a/tests/e2e/features.spec.ts
+++ b/tests/e2e/features.spec.ts
@@ -1,3 +1,6 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import type { AddressInfo, Socket } from "node:net";
+
 import { expect, test } from "@playwright/test";
 
 async function signIn(page: import("@playwright/test").Page) {
@@ -54,7 +57,7 @@ async function mockChatResponse(page: import("@playwright/test").Page) {
 }
 
 async function createNewChat(page: import("@playwright/test").Page) {
-  const newChatButton = page.getByRole("button", { name: "New chat", exact: true });
+  const newChatButton = page.locator('button[aria-label="New chat"]:not([disabled])').first();
   await expect(newChatButton).toBeVisible({ timeout: 10000 });
   await expect(newChatButton).toBeEnabled({ timeout: 10000 });
 
@@ -71,6 +74,348 @@ async function createNewChat(page: import("@playwright/test").Page) {
       await page.waitForTimeout(500);
     }
   }
+}
+
+type MockChatRequest = {
+  stream: boolean;
+  lastUserContent: string;
+  isTitleRequest: boolean;
+};
+
+async function startMockOpenAiCompatibleServer() {
+  const chatRequests: MockChatRequest[] = [];
+  let initialStreamConnections = 0;
+  const openSockets = new Set<Socket>();
+
+  const server = createServer(async (request, response) => {
+    if (request.method !== "POST" || request.url !== "/v1/chat/completions") {
+      response.writeHead(404, { "content-type": "application/json" });
+      response.end(JSON.stringify({ error: { message: "Not found" } }));
+      return;
+    }
+
+    const body = await readJsonBody(request);
+    const lastUserContent = extractLastUserContent(body);
+    const isStream = body.stream === true;
+    const isTitleRequest = !isStream;
+
+    chatRequests.push({
+      stream: isStream,
+      lastUserContent,
+      isTitleRequest
+    });
+
+    if (!isStream) {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(
+        JSON.stringify({
+          id: "chatcmpl_mock_title",
+          object: "chat.completion",
+          created: Math.floor(Date.now() / 1000),
+          model: body.model ?? "mock-model",
+          choices: [
+            {
+              index: 0,
+              finish_reason: "stop",
+              message: {
+                role: "assistant",
+                content: "Mock title"
+              }
+            }
+          ]
+        })
+      );
+      return;
+    }
+
+    if (lastUserContent === "Initial question") {
+      initialStreamConnections += 1;
+      await streamInitialTurn(response, request, initialStreamConnections);
+      return;
+    }
+
+    await streamQueuedTurn(response, body.model ?? "mock-model", lastUserContent);
+  });
+
+  server.on("connection", (socket) => {
+    openSockets.add(socket);
+    socket.on("close", () => {
+      openSockets.delete(socket);
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+
+  const address = server.address() as AddressInfo;
+  const origin = `http://127.0.0.1:${address.port}`;
+
+  return {
+    apiBaseUrl: `${origin}/v1`,
+    close: async () => {
+      for (const socket of openSockets) {
+        socket.destroy();
+      }
+
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      });
+    },
+    reset() {
+      chatRequests.length = 0;
+      initialStreamConnections = 0;
+    },
+    listChatRequests() {
+      return [...chatRequests];
+    }
+  };
+}
+
+async function readJsonBody(request: IncomingMessage) {
+  const chunks: Buffer[] = [];
+
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+
+  return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+}
+
+function extractLastUserContent(body: any) {
+  const messages = Array.isArray(body?.messages) ? body.messages : [];
+  const lastUserMessage = [...messages].reverse().find((message) => message?.role === "user");
+
+  if (!lastUserMessage) {
+    return "";
+  }
+
+  const { content } = lastUserMessage;
+  if (typeof content === "string") {
+    return content;
+  }
+
+  if (Array.isArray(content)) {
+    return content
+      .map((part) => {
+        if (typeof part === "string") {
+          return part;
+        }
+
+        if (part && typeof part === "object" && "text" in part && typeof part.text === "string") {
+          return part.text;
+        }
+
+        return "";
+      })
+      .join("");
+  }
+
+  return "";
+}
+
+function writeChatCompletionChunk(response: ServerResponse, chunk: Record<string, unknown>) {
+  response.write(`data: ${JSON.stringify(chunk)}\n\n`);
+}
+
+async function streamInitialTurn(
+  response: ServerResponse,
+  request: IncomingMessage,
+  connectionNumber: number
+) {
+  response.writeHead(200, {
+    "content-type": "text/event-stream; charset=utf-8",
+    "cache-control": "no-cache",
+    connection: "keep-alive"
+  });
+
+  writeChatCompletionChunk(response, {
+    id: "chatcmpl_initial",
+    object: "chat.completion.chunk",
+    created: Math.floor(Date.now() / 1000),
+    model: "mock-model",
+    choices: [
+      {
+        index: 0,
+        delta: {
+          role: "assistant",
+          content: connectionNumber === 1 ? "Working on the first answer..." : "Still working..."
+        },
+        finish_reason: null
+      }
+    ]
+  });
+
+  const keepAlive = setInterval(() => {
+    if (response.destroyed) {
+      clearInterval(keepAlive);
+      return;
+    }
+
+    response.write(": keep-alive\n\n");
+  }, 250);
+
+  await new Promise<void>((resolve) => {
+    request.once("close", () => {
+      clearInterval(keepAlive);
+      resolve();
+    });
+  });
+}
+
+async function streamQueuedTurn(
+  response: ServerResponse,
+  model: string,
+  lastUserContent: string
+) {
+  response.writeHead(200, {
+    "content-type": "text/event-stream; charset=utf-8",
+    "cache-control": "no-cache",
+    connection: "keep-alive"
+  });
+
+  writeChatCompletionChunk(response, {
+    id: `chatcmpl_${lastUserContent}`,
+    object: "chat.completion.chunk",
+    created: Math.floor(Date.now() / 1000),
+    model,
+    choices: [
+      {
+        index: 0,
+        delta: {
+          role: "assistant",
+          content: `Handled ${lastUserContent}`
+        },
+        finish_reason: null
+      }
+    ]
+  });
+
+  writeChatCompletionChunk(response, {
+    id: `chatcmpl_${lastUserContent}`,
+    object: "chat.completion.chunk",
+    created: Math.floor(Date.now() / 1000),
+    model,
+    choices: [
+      {
+        index: 0,
+        delta: {},
+        finish_reason: "stop"
+      }
+    ]
+  });
+  response.write("data: [DONE]\n\n");
+  response.end();
+}
+
+async function configureMockProvider(
+  page: import("@playwright/test").Page,
+  apiBaseUrl: string
+) {
+  const settingsResponse = await page.request.get("/api/settings");
+  expect(settingsResponse.ok()).toBeTruthy();
+
+  const settingsPayload = (await settingsResponse.json()) as {
+    settings: {
+      defaultProviderProfileId: string;
+      skillsEnabled: boolean;
+      conversationRetention: "forever" | "90d" | "30d" | "7d";
+      memoriesEnabled: boolean;
+      memoriesMaxCount: number;
+      mcpTimeout: number;
+      providerProfiles: Array<Record<string, unknown>>;
+    };
+  };
+
+  const currentProfile = settingsPayload.settings.providerProfiles[0];
+  expect(currentProfile).toBeTruthy();
+  const mockProfileId = `${currentProfile.id as string}_queued_mock`;
+
+  const nextSettings = {
+    defaultProviderProfileId: mockProfileId,
+    skillsEnabled: settingsPayload.settings.skillsEnabled,
+    conversationRetention: settingsPayload.settings.conversationRetention,
+    memoriesEnabled: settingsPayload.settings.memoriesEnabled,
+    memoriesMaxCount: settingsPayload.settings.memoriesMaxCount,
+    mcpTimeout: settingsPayload.settings.mcpTimeout,
+    providerProfiles: [
+      ...settingsPayload.settings.providerProfiles,
+      {
+        ...currentProfile,
+        id: mockProfileId,
+        name: `${String(currentProfile.name ?? "Profile")} (Queued Follow-ups Test)`,
+        providerKind: "openai_compatible",
+        apiBaseUrl,
+        apiKey: "test-api-key",
+        model: "mock-model",
+        apiMode: "chat_completions",
+        systemPrompt:
+          typeof currentProfile.systemPrompt === "string" && currentProfile.systemPrompt.length > 0
+            ? currentProfile.systemPrompt
+            : "You are a concise assistant.",
+        temperature: 0.2,
+        maxOutputTokens: 512,
+        reasoningEffort: "medium",
+        reasoningSummaryEnabled: false,
+        modelContextLimit: 16384,
+        compactionThreshold: 0.8,
+        freshTailCount: 12,
+        tokenizerModel: "gpt-tokenizer",
+        safetyMarginTokens: 1200,
+        leafSourceTokenLimit: 12000,
+        leafMinMessageCount: 6,
+        mergedMinNodeCount: 4,
+        mergedTargetTokens: 1600,
+        visionMode: "native",
+        visionMcpServerId: null
+      }
+    ]
+  };
+
+  const providerResponse = await page.request.put("/api/settings/providers", {
+    data: nextSettings
+  });
+
+  expect(providerResponse.ok()).toBeTruthy();
+
+  return async () => {
+    const restoreResponse = await page.request.put("/api/settings/providers", {
+      data: settingsPayload.settings
+    });
+
+    expect(restoreResponse.ok()).toBeTruthy();
+  };
+}
+
+async function enterComposerText(
+  composer: import("@playwright/test").Locator,
+  text: string
+) {
+  await composer.evaluate((element, nextValue) => {
+    const textarea = element as HTMLTextAreaElement & {
+      _valueTracker?: { setValue: (value: string) => void };
+    };
+    const previousValue = textarea.value;
+    const valueSetter = Object.getOwnPropertyDescriptor(
+      HTMLTextAreaElement.prototype,
+      "value"
+    )?.set;
+
+    valueSetter?.call(textarea, nextValue);
+    textarea._valueTracker?.setValue(previousValue);
+    textarea.dispatchEvent(new Event("input", { bubbles: true }));
+  }, text);
+  await expect(composer).toHaveValue(text);
 }
 
 const TINY_PNG = Buffer.from(
@@ -640,5 +985,194 @@ test.describe("Feature: Chat attachments", () => {
     await expect(page.getByRole("button", { name: "Send message" })).toBeEnabled({
       timeout: 5000
     });
+  });
+});
+
+test.describe("Feature: Queued chat follow-ups", () => {
+  test("shows queued follow-ups above the composer and keeps them across a reconnect", async ({
+    page
+  }) => {
+    test.setTimeout(60_000);
+    const mockServer = await startMockOpenAiCompatibleServer();
+    let restoreProviderSettings: (() => Promise<void>) | null = null;
+
+    try {
+      await signIn(page);
+      restoreProviderSettings = await configureMockProvider(page, mockServer.apiBaseUrl);
+      mockServer.reset();
+
+      await createNewChat(page);
+      await expect(page).toHaveURL(/\/chat\//, { timeout: 10000 });
+      const initialStreamRequestCount = mockServer
+        .listChatRequests()
+        .filter((request) => request.stream && !request.isTitleRequest).length;
+
+      const composer = page.getByPlaceholder(/Ask, create, or start a task/i);
+      const sendMessageButton = page.getByRole("button", { name: "Send message" });
+      const startVoiceInputButton = page.getByRole("button", { name: "Start voice input" });
+
+      await expect(composer).toBeEditable({ timeout: 10000 });
+      await expect(startVoiceInputButton).toBeEnabled({ timeout: 10000 });
+      await enterComposerText(composer, "Initial question");
+      await expect(sendMessageButton).toBeEnabled({ timeout: 10000 });
+      await sendMessageButton.click();
+      await expect(composer).toHaveValue("");
+
+      await expect.poll(
+        () =>
+          mockServer
+            .listChatRequests()
+            .filter((request) => request.stream && !request.isTitleRequest)
+            .length,
+        { timeout: 10000 }
+      ).toBe(initialStreamRequestCount + 1);
+
+      await expect(page.getByRole("button", { name: "Stop response" }).first()).toBeVisible({
+        timeout: 10000
+      });
+
+      await enterComposerText(composer, "First queued follow-up");
+      await page.getByRole("button", { name: "Queue follow-up" }).click();
+      await expect(composer).toHaveValue("");
+      await enterComposerText(composer, "Second queued follow-up");
+      await page.getByRole("button", { name: "Queue follow-up" }).click();
+      await expect(composer).toHaveValue("");
+      await enterComposerText(composer, "Third queued follow-up");
+      await page.getByRole("button", { name: "Queue follow-up" }).click();
+      await expect(composer).toHaveValue("");
+
+      const queueHeader = page.getByText("3 queued follow-ups");
+      await expect(queueHeader).toBeVisible({ timeout: 10000 });
+      await expect(page.getByText("First queued follow-up", { exact: true })).toBeVisible();
+      await expect(page.getByText("Second queued follow-up", { exact: true })).toBeVisible();
+      await expect(page.getByText("Third queued follow-up", { exact: true })).toBeVisible();
+
+      const queueHeaderBox = await queueHeader.boundingBox();
+      const composerBox = await composer.boundingBox();
+      expect(queueHeaderBox?.y).toBeLessThan(composerBox?.y ?? Number.POSITIVE_INFINITY);
+
+      const reconnectedPage = await page.context().newPage();
+      await reconnectedPage.goto(page.url(), { waitUntil: "domcontentloaded" });
+
+      const reconnectedComposer = reconnectedPage.getByPlaceholder(/Ask, create, or start a task/i);
+      const reconnectedQueueHeader = reconnectedPage.getByText("3 queued follow-ups");
+
+      await expect(reconnectedComposer).toBeEditable({ timeout: 10000 });
+      await expect(reconnectedQueueHeader).toBeVisible({ timeout: 10000 });
+      await expect(reconnectedPage.getByText("First queued follow-up", { exact: true })).toBeVisible();
+      await expect(reconnectedPage.getByText("Second queued follow-up", { exact: true })).toBeVisible();
+      await expect(reconnectedPage.getByText("Third queued follow-up", { exact: true })).toBeVisible();
+      await reconnectedPage.close();
+    } finally {
+      if (restoreProviderSettings) {
+        await restoreProviderSettings();
+      }
+      await mockServer.close();
+    }
+  });
+
+  test("sends the selected queued item next and preserves the remaining FIFO order", async ({
+    page
+  }) => {
+    test.setTimeout(60_000);
+    const mockServer = await startMockOpenAiCompatibleServer();
+    let restoreProviderSettings: (() => Promise<void>) | null = null;
+
+    try {
+      await signIn(page);
+      restoreProviderSettings = await configureMockProvider(page, mockServer.apiBaseUrl);
+      mockServer.reset();
+
+      await createNewChat(page);
+      await expect(page).toHaveURL(/\/chat\//, { timeout: 10000 });
+      const initialStreamRequestCount = mockServer
+        .listChatRequests()
+        .filter((request) => request.stream && !request.isTitleRequest).length;
+
+      const composer = page.getByPlaceholder(/Ask, create, or start a task/i);
+      const sendMessageButton = page.getByRole("button", { name: "Send message" });
+      const startVoiceInputButton = page.getByRole("button", { name: "Start voice input" });
+
+      await expect(composer).toBeEditable({ timeout: 10000 });
+      await expect(startVoiceInputButton).toBeEnabled({ timeout: 10000 });
+      await enterComposerText(composer, "Initial question");
+      await expect(sendMessageButton).toBeEnabled({ timeout: 10000 });
+      await sendMessageButton.click();
+      await expect(composer).toHaveValue("");
+
+      await expect.poll(
+        () =>
+          mockServer
+            .listChatRequests()
+            .filter((request) => request.stream && !request.isTitleRequest)
+            .length,
+        { timeout: 10000 }
+      ).toBe(initialStreamRequestCount + 1);
+
+      await expect(page.getByRole("button", { name: "Stop response" }).first()).toBeVisible({
+        timeout: 10000
+      });
+
+      await enterComposerText(composer, "First queued follow-up");
+      await page.getByRole("button", { name: "Queue follow-up" }).click();
+      await expect(composer).toHaveValue("");
+      await enterComposerText(composer, "Second queued follow-up");
+      await page.getByRole("button", { name: "Queue follow-up" }).click();
+      await expect(composer).toHaveValue("");
+      await enterComposerText(composer, "Third queued follow-up");
+      await page.getByRole("button", { name: "Queue follow-up" }).click();
+      await expect(composer).toHaveValue("");
+
+      const queueHeader = page.getByText("3 queued follow-ups");
+      await expect(queueHeader).toBeVisible({ timeout: 10000 });
+
+      const thirdQueuedRow = page
+        .getByText("Third queued follow-up", { exact: true })
+        .locator("xpath=..");
+      await thirdQueuedRow.getByRole("button", { name: "Delete" }).click();
+      await expect(page.getByText("Third queued follow-up", { exact: true })).toHaveCount(0);
+
+      const secondQueuedRow = page
+        .getByText("Second queued follow-up", { exact: true })
+        .locator("xpath=..");
+      await secondQueuedRow.getByRole("button", { name: "Send now" }).click();
+
+      await expect.poll(
+        () =>
+          mockServer
+            .listChatRequests()
+            .filter((request) => request.stream && !request.isTitleRequest)
+            .length,
+        { timeout: 15000 }
+      ).toBe(initialStreamRequestCount + 3);
+
+      const dispatchedMessages = mockServer
+        .listChatRequests()
+        .filter((request) => request.stream && !request.isTitleRequest)
+        .slice(initialStreamRequestCount)
+        .map((request) => request.lastUserContent);
+
+      expect(dispatchedMessages).toEqual([
+        "Initial question",
+        "Second queued follow-up",
+        "First queued follow-up"
+      ]);
+      expect(dispatchedMessages).not.toContain("Third queued follow-up");
+
+      await expect(page.getByText("Second queued follow-up", { exact: true })).toHaveCount(0, {
+        timeout: 10000
+      });
+      await expect(page.getByText("First queued follow-up", { exact: true })).toHaveCount(0, {
+        timeout: 10000
+      });
+      await expect(page.getByText("Handled Second queued follow-up")).toBeVisible({
+        timeout: 10000
+      });
+    } finally {
+      if (restoreProviderSettings) {
+        await restoreProviderSettings();
+      }
+      await mockServer.close();
+    }
   });
 });

--- a/tests/unit/chat-turn.test.ts
+++ b/tests/unit/chat-turn.test.ts
@@ -360,4 +360,46 @@ describe("chat-turn", () => {
       })
     );
   });
+
+  it("ensures queued dispatch runs after the turn finalizes", async () => {
+    const ensureQueuedDispatch = vi.fn().mockResolvedValue(undefined);
+    vi.doMock("@/lib/queued-chat-dispatcher", () => ({
+      ensureQueuedDispatch
+    }));
+
+    const { streamProviderResponse } = await import("@/lib/provider");
+    const mockedStreamProviderResponse = vi.mocked(streamProviderResponse);
+    const { createConversationManager } = await import("@/lib/conversation-manager");
+    const { updateSettings } = await import("@/lib/settings");
+
+    const manager = createConversationManager();
+    const { profileId, profile } = setupProviderProfile();
+    updateSettings({
+      defaultProviderProfileId: profileId,
+      skillsEnabled: false,
+      providerProfiles: [profile]
+    });
+
+    const conv = (await import("@/lib/conversations")).createConversation(
+      undefined,
+      undefined,
+      { providerProfileId: null }
+    );
+
+    mockedStreamProviderResponse.mockReturnValueOnce(
+      (async function* () {
+        yield { type: "answer_delta", text: "Hello" };
+        return { answer: "Hello", thinking: "", usage: { outputTokens: 1 } };
+      })()
+    );
+
+    const { startChatTurn } = await import("@/lib/chat-turn");
+    await startChatTurn(manager, conv.id, "Hi", []);
+
+    expect(ensureQueuedDispatch).toHaveBeenCalledWith({
+      manager,
+      conversationId: conv.id,
+      startChatTurn
+    });
+  });
 });

--- a/tests/unit/chat-turn.test.ts
+++ b/tests/unit/chat-turn.test.ts
@@ -395,6 +395,7 @@ describe("chat-turn", () => {
 
     const { startChatTurn } = await import("@/lib/chat-turn");
     await startChatTurn(manager, conv.id, "Hi", []);
+    await vi.dynamicImportSettled();
 
     expect(ensureQueuedDispatch).toHaveBeenCalledWith({
       manager,
@@ -445,6 +446,7 @@ describe("chat-turn", () => {
       status: "failed",
       errorMessage: "Queue callback failed"
     });
+    await vi.dynamicImportSettled();
     expect(manager.isActive(conv.id)).toBe(false);
     expect(conversations.getConversation(conv.id)?.isActive).toBe(false);
     expect(conversations.listVisibleMessages(conv.id).find((message) => message.role === "assistant")?.status).toBe("error");
@@ -453,5 +455,53 @@ describe("chat-turn", () => {
       conversationId: conv.id,
       startChatTurn
     });
+  });
+
+  it("preserves the turn result when queued dispatch throws", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const ensureQueuedDispatch = vi.fn().mockRejectedValue(new Error("dispatcher failed"));
+    vi.doMock("@/lib/queued-chat-dispatcher", () => ({
+      ensureQueuedDispatch
+    }));
+
+    const { streamProviderResponse } = await import("@/lib/provider");
+    const mockedStreamProviderResponse = vi.mocked(streamProviderResponse);
+    const { createConversationManager } = await import("@/lib/conversation-manager");
+    const { updateSettings } = await import("@/lib/settings");
+
+    const manager = createConversationManager();
+    const { profileId, profile } = setupProviderProfile();
+    updateSettings({
+      defaultProviderProfileId: profileId,
+      skillsEnabled: false,
+      providerProfiles: [profile]
+    });
+
+    const conversations = await import("@/lib/conversations");
+    const conv = conversations.createConversation(
+      undefined,
+      undefined,
+      { providerProfileId: null }
+    );
+
+    mockedStreamProviderResponse.mockReturnValueOnce(
+      (async function* () {
+        yield { type: "answer_delta", text: "Hello" };
+        return { answer: "Hello", thinking: "", usage: { outputTokens: 1 } };
+      })()
+    );
+
+    const { startChatTurn } = await import("@/lib/chat-turn");
+    const result = await startChatTurn(manager, conv.id, "Hi", []);
+    await vi.dynamicImportSettled();
+
+    expect(result).toEqual({ status: "completed" });
+    expect(ensureQueuedDispatch).toHaveBeenCalledWith({
+      manager,
+      conversationId: conv.id,
+      startChatTurn
+    });
+    expect(consoleError).toHaveBeenCalled();
+    consoleError.mockRestore();
   });
 });

--- a/tests/unit/chat-turn.test.ts
+++ b/tests/unit/chat-turn.test.ts
@@ -402,4 +402,56 @@ describe("chat-turn", () => {
       startChatTurn
     });
   });
+
+  it("cleans up normally when onMessagesCreated throws", async () => {
+    const ensureQueuedDispatch = vi.fn().mockResolvedValue(undefined);
+    vi.doMock("@/lib/queued-chat-dispatcher", () => ({
+      ensureQueuedDispatch
+    }));
+
+    const { createConversationManager } = await import("@/lib/conversation-manager");
+    const { updateSettings } = await import("@/lib/settings");
+
+    const manager = createConversationManager();
+    const { profileId, profile } = setupProviderProfile();
+    updateSettings({
+      defaultProviderProfileId: profileId,
+      skillsEnabled: false,
+      providerProfiles: [profile]
+    });
+
+    const conversations = await import("@/lib/conversations");
+    const conv = conversations.createConversation(
+      undefined,
+      undefined,
+      { providerProfileId: null }
+    );
+
+    const { startChatTurn } = await import("@/lib/chat-turn");
+    const result = await startChatTurn(
+      manager,
+      conv.id,
+      "Hi",
+      [],
+      undefined,
+      {
+        onMessagesCreated() {
+          throw new Error("Queue callback failed");
+        }
+      }
+    );
+
+    expect(result).toEqual({
+      status: "failed",
+      errorMessage: "Queue callback failed"
+    });
+    expect(manager.isActive(conv.id)).toBe(false);
+    expect(conversations.getConversation(conv.id)?.isActive).toBe(false);
+    expect(conversations.listVisibleMessages(conv.id).find((message) => message.role === "assistant")?.status).toBe("error");
+    expect(ensureQueuedDispatch).toHaveBeenCalledWith({
+      manager,
+      conversationId: conv.id,
+      startChatTurn
+    });
+  });
 });

--- a/tests/unit/chat-view.test.ts
+++ b/tests/unit/chat-view.test.ts
@@ -2004,6 +2004,58 @@ describe("chat view", () => {
     });
   });
 
+  it("keeps the active stream running when a queued-message websocket error arrives", async () => {
+    renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
+
+    await act(async () => {
+      wsMock.onMessage?.({
+        type: "delta",
+        conversationId: "conv_1",
+        event: { type: "message_start", messageId: "msg_assistant_queued_error" }
+      });
+      wsMock.onMessage?.({
+        type: "delta",
+        conversationId: "conv_1",
+        event: { type: "answer_delta", text: "Still streaming" }
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Stop response" })).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      wsMock.onMessage?.({
+        type: "error",
+        message: "Queued message not found"
+      });
+    });
+
+    expect(screen.getByText("Queued message not found")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Stop response" })).toBeInTheDocument();
+  });
+
+  it("keeps stop control available while drafting a queued follow-up during an active turn", async () => {
+    renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
+
+    await act(async () => {
+      wsMock.onMessage?.({
+        type: "delta",
+        conversationId: "conv_1",
+        event: { type: "message_start", messageId: "msg_assistant_draft_stop" }
+      });
+    });
+
+    const textarea = screen.getByPlaceholderText(
+      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
+    );
+
+    fireEvent.change(textarea, { target: { value: "Queued while streaming" } });
+
+    expect(screen.getByRole("button", { name: "Stop response" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Queue follow-up" })).toBeInTheDocument();
+  });
+
   it("updates token usage gauge when usage event arrives", async () => {
     renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
 

--- a/tests/unit/chat-view.test.ts
+++ b/tests/unit/chat-view.test.ts
@@ -6,7 +6,7 @@ import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { ChatView } from "@/components/chat-view";
 import { ContextTokensProvider } from "@/lib/context-tokens-context";
 import type { SpeechSessionSnapshot, SttEngine, SttLanguage } from "@/lib/speech/types";
-import type { Message, MessageAttachment, MessageTimelineItem } from "@/lib/types";
+import type { Message, MessageAttachment, MessageTimelineItem, QueuedMessage } from "@/lib/types";
 
 const push = vi.fn();
 const refresh = vi.fn();
@@ -153,6 +153,21 @@ function createAttachment(overrides: Partial<MessageAttachment> = {}): MessageAt
     kind: "image",
     extractedText: "",
     createdAt: new Date().toISOString(),
+    ...overrides
+  };
+}
+
+function createQueuedMessage(overrides: Partial<QueuedMessage> = {}): QueuedMessage {
+  return {
+    id: "queue_1",
+    conversationId: "conv_1",
+    content: "Queued follow-up",
+    status: "pending",
+    sortOrder: 0,
+    failureMessage: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    processingStartedAt: null,
     ...overrides
   };
 }
@@ -787,6 +802,40 @@ describe("chat view", () => {
     });
   });
 
+  it("queues a follow-up over WebSocket when the conversation already has an active turn", async () => {
+    renderWithProvider(
+      React.createElement(ChatView, {
+        payload: createPayload({
+          conversation: {
+            ...createPayload().conversation,
+            isActive: true
+          }
+        })
+      })
+    );
+
+    const textarea = screen.getByPlaceholderText(
+      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
+    );
+
+    fireEvent.change(textarea, { target: { value: "Queued follow-up" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(wsMock.send).toHaveBeenCalledWith({
+        type: "queue_message",
+        conversationId: "conv_1",
+        content: "Queued follow-up"
+      });
+    });
+
+    expect(wsMock.send).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "message"
+      })
+    );
+  });
+
   it("shows an error instead of queuing a message when the websocket transport is unavailable", async () => {
     wsMock.connected = false;
     wsMock.failed = true;
@@ -991,6 +1040,40 @@ describe("chat view", () => {
     await waitFor(() => {
       expect(screen.getByText("Hello")).toBeInTheDocument();
       expect(screen.getByText("Hi there!")).toBeInTheDocument();
+    });
+  });
+
+  it("hydrates queued messages from a WebSocket snapshot", async () => {
+    renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
+
+    wsMock.onMessage!({
+      type: "snapshot",
+      conversationId: "conv_1",
+      messages: [],
+      queuedMessages: [createQueuedMessage()]
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Queued follow-up")).toBeInTheDocument();
+    });
+  });
+
+  it("hydrates queued messages from queue updates", async () => {
+    renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
+
+    wsMock.onMessage!({
+      type: "queue_updated",
+      conversationId: "conv_1",
+      queuedMessages: [
+        createQueuedMessage({
+          id: "queue_2",
+          content: "Second queued follow-up"
+        })
+      ]
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Second queued follow-up")).toBeInTheDocument();
     });
   });
 

--- a/tests/unit/chat-view.test.ts
+++ b/tests/unit/chat-view.test.ts
@@ -176,6 +176,7 @@ function createPayload(overrides: Partial<ChatViewPayload> = {}): ChatViewPayloa
       isActive: false
     },
     messages: [] as Message[],
+    queuedMessages: [],
     settings: {
       sttEngine: "browser",
       sttLanguage: "en"

--- a/tests/unit/chat-view.test.ts
+++ b/tests/unit/chat-view.test.ts
@@ -2033,9 +2033,10 @@ describe("chat view", () => {
 
     expect(screen.getByText("Queued message not found")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Stop response" })).toBeInTheDocument();
+    expect(screen.getByText("Agent working - send still queues")).toBeInTheDocument();
   });
 
-  it("keeps stop control available while drafting a queued follow-up during an active turn", async () => {
+  it("reuses the primary action as queue follow-up while drafting during an active turn", async () => {
     renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
 
     await act(async () => {
@@ -2052,8 +2053,23 @@ describe("chat view", () => {
 
     fireEvent.change(textarea, { target: { value: "Queued while streaming" } });
 
-    expect(screen.getByRole("button", { name: "Stop response" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Queue follow-up" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Stop response" })).toBeNull();
+    expect(screen.getByText("Agent working - send still queues")).toBeInTheDocument();
+  });
+
+  it("centers the composer controls against the textarea body", async () => {
+    await act(async () => {
+      renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
+    });
+
+    const textarea = screen.getByPlaceholderText(
+      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
+    );
+    const composerRow = textarea.parentElement?.parentElement;
+
+    expect(composerRow).toHaveClass("items-center");
+    expect(composerRow).not.toHaveClass("items-end");
   });
 
   it("updates token usage gauge when usage event arrives", async () => {

--- a/tests/unit/conversations.test.ts
+++ b/tests/unit/conversations.test.ts
@@ -1254,6 +1254,58 @@ describe("conversation helpers", () => {
     expect(snapshot!.messages[1].textSegments![0].content).toBe("partial answer");
     expect(snapshot!.messages[1].actions).toHaveLength(1);
   });
+
+  it("creates, reorders, and claims queued messages for a conversation", async () => {
+    const {
+      createConversation,
+      createQueuedMessage,
+      listQueuedMessages,
+      moveQueuedMessageToFront,
+      claimNextQueuedMessageForDispatch
+    } = await import("@/lib/conversations");
+
+    const conversation = createConversation();
+    const first = createQueuedMessage({
+      conversationId: conversation.id,
+      content: "First queued follow-up"
+    });
+    const second = createQueuedMessage({
+      conversationId: conversation.id,
+      content: "Second queued follow-up"
+    });
+
+    moveQueuedMessageToFront({
+      conversationId: conversation.id,
+      queuedMessageId: second.id
+    });
+
+    expect(listQueuedMessages(conversation.id).map((item) => item.id)).toEqual([second.id, first.id]);
+
+    const claimed = claimNextQueuedMessageForDispatch(conversation.id);
+    expect(claimed?.id).toBe(second.id);
+    expect(listQueuedMessages(conversation.id)[0]).toMatchObject({
+      id: second.id,
+      status: "processing"
+    });
+  });
+
+  it("includes queued messages in conversation snapshots", async () => {
+    const { createConversation, createQueuedMessage, getConversationSnapshot } =
+      await import("@/lib/conversations");
+
+    const conversation = createConversation();
+    createQueuedMessage({
+      conversationId: conversation.id,
+      content: "Queued while busy"
+    });
+
+    expect(getConversationSnapshot(conversation.id)?.queuedMessages).toEqual([
+      expect.objectContaining({
+        content: "Queued while busy",
+        status: "pending"
+      })
+    ]);
+  });
 });
 
 describe("message fork routes", () => {

--- a/tests/unit/conversations.test.ts
+++ b/tests/unit/conversations.test.ts
@@ -1311,6 +1311,41 @@ describe("conversation helpers", () => {
     expect(transactionSpy).toHaveBeenCalledTimes(1);
   });
 
+  it("clears stale failure text when claiming a retried queued message", async () => {
+    const { createConversation, createQueuedMessage, claimNextQueuedMessageForDispatch, listQueuedMessages } =
+      await import("@/lib/conversations");
+
+    const conversation = createConversation();
+    const queuedMessage = createQueuedMessage({
+      conversationId: conversation.id,
+      content: "Retry me"
+    });
+
+    getDb()
+      .prepare(
+        `UPDATE queued_messages
+         SET status = 'pending',
+             failure_message = ?
+         WHERE id = ?`
+      )
+      .run("Previous dispatch failed", queuedMessage.id);
+
+    const claimed = claimNextQueuedMessageForDispatch(conversation.id);
+
+    expect(claimed).toMatchObject({
+      id: queuedMessage.id,
+      status: "processing",
+      failureMessage: null
+    });
+    expect(listQueuedMessages(conversation.id)).toEqual([
+      expect.objectContaining({
+        id: queuedMessage.id,
+        status: "processing",
+        failureMessage: null
+      })
+    ]);
+  });
+
   it("includes queued messages in conversation snapshots", async () => {
     const { createConversation, createQueuedMessage, getConversationSnapshot } =
       await import("@/lib/conversations");

--- a/tests/unit/conversations.test.ts
+++ b/tests/unit/conversations.test.ts
@@ -1289,6 +1289,28 @@ describe("conversation helpers", () => {
     });
   });
 
+  it("creates queued messages inside a transaction when assigning sort order", async () => {
+    const { createConversation, createQueuedMessage } = await import("@/lib/conversations");
+
+    const conversation = createConversation();
+    const db = getDb();
+    const originalTransaction = db.transaction.bind(db);
+    const transactionSpy = vi.fn((callback: (...args: unknown[]) => unknown) => originalTransaction(callback));
+
+    db.transaction = transactionSpy as typeof db.transaction;
+
+    try {
+      createQueuedMessage({
+        conversationId: conversation.id,
+        content: "Transactional queue insert"
+      });
+    } finally {
+      db.transaction = originalTransaction as typeof db.transaction;
+    }
+
+    expect(transactionSpy).toHaveBeenCalledTimes(1);
+  });
+
   it("includes queued messages in conversation snapshots", async () => {
     const { createConversation, createQueuedMessage, getConversationSnapshot } =
       await import("@/lib/conversations");

--- a/tests/unit/conversations.test.ts
+++ b/tests/unit/conversations.test.ts
@@ -1346,6 +1346,37 @@ describe("conversation helpers", () => {
     ]);
   });
 
+  it("does not claim a second queued message while one is already processing", async () => {
+    const { createConversation, createQueuedMessage, claimNextQueuedMessageForDispatch, listQueuedMessages } =
+      await import("@/lib/conversations");
+
+    const conversation = createConversation();
+    const first = createQueuedMessage({
+      conversationId: conversation.id,
+      content: "First queued follow-up"
+    });
+    const second = createQueuedMessage({
+      conversationId: conversation.id,
+      content: "Second queued follow-up"
+    });
+
+    const firstClaim = claimNextQueuedMessageForDispatch(conversation.id);
+    const secondClaim = claimNextQueuedMessageForDispatch(conversation.id);
+
+    expect(firstClaim?.id).toBe(first.id);
+    expect(secondClaim).toBeNull();
+    expect(listQueuedMessages(conversation.id)).toEqual([
+      expect.objectContaining({
+        id: first.id,
+        status: "processing"
+      }),
+      expect.objectContaining({
+        id: second.id,
+        status: "pending"
+      })
+    ]);
+  });
+
   it("includes queued messages in conversation snapshots", async () => {
     const { createConversation, createQueuedMessage, getConversationSnapshot } =
       await import("@/lib/conversations");

--- a/tests/unit/queued-chat-dispatcher.test.ts
+++ b/tests/unit/queued-chat-dispatcher.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("queued-chat-dispatcher", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("claims only one queued message per conversation at a time", async () => {
+    const { createConversationManager } = await import("@/lib/conversation-manager");
+    const { createConversation, createQueuedMessage, listQueuedMessages } = await import("@/lib/conversations");
+    const { ensureQueuedDispatch } = await import("@/lib/queued-chat-dispatcher");
+
+    const manager = createConversationManager();
+    const conversation = createConversation();
+    createQueuedMessage({ conversationId: conversation.id, content: "First queued follow-up" });
+    createQueuedMessage({ conversationId: conversation.id, content: "Second queued follow-up" });
+
+    let releaseDispatch!: () => void;
+    const dispatchStarted = new Promise<void>((resolve) => {
+      releaseDispatch = resolve;
+    });
+    const startChatTurn = vi.fn(async () => {
+      await dispatchStarted;
+      return { status: "completed" as const };
+    });
+
+    const firstDispatch = ensureQueuedDispatch({
+      manager,
+      conversationId: conversation.id,
+      startChatTurn
+    });
+    const secondDispatch = ensureQueuedDispatch({
+      manager,
+      conversationId: conversation.id,
+      startChatTurn
+    });
+
+    await Promise.resolve();
+
+    expect(startChatTurn).toHaveBeenCalledTimes(1);
+    expect(listQueuedMessages(conversation.id)).toEqual([
+      expect.objectContaining({ content: "First queued follow-up", status: "processing" }),
+      expect.objectContaining({ content: "Second queued follow-up", status: "pending" })
+    ]);
+
+    releaseDispatch();
+    await Promise.all([firstDispatch, secondDispatch]);
+  });
+
+  it("consumes only the claimed queue row after a successful dispatch", async () => {
+    const { createConversationManager } = await import("@/lib/conversation-manager");
+    const { createConversation, createQueuedMessage, listQueuedMessages } = await import("@/lib/conversations");
+    const { ensureQueuedDispatch } = await import("@/lib/queued-chat-dispatcher");
+
+    const manager = createConversationManager();
+    const conversation = createConversation();
+    const first = createQueuedMessage({ conversationId: conversation.id, content: "First queued follow-up" });
+    const second = createQueuedMessage({ conversationId: conversation.id, content: "Second queued follow-up" });
+
+    const startChatTurn = vi.fn(async (_manager, _conversationId, _content, _attachmentIds, _personaId, options) => {
+      options?.onMessagesCreated?.({
+        userMessageId: "msg_user_1",
+        assistantMessageId: "msg_assistant_1"
+      });
+      return { status: "completed" as const };
+    });
+
+    await ensureQueuedDispatch({
+      manager,
+      conversationId: conversation.id,
+      startChatTurn
+    });
+
+    expect(startChatTurn).toHaveBeenCalledWith(
+      manager,
+      conversation.id,
+      "First queued follow-up",
+      [],
+      undefined,
+      expect.objectContaining({ source: "queue", onMessagesCreated: expect.any(Function) })
+    );
+    expect(listQueuedMessages(conversation.id)).toEqual([
+      expect.objectContaining({
+        id: second.id,
+        content: "Second queued follow-up",
+        status: "pending"
+      })
+    ]);
+    expect(listQueuedMessages(conversation.id).some((item) => item.id === first.id)).toBe(false);
+  });
+});

--- a/tests/unit/queued-chat-dispatcher.test.ts
+++ b/tests/unit/queued-chat-dispatcher.test.ts
@@ -93,6 +93,189 @@ describe("queued-chat-dispatcher", () => {
     expect(listQueuedMessages(conversation.id).some((item) => item.id === first.id)).toBe(false);
   });
 
+  it("broadcasts queue updates when queued items are consumed by automatic dispatch", async () => {
+    const { createConversationManager } = await import("@/lib/conversation-manager");
+    const { createConversation, createQueuedMessage, listQueuedMessages } =
+      await import("@/lib/conversations");
+    const { ensureQueuedDispatch } = await import("@/lib/queued-chat-dispatcher");
+
+    const manager = createConversationManager();
+    const broadcastSpy = vi.spyOn(manager, "broadcast");
+    const conversation = createConversation();
+    createQueuedMessage({ conversationId: conversation.id, content: "First queued follow-up" });
+    createQueuedMessage({ conversationId: conversation.id, content: "Second queued follow-up" });
+
+    const startChatTurn = vi.fn(
+      async (_manager, _conversationId, content, _attachmentIds, _personaId, options) => {
+        options?.onMessagesCreated?.({
+          userMessageId: `user-${content}`,
+          assistantMessageId: `assistant-${content}`
+        });
+        return { status: "completed" as const };
+      }
+    );
+
+    await ensureQueuedDispatch({
+      manager,
+      conversationId: conversation.id,
+      startChatTurn
+    });
+
+    const queueUpdatedEvents = broadcastSpy.mock.calls
+      .filter(([, event]) => event.type === "queue_updated")
+      .map(([, event]) => event);
+
+    expect(queueUpdatedEvents).toEqual([
+      {
+        type: "queue_updated",
+        conversationId: conversation.id,
+        queuedMessages: [
+          expect.objectContaining({
+            content: "First queued follow-up",
+            status: "processing"
+          }),
+          expect.objectContaining({
+            content: "Second queued follow-up",
+            status: "pending"
+          })
+        ]
+      },
+      {
+        type: "queue_updated",
+        conversationId: conversation.id,
+        queuedMessages: [
+          expect.objectContaining({
+            content: "Second queued follow-up",
+            status: "pending"
+          })
+        ]
+      },
+      {
+        type: "queue_updated",
+        conversationId: conversation.id,
+        queuedMessages: [
+          expect.objectContaining({
+            content: "Second queued follow-up",
+            status: "processing"
+          })
+        ]
+      },
+      {
+        type: "queue_updated",
+        conversationId: conversation.id,
+        queuedMessages: []
+      }
+    ]);
+    expect(listQueuedMessages(conversation.id)).toEqual([]);
+  });
+
+  it("broadcasts queue updates when automatic dispatch fails before creating messages", async () => {
+    const { createConversationManager } = await import("@/lib/conversation-manager");
+    const { createConversation, createQueuedMessage } = await import("@/lib/conversations");
+    const { ensureQueuedDispatch } = await import("@/lib/queued-chat-dispatcher");
+
+    const manager = createConversationManager();
+    const broadcastSpy = vi.spyOn(manager, "broadcast");
+    const conversation = createConversation();
+    createQueuedMessage({ conversationId: conversation.id, content: "Queued follow-up" });
+
+    const startChatTurn = vi.fn(async () => ({
+      status: "failed" as const,
+      errorMessage: "Provider rejected the queued follow-up"
+    }));
+
+    await ensureQueuedDispatch({
+      manager,
+      conversationId: conversation.id,
+      startChatTurn
+    });
+
+    const queueUpdatedEvents = broadcastSpy.mock.calls
+      .filter(([, event]) => event.type === "queue_updated")
+      .map(([, event]) => event);
+
+    expect(queueUpdatedEvents).toEqual([
+      {
+        type: "queue_updated",
+        conversationId: conversation.id,
+        queuedMessages: [
+          expect.objectContaining({
+            content: "Queued follow-up",
+            status: "processing",
+            failureMessage: null
+          })
+        ]
+      },
+      {
+        type: "queue_updated",
+        conversationId: conversation.id,
+        queuedMessages: [
+          expect.objectContaining({
+            content: "Queued follow-up",
+            status: "failed",
+            failureMessage: "Provider rejected the queued follow-up"
+          })
+        ]
+      }
+    ]);
+  });
+
+  it("broadcasts queue updates when orphaned processing rows are recovered", async () => {
+    const { createConversationManager } = await import("@/lib/conversation-manager");
+    const { createConversation, createQueuedMessage } = await import("@/lib/conversations");
+    const { ensureQueuedDispatch } = await import("@/lib/queued-chat-dispatcher");
+
+    const manager = createConversationManager();
+    const broadcastSpy = vi.spyOn(manager, "broadcast");
+    const conversation = createConversation();
+
+    createQueuedMessage({ conversationId: conversation.id, content: "Recovered follow-up" });
+
+    const stalledStartChatTurn = vi.fn(async () => ({ status: "completed" as const }));
+    await ensureQueuedDispatch({
+      manager,
+      conversationId: conversation.id,
+      startChatTurn: stalledStartChatTurn
+    });
+
+    const recoveryStartChatTurn = vi.fn(async () => ({ status: "completed" as const }));
+    await ensureQueuedDispatch({
+      manager,
+      conversationId: conversation.id,
+      startChatTurn: recoveryStartChatTurn
+    });
+
+    const queueUpdatedEvents = broadcastSpy.mock.calls
+      .filter(([, event]) => event.type === "queue_updated")
+      .map(([, event]) => event);
+
+    expect(queueUpdatedEvents).toEqual([
+      {
+        type: "queue_updated",
+        conversationId: conversation.id,
+        queuedMessages: [
+          expect.objectContaining({
+            content: "Recovered follow-up",
+            status: "processing",
+            failureMessage: null
+          })
+        ]
+      },
+      {
+        type: "queue_updated",
+        conversationId: conversation.id,
+        queuedMessages: [
+          expect.objectContaining({
+            content: "Recovered follow-up",
+            status: "failed",
+            failureMessage: "Queued follow-up was abandoned before dispatch completed"
+          })
+        ]
+      }
+    ]);
+    expect(recoveryStartChatTurn).not.toHaveBeenCalled();
+  });
+
   it("drains multiple queued items from a single dispatcher kick", async () => {
     const { createConversationManager } = await import("@/lib/conversation-manager");
     const { createConversation, createQueuedMessage, listQueuedMessages } = await import("@/lib/conversations");

--- a/tests/unit/queued-chat-dispatcher.test.ts
+++ b/tests/unit/queued-chat-dispatcher.test.ts
@@ -49,7 +49,8 @@ describe("queued-chat-dispatcher", () => {
 
   it("consumes only the claimed queue row after a successful dispatch", async () => {
     const { createConversationManager } = await import("@/lib/conversation-manager");
-    const { createConversation, createQueuedMessage, listQueuedMessages } = await import("@/lib/conversations");
+    const { createConversation, createQueuedMessage, listQueuedMessages, setConversationActive } =
+      await import("@/lib/conversations");
     const { ensureQueuedDispatch } = await import("@/lib/queued-chat-dispatcher");
 
     const manager = createConversationManager();
@@ -62,6 +63,8 @@ describe("queued-chat-dispatcher", () => {
         userMessageId: "msg_user_1",
         assistantMessageId: "msg_assistant_1"
       });
+      manager.setActive(conversation.id, true);
+      setConversationActive(conversation.id, true);
       return { status: "completed" as const };
     });
 
@@ -79,6 +82,7 @@ describe("queued-chat-dispatcher", () => {
       undefined,
       expect.objectContaining({ source: "queue", onMessagesCreated: expect.any(Function) })
     );
+    expect(startChatTurn).toHaveBeenCalledTimes(1);
     expect(listQueuedMessages(conversation.id)).toEqual([
       expect.objectContaining({
         id: second.id,
@@ -87,5 +91,39 @@ describe("queued-chat-dispatcher", () => {
       })
     ]);
     expect(listQueuedMessages(conversation.id).some((item) => item.id === first.id)).toBe(false);
+  });
+
+  it("drains multiple queued items from a single dispatcher kick", async () => {
+    const { createConversationManager } = await import("@/lib/conversation-manager");
+    const { createConversation, createQueuedMessage, listQueuedMessages } = await import("@/lib/conversations");
+    const { ensureQueuedDispatch } = await import("@/lib/queued-chat-dispatcher");
+
+    const manager = createConversationManager();
+    const conversation = createConversation();
+    createQueuedMessage({ conversationId: conversation.id, content: "First queued follow-up" });
+    createQueuedMessage({ conversationId: conversation.id, content: "Second queued follow-up" });
+    createQueuedMessage({ conversationId: conversation.id, content: "Third queued follow-up" });
+
+    const startChatTurn = vi.fn(async (_manager, _conversationId, content, _attachmentIds, _personaId, options) => {
+      options?.onMessagesCreated?.({
+        userMessageId: `user-${content}`,
+        assistantMessageId: `assistant-${content}`
+      });
+      return { status: "completed" as const };
+    });
+
+    await ensureQueuedDispatch({
+      manager,
+      conversationId: conversation.id,
+      startChatTurn
+    });
+
+    expect(startChatTurn).toHaveBeenCalledTimes(3);
+    expect(startChatTurn.mock.calls.map((call) => call[2])).toEqual([
+      "First queued follow-up",
+      "Second queued follow-up",
+      "Third queued follow-up"
+    ]);
+    expect(listQueuedMessages(conversation.id)).toEqual([]);
   });
 });

--- a/tests/unit/queued-message-banner.test.tsx
+++ b/tests/unit/queued-message-banner.test.tsx
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { QueuedMessageBanner } from "@/components/queued-message-banner";
+import type { QueuedMessage } from "@/lib/types";
+
+function createQueuedMessage(overrides: Partial<QueuedMessage> = {}): QueuedMessage {
+  return {
+    id: "queue_1",
+    conversationId: "conv_1",
+    content: "Queued follow-up",
+    status: "pending",
+    sortOrder: 0,
+    failureMessage: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    processingStartedAt: null,
+    ...overrides
+  };
+}
+
+describe("queued message banner", () => {
+  it("renders queued pending items and exposes pending-item actions", () => {
+    render(
+      <QueuedMessageBanner
+        items={[
+          createQueuedMessage(),
+          createQueuedMessage({
+            id: "queue_2",
+            content: "Processing follow-up",
+            status: "processing"
+          })
+        ]}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        onSendNow={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("Queued follow-up")).toBeInTheDocument();
+    expect(screen.getByText("Processing follow-up")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Edit" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Delete" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Send now" })).toBeInTheDocument();
+  });
+
+  it("invokes onSendNow with the queued message id", () => {
+    const onSendNow = vi.fn();
+
+    render(
+      <QueuedMessageBanner
+        items={[createQueuedMessage({ id: "queue_send_now" })]}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        onSendNow={onSendNow}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Send now" }));
+
+    expect(onSendNow).toHaveBeenCalledWith("queue_send_now");
+  });
+
+  it("supports inline editing for pending items", () => {
+    const onEdit = vi.fn();
+
+    render(
+      <QueuedMessageBanner
+        items={[createQueuedMessage()]}
+        onEdit={onEdit}
+        onDelete={vi.fn()}
+        onSendNow={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+    fireEvent.change(screen.getByDisplayValue("Queued follow-up"), {
+      target: { value: "Edited follow-up" }
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(onEdit).toHaveBeenCalledWith("queue_1", "Edited follow-up");
+  });
+});

--- a/tests/unit/queued-message-banner.test.tsx
+++ b/tests/unit/queued-message-banner.test.tsx
@@ -21,6 +21,31 @@ function createQueuedMessage(overrides: Partial<QueuedMessage> = {}): QueuedMess
   };
 }
 
+const originalMatchMedia = window.matchMedia;
+
+function mockViewportMatches(matches: boolean) {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: query === "(max-width: 639px)" ? matches : false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn()
+    }))
+  });
+}
+
+afterEach(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: originalMatchMedia
+  });
+});
+
 describe("queued message banner", () => {
   it("renders queued pending items and exposes pending-item actions", () => {
     render(
@@ -41,9 +66,25 @@ describe("queued message banner", () => {
 
     expect(screen.getByText("Queued follow-up")).toBeInTheDocument();
     expect(screen.getByText("Processing follow-up")).toBeInTheDocument();
+    expect(screen.getAllByText(/^[12]$/)).toHaveLength(2);
+    expect(screen.getByTestId("queued-message-body-queue_1").firstElementChild).toHaveTextContent(
+      "1"
+    );
+    expect(screen.getByTestId("queued-message-body-queue_2").firstElementChild).toHaveTextContent(
+      "2"
+    );
+    expect(screen.getByTestId("queued-message-body-queue_1").children).toHaveLength(3);
+    expect(screen.getByTestId("queued-message-actions-queue_1")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Edit" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Delete" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Send now" })).toBeInTheDocument();
+    expect(screen.getByText("Processing")).toBeInTheDocument();
+    expect(screen.queryByText("Pending")).toBeNull();
+    expect(screen.queryByText("Next")).toBeNull();
+    expect(screen.queryByText("Then 1")).toBeNull();
+    expect(screen.queryByText("Edit")).toBeNull();
+    expect(screen.queryByText("Delete")).toBeNull();
+    expect(screen.queryByText("Send now")).toBeNull();
   });
 
   it("invokes onSendNow with the queued message id", () => {
@@ -82,5 +123,28 @@ describe("queued message banner", () => {
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     expect(onEdit).toHaveBeenCalledWith("queue_1", "Edited follow-up");
+  });
+
+  it("starts collapsed on mobile and toggles from the header", () => {
+    mockViewportMatches(true);
+
+    render(
+      <QueuedMessageBanner
+        items={[createQueuedMessage()]}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        onSendNow={vi.fn()}
+      />
+    );
+
+    const header = screen.getByRole("button", { name: "1 queued follow-up" });
+
+    expect(header).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByText("Queued follow-up")).toBeNull();
+
+    fireEvent.click(header);
+
+    expect(header).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText("Queued follow-up")).toBeInTheDocument();
   });
 });

--- a/tests/unit/ws-handler.test.ts
+++ b/tests/unit/ws-handler.test.ts
@@ -185,6 +185,115 @@ describe("ws-handler", () => {
     expect(listQueuedMessages).toHaveBeenCalledWith("conv-1");
   });
 
+  it("sends an error when deleting a queued message fails", async () => {
+    const { verifySessionToken } = await import("@/lib/auth");
+    (verifySessionToken as ReturnType<typeof vi.fn>).mockResolvedValue({ userId: "user-1" });
+
+    const {
+      deleteQueuedMessage,
+      getConversationSnapshot,
+      listActiveConversations,
+      listQueuedMessages
+    } = await import("@/lib/conversations");
+    (listActiveConversations as ReturnType<typeof vi.fn>).mockReturnValue([]);
+    (getConversationSnapshot as ReturnType<typeof vi.fn>).mockReturnValue({
+      conversation: { id: "conv-1", title: "Test", is_active: false },
+      messages: [],
+      queuedMessages: []
+    });
+    (deleteQueuedMessage as ReturnType<typeof vi.fn>).mockReturnValue(false);
+
+    const { handleConnection } = await import("@/lib/ws-handler");
+    const sent: string[] = [];
+    const messageHandlers: Array<(data: string) => void> = [];
+    const ws = {
+      readyState: 1,
+      send: vi.fn((data: string) => sent.push(data)),
+      close: vi.fn(),
+      on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+        if (event === "message") messageHandlers.push((d: string) => handler(d));
+      })
+    } as unknown as WebSocket;
+
+    await handleConnection(ws, "session=valid-token");
+
+    messageHandlers.forEach((handler) => handler(JSON.stringify({ type: "subscribe", conversationId: "conv-1" })));
+    (listQueuedMessages as ReturnType<typeof vi.fn>).mockClear();
+    messageHandlers.forEach((handler) =>
+      handler(JSON.stringify({ type: "delete_queued_message", conversationId: "conv-1", queuedMessageId: "queue-404" }))
+    );
+
+    expect(deleteQueuedMessage).toHaveBeenCalledWith({
+      conversationId: "conv-1",
+      queuedMessageId: "queue-404"
+    });
+    expect(listQueuedMessages).not.toHaveBeenCalled();
+
+    const parsed = sent.map((raw) => JSON.parse(raw));
+    expect(parsed.some((message) => message.type === "queue_updated")).toBe(false);
+    expect(parsed.find((message) => message.type === "error")).toEqual({
+      type: "error",
+      message: "Queued message not found"
+    });
+  });
+
+  it("sends an error when reprioritizing a queued message fails", async () => {
+    const requestStop = vi.fn();
+    vi.doMock("@/lib/chat-turn-control", () => ({ requestStop }));
+
+    const { verifySessionToken } = await import("@/lib/auth");
+    (verifySessionToken as ReturnType<typeof vi.fn>).mockResolvedValue({ userId: "user-1" });
+
+    const {
+      getConversationSnapshot,
+      listActiveConversations,
+      listQueuedMessages,
+      moveQueuedMessageToFront
+    } = await import("@/lib/conversations");
+    (listActiveConversations as ReturnType<typeof vi.fn>).mockReturnValue([]);
+    (getConversationSnapshot as ReturnType<typeof vi.fn>).mockReturnValue({
+      conversation: { id: "conv-1", title: "Test", is_active: false },
+      messages: [],
+      queuedMessages: []
+    });
+    (moveQueuedMessageToFront as ReturnType<typeof vi.fn>).mockReturnValue(false);
+
+    const { handleConnection } = await import("@/lib/ws-handler");
+    const sent: string[] = [];
+    const messageHandlers: Array<(data: string) => void> = [];
+    const ws = {
+      readyState: 1,
+      send: vi.fn((data: string) => sent.push(data)),
+      close: vi.fn(),
+      on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+        if (event === "message") messageHandlers.push((d: string) => handler(d));
+      })
+    } as unknown as WebSocket;
+
+    await handleConnection(ws, "session=valid-token");
+
+    messageHandlers.forEach((handler) => handler(JSON.stringify({ type: "subscribe", conversationId: "conv-1" })));
+    (listQueuedMessages as ReturnType<typeof vi.fn>).mockClear();
+    requestStop.mockClear();
+    messageHandlers.forEach((handler) =>
+      handler(JSON.stringify({ type: "send_queued_message_now", conversationId: "conv-1", queuedMessageId: "queue-404" }))
+    );
+
+    expect(moveQueuedMessageToFront).toHaveBeenCalledWith({
+      conversationId: "conv-1",
+      queuedMessageId: "queue-404"
+    });
+    expect(requestStop).not.toHaveBeenCalled();
+    expect(listQueuedMessages).not.toHaveBeenCalled();
+
+    const parsed = sent.map((raw) => JSON.parse(raw));
+    expect(parsed.some((message) => message.type === "queue_updated")).toBe(false);
+    expect(parsed.find((message) => message.type === "error")).toEqual({
+      type: "error",
+      message: "Queued message not found"
+    });
+  });
+
   it("sends error and closes when no token provided", async () => {
     const { handleConnection } = await import("@/lib/ws-handler");
     const sent: string[] = [];

--- a/tests/unit/ws-handler.test.ts
+++ b/tests/unit/ws-handler.test.ts
@@ -7,7 +7,12 @@ vi.mock("@/lib/auth", () => ({
 
 vi.mock("@/lib/conversations", () => ({
   getConversationSnapshot: vi.fn(),
-  listActiveConversations: vi.fn()
+  listActiveConversations: vi.fn(),
+  createQueuedMessage: vi.fn(),
+  listQueuedMessages: vi.fn(),
+  updateQueuedMessage: vi.fn(),
+  deleteQueuedMessage: vi.fn(),
+  moveQueuedMessageToFront: vi.fn()
 }));
 
 describe("ws-handler", () => {
@@ -42,9 +47,23 @@ describe("ws-handler", () => {
 
     const { getConversationSnapshot, listActiveConversations } = await import("@/lib/conversations");
     (listActiveConversations as ReturnType<typeof vi.fn>).mockReturnValue([]);
+    const queuedMessages = [
+      {
+        id: "queue-1",
+        conversationId: "conv-1",
+        content: "Queued follow-up",
+        status: "pending",
+        sortOrder: 0,
+        failureMessage: null,
+        createdAt: "2026-04-13T00:00:00.000Z",
+        updatedAt: "2026-04-13T00:00:00.000Z",
+        processingStartedAt: null
+      }
+    ];
     (getConversationSnapshot as ReturnType<typeof vi.fn>).mockReturnValue({
       conversation: { id: "conv-1", title: "Test", is_active: false },
-      messages: []
+      messages: [],
+      queuedMessages
     });
 
     const { handleConnection } = await import("@/lib/ws-handler");
@@ -72,6 +91,7 @@ describe("ws-handler", () => {
     const snapshot = sent.find(s => JSON.parse(s).type === "snapshot");
     expect(snapshot).toBeDefined();
     expect(JSON.parse(snapshot!).conversationId).toBe("conv-1");
+    expect(JSON.parse(snapshot!).queuedMessages).toEqual(queuedMessages);
     expect(getConversationSnapshot).toHaveBeenCalledWith("conv-1", "user-1");
   });
 
@@ -96,6 +116,73 @@ describe("ws-handler", () => {
     messageHandlers.forEach((handler) => handler(JSON.stringify({ type: "stop", conversationId: "conv-1" })));
 
     expect(requestStop).toHaveBeenCalledWith("conv-1");
+  });
+
+  it("creates queued messages and broadcasts queue updates", async () => {
+    const { verifySessionToken } = await import("@/lib/auth");
+    (verifySessionToken as ReturnType<typeof vi.fn>).mockResolvedValue({ userId: "user-1" });
+
+    const {
+      createQueuedMessage,
+      getConversationSnapshot,
+      listActiveConversations,
+      listQueuedMessages
+    } = await import("@/lib/conversations");
+    (listActiveConversations as ReturnType<typeof vi.fn>).mockReturnValue([]);
+    (getConversationSnapshot as ReturnType<typeof vi.fn>).mockReturnValue({
+      conversation: { id: "conv-1", title: "Test", is_active: false },
+      messages: [],
+      queuedMessages: []
+    });
+    const queuedMessages = [
+      {
+        id: "queue-1",
+        conversationId: "conv-1",
+        content: "Queued follow-up",
+        status: "pending",
+        sortOrder: 0,
+        failureMessage: null,
+        createdAt: "2026-04-13T00:00:00.000Z",
+        updatedAt: "2026-04-13T00:00:00.000Z",
+        processingStartedAt: null
+      }
+    ];
+    (listQueuedMessages as ReturnType<typeof vi.fn>).mockReturnValue(queuedMessages);
+
+    const { handleConnection } = await import("@/lib/ws-handler");
+    const sent: string[] = [];
+    const messageHandlers: Array<(data: string) => void> = [];
+    const ws = {
+      readyState: 1,
+      send: vi.fn((data: string) => sent.push(data)),
+      close: vi.fn(),
+      on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+        if (event === "message") messageHandlers.push((d: string) => handler(d));
+      })
+    } as unknown as WebSocket;
+
+    await handleConnection(ws, "session=valid-token");
+
+    messageHandlers.forEach((handler) => handler(JSON.stringify({ type: "subscribe", conversationId: "conv-1" })));
+    messageHandlers.forEach((handler) =>
+      handler(JSON.stringify({ type: "queue_message", conversationId: "conv-1", content: "Queued follow-up" }))
+    );
+
+    expect(createQueuedMessage).toHaveBeenCalledWith({
+      conversationId: "conv-1",
+      content: "Queued follow-up"
+    });
+
+    const queueUpdated = sent
+      .map((raw) => JSON.parse(raw))
+      .find((message) => message.type === "queue_updated");
+
+    expect(queueUpdated).toEqual({
+      type: "queue_updated",
+      conversationId: "conv-1",
+      queuedMessages
+    });
+    expect(listQueuedMessages).toHaveBeenCalledWith("conv-1");
   });
 
   it("sends error and closes when no token provided", async () => {

--- a/tests/unit/ws-protocol.test.ts
+++ b/tests/unit/ws-protocol.test.ts
@@ -17,6 +17,13 @@ describe("ws-protocol", () => {
     expect(parsed).toEqual(msg);
   });
 
+  it("serializes and parses queue client messages", async () => {
+    const { serializeClientMessage, parseClientMessage } = await import("@/lib/ws-protocol");
+    const message = { type: "queue_message", conversationId: "conv-1", content: "Queued follow-up" } as const;
+
+    expect(parseClientMessage(serializeClientMessage(message))).toEqual(message);
+  });
+
   it("serializes a server ready message", async () => {
     const { serializeServerMessage } = await import("@/lib/ws-protocol");
     const msg = { type: "ready" as const, activeConversations: [{ id: "conv-1", title: "Test", status: "streaming" as const }] };


### PR DESCRIPTION
Adds durable queued follow-ups for chats, including server-side queue persistence, websocket updates, and dispatcher integration that promotes deferred inputs through the normal chat-turn lifecycle. Updates the composer and queued-banner UX so users can queue during active turns, edit/delete/send queued items, use the mobile collapsed banner, and see the refined single-button send/stop state. Includes the queued follow-up design and implementation docs, plus unit and e2e coverage for reconnect, ordering, failure, and queue UI behavior. Verification: npm run typecheck, npm run lint, npm test.