### PR TITLE
Mask stored API key placeholders

### DIFF
--- a/components/settings/sections/general-section.tsx
+++ b/components/settings/sections/general-section.tsx
@@ -263,7 +263,7 @@ export function GeneralSection({ settings }: { settings: GeneralSectionSettings 
                     autoComplete="off"
                     value={exaApiKey}
                     placeholder={
-                      hasStoredExaApiKey && !hasEditedExaApiKey ? "Stored API key" : "Optional"
+                      hasStoredExaApiKey && !hasEditedExaApiKey ? "••••••••" : "Optional"
                     }
                     onChange={(event) => {
                       resetMessages();
@@ -281,19 +281,19 @@ export function GeneralSection({ settings }: { settings: GeneralSectionSettings 
                 <label htmlFor="tavily-api-key" className={fieldLabelClassName}>
                   Tavily API key
                 </label>
-                <input
-                  id="tavily-api-key"
-                  aria-label="Tavily API key"
-                  type="password"
-                  autoComplete="off"
-                  value={tavilyApiKey}
-                  placeholder={
-                    hasStoredTavilyApiKey && !hasEditedTavilyApiKey ? "Stored API key" : "Required"
-                  }
-                  onChange={(event) => {
-                    resetMessages();
-                    setHasEditedTavilyApiKey(true);
-                    setTavilyApiKey(event.target.value);
+                  <input
+                    id="tavily-api-key"
+                    aria-label="Tavily API key"
+                    type="password"
+                    autoComplete="off"
+                    value={tavilyApiKey}
+                    placeholder={
+                      hasStoredTavilyApiKey && !hasEditedTavilyApiKey ? "••••••••" : "Required"
+                    }
+                    onChange={(event) => {
+                      resetMessages();
+                      setHasEditedTavilyApiKey(true);
+                      setTavilyApiKey(event.target.value);
                   }}
                   className={inputClassName}
                 />

--- a/components/settings/sections/providers-section.tsx
+++ b/components/settings/sections/providers-section.tsx
@@ -96,6 +96,7 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
   const [showApiKey, setShowApiKey] = useState(false);
   const [mcpServers, setMcpServers] = useState<McpServer[]>([]);
   const [copilotModels, setCopilotModels] = useState<Array<{ id: string; name: string; maxContextWindowTokens: number | null }>>([]);
+  const maskedApiKeyValue = "••••••••";
 
   useEffect(() => {
     fetch("/api/mcp-servers")
@@ -612,7 +613,7 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
                             }
                             placeholder={
                               activeProviderProfile.hasApiKey
-                                ? "Stored securely. Leave blank to keep."
+                                ? maskedApiKeyValue
                                 : "sk-..."
                             }
                             className="pr-10"

--- a/tests/unit/general-section.test.tsx
+++ b/tests/unit/general-section.test.tsx
@@ -256,6 +256,31 @@ describe("general section", () => {
     expect(body).not.toHaveProperty("clearTavilyApiKey");
   });
 
+  it("renders masked placeholders for stored Exa and Tavily API keys", () => {
+    const { unmount } = render(
+      React.createElement(GeneralSection, {
+        settings: makeSettings({
+          webSearchEngine: "exa",
+          hasExaApiKey: true
+        })
+      })
+    );
+
+    expect(screen.getByLabelText("Exa API key")).toHaveAttribute("placeholder", "••••••••");
+    unmount();
+
+    render(
+      React.createElement(GeneralSection, {
+        settings: makeSettings({
+          webSearchEngine: "tavily",
+          hasTavilyApiKey: true
+        })
+      })
+    );
+
+    expect(screen.getByLabelText("Tavily API key")).toHaveAttribute("placeholder", "••••••••");
+  });
+
   it("sends an explicit clear flag when a saved Exa key is intentionally cleared", async () => {
     const settings = makeSettings({
       webSearchEngine: "exa",


### PR DESCRIPTION
Updated Settings to show masked values when API keys are already configured so users can see a secret exists without exposing it. This updates Exa and Tavily API key placeholders in general settings and the provider API key placeholder in provider settings. Added unit coverage to verify both Exa and Tavily stored-key placeholders render as masked text. Confirmed no visible secret value is displayed when a key is stored and fields are untouched. The change is validated with a settings UI capture at /tmp/agent_browser_shots/screenshot-1776173692682.png.