### PR TITLE
Inject hidden date context into LLM prompts

### DIFF
--- a/lib/provider.ts
+++ b/lib/provider.ts
@@ -17,6 +17,52 @@ import type {
   ProviderToolCall
 } from "@/lib/types";
 
+function buildDateContextSystemContent() {
+  const now = new Date();
+  const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const localTime = now.toLocaleString("en-US", {
+    timeZone: timezone,
+    dateStyle: "full",
+    timeStyle: "long"
+  });
+
+  return [
+    "Current date and time context for this request (not shown to the user):",
+    `- Local: ${localTime} (${timezone})`,
+    `- UTC: ${now.toISOString()}`
+  ].join("\n");
+}
+
+function withDateContextSystemMessage(messages: PromptMessage[]): PromptMessage[] {
+  const contextMessage: PromptMessage = {
+    role: "system",
+    content: buildDateContextSystemContent()
+  };
+
+  const systemIndex = messages.findIndex((message) => message.role === "system");
+  if (systemIndex === -1) {
+    return [contextMessage, ...messages];
+  }
+
+  const systemMessage = messages[systemIndex];
+  const systemContent = typeof systemMessage.content === "string"
+    ? systemMessage.content
+    : systemMessage.content.map((part) => "text" in part ? part.text : "").join("");
+
+  return messages.map((message, index) => {
+    if (index !== systemIndex) return message;
+    return {
+      ...message,
+      content: `${systemContent}\n\n${contextMessage.content}`
+    };
+  });
+}
+
+function withDateContextSystemPrompt(systemPrompt: string) {
+  const context = buildDateContextSystemContent();
+  return `${systemPrompt.trim()}\n\n${context}`;
+}
+
 function createClient(settings: ProviderProfile, apiKey: string) {
   return new OpenAI({
     apiKey,
@@ -301,11 +347,16 @@ export async function callProviderText(input: {
   conversationId?: string;
 }) {
   const { settings } = input;
+  const contextualPrompt = withDateContextSystemMessage([{
+    role: "user",
+    content: input.prompt
+  }]);
 
   if (settings.providerKind === "github_copilot") {
     const freshSettings = await ensureFreshGithubAccessToken(settings);
     const result = await runGithubCopilotChat({
       ...freshSettings,
+      systemPrompt: withDateContextSystemPrompt(freshSettings.systemPrompt),
       messages: [{ role: "user", content: input.prompt }]
     });
 
@@ -318,7 +369,7 @@ export async function callProviderText(input: {
     const reasoning = buildReasoningConfig(settings);
     const response = await client.responses.create({
       model: settings.model,
-      input: input.prompt,
+      input: buildResponsesInput(contextualPrompt),
       max_output_tokens: Math.min(settings.maxOutputTokens, 4000),
       reasoning
     });
@@ -334,7 +385,7 @@ export async function callProviderText(input: {
 
   const response = await client.chat.completions.create({
     model: settings.model,
-    messages: [{ role: "user", content: input.prompt }],
+    messages: contextualPrompt,
     temperature: settings.temperature,
     max_completion_tokens: Math.min(settings.maxOutputTokens, 4000),
     ...buildChatCompletionsOptions(settings)
@@ -365,6 +416,7 @@ export async function* streamProviderResponse(input: {
   void
 > {
   const { settings, promptMessages } = input;
+  const contextualPromptMessages = withDateContextSystemMessage(promptMessages);
   setActiveTokenizer(settings.tokenizerModel ?? "gpt-tokenizer");
 
   if (settings.providerKind === "github_copilot") {
@@ -434,6 +486,7 @@ export async function* streamProviderResponse(input: {
 
     const copilotPromise = streamGithubCopilotChat({
       ...freshSettings,
+      systemPrompt: withDateContextSystemPrompt(freshSettings.systemPrompt),
       messages: messageTexts.map((content) => ({ role: "user" as const, content })),
       ...(copilotTools?.length ? { tools: copilotTools } : {}),
       onEvent: (rawEvent: unknown) => {
@@ -537,7 +590,7 @@ export async function* streamProviderResponse(input: {
       item = await dequeue();
     }
 
-    return { answer, thinking, usage: { inputTokens: estimatePromptTokens(promptMessages) } };
+    return { answer, thinking, usage: { inputTokens: estimatePromptTokens(contextualPromptMessages) } };
   }
 
   const client = createClient(settings, settings.apiKey);
@@ -550,7 +603,7 @@ export async function* streamProviderResponse(input: {
     outputTokens?: number;
     reasoningTokens?: number;
   } = {
-    inputTokens: estimatePromptTokens(promptMessages)
+    inputTokens: estimatePromptTokens(contextualPromptMessages)
   };
 
   if (settings.apiMode === "responses") {
@@ -558,7 +611,7 @@ export async function* streamProviderResponse(input: {
 
     const responseCreateParams: Record<string, unknown> = {
       model: settings.model,
-      input: buildResponsesInput(promptMessages),
+      input: buildResponsesInput(contextualPromptMessages),
       stream: true,
       temperature: settings.temperature,
       max_output_tokens: settings.maxOutputTokens,
@@ -800,7 +853,7 @@ export async function* streamProviderResponse(input: {
 
   const chatCreateParams: Record<string, unknown> = {
     model: settings.model,
-    messages: buildChatCompletionMessages(promptMessages),
+    messages: buildChatCompletionMessages(contextualPromptMessages),
     stream: true,
     temperature: settings.temperature,
     max_completion_tokens: settings.maxOutputTokens,

--- a/lib/provider.ts
+++ b/lib/provider.ts
@@ -385,7 +385,7 @@ export async function callProviderText(input: {
 
   const response = await client.chat.completions.create({
     model: settings.model,
-    messages: contextualPrompt,
+    messages: buildChatCompletionMessages(contextualPrompt),
     temperature: settings.temperature,
     max_completion_tokens: Math.min(settings.maxOutputTokens, 4000),
     ...buildChatCompletionsOptions(settings)

--- a/tests/unit/provider.test.ts
+++ b/tests/unit/provider.test.ts
@@ -622,7 +622,16 @@ describe("provider integration", () => {
 
     expect(responsesCreate).toHaveBeenCalledWith(
       expect.objectContaining({
-        input: [
+        input: expect.arrayContaining([
+          expect.objectContaining({
+            role: "system",
+            content: expect.arrayContaining([
+              expect.objectContaining({
+                type: "input_text",
+                text: expect.stringContaining("Current date and time context")
+              })
+            ])
+          }),
           {
             role: "user",
             content: [
@@ -630,7 +639,7 @@ describe("provider integration", () => {
               { type: "input_image", image_url: "data:image/png;base64,abc123" }
             ]
           }
-        ]
+        ])
       }),
       expect.objectContaining({
         signal: expect.any(AbortSignal)
@@ -721,6 +730,15 @@ describe("provider integration", () => {
     expect(responsesCreate).toHaveBeenCalledWith(
       expect.objectContaining({
         input: [
+          expect.objectContaining({
+            role: "system",
+            content: expect.arrayContaining([
+              expect.objectContaining({
+                type: "input_text",
+                text: expect.stringContaining("Current date and time context")
+              })
+            ])
+          }),
           {
             type: "function_call",
             id: "call_0",
@@ -791,6 +809,10 @@ describe("provider integration", () => {
     expect(chatCreate).toHaveBeenCalledWith(
       expect.objectContaining({
         messages: [
+          expect.objectContaining({
+            role: "system",
+            content: expect.any(String)
+          }),
           {
             role: "user",
             content: [
@@ -858,7 +880,11 @@ describe("provider integration", () => {
     expect(events).toEqual([
       { type: "thinking_delta", text: "Thinking " },
       { type: "answer_delta", text: "Hi there" },
-      { type: "usage", inputTokens: 13, outputTokens: undefined }
+      expect.objectContaining({
+        type: "usage",
+        inputTokens: expect.any(Number),
+        outputTokens: undefined
+      })
     ]);
   });
 
@@ -976,6 +1002,10 @@ describe("provider integration", () => {
           }
         ],
         messages: [
+          expect.objectContaining({
+            role: "system",
+            content: expect.any(String)
+          }),
           {
             role: "assistant",
             content: null,
@@ -1004,7 +1034,7 @@ describe("provider integration", () => {
 
     expect(events).toContainEqual({ type: "thinking_delta", text: "Plan " });
     expect(events).toContainEqual({ type: "answer_delta", text: "Done" });
-    expect(events).toContainEqual({ type: "usage", inputTokens: 7, outputTokens: 3 });
+    expect(events).toContainEqual(expect.objectContaining({ type: "usage", inputTokens: expect.any(Number), outputTokens: 3 }));
   });
 
   it("uses ollama reasoning controls and parses thinking deltas", async () => {
@@ -1057,7 +1087,11 @@ describe("provider integration", () => {
     expect(events).toEqual([
       { type: "thinking_delta", text: "Thinking " },
       { type: "answer_delta", text: "Hi there" },
-      { type: "usage", inputTokens: 13, outputTokens: undefined }
+      expect.objectContaining({
+        type: "usage",
+        inputTokens: expect.any(Number),
+        outputTokens: undefined
+      })
     ]);
   });
 


### PR DESCRIPTION
## Summary
This change ensures every LLM request receives current date/time context internally so compaction and stream flows keep temporal awareness.
It prepends or appends a hidden system message with local timezone and UTC timestamp for responses, chat completions, and GitHub Copilot paths.
Token estimates are updated to account for the injected context before provider calls.
Prompt serialization and streaming handlers now use contextualized messages consistently across request modes.
Unit tests were updated to assert context injection and use non-brittle token expectations.
