### PR TITLE
Fix vision warning for vision-mode settings

### DIFF
--- a/components/chat-composer.tsx
+++ b/components/chat-composer.tsx
@@ -432,7 +432,7 @@ export function ChatComposer({
         >
           <AlertCircle className="h-3.5 w-3.5 shrink-0" />
           <span>
-            Selected model might not support vision input.
+            Selected model has no vision capabilities enabled.
           </span>
         </motion.div>
       ) : null}

--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -13,7 +13,6 @@ import {
 } from "@/lib/conversation-events";
 import { useWebSocket } from "@/lib/ws-client";
 import { deleteConversationIfStillEmpty } from "@/lib/conversation-drafts";
-import { supportsImageInput } from "@/lib/model-capabilities";
 import { appendTranscriptToDraft } from "@/lib/speech/append-transcript-to-draft";
 import { useSpeechInput } from "@/lib/speech/use-speech-input";
 import { shouldAutofocusTextInput } from "@/lib/utils";
@@ -1044,7 +1043,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
   const showVisionWarning =
     hasPendingImages &&
     selectedProfile &&
-    !supportsImageInput(selectedProfile.model, selectedProfile.apiMode as "responses" | "chat_completions");
+    selectedProfile.visionMode === "none";
 
   async function uploadFiles(files: File[]) {
     if (!files.length) {

--- a/components/home-view.tsx
+++ b/components/home-view.tsx
@@ -5,7 +5,6 @@ import { useRouter } from "next/navigation";
 
 import { ChatComposer } from "@/components/chat-composer";
 import { storeChatBootstrap } from "@/lib/chat-bootstrap";
-import { supportsImageInput } from "@/lib/model-capabilities";
 import { appendTranscriptToDraft } from "@/lib/speech/append-transcript-to-draft";
 import { useSpeechInput } from "@/lib/speech/use-speech-input";
 import { shouldAutofocusTextInput } from "@/lib/utils";
@@ -85,10 +84,7 @@ export function HomeView({
   const showVisionWarning =
     hasPendingImages &&
     selectedProfile &&
-    !supportsImageInput(
-      selectedProfile.model,
-      selectedProfile.apiMode as "responses" | "chat_completions"
-    );
+    selectedProfile.visionMode === "none";
 
   async function ensureDraftConversation() {
     if (draftConversationId) {


### PR DESCRIPTION
This changes the chat image warning behavior to align with provider vision configuration.
The warning is now displayed only when the selected profile has visionMode set to "none" and images are attached.
I updated the computation in both chat and home views and removed the old model-capability based check.
I also updated the warning copy to explicitly say: "Selected model has no vision capabilities enabled."\n\nThis keeps messaging accurate when models intentionally have vision support disabled.