### PR TITLE
Refine MCP and skill enable/save behavior

### DIFF
--- a/components/settings/profile-card.tsx
+++ b/components/settings/profile-card.tsx
@@ -5,12 +5,14 @@ import type { BadgeVariant } from "./badge";
 export function ProfileCard({
   isActive,
   onClick,
+  isDisabled = false,
   title,
   subtitle,
   badges,
   rightSlot,
 }: {
   isActive: boolean;
+  isDisabled?: boolean;
   onClick: () => void;
   title: string;
   subtitle?: string;
@@ -21,6 +23,8 @@ export function ProfileCard({
     <div
       onClick={onClick}
       className={`rounded-xl px-3 py-3 transition-all duration-200 cursor-pointer ${
+        isDisabled ? "opacity-70" : ""
+      } ${
         isActive
           ? "bg-[rgba(139,92,246,0.08)] border border-[rgba(139,92,246,0.2)]"
           : "border border-[rgba(255,255,255,0.04)] hover:bg-[rgba(255,255,255,0.02)]"
@@ -30,12 +34,20 @@ export function ProfileCard({
         <div className="flex items-center gap-2 min-w-0">
           <div
             className={`h-2 w-2 rounded-full flex-shrink-0 ${
-              isActive ? "bg-[#8b5cf6]" : "bg-[#3b3b3b]"
+              isDisabled
+                ? "bg-[#52525b]"
+                : isActive
+                  ? "bg-[#8b5cf6]"
+                  : "bg-[#3b3b3b]"
             }`}
           />
           <span
             className={`text-[0.82rem] truncate ${
-              isActive ? "text-[#f4f4f5] font-medium" : "text-[#a1a1aa]"
+              isDisabled
+                ? "text-[#6b7280]"
+                : isActive
+                  ? "text-[#f4f4f5] font-medium"
+                  : "text-[#f4f4f5]"
             }`}
           >
             {title}
@@ -49,7 +61,11 @@ export function ProfileCard({
         {rightSlot}
       </div>
       {subtitle ? (
-        <p className="mt-1 truncate text-[0.7rem] text-[#52525b] pl-4">
+        <p
+          className={`mt-1 truncate text-[0.7rem] pl-4 ${
+            isDisabled ? "text-[#4f5868]" : "text-[#d4d4d8]"
+          }`}
+        >
           {subtitle}
         </p>
       ) : null}

--- a/components/settings/sections/mcp-servers-section.tsx
+++ b/components/settings/sections/mcp-servers-section.tsx
@@ -24,6 +24,7 @@ export function McpServersSection() {
   const [mcpDraftTestResult, setMcpDraftTestResult] = useState("");
   const [mcpRowTestResults, setMcpRowTestResults] = useState<Record<string, string>>({});
   const [mcpTestingTarget, setMcpTestingTarget] = useState<string | null>(null);
+  const [mcpEnabledDraft, setMcpEnabledDraft] = useState(true);
   const [error, setError] = useState("");
   const [success, setSuccess] = useState("");
 
@@ -78,7 +79,8 @@ export function McpServersSection() {
 
     const payload: Record<string, unknown> = {
       name: mcpName,
-      transport: mcpTransport
+      transport: mcpTransport,
+      enabled: mcpEnabledDraft
     };
 
     if (mcpTransport === "streamable_http") {
@@ -116,6 +118,14 @@ export function McpServersSection() {
       }
       const created = (await postRes.json()) as { server: McpServer };
       savedId = created.server.id;
+
+      if (savedId && mcpEnabledDraft === false) {
+        await fetch(`/api/mcp-servers/${savedId}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ enabled: false })
+        });
+      }
     }
 
     const res = await fetch("/api/mcp-servers");
@@ -133,6 +143,7 @@ export function McpServersSection() {
       setMcpCommand(savedServer.command ?? "");
       setMcpArgs(savedServer.args ? JSON.stringify(savedServer.args) : "");
       setMcpEnv(savedServer.env ? JSON.stringify(savedServer.env, null, 2) : "");
+      setMcpEnabledDraft(savedServer.enabled);
       setMcpDraftTestResult("");
       setIsAddingNew(false);
       setMobileDetailVisible(true);
@@ -231,15 +242,6 @@ export function McpServersSection() {
     }
   }
 
-  async function toggleMcpServer(id: string, enabled: boolean) {
-    await fetch(`/api/mcp-servers/${id}`, {
-      method: "PATCH",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ enabled })
-    });
-    setMcpServers((prev) => prev.map((s) => (s.id === id ? { ...s, enabled } : s)));
-  }
-
   function editMcpServer(server: McpServer) {
     setEditingMcpId(server.id);
     setMcpName(server.name);
@@ -250,6 +252,7 @@ export function McpServersSection() {
     setMcpArgs(server.args ? JSON.stringify(server.args) : "");
     setMcpEnv(server.env ? JSON.stringify(server.env, null, 2) : "");
     setMcpDraftTestResult(mcpRowTestResults[server.id] ?? "");
+    setMcpEnabledDraft(server.enabled);
   }
 
   function resetMcpForm() {
@@ -260,6 +263,7 @@ export function McpServersSection() {
     setMcpCommand("");
     setMcpArgs("");
     setMcpEnv("");
+    setMcpEnabledDraft(true);
     setEditingMcpId(null);
     setMcpDraftTestResult("");
     setSelectedServerId(null);
@@ -307,13 +311,14 @@ export function McpServersSection() {
         listPanel={
           <div className="space-y-1">
             {mcpServers.map((server) => (
-              <ProfileCard
-                key={server.id}
-                isActive={server.id === selectedServerId}
-                onClick={() => handleSelectServer(server)}
-                title={server.name}
-                subtitle={
-                  server.transport === "stdio"
+                <ProfileCard
+                  key={server.id}
+                  isActive={server.id === selectedServerId}
+                  isDisabled={!server.enabled}
+                  onClick={() => handleSelectServer(server)}
+                  title={server.name}
+                  subtitle={
+                    server.transport === "stdio"
                     ? `${server.command}${server.args?.length ? " " + server.args.join(" ") : ""}`
                     : server.url
                 }
@@ -322,20 +327,6 @@ export function McpServersSection() {
                     ? { variant: "stdio" as const, label: "STDIO" }
                     : { variant: "http" as const, label: "HTTP" }
                 ]}
-                rightSlot={
-                  <label className="flex cursor-pointer items-center gap-1.5 text-xs text-white/40">
-                    <input
-                      type="checkbox"
-                      checked={server.enabled}
-                      onChange={(e) => {
-                        e.stopPropagation();
-                        void toggleMcpServer(server.id, e.target.checked);
-                      }}
-                      className="rounded"
-                    />
-                    On
-                  </label>
-                }
               />
             ))}
             {mcpServers.length === 0 && (
@@ -435,6 +426,20 @@ export function McpServersSection() {
                 )}
               </div>
 
+              {editingMcpId ? (
+                <div className="flex items-center gap-2">
+                  <label className="flex cursor-pointer items-center gap-2 rounded-lg border border-white/8 bg-white/[0.04] px-2.5 py-1.5 text-xs text-white/65 transition-colors hover:border-white/15">
+                    <input
+                      type="checkbox"
+                      checked={mcpEnabledDraft}
+                      onChange={(e) => setMcpEnabledDraft(e.target.checked)}
+                      className="rounded"
+                    />
+                    Enabled
+                  </label>
+                </div>
+              ) : null}
+
               <div className="flex items-center gap-2">
                 <Button
                   type="button"
@@ -447,12 +452,6 @@ export function McpServersSection() {
                 <Button type="button" onClick={() => void saveMcpServer()}>
                   {editingMcpId ? "Update" : "Add server"}
                 </Button>
-                {success ? (
-                  <div className="flex items-center gap-1.5 text-sm text-emerald-400">
-                    <Check className="h-3.5 w-3.5" />
-                    {success}
-                  </div>
-                ) : null}
                 {editingMcpId && (
                   <Button
                     type="button"
@@ -462,6 +461,12 @@ export function McpServersSection() {
                     Delete
                   </Button>
                 )}
+                {success ? (
+                  <div className="flex items-center gap-1.5 text-sm text-emerald-400">
+                    <Check className="h-3.5 w-3.5" />
+                    {success}
+                  </div>
+                ) : null}
               </div>
 
               {mcpDraftTestResult && (

--- a/components/settings/sections/skills-section.tsx
+++ b/components/settings/sections/skills-section.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { Plus, FileText, Upload } from "lucide-react";
+import { Check, Plus, FileText, Upload } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -21,6 +21,8 @@ export function SkillsSection() {
   const [selectedSkillId, setSelectedSkillId] = useState<string | null>(null);
   const [mobileDetailVisible, setMobileDetailVisible] = useState(false);
   const [isAddingNew, setIsAddingNew] = useState(false);
+  const [skillSuccess, setSkillSuccess] = useState("");
+  const [skillEnabledDraft, setSkillEnabledDraft] = useState(true);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -34,19 +36,33 @@ export function SkillsSection() {
 
   async function saveSkill() {
     if (!skillName.trim() || !skillDescription.trim() || !skillContent.trim()) return;
+    setSkillSuccess("");
+
+    let savedId = editingSkillId;
+    const isBuiltin = editingSkillId?.startsWith("builtin-") ?? false;
+    const payload: {
+      name?: string;
+      description?: string;
+      content?: string;
+      enabled: boolean;
+    } = {
+      enabled: skillEnabledDraft
+    };
+
+    if (!isBuiltin) {
+      payload.name = skillName;
+      payload.description = skillDescription;
+      payload.content = skillContent;
+    }
 
     if (editingSkillId) {
       await fetch(`/api/skills/${editingSkillId}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          name: skillName,
-          description: skillDescription,
-          content: skillContent
-        })
+        body: JSON.stringify(payload)
       });
     } else {
-      await fetch("/api/skills", {
+      const createRes = await fetch("/api/skills", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -55,30 +71,56 @@ export function SkillsSection() {
           content: skillContent
         })
       });
+      const createdData = (await createRes.json().catch(() => null)) as { skill?: Skill } | null;
+      savedId = createdData?.skill?.id ?? savedId;
+      if (savedId && skillEnabledDraft === false) {
+        await fetch(`/api/skills/${savedId}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ enabled: false })
+        });
+      }
     }
 
     const res = await fetch("/api/skills");
     const data = (await res.json()) as { skills: Skill[] };
     setSkills(data.skills);
-    resetSkillForm();
+
+    const savedSkill = data.skills.find((skill) => (savedId ? skill.id === savedId : false));
+    if (savedSkill) {
+      setSelectedSkillId(savedSkill.id);
+      setEditingSkillId(savedSkill.id);
+      setSkillName(savedSkill.name);
+      setSkillDescription(savedSkill.description);
+      setSkillContent(savedSkill.content);
+      setSkillEnabledDraft(savedSkill.enabled);
+    } else if (data.skills.length > 0) {
+      const firstMatch = data.skills.find(
+        (skill) => skill.name === skillName && skill.content === skillContent
+      );
+      if (firstMatch) {
+        setSelectedSkillId(firstMatch.id);
+        setEditingSkillId(firstMatch.id);
+        setSkillName(firstMatch.name);
+        setSkillDescription(firstMatch.description);
+        setSkillContent(firstMatch.content);
+        setSkillEnabledDraft(firstMatch.enabled);
+      }
+    }
+
+    setSkillSuccess("Skill saved.");
+    setIsAddingNew(false);
+    setMobileDetailVisible(true);
   }
 
   async function deleteSkill(id: string) {
     await fetch(`/api/skills/${id}`, { method: "DELETE" });
     setSkills((prev) => prev.filter((s) => s.id !== id));
+    setSkillSuccess("");
     if (selectedSkillId === id) {
       setSelectedSkillId(null);
       setMobileDetailVisible(false);
     }
-  }
-
-  async function toggleSkill(id: string, enabled: boolean) {
-    await fetch(`/api/skills/${id}`, {
-      method: "PATCH",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ enabled })
-    });
-    setSkills((prev) => prev.map((s) => (s.id === id ? { ...s, enabled } : s)));
   }
 
   function handleSelectSkill(skill: Skill) {
@@ -86,6 +128,8 @@ export function SkillsSection() {
     setSkillName(skill.name);
     setSkillDescription(skill.description);
     setSkillContent(skill.content);
+    setSkillEnabledDraft(skill.enabled);
+    setSkillSuccess("");
     setSelectedSkillId(skill.id);
     setIsAddingNew(false);
     setMobileDetailVisible(true);
@@ -96,6 +140,8 @@ export function SkillsSection() {
     setSkillName("");
     setSkillDescription("");
     setSkillContent("");
+    setSkillEnabledDraft(true);
+    setSkillSuccess("");
     setSelectedSkillId(null);
     setIsAddingNew(true);
     setMobileDetailVisible(true);
@@ -125,10 +171,12 @@ export function SkillsSection() {
     setSkillName("");
     setSkillDescription("");
     setSkillContent("");
+    setSkillEnabledDraft(true);
     setEditingSkillId(null);
     setSelectedSkillId(null);
     setIsAddingNew(false);
     setMobileDetailVisible(false);
+    setSkillSuccess("");
   }
 
   const selectedSkill = skills.find((s) => s.id === selectedSkillId);
@@ -182,6 +230,7 @@ export function SkillsSection() {
               <ProfileCard
                 key={skill.id}
                 isActive={skill.id === selectedSkillId}
+                isDisabled={!skill.enabled}
                 onClick={() => handleSelectSkill(skill)}
                 title={skill.name}
                 subtitle={skill.description}
@@ -189,16 +238,6 @@ export function SkillsSection() {
                   skill.id.startsWith("builtin-")
                     ? [{ variant: "builtin" as const, label: "BUILT-IN" }]
                     : undefined
-                }
-                rightSlot={
-                  <label className="flex items-center gap-1 text-[0.7rem] text-[#52525b] cursor-pointer">
-                    <input
-                      type="checkbox"
-                      checked={skill.enabled}
-                      onChange={(e) => toggleSkill(skill.id, e.target.checked)}
-                      className="rounded"
-                    />
-                  </label>
                 }
               />
             ))}
@@ -237,7 +276,7 @@ export function SkillsSection() {
                 <div className="space-y-5">
                   {selectedSkill && isBuiltin ? (
                     <div className="rounded-md border border-amber-500/30 bg-amber-500/5 px-3 py-2">
-                    <p className="text-[0.68rem] font-medium uppercase tracking-[0.08em] text-amber-200">
+                      <p className="text-[0.68rem] font-medium uppercase tracking-[0.08em] text-amber-200">
                         Built-in skill
                       </p>
                       <p className="mt-1 text-sm text-amber-100">
@@ -277,15 +316,33 @@ export function SkillsSection() {
                   </div>
                 </div>
 
+                {selectedSkill ? (
+                  <div className="flex gap-2 pt-2">
+                    <label className="flex cursor-pointer items-center gap-2 rounded-lg border border-white/8 bg-white/[0.04] px-2.5 py-1.5 text-xs text-[#52525b] transition-colors hover:border-white/15">
+                      <input
+                        type="checkbox"
+                        checked={skillEnabledDraft}
+                        onChange={(e) => setSkillEnabledDraft(e.target.checked)}
+                        className="rounded"
+                      />
+                      Enabled
+                    </label>
+                  </div>
+                ) : null}
+
                 <div className="flex gap-2 pt-2">
-                  {!isBuiltin ? (
-                    <Button type="button" onClick={saveSkill}>
-                      {editingSkillId ? "Update" : "Add skill"}
-                    </Button>
-                  ) : null}
+                  <Button type="button" onClick={saveSkill}>
+                    {editingSkillId ? "Update" : "Add skill"}
+                  </Button>
                   <Button type="button" variant="secondary" onClick={resetSkillForm}>
                     {isBuiltin ? "Close" : "Cancel"}
                   </Button>
+                  {skillSuccess ? (
+                    <div className="flex items-center gap-1.5 text-sm text-emerald-400">
+                      <Check className="h-3.5 w-3.5" />
+                      {skillSuccess}
+                    </div>
+                  ) : null}
                 </div>
               </>
             ) : (


### PR DESCRIPTION
## Summary
- Move enable/disable controls into the MCP server and skill detail forms so status updates happen on Save/Update instead of checkbox click.
- Keep disabled items visually distinct in both MCP and Skills lists via soft fade and muted text while preserving white emphasis for enabled/selected items.
- Preserve built-in skill editability constraints while still allowing Enabled toggling and saving for them.
- Improve post-save behavior to stay in the current detail context and show the success confirmation beside action buttons for both sections.