### PR TITLE
Improve assistant code block rendering and copy

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -270,6 +270,7 @@ select {
 
 .assistant-code-block__header {
   display: flex;
+  min-width: 0;
   align-items: center;
   justify-content: space-between;
   gap: 0.75rem;
@@ -279,13 +280,15 @@ select {
 }
 
 .assistant-code-block__language {
-  display: inline-flex;
+  display: block;
+  flex: 1 1 auto;
   min-width: 0;
-  align-items: center;
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
   font-size: 11px;
   line-height: 1;
   color: rgba(255, 255, 255, 0.56);
+  overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 
@@ -328,14 +331,14 @@ select {
 }
 
 @media (hover: hover) and (pointer: fine) {
-  .assistant-code-block__copy {
+  .assistant-code-block__copy[data-copy-state="idle"] {
     opacity: 0;
     pointer-events: none;
     transform: translateY(4px);
   }
 
-  .assistant-code-block:hover .assistant-code-block__copy,
-  .assistant-code-block:focus-within .assistant-code-block__copy {
+  .assistant-code-block:hover .assistant-code-block__copy[data-copy-state="idle"],
+  .assistant-code-block:focus-within .assistant-code-block__copy[data-copy-state="idle"] {
     opacity: 1;
     pointer-events: auto;
     transform: translateY(0);

--- a/app/globals.css
+++ b/app/globals.css
@@ -330,6 +330,10 @@ select {
   color: #f87171;
 }
 
+.assistant-code-block[data-complete="false"] .assistant-code-block__copy {
+  display: none;
+}
+
 @media (hover: hover) and (pointer: fine) {
   .assistant-code-block__copy[data-copy-state="idle"] {
     opacity: 0;

--- a/app/globals.css
+++ b/app/globals.css
@@ -262,6 +262,8 @@ select {
 
 .assistant-code-block {
   margin: 0.9rem 0;
+  max-width: 100%;
+  min-width: 0;
   overflow: hidden;
   border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 0.9rem;
@@ -351,7 +353,10 @@ select {
 
 .markdown-body .assistant-code-block__body {
   margin: 0;
+  max-width: 100%;
   overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior-x: contain;
   border: 0;
   border-radius: 0;
   background: transparent;
@@ -363,7 +368,8 @@ select {
 
 .assistant-code-block__code {
   display: block;
-  min-width: max-content;
+  width: max-content;
+  min-width: 100%;
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
 }
 
@@ -410,6 +416,18 @@ select {
 .assistant-code-block__body .hljs-meta,
 .assistant-code-block__body .hljs-punctuation {
   color: #b1bac4;
+}
+
+@media (max-width: 767px) {
+  .markdown-body .assistant-code-block__body {
+    padding: 0.75rem 0.75rem 0.8rem;
+    font-size: 12px;
+    line-height: 1.55;
+  }
+
+  .assistant-code-block__header {
+    padding: 0.5rem 0.65rem;
+  }
 }
 
 .markdown-body table {

--- a/app/globals.css
+++ b/app/globals.css
@@ -260,6 +260,151 @@ select {
   color: rgba(255, 255, 255, 0.88);
 }
 
+.assistant-code-block {
+  margin: 0.9rem 0;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 0.9rem;
+  background: rgba(7, 8, 11, 0.92);
+}
+
+.assistant-code-block__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.03);
+  padding: 0.5rem 0.75rem;
+}
+
+.assistant-code-block__language {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 11px;
+  line-height: 1;
+  color: rgba(255, 255, 255, 0.56);
+  white-space: nowrap;
+}
+
+.assistant-code-block__copy {
+  display: inline-flex;
+  height: 1.75rem;
+  width: 1.75rem;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 0.5rem;
+  background: rgba(255, 255, 255, 0.02);
+  color: rgba(255, 255, 255, 0.42);
+  transition:
+    opacity 120ms ease,
+    transform 120ms ease,
+    border-color 120ms ease,
+    background-color 120ms ease,
+    color 120ms ease;
+}
+
+.assistant-code-block__copy:hover,
+.assistant-code-block__copy:focus-visible {
+  border-color: rgba(255, 255, 255, 0.14);
+  background: rgba(255, 255, 255, 0.05);
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.assistant-code-block__copy:focus-visible {
+  outline: none;
+}
+
+.assistant-code-block__copy[data-copy-state="copied"] {
+  color: #4ade80;
+}
+
+.assistant-code-block__copy[data-copy-state="error"] {
+  color: #f87171;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .assistant-code-block__copy {
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(4px);
+  }
+
+  .assistant-code-block:hover .assistant-code-block__copy,
+  .assistant-code-block:focus-within .assistant-code-block__copy {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
+  }
+}
+
+.markdown-body .assistant-code-block__body {
+  margin: 0;
+  overflow-x: auto;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 0.85rem 1rem;
+  color: rgba(255, 255, 255, 0.88);
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.assistant-code-block__code {
+  display: block;
+  min-width: max-content;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+}
+
+.assistant-code-block__body .hljs {
+  display: block;
+  overflow-x: auto;
+  background: transparent;
+  color: #e6edf3;
+}
+
+.assistant-code-block__body .hljs-keyword,
+.assistant-code-block__body .hljs-selector-tag,
+.assistant-code-block__body .hljs-built_in,
+.assistant-code-block__body .hljs-type {
+  color: #ff7b72;
+}
+
+.assistant-code-block__body .hljs-string,
+.assistant-code-block__body .hljs-attr,
+.assistant-code-block__body .hljs-template-variable,
+.assistant-code-block__body .hljs-regexp {
+  color: #a5d6ff;
+}
+
+.assistant-code-block__body .hljs-title,
+.assistant-code-block__body .hljs-function,
+.assistant-code-block__body .hljs-section,
+.assistant-code-block__body .hljs-title.function_ {
+  color: #d2a8ff;
+}
+
+.assistant-code-block__body .hljs-number,
+.assistant-code-block__body .hljs-literal,
+.assistant-code-block__body .hljs-variable,
+.assistant-code-block__body .hljs-symbol {
+  color: #79c0ff;
+}
+
+.assistant-code-block__body .hljs-comment,
+.assistant-code-block__body .hljs-quote {
+  color: #8b949e;
+}
+
+.assistant-code-block__body .hljs-meta,
+.assistant-code-block__body .hljs-punctuation {
+  color: #b1bac4;
+}
+
 .markdown-body table {
   width: 100%;
   margin: 0.9rem 0;

--- a/components/assistant-code-block.tsx
+++ b/components/assistant-code-block.tsx
@@ -54,31 +54,32 @@ export function AssistantCodeBlock({
 
   return (
     <div
-      className="overflow-hidden rounded-xl border border-white/8 bg-black/35"
+      className="assistant-code-block"
       data-testid="assistant-code-block"
     >
-      <div className="flex items-center justify-between gap-3 border-b border-white/8 px-3 py-2 text-[11px]">
-        <span className="font-mono text-white/45">
+      <div className="assistant-code-block__header">
+        <span className="assistant-code-block__language">
           {highlighted.displayLanguage ?? "text"}
         </span>
         <button
           type="button"
           aria-label={copyState === "copied" ? "Copied code block" : "Copy code block"}
           onClick={() => void handleCopy()}
-          className="flex h-6 w-6 items-center justify-center rounded-md border border-white/8 bg-white/[0.03] text-white/45 transition hover:border-white/14 hover:text-white/70"
+          className="assistant-code-block__copy"
+          data-copy-state={copyState}
         >
           {copyState === "copied" ? (
-            <Check className="h-3.5 w-3.5 text-emerald-400" />
+            <Check className="h-3.5 w-3.5" />
           ) : copyState === "error" ? (
-            <X className="h-3.5 w-3.5 text-red-400" />
+            <X className="h-3.5 w-3.5" />
           ) : (
             <Copy className="h-3.5 w-3.5" />
           )}
         </button>
       </div>
-      <pre className="overflow-x-auto px-3 py-3 text-[13px] leading-6 text-white/88">
+      <pre className="assistant-code-block__body">
         <code
-          className={`hljs${highlighted.language ? ` language-${highlighted.language}` : ""}`}
+          className={`assistant-code-block__code hljs${highlighted.language ? ` language-${highlighted.language}` : ""}`}
           dangerouslySetInnerHTML={{ __html: highlighted.html }}
         />
       </pre>

--- a/components/assistant-code-block.tsx
+++ b/components/assistant-code-block.tsx
@@ -59,6 +59,7 @@ export function AssistantCodeBlock({
     <div
       className="assistant-code-block"
       data-testid="assistant-code-block"
+      data-complete={isComplete ? "true" : "false"}
     >
       <div className="assistant-code-block__header">
         <span className="assistant-code-block__language" title={displayLanguage}>

--- a/components/assistant-code-block.tsx
+++ b/components/assistant-code-block.tsx
@@ -17,6 +17,7 @@ export function AssistantCodeBlock({
   const [copyState, setCopyState] = useState<"idle" | "copied" | "error">("idle");
   const resetHandle = useRef<number | null>(null);
   const highlighted = renderHighlightedCode(language, code);
+  const displayLanguage = highlighted.displayLanguage ?? "text";
 
   useEffect(() => {
     return () => {
@@ -58,8 +59,8 @@ export function AssistantCodeBlock({
       data-testid="assistant-code-block"
     >
       <div className="assistant-code-block__header">
-        <span className="assistant-code-block__language">
-          {highlighted.displayLanguage ?? "text"}
+        <span className="assistant-code-block__language" title={displayLanguage}>
+          {displayLanguage}
         </span>
         <button
           type="button"

--- a/components/assistant-code-block.tsx
+++ b/components/assistant-code-block.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import React, { useEffect, useRef, useState } from "react";
+import { Check, Copy, X } from "lucide-react";
+
+import { renderHighlightedCode } from "@/lib/code-highlighting";
+
+const COPY_RESET_DELAY_MS = 1600;
+
+export function AssistantCodeBlock({
+  code,
+  language
+}: {
+  code: string;
+  language?: string | null;
+}) {
+  const [copyState, setCopyState] = useState<"idle" | "copied" | "error">("idle");
+  const resetHandle = useRef<number | null>(null);
+  const highlighted = renderHighlightedCode(language, code);
+
+  useEffect(() => {
+    return () => {
+      if (resetHandle.current) {
+        window.clearTimeout(resetHandle.current);
+      }
+    };
+  }, []);
+
+  function setCopyFeedback(nextState: "copied" | "error") {
+    setCopyState(nextState);
+
+    if (resetHandle.current) {
+      window.clearTimeout(resetHandle.current);
+    }
+
+    resetHandle.current = window.setTimeout(() => {
+      setCopyState("idle");
+      resetHandle.current = null;
+    }, COPY_RESET_DELAY_MS);
+  }
+
+  async function handleCopy() {
+    try {
+      if (typeof navigator === "undefined" || !navigator.clipboard) {
+        throw new Error("Clipboard unavailable");
+      }
+
+      await navigator.clipboard.writeText(code);
+      setCopyFeedback("copied");
+    } catch {
+      setCopyFeedback("error");
+    }
+  }
+
+  return (
+    <div
+      className="overflow-hidden rounded-xl border border-white/8 bg-black/35"
+      data-testid="assistant-code-block"
+    >
+      <div className="flex items-center justify-between gap-3 border-b border-white/8 px-3 py-2 text-[11px]">
+        <span className="font-mono text-white/45">
+          {highlighted.displayLanguage ?? "text"}
+        </span>
+        <button
+          type="button"
+          aria-label={copyState === "copied" ? "Copied code block" : "Copy code block"}
+          onClick={() => void handleCopy()}
+          className="flex h-6 w-6 items-center justify-center rounded-md border border-white/8 bg-white/[0.03] text-white/45 transition hover:border-white/14 hover:text-white/70"
+        >
+          {copyState === "copied" ? (
+            <Check className="h-3.5 w-3.5 text-emerald-400" />
+          ) : copyState === "error" ? (
+            <X className="h-3.5 w-3.5 text-red-400" />
+          ) : (
+            <Copy className="h-3.5 w-3.5" />
+          )}
+        </button>
+      </div>
+      <pre className="overflow-x-auto px-3 py-3 text-[13px] leading-6 text-white/88">
+        <code
+          className={`hljs${highlighted.language ? ` language-${highlighted.language}` : ""}`}
+          dangerouslySetInnerHTML={{ __html: highlighted.html }}
+        />
+      </pre>
+    </div>
+  );
+}

--- a/components/assistant-code-block.tsx
+++ b/components/assistant-code-block.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import { Check, Copy, X } from "lucide-react";
 
+import { writeTextToClipboard } from "@/lib/clipboard";
 import { renderHighlightedCode } from "@/lib/code-highlighting";
 
 const COPY_RESET_DELAY_MS = 1600;
@@ -44,11 +45,7 @@ export function AssistantCodeBlock({
 
   async function handleCopy() {
     try {
-      if (typeof navigator === "undefined" || !navigator.clipboard) {
-        throw new Error("Clipboard unavailable");
-      }
-
-      await navigator.clipboard.writeText(code);
+      await writeTextToClipboard(code);
       setCopyFeedback("copied");
     } catch {
       setCopyFeedback("error");

--- a/components/assistant-code-block.tsx
+++ b/components/assistant-code-block.tsx
@@ -9,10 +9,12 @@ const COPY_RESET_DELAY_MS = 1600;
 
 export function AssistantCodeBlock({
   code,
-  language
+  language,
+  isComplete = true
 }: {
   code: string;
   language?: string | null;
+  isComplete?: boolean;
 }) {
   const [copyState, setCopyState] = useState<"idle" | "copied" | "error">("idle");
   const resetHandle = useRef<number | null>(null);
@@ -62,21 +64,23 @@ export function AssistantCodeBlock({
         <span className="assistant-code-block__language" title={displayLanguage}>
           {displayLanguage}
         </span>
-        <button
-          type="button"
-          aria-label={copyState === "copied" ? "Copied code block" : "Copy code block"}
-          onClick={() => void handleCopy()}
-          className="assistant-code-block__copy"
-          data-copy-state={copyState}
-        >
-          {copyState === "copied" ? (
-            <Check className="h-3.5 w-3.5" />
-          ) : copyState === "error" ? (
-            <X className="h-3.5 w-3.5" />
-          ) : (
-            <Copy className="h-3.5 w-3.5" />
-          )}
-        </button>
+        {isComplete ? (
+          <button
+            type="button"
+            aria-label={copyState === "copied" ? "Copied code block" : "Copy code block"}
+            onClick={() => void handleCopy()}
+            className="assistant-code-block__copy"
+            data-copy-state={copyState}
+          >
+            {copyState === "copied" ? (
+              <Check className="h-3.5 w-3.5" />
+            ) : copyState === "error" ? (
+              <X className="h-3.5 w-3.5" />
+            ) : (
+              <Copy className="h-3.5 w-3.5" />
+            )}
+          </button>
+        ) : null}
       </div>
       <pre className="assistant-code-block__body">
         <code

--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/attachment-preview-modal";
 import { CompactionIndicator } from "@/components/compaction-indicator";
 import { Textarea } from "@/components/ui/textarea";
+import { writeRichTextToClipboard } from "@/lib/clipboard";
 import type {
   MemoryCategory,
   Message,
@@ -24,6 +25,7 @@ import { normalizeMarkdownLineBreaks } from "@/lib/text-utils";
 
 const MARKDOWN_PLUGINS = [remarkGfm, remarkBreaks];
 const COPY_RESET_DELAY_MS = 1600;
+const AssistantMarkdownCopyReadyContext = React.createContext<Map<number, boolean> | null>(null);
 
 function getMarkdownCodeValue(children: React.ReactNode) {
   return React.Children.toArray(children)
@@ -37,14 +39,18 @@ function getMarkdownCodeValue(children: React.ReactNode) {
     .join("");
 }
 
-function getFencedCodeBlockCopyReadyStates(content: string, isStreaming: boolean) {
-  const blocks: Array<{ endLineIndex: number | null }> = [];
+function stripFenceContainerPrefixes(line: string) {
+  return line.replace(/^(?:>\s*)+/, "");
+}
+
+function getFencedCodeBlocks(content: string) {
+  const blocks: Array<{ startLineNumber: number; endLineIndex: number | null }> = [];
   const lines = content.split("\n");
   let activeFenceCharacter: "`" | "~" | null = null;
   let activeFenceLength = 0;
 
   lines.forEach((line, lineIndex) => {
-    const trimmedLine = line.trim();
+    const trimmedLine = stripFenceContainerPrefixes(line.trim());
 
     if (!activeFenceCharacter) {
       const openingFence = trimmedLine.match(/^(`{3,}|~{3,})(.*)$/);
@@ -55,7 +61,7 @@ function getFencedCodeBlockCopyReadyStates(content: string, isStreaming: boolean
 
       activeFenceCharacter = openingFence[1][0] as "`" | "~";
       activeFenceLength = openingFence[1].length;
-      blocks.push({ endLineIndex: null });
+      blocks.push({ startLineNumber: lineIndex + 1, endLineIndex: null });
       return;
     }
 
@@ -76,73 +82,116 @@ function getFencedCodeBlockCopyReadyStates(content: string, isStreaming: boolean
     activeFenceLength = 0;
   });
 
-  return blocks.map((block) => {
-    if (block.endLineIndex === null) {
-      return false;
-    }
+  return blocks;
+}
 
-    if (!isStreaming) {
-      return true;
-    }
+function getFencedCodeBlockCopyReadyByStartLine(content: string, isStreaming: boolean) {
+  const blocks = getFencedCodeBlocks(content);
+  const lines = content.split("\n");
 
-    return lines
-      .slice(block.endLineIndex + 1)
-      .some((line) => line.trim().length > 0);
-  });
+  return new Map(
+    blocks.map((block) => {
+      if (block.endLineIndex === null) {
+        return [block.startLineNumber, false] as const;
+      }
+
+      if (!isStreaming) {
+        return [block.startLineNumber, true] as const;
+      }
+
+      return [
+        block.startLineNumber,
+        lines
+          .slice(block.endLineIndex + 1)
+          .some((line) => line.trim().length > 0)
+      ] as const;
+    })
+  );
 }
 
 function hasIncompleteFencedCodeBlock(content: string, isStreaming: boolean) {
-  return getFencedCodeBlockCopyReadyStates(content, isStreaming).some((isReady) => !isReady);
+  return Array.from(getFencedCodeBlockCopyReadyByStartLine(content, isStreaming).values()).some((isReady) => !isReady);
+}
+
+function AssistantMarkdownPre({
+  node,
+  children
+}: React.ComponentPropsWithoutRef<"pre"> & {
+  node?: {
+    position?: {
+      start?: {
+        line?: number;
+      };
+    };
+  };
+}) {
+  const copyReadyByStartLine = React.useContext(AssistantMarkdownCopyReadyContext);
+  const codeChild = React.Children.toArray(children)[0];
+
+  if (!React.isValidElement(codeChild)) {
+    return <pre>{children}</pre>;
+  }
+
+  const typedCodeChild = codeChild as React.ReactElement<{
+    children?: React.ReactNode;
+    className?: string;
+  }>;
+  const className =
+    typeof typedCodeChild.props.className === "string"
+      ? typedCodeChild.props.className
+      : undefined;
+  const languageClass = className
+    ?.split(/\s+/)
+    .find((token: string) => token.startsWith("language-"));
+  const language = languageClass
+    ? languageClass.slice("language-".length)
+    : null;
+  const value = getMarkdownCodeValue(typedCodeChild.props.children ?? "").replace(/\n$/, "");
+  const startLineNumber = node?.position?.start?.line;
+  const isComplete =
+    typeof startLineNumber === "number"
+      ? copyReadyByStartLine?.get(startLineNumber) ?? true
+      : true;
+
+  return <AssistantCodeBlock code={value} language={language} isComplete={isComplete} />;
+}
+
+function AssistantMarkdownInlineCode({
+  node: _node,
+  className,
+  children,
+  ...props
+}: {
+  node?: unknown;
+  className?: string;
+  children?: React.ReactNode;
+} & React.ComponentPropsWithoutRef<"code"> & {
+  inline?: boolean;
+}) {
+  const { inline: _inline, ...codeProps } = props;
+
+  return (
+    <code className={className} {...codeProps}>
+      {children}
+    </code>
+  );
 }
 
 function renderAssistantMarkdown(content: string, isStreaming: boolean) {
-  const fencedCodeBlockCopyReadyStates = getFencedCodeBlockCopyReadyStates(content, isStreaming);
-  let fencedCodeBlockIndex = 0;
+  const fencedCodeBlockCopyReadyByStartLine = getFencedCodeBlockCopyReadyByStartLine(content, isStreaming);
 
   return (
-    <ReactMarkdown
-      remarkPlugins={MARKDOWN_PLUGINS}
-      components={{
-        pre({ children }) {
-          const codeChild = React.Children.toArray(children)[0];
-
-          if (!React.isValidElement(codeChild)) {
-            return <pre>{children}</pre>;
-          }
-
-          const typedCodeChild = codeChild as React.ReactElement<{
-            children?: React.ReactNode;
-            className?: string;
-          }>;
-          const className =
-            typeof typedCodeChild.props.className === "string"
-              ? typedCodeChild.props.className
-              : undefined;
-          const languageClass = className
-            ?.split(/\s+/)
-            .find((token: string) => token.startsWith("language-"));
-          const language = languageClass
-            ? languageClass.slice("language-".length)
-            : null;
-          const value = getMarkdownCodeValue(typedCodeChild.props.children ?? "").replace(/\n$/, "");
-          const isComplete = fencedCodeBlockCopyReadyStates[fencedCodeBlockIndex] ?? true;
-
-          fencedCodeBlockIndex += 1;
-
-          return <AssistantCodeBlock code={value} language={language} isComplete={isComplete} />;
-        },
-        code({ node: _node, className, children, ...props }) {
-          const { inline: _inline, ...codeProps } = props as { inline?: boolean } & React.ComponentPropsWithoutRef<"code">;
-          return (
-            <code className={className} {...codeProps}>
-              {children}
-            </code>
-          );
-        }
-      }}
-    >
-      {content}
-    </ReactMarkdown>
+    <AssistantMarkdownCopyReadyContext.Provider value={fencedCodeBlockCopyReadyByStartLine}>
+      <ReactMarkdown
+        remarkPlugins={MARKDOWN_PLUGINS}
+        components={{
+          pre: AssistantMarkdownPre,
+          code: AssistantMarkdownInlineCode
+        }}
+      >
+        {content}
+      </ReactMarkdown>
+    </AssistantMarkdownCopyReadyContext.Provider>
   );
 }
 
@@ -537,7 +586,7 @@ function MemoryProposalCard({
 
 const ASSISTANT_MAX_WIDTH = "max-w-[96%] md:max-w-[95%]";
 const ASSISTANT_BUBBLE =
-  "w-fit rounded-2xl border border-white/8 bg-white/[0.03] px-2.5 py-2 md:px-4 md:py-3 text-[var(--text)] shadow-[0_8px_24px_rgba(0,0,0,0.28)]";
+  "w-fit max-w-full rounded-2xl border border-white/8 bg-white/[0.03] px-2.5 py-2 md:px-4 md:py-3 text-[var(--text)] shadow-[0_8px_24px_rgba(0,0,0,0.28)]";
 const ASSISTANT_LOADING_SHELL =
   "mt-[6px] inline-flex items-center overflow-hidden rounded-lg border border-white/5 bg-white/[0.015] px-2 py-1";
 
@@ -559,28 +608,6 @@ function formatPlainTextHtml(value: string) {
     .split(/\n{2,}/)
     .map((paragraph) => `<p>${escapeHtml(paragraph).replace(/\n/g, "<br />")}</p>`)
     .join("");
-}
-
-async function writeMessageToClipboard(input: { html: string; text: string }) {
-  if (typeof navigator === "undefined" || !navigator.clipboard) {
-    throw new Error("Clipboard unavailable");
-  }
-
-  if (
-    typeof ClipboardItem !== "undefined" &&
-    typeof navigator.clipboard.write === "function" &&
-    input.html
-  ) {
-    await navigator.clipboard.write([
-      new ClipboardItem({
-        "text/plain": new Blob([input.text], { type: "text/plain" }),
-        "text/html": new Blob([input.html], { type: "text/html" })
-      })
-    ]);
-    return;
-  }
-
-  await navigator.clipboard.writeText(input.text);
 }
 
 function ActionButton({
@@ -917,7 +944,7 @@ export function MessageBubble({
           ? assistantText
           : message.content;
 
-      await writeMessageToClipboard({ html, text });
+      await writeRichTextToClipboard({ html, text });
       setCopyFeedback("copied");
     } catch {
       setCopyFeedback("error");
@@ -1114,7 +1141,7 @@ export function MessageBubble({
                 </div>
               )
             ) : assistantBlocks.length || content ? (
-              <div className="group flex flex-col items-start">
+              <div className="group flex w-full min-w-0 flex-col items-start">
                 <div ref={contentRef} className={`flex w-full ${ASSISTANT_MAX_WIDTH} flex-col gap-3`}>
                   {assistantBlocks.map((item) => {
                     if (item.timelineKind === "action") {

--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -6,6 +6,7 @@ import ReactMarkdown from "react-markdown";
 import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
 
+import { AssistantCodeBlock } from "@/components/assistant-code-block";
 import {
   AttachmentPreviewModal,
   useAttachmentPreviewController
@@ -23,6 +24,33 @@ import { normalizeMarkdownLineBreaks } from "@/lib/text-utils";
 
 const MARKDOWN_PLUGINS = [remarkGfm, remarkBreaks];
 const COPY_RESET_DELAY_MS = 1600;
+
+function renderAssistantMarkdown(content: string) {
+  return (
+    <ReactMarkdown
+      remarkPlugins={MARKDOWN_PLUGINS}
+      components={{
+        code({ node: _node, className, children, ...props }) {
+          const value = String(children).replace(/\n$/, "");
+          const language = className?.match(/language-([\w-]+)/)?.[1] ?? null;
+          const isBlock = Boolean(className) || value.includes("\n");
+
+          if (!isBlock) {
+            return (
+              <code className={className} {...props}>
+                {children}
+              </code>
+            );
+          }
+
+          return <AssistantCodeBlock code={value} language={language} />;
+        }
+      }}
+    >
+      {content}
+    </ReactMarkdown>
+  );
+}
 
 function TypingIndicator({ compact = false }: { compact?: boolean }) {
   return (
@@ -1010,7 +1038,7 @@ export function MessageBubble({
                         data-testid="assistant-message-bubble"
                       >
                         <div className="markdown-body">
-                          <ReactMarkdown remarkPlugins={MARKDOWN_PLUGINS}>{item.content}</ReactMarkdown>
+                          {renderAssistantMarkdown(item.content)}
                         </div>
                       </div>
                     );

--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -25,37 +25,55 @@ import { normalizeMarkdownLineBreaks } from "@/lib/text-utils";
 const MARKDOWN_PLUGINS = [remarkGfm, remarkBreaks];
 const COPY_RESET_DELAY_MS = 1600;
 
+function getMarkdownCodeValue(children: React.ReactNode) {
+  return React.Children.toArray(children)
+    .map((child) => {
+      if (typeof child === "string" || typeof child === "number") {
+        return String(child);
+      }
+
+      return "";
+    })
+    .join("");
+}
+
 function renderAssistantMarkdown(content: string) {
   return (
     <ReactMarkdown
       remarkPlugins={MARKDOWN_PLUGINS}
       components={{
         pre({ children }) {
-          return <>{children}</>;
-        },
-        code({ node: _node, className, children, ...props }) {
-          const rawValue = String(children);
-          const value = rawValue.replace(/\n$/, "");
+          const codeChild = React.Children.toArray(children)[0];
+
+          if (!React.isValidElement(codeChild)) {
+            return <pre>{children}</pre>;
+          }
+
+          const typedCodeChild = codeChild as React.ReactElement<{
+            children?: React.ReactNode;
+            className?: string;
+          }>;
+          const className =
+            typeof typedCodeChild.props.className === "string"
+              ? typedCodeChild.props.className
+              : undefined;
           const languageClass = className
             ?.split(/\s+/)
-            .find((token) => token.startsWith("language-"));
+            .find((token: string) => token.startsWith("language-"));
           const language = languageClass
             ? languageClass.slice("language-".length)
             : null;
-          const isBlock =
-            Boolean(className) ||
-            rawValue.endsWith("\n") ||
-            value.includes("\n");
-
-          if (!isBlock) {
-            return (
-              <code className={className} {...props}>
-                {children}
-              </code>
-            );
-          }
+          const value = getMarkdownCodeValue(typedCodeChild.props.children ?? "").replace(/\n$/, "");
 
           return <AssistantCodeBlock code={value} language={language} />;
+        },
+        code({ node: _node, className, children, ...props }) {
+          const { inline: _inline, ...codeProps } = props as { inline?: boolean } & React.ComponentPropsWithoutRef<"code">;
+          return (
+            <code className={className} {...codeProps}>
+              {children}
+            </code>
+          );
         }
       }}
     >

--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -30,6 +30,9 @@ function renderAssistantMarkdown(content: string) {
     <ReactMarkdown
       remarkPlugins={MARKDOWN_PLUGINS}
       components={{
+        pre({ children }) {
+          return <>{children}</>;
+        },
         code({ node: _node, className, children, ...props }) {
           const rawValue = String(children);
           const value = rawValue.replace(/\n$/, "");

--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -858,7 +858,14 @@ export function MessageBubble({
   const copyResetHandle = useRef<number | null>(null);
   const showThinkingShell = !awaitingFirstToken && (thinkingInProgress || hasThinking || Boolean(thinkingContent));
   const showUserBubbleActions = Boolean(content) && !awaitingFirstToken;
-  const isAssistantStreaming = message.role === "assistant" && message.status === "streaming";
+  const isAssistantStreaming =
+    message.role === "assistant" &&
+    (
+      message.status === "streaming" ||
+      streamingTimeline !== undefined ||
+      streamingThinking !== undefined ||
+      streamingAnswer !== undefined
+    );
   const showAssistantBubbleActions =
     Boolean(assistantText) &&
     !awaitingFirstToken &&

--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -31,9 +31,13 @@ function renderAssistantMarkdown(content: string) {
       remarkPlugins={MARKDOWN_PLUGINS}
       components={{
         code({ node: _node, className, children, ...props }) {
-          const value = String(children).replace(/\n$/, "");
+          const rawValue = String(children);
+          const value = rawValue.replace(/\n$/, "");
           const language = className?.match(/language-([\w-]+)/)?.[1] ?? null;
-          const isBlock = Boolean(className) || value.includes("\n");
+          const isBlock =
+            Boolean(className) ||
+            rawValue.endsWith("\n") ||
+            value.includes("\n");
 
           if (!isBlock) {
             return (

--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -37,50 +37,66 @@ function getMarkdownCodeValue(children: React.ReactNode) {
     .join("");
 }
 
-function getFencedCodeBlockCompletionStates(content: string) {
-  const completionStates: boolean[] = [];
+function getFencedCodeBlockCopyReadyStates(content: string, isStreaming: boolean) {
+  const blocks: Array<{ endLineIndex: number | null }> = [];
   const lines = content.split("\n");
   let activeFenceCharacter: "`" | "~" | null = null;
   let activeFenceLength = 0;
 
-  for (const line of lines) {
+  lines.forEach((line, lineIndex) => {
     const trimmedLine = line.trim();
 
     if (!activeFenceCharacter) {
       const openingFence = trimmedLine.match(/^(`{3,}|~{3,})(.*)$/);
 
       if (!openingFence) {
-        continue;
+        return;
       }
 
       activeFenceCharacter = openingFence[1][0] as "`" | "~";
       activeFenceLength = openingFence[1].length;
-      completionStates.push(false);
-      continue;
+      blocks.push({ endLineIndex: null });
+      return;
     }
 
     const closingFence = trimmedLine.match(/^(`{3,}|~{3,})\s*$/);
 
     if (!closingFence) {
-      continue;
+      return;
     }
 
     const fenceToken = closingFence[1];
 
     if (fenceToken[0] !== activeFenceCharacter || fenceToken.length < activeFenceLength) {
-      continue;
+      return;
     }
 
-    completionStates[completionStates.length - 1] = true;
+    blocks[blocks.length - 1].endLineIndex = lineIndex;
     activeFenceCharacter = null;
     activeFenceLength = 0;
-  }
+  });
 
-  return completionStates;
+  return blocks.map((block) => {
+    if (block.endLineIndex === null) {
+      return false;
+    }
+
+    if (!isStreaming) {
+      return true;
+    }
+
+    return lines
+      .slice(block.endLineIndex + 1)
+      .some((line) => line.trim().length > 0);
+  });
 }
 
-function renderAssistantMarkdown(content: string) {
-  const fencedCodeBlockCompletionStates = getFencedCodeBlockCompletionStates(content);
+function hasIncompleteFencedCodeBlock(content: string, isStreaming: boolean) {
+  return getFencedCodeBlockCopyReadyStates(content, isStreaming).some((isReady) => !isReady);
+}
+
+function renderAssistantMarkdown(content: string, isStreaming: boolean) {
+  const fencedCodeBlockCopyReadyStates = getFencedCodeBlockCopyReadyStates(content, isStreaming);
   let fencedCodeBlockIndex = 0;
 
   return (
@@ -109,7 +125,7 @@ function renderAssistantMarkdown(content: string) {
             ? languageClass.slice("language-".length)
             : null;
           const value = getMarkdownCodeValue(typedCodeChild.props.children ?? "").replace(/\n$/, "");
-          const isComplete = fencedCodeBlockCompletionStates[fencedCodeBlockIndex] ?? true;
+          const isComplete = fencedCodeBlockCopyReadyStates[fencedCodeBlockIndex] ?? true;
 
           fencedCodeBlockIndex += 1;
 
@@ -842,7 +858,11 @@ export function MessageBubble({
   const copyResetHandle = useRef<number | null>(null);
   const showThinkingShell = !awaitingFirstToken && (thinkingInProgress || hasThinking || Boolean(thinkingContent));
   const showUserBubbleActions = Boolean(content) && !awaitingFirstToken;
-  const showAssistantBubbleActions = Boolean(assistantText) && !awaitingFirstToken;
+  const isAssistantStreaming = message.role === "assistant" && message.status === "streaming";
+  const showAssistantBubbleActions =
+    Boolean(assistantText) &&
+    !awaitingFirstToken &&
+    !hasIncompleteFencedCodeBlock(assistantText, isAssistantStreaming);
 
   useEffect(() => {
     setDraft(message.content);
@@ -1116,7 +1136,7 @@ export function MessageBubble({
                         data-testid="assistant-message-bubble"
                       >
                         <div className="markdown-body">
-                          {renderAssistantMarkdown(item.content)}
+                          {renderAssistantMarkdown(item.content, isAssistantStreaming)}
                         </div>
                       </div>
                     );

--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -37,7 +37,52 @@ function getMarkdownCodeValue(children: React.ReactNode) {
     .join("");
 }
 
+function getFencedCodeBlockCompletionStates(content: string) {
+  const completionStates: boolean[] = [];
+  const lines = content.split("\n");
+  let activeFenceCharacter: "`" | "~" | null = null;
+  let activeFenceLength = 0;
+
+  for (const line of lines) {
+    const trimmedLine = line.trim();
+
+    if (!activeFenceCharacter) {
+      const openingFence = trimmedLine.match(/^(`{3,}|~{3,})(.*)$/);
+
+      if (!openingFence) {
+        continue;
+      }
+
+      activeFenceCharacter = openingFence[1][0] as "`" | "~";
+      activeFenceLength = openingFence[1].length;
+      completionStates.push(false);
+      continue;
+    }
+
+    const closingFence = trimmedLine.match(/^(`{3,}|~{3,})\s*$/);
+
+    if (!closingFence) {
+      continue;
+    }
+
+    const fenceToken = closingFence[1];
+
+    if (fenceToken[0] !== activeFenceCharacter || fenceToken.length < activeFenceLength) {
+      continue;
+    }
+
+    completionStates[completionStates.length - 1] = true;
+    activeFenceCharacter = null;
+    activeFenceLength = 0;
+  }
+
+  return completionStates;
+}
+
 function renderAssistantMarkdown(content: string) {
+  const fencedCodeBlockCompletionStates = getFencedCodeBlockCompletionStates(content);
+  let fencedCodeBlockIndex = 0;
+
   return (
     <ReactMarkdown
       remarkPlugins={MARKDOWN_PLUGINS}
@@ -64,8 +109,11 @@ function renderAssistantMarkdown(content: string) {
             ? languageClass.slice("language-".length)
             : null;
           const value = getMarkdownCodeValue(typedCodeChild.props.children ?? "").replace(/\n$/, "");
+          const isComplete = fencedCodeBlockCompletionStates[fencedCodeBlockIndex] ?? true;
 
-          return <AssistantCodeBlock code={value} language={language} />;
+          fencedCodeBlockIndex += 1;
+
+          return <AssistantCodeBlock code={value} language={language} isComplete={isComplete} />;
         },
         code({ node: _node, className, children, ...props }) {
           const { inline: _inline, ...codeProps } = props as { inline?: boolean } & React.ComponentPropsWithoutRef<"code">;

--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -33,7 +33,12 @@ function renderAssistantMarkdown(content: string) {
         code({ node: _node, className, children, ...props }) {
           const rawValue = String(children);
           const value = rawValue.replace(/\n$/, "");
-          const language = className?.match(/language-([\w-]+)/)?.[1] ?? null;
+          const languageClass = className
+            ?.split(/\s+/)
+            .find((token) => token.startsWith("language-"));
+          const language = languageClass
+            ? languageClass.slice("language-".length)
+            : null;
           const isBlock =
             Boolean(className) ||
             rawValue.endsWith("\n") ||

--- a/docs/superpowers/plans/2026-04-14-codeblock-highlighting.md
+++ b/docs/superpowers/plans/2026-04-14-codeblock-highlighting.md
@@ -1,0 +1,647 @@
+# Assistant Code Block Highlighting Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add syntax-highlighted fenced code blocks with per-block copy controls in assistant answer bubbles, while leaving thinking bubbles unchanged.
+
+**Architecture:** Keep `ReactMarkdown` as the answer renderer in `components/message-bubble.tsx`, but route fenced multi-line code blocks through a dedicated `AssistantCodeBlock` component. Put language alias normalization, auto-detection, and safe highlighting into a focused helper so the renderer stays readable and unsupported languages degrade cleanly to plain code. Style the new block chrome in `app/globals.css` and keep the existing message-level copy button untouched.
+
+**Tech Stack:** React 19, Next.js 15, `react-markdown`, `remark-gfm`, `remark-breaks`, Vitest, Testing Library, `highlight.js`
+
+---
+
+## File Structure
+
+**Create:**
+
+- `lib/code-highlighting.ts`
+  Responsibility: normalize fence language aliases, auto-detect untagged snippets, and safely produce highlighted HTML or plain-text fallback metadata.
+- `components/assistant-code-block.tsx`
+  Responsibility: render one fenced assistant code block with compact header chrome, local copy state, and highlighted markup.
+- `tests/unit/code-highlighting.test.ts`
+  Responsibility: lock helper behavior for alias normalization, auto-detection, and unsupported-language fallback.
+
+**Modify:**
+
+- `components/message-bubble.tsx:3-25, 776-792, 983-1015`
+  Responsibility: keep existing message copy behavior, add custom markdown `code` renderer for assistant answer bubbles only, and leave thinking markdown unchanged.
+- `tests/unit/message-bubble.test.ts:3-8, 745-827`
+  Responsibility: add rendering and copy assertions for the new fenced-code path without regressing existing markdown behavior.
+- `app/globals.css:147-364`
+  Responsibility: add compact code-block chrome, hover/focus reveal rules, and scoped syntax token styling for the new assistant code block surface.
+- `package.json:18-44`
+  Responsibility: add the highlighting dependency used by the helper.
+
+## Task 1: Add A Testable Highlighting Helper
+
+**Files:**
+
+- Create: `tests/unit/code-highlighting.test.ts`
+- Create: `lib/code-highlighting.ts`
+- Modify: `package.json`
+
+- [ ] **Step 1: Write the failing helper tests**
+
+```ts
+// tests/unit/code-highlighting.test.ts
+import { describe, expect, it } from "vitest";
+
+import {
+  detectCodeLanguage,
+  normalizeCodeFenceLanguage,
+  renderHighlightedCode
+} from "@/lib/code-highlighting";
+
+describe("code highlighting helper", () => {
+  it("normalizes common fence aliases", () => {
+    expect(normalizeCodeFenceLanguage("py")).toBe("python");
+    expect(normalizeCodeFenceLanguage("ts")).toBe("typescript");
+    expect(normalizeCodeFenceLanguage("yml")).toBe("yaml");
+    expect(normalizeCodeFenceLanguage("zsh")).toBe("bash");
+  });
+
+  it("auto-detects an untagged SQL snippet", () => {
+    const detected = detectCodeLanguage("SELECT id, email FROM users WHERE active = 1;");
+
+    expect(detected).toBe("sql");
+  });
+
+  it("falls back to plain escaped code for unsupported declared languages", () => {
+    const result = renderHighlightedCode("customlang", "hello <world>");
+
+    expect(result.language).toBeNull();
+    expect(result.highlightedHtml).toContain("&lt;world&gt;");
+    expect(result.usedFallback).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run the helper test to verify it fails**
+
+Run: `npx vitest run tests/unit/code-highlighting.test.ts`
+
+Expected: FAIL with a module resolution error for `@/lib/code-highlighting` because the helper does not exist yet.
+
+- [ ] **Step 3: Add the highlighting dependency and implement the helper**
+
+```json
+// package.json
+{
+  "dependencies": {
+    "highlight.js": "^11.11.1"
+  }
+}
+```
+
+```ts
+// lib/code-highlighting.ts
+import hljs from "highlight.js/lib/core";
+import bash from "highlight.js/lib/languages/bash";
+import css from "highlight.js/lib/languages/css";
+import javascript from "highlight.js/lib/languages/javascript";
+import json from "highlight.js/lib/languages/json";
+import python from "highlight.js/lib/languages/python";
+import sql from "highlight.js/lib/languages/sql";
+import typescript from "highlight.js/lib/languages/typescript";
+import xml from "highlight.js/lib/languages/xml";
+import yaml from "highlight.js/lib/languages/yaml";
+
+hljs.registerLanguage("bash", bash);
+hljs.registerLanguage("css", css);
+hljs.registerLanguage("javascript", javascript);
+hljs.registerLanguage("json", json);
+hljs.registerLanguage("python", python);
+hljs.registerLanguage("sql", sql);
+hljs.registerLanguage("typescript", typescript);
+hljs.registerLanguage("xml", xml);
+hljs.registerLanguage("yaml", yaml);
+hljs.registerAliases(["js"], { languageName: "javascript" });
+hljs.registerAliases(["ts"], { languageName: "typescript" });
+hljs.registerAliases(["py"], { languageName: "python" });
+hljs.registerAliases(["yml"], { languageName: "yaml" });
+hljs.registerAliases(["zsh", "sh", "shell"], { languageName: "bash" });
+hljs.registerAliases(["html"], { languageName: "xml" });
+hljs.registerAliases(["tsx", "jsx"], { languageName: "javascript" });
+
+const LANGUAGE_ALIASES: Record<string, string> = {
+  html: "xml",
+  js: "javascript",
+  jsx: "javascript",
+  py: "python",
+  shell: "bash",
+  sh: "bash",
+  ts: "typescript",
+  tsx: "javascript",
+  yml: "yaml",
+  zsh: "bash"
+};
+
+function escapeHtml(value: string) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+export function normalizeCodeFenceLanguage(language: string | null | undefined) {
+  const normalized = language?.trim().toLowerCase();
+
+  if (!normalized) {
+    return null;
+  }
+
+  return LANGUAGE_ALIASES[normalized] ?? normalized;
+}
+
+export function detectCodeLanguage(code: string) {
+  const detected = hljs.highlightAuto(code);
+  return detected.language ?? null;
+}
+
+export function renderHighlightedCode(language: string | null | undefined, code: string) {
+  const normalizedLanguage = normalizeCodeFenceLanguage(language);
+
+  if (normalizedLanguage && hljs.getLanguage(normalizedLanguage)) {
+    return {
+      displayLanguage: normalizedLanguage,
+      highlightedHtml: hljs.highlight(code, { language: normalizedLanguage, ignoreIllegals: true }).value,
+      language: normalizedLanguage,
+      usedFallback: false
+    };
+  }
+
+  if (!normalizedLanguage) {
+    const detectedLanguage = detectCodeLanguage(code);
+
+    if (detectedLanguage) {
+      return {
+        displayLanguage: detectedLanguage,
+        highlightedHtml: hljs.highlight(code, { language: detectedLanguage, ignoreIllegals: true }).value,
+        language: detectedLanguage,
+        usedFallback: false
+      };
+    }
+  }
+
+  return {
+    displayLanguage: normalizedLanguage,
+    highlightedHtml: escapeHtml(code),
+    language: null,
+    usedFallback: true
+  };
+}
+```
+
+- [ ] **Step 4: Run the helper test to verify it passes**
+
+Run: `npx vitest run tests/unit/code-highlighting.test.ts`
+
+Expected: PASS with 3 passing tests in `tests/unit/code-highlighting.test.ts`.
+
+- [ ] **Step 5: Commit the helper slice**
+
+```bash
+git add package.json lib/code-highlighting.ts tests/unit/code-highlighting.test.ts
+git commit -m "feat: add assistant code highlighting helper"
+```
+
+## Task 2: Route Assistant Fenced Blocks Through A Dedicated Component
+
+**Files:**
+
+- Create: `components/assistant-code-block.tsx`
+- Modify: `components/message-bubble.tsx`
+- Modify: `tests/unit/message-bubble.test.ts`
+
+- [ ] **Step 1: Write the failing message-bubble tests for declared-language rendering and block copy**
+
+```ts
+// tests/unit/message-bubble.test.ts
+it("renders fenced assistant code blocks with a language label and block-local copy action", () => {
+  render(
+    React.createElement(MessageBubble, {
+      message: {
+        ...createAssistantMessage(),
+        content: ["```python", "print('hello')", "```"].join("\n")
+      }
+    })
+  );
+
+  expect(screen.getByTestId("assistant-code-block")).toBeInTheDocument();
+  expect(screen.getByText("python")).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: "Copy code block" })).toBeInTheDocument();
+});
+
+it("copies only the fenced code payload from the block action", async () => {
+  const writeText = vi.fn().mockResolvedValue(undefined);
+
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true
+  });
+  vi.stubGlobal("ClipboardItem", undefined);
+
+  render(
+    React.createElement(MessageBubble, {
+      message: {
+        ...createAssistantMessage(),
+        content: [
+          "Before",
+          "",
+          "```python",
+          "print('hello')",
+          "```",
+          "",
+          "After"
+        ].join("\n")
+      }
+    })
+  );
+
+  fireEvent.click(screen.getByRole("button", { name: "Copy code block" }));
+
+  await waitFor(() => {
+    expect(writeText).toHaveBeenCalledWith("print('hello')");
+  });
+});
+```
+
+- [ ] **Step 2: Run the message bubble test to verify it fails**
+
+Run: `npx vitest run tests/unit/message-bubble.test.ts -t "renders fenced assistant code blocks with a language label and block-local copy action|copies only the fenced code payload from the block action"`
+
+Expected: FAIL because the assistant markdown path still renders fenced code as a generic `pre code` block and there is no `Copy code block` action.
+
+- [ ] **Step 3: Create the dedicated code block component and wire it into assistant markdown only**
+
+```tsx
+// components/assistant-code-block.tsx
+"use client";
+
+import React, { useEffect, useRef, useState } from "react";
+import { Check, Copy, X } from "lucide-react";
+
+import { renderHighlightedCode } from "@/lib/code-highlighting";
+
+const COPY_RESET_DELAY_MS = 1600;
+
+export function AssistantCodeBlock({
+  code,
+  language
+}: {
+  code: string;
+  language?: string | null;
+}) {
+  const [copyState, setCopyState] = useState<"idle" | "copied" | "error">("idle");
+  const resetHandle = useRef<number | null>(null);
+  const result = renderHighlightedCode(language, code);
+
+  useEffect(() => {
+    return () => {
+      if (resetHandle.current) {
+        window.clearTimeout(resetHandle.current);
+      }
+    };
+  }, []);
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopyState("copied");
+    } catch {
+      setCopyState("error");
+    }
+
+    if (resetHandle.current) {
+      window.clearTimeout(resetHandle.current);
+    }
+
+    resetHandle.current = window.setTimeout(() => {
+      setCopyState("idle");
+      resetHandle.current = null;
+    }, COPY_RESET_DELAY_MS);
+  }
+
+  return (
+    <div className="assistant-code-block group" data-testid="assistant-code-block">
+      <div className="assistant-code-block__header">
+        {result.displayLanguage ? (
+          <span className="assistant-code-block__language">{result.displayLanguage}</span>
+        ) : <span />}
+        <button
+          type="button"
+          aria-label={copyState === "copied" ? "Copied code block" : "Copy code block"}
+          className="assistant-code-block__copy"
+          onClick={() => void handleCopy()}
+        >
+          {copyState === "copied" ? <Check className="h-3.5 w-3.5" /> : copyState === "error" ? <X className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+        </button>
+      </div>
+      <pre className="assistant-code-block__body">
+        <code
+          className={`hljs${result.language ? ` language-${result.language}` : ""}`}
+          dangerouslySetInnerHTML={{ __html: result.highlightedHtml }}
+        />
+      </pre>
+    </div>
+  );
+}
+```
+
+```tsx
+// components/message-bubble.tsx
+import { AssistantCodeBlock } from "@/components/assistant-code-block";
+
+function renderAssistantMarkdown(content: string) {
+  return (
+    <ReactMarkdown
+      remarkPlugins={MARKDOWN_PLUGINS}
+      components={{
+        code({ className, children, ...props }) {
+          const value = String(children).replace(/\n$/, "");
+          const language = className?.match(/language-([\w-]+)/)?.[1] ?? null;
+          const isBlock = Boolean(className) || value.includes("\n");
+
+          if (!isBlock) {
+            return (
+              <code className={className} {...props}>
+                {children}
+              </code>
+            );
+          }
+
+          return <AssistantCodeBlock code={value} language={language} />;
+        }
+      }}
+    >
+      {content}
+    </ReactMarkdown>
+  );
+}
+```
+
+```tsx
+// components/message-bubble.tsx, inside assistant answer bubble
+<div className="markdown-body">
+  {renderAssistantMarkdown(item.content)}
+</div>
+```
+
+- [ ] **Step 4: Run the message bubble tests to verify they pass**
+
+Run: `npx vitest run tests/unit/message-bubble.test.ts -t "renders fenced assistant code blocks with a language label and block-local copy action|copies only the fenced code payload from the block action"`
+
+Expected: PASS with both new tests green.
+
+- [ ] **Step 5: Commit the renderer slice**
+
+```bash
+git add components/assistant-code-block.tsx components/message-bubble.tsx tests/unit/message-bubble.test.ts
+git commit -m "feat: add assistant code block renderer"
+```
+
+## Task 3: Add Fallback Coverage, Scoped Styling, And Regression Checks
+
+**Files:**
+
+- Modify: `tests/unit/message-bubble.test.ts`
+- Modify: `app/globals.css`
+- Modify: `components/message-bubble.tsx`
+
+- [ ] **Step 1: Add the failing tests for untagged detection, unsupported fallback, and thinking isolation**
+
+```ts
+// tests/unit/message-bubble.test.ts
+it("auto-detects untagged assistant code blocks without changing the thinking bubble", () => {
+  const { container } = render(
+    React.createElement(MessageBubble, {
+      message: {
+        ...createAssistantMessage(),
+        content: ["```", "SELECT id,", "  email FROM users;", "```"].join("\n"),
+        thinkingContent: ["```", "SELECT thought FROM steps;", "```"].join("\n")
+      }
+    })
+  );
+
+  fireEvent.click(screen.getByRole("button", { name: /Thought/i }));
+
+  expect(screen.getByTestId("assistant-code-block")).toBeInTheDocument();
+  expect(screen.getByText("sql")).toBeInTheDocument();
+  expect(container.querySelector(".thinking-markdown-body .assistant-code-block")).toBeNull();
+});
+
+it("renders unsupported fenced languages as plain code without losing the block chrome", () => {
+  render(
+    React.createElement(MessageBubble, {
+      message: {
+        ...createAssistantMessage(),
+        content: ["```mermadeidon", "opaque => still visible", "```"].join("\n")
+      }
+    })
+  );
+
+  expect(screen.getByTestId("assistant-code-block")).toBeInTheDocument();
+  expect(screen.getByText("opaque => still visible")).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run the focused test set to verify it fails**
+
+Run: `npx vitest run tests/unit/message-bubble.test.ts -t "auto-detects untagged assistant code blocks without changing the thinking bubble|renders unsupported fenced languages as plain code without losing the block chrome"`
+
+Expected: FAIL because the current implementation has no scoped block chrome classes or reliable untagged fallback assertions yet.
+
+- [ ] **Step 3: Add scoped styles and finish fallback polish**
+
+```css
+/* app/globals.css */
+.assistant-code-block {
+  margin: 0.9rem 0;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 0.9rem;
+  background: rgba(9, 11, 18, 0.92);
+}
+
+.assistant-code-block__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 0.5rem 0.75rem;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.assistant-code-block__language {
+  font-size: 11px;
+  line-height: 1;
+  color: rgba(255, 255, 255, 0.56);
+  text-transform: lowercase;
+}
+
+.assistant-code-block__copy {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 1.75rem;
+  width: 1.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 0.5rem;
+  background: rgba(255, 255, 255, 0.02);
+  color: rgba(255, 255, 255, 0.4);
+  transition: border-color 120ms ease, background-color 120ms ease, color 120ms ease, opacity 120ms ease;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .assistant-code-block__copy {
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  .assistant-code-block:hover .assistant-code-block__copy,
+  .assistant-code-block:focus-within .assistant-code-block__copy {
+    opacity: 1;
+    pointer-events: auto;
+  }
+}
+
+.assistant-code-block__body {
+  margin: 0;
+  overflow-x: auto;
+  padding: 0.85rem 1rem;
+  background: transparent;
+}
+
+.assistant-code-block__body .hljs {
+  display: block;
+  overflow-x: auto;
+  background: transparent;
+  color: #e6edf3;
+}
+
+.assistant-code-block__body .hljs-keyword,
+.assistant-code-block__body .hljs-selector-tag,
+.assistant-code-block__body .hljs-built_in {
+  color: #ff7b72;
+}
+
+.assistant-code-block__body .hljs-string,
+.assistant-code-block__body .hljs-attr,
+.assistant-code-block__body .hljs-template-variable {
+  color: #a5d6ff;
+}
+
+.assistant-code-block__body .hljs-title,
+.assistant-code-block__body .hljs-function,
+.assistant-code-block__body .hljs-section {
+  color: #d2a8ff;
+}
+
+.assistant-code-block__body .hljs-number,
+.assistant-code-block__body .hljs-literal,
+.assistant-code-block__body .hljs-variable {
+  color: #79c0ff;
+}
+
+.assistant-code-block__body .hljs-comment,
+.assistant-code-block__body .hljs-quote {
+  color: #8b949e;
+}
+```
+
+```tsx
+// components/message-bubble.tsx, keep thinking untouched
+{thinkingOpen && thinkingContent ? (
+  <div className="markdown-body thinking-markdown-body mt-1.5">
+    <ReactMarkdown remarkPlugins={MARKDOWN_PLUGINS}>{thinkingContent}</ReactMarkdown>
+  </div>
+) : null}
+```
+
+- [ ] **Step 4: Run the targeted test files to verify they pass**
+
+Run: `npx vitest run tests/unit/code-highlighting.test.ts tests/unit/message-bubble.test.ts`
+
+Expected: PASS with the new helper and message-bubble assertions green.
+
+- [ ] **Step 5: Commit the styled fallback slice**
+
+```bash
+git add app/globals.css components/message-bubble.tsx tests/unit/message-bubble.test.ts
+git commit -m "feat: style assistant code blocks"
+```
+
+## Task 4: Run Full Verification And Browser Validation
+
+**Files:**
+
+- Reuse: `.dev-server` if present and healthy
+- Validate: browser screenshots saved to the temp directory created by `agent-browser`
+
+- [ ] **Step 1: Run lint**
+
+Run: `npm run lint`
+
+Expected: exit code 0 with no ESLint errors.
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `npm run typecheck`
+
+Expected: exit code 0 with no TypeScript errors.
+
+- [ ] **Step 3: Run the full test suite with coverage**
+
+Run: `npm test`
+
+Expected: exit code 0 and the repository coverage thresholds met.
+
+- [ ] **Step 4: Start or reuse the dev server for UI validation**
+
+Run:
+
+```bash
+if [ -f .dev-server ]; then
+  url=$(head -n 1 .dev-server)
+  curl -fsS "$url" >/dev/null || rm .dev-server
+fi
+
+if [ ! -f .dev-server ]; then
+  npm run dev >/tmp/eidon-dev.log 2>&1 &
+  while [ ! -f .dev-server ]; do sleep 1; done
+fi
+
+head -n 2 .dev-server
+```
+
+Expected: `.dev-server` contains a localhost URL and PID.
+
+- [ ] **Step 5: Validate the assistant code block UI in the browser**
+
+Run the required browser flow with `agent-browser`:
+
+```bash
+agent-browser open "$(head -n 1 .dev-server)" &&
+agent-browser wait --load networkidle &&
+agent-browser snapshot -i
+```
+
+Then:
+
+- navigate to a conversation that contains an assistant fenced code block, or create one using the app flow
+- confirm the assistant answer bubble shows syntax-highlighted code
+- confirm the copy button appears on hover/focus for desktop-sized viewport
+- confirm the thinking bubble still uses the old markdown rendering
+- take a screenshot with `agent-browser screenshot --full`
+
+- [ ] **Step 6: Commit any verification-driven fixups**
+
+```bash
+git add package.json app/globals.css components/message-bubble.tsx components/assistant-code-block.tsx lib/code-highlighting.ts tests/unit/code-highlighting.test.ts tests/unit/message-bubble.test.ts
+git commit -m "fix: polish assistant code block highlighting"
+```
+
+Skip this commit if verification finds no additional issues.

--- a/docs/superpowers/specs/2026-04-14-codeblock-highlighting-design.md
+++ b/docs/superpowers/specs/2026-04-14-codeblock-highlighting-design.md
@@ -1,0 +1,205 @@
+# Assistant Code Block Highlighting
+
+**Date:** 2026-04-14
+**Status:** Draft
+
+## Problem
+
+Assistant answer bubbles currently render fenced code blocks through the same generic markdown styles as the surrounding prose. That means code blocks are readable, but they are not syntax-highlighted by language and there is no way to copy only a single block without copying the entire assistant message.
+
+The goal is to improve code blocks inside assistant answer bubbles so they:
+
+- render with real syntax highlighting when possible
+- support many languages, not just the app stack
+- expose a compact block-local copy action
+- preserve the existing message-level copy behavior
+- leave the expanded thinking panel unchanged
+
+## Recommended Approach
+
+Keep the existing `ReactMarkdown` rendering path in [components/message-bubble.tsx](/Users/charles/conductor/workspaces/Eidon-AI/atlanta/components/message-bubble.tsx), but add a custom fenced-code renderer for assistant answer bubbles only.
+
+Use a dedicated `AssistantCodeBlock` component that owns:
+
+- fence language parsing and normalization
+- best-effort auto-detection when no language is declared
+- syntax-highlighted rendering for supported languages
+- graceful fallback to plain code for unsupported or ambiguous cases
+- a compact per-block copy button with local copied/error feedback
+
+Do not apply this renderer to the expanded thinking panel. Thinking content should continue using the existing compact markdown wrapper and generic markdown code treatment.
+
+## Rendering Architecture
+
+### Assistant answers
+
+Assistant answer bubbles should continue rendering through `ReactMarkdown`, but with a custom `components.code` renderer:
+
+- inline code spans continue using the existing markdown inline code styles
+- fenced multi-line blocks route to `AssistantCodeBlock`
+- prose, lists, tables, links, and all other markdown elements stay on the current rendering path
+
+This keeps the change isolated to assistant answer code blocks without forking the broader markdown system.
+
+### Thinking output
+
+The expanded thinking shell must remain unchanged:
+
+- no syntax highlighting
+- no code-block-local copy button
+- no new language label or code chrome
+
+This preserves the current distinction between primary answer output and quieter thinking content.
+
+## Code Block Behavior
+
+Each fenced code block in an assistant answer bubble should render inside a compact block container with two parts:
+
+1. A top bar
+2. The highlighted code body
+
+### Top bar
+
+The top bar should include:
+
+- a language label on the left when a declared or detected language is available
+- a compact copy button on the right
+
+The top bar should feel like part of the code block rather than a separate floating control. Keep spacing tight and visual treatment restrained so the block still fits the existing bubble design.
+
+### Copy interaction
+
+The copy button should:
+
+- copy only the raw code content of that fenced block
+- exclude the backticks, language fence label, and surrounding answer text
+- follow the same feedback model as the existing message copy action
+- briefly show copied or error state after interaction
+
+Visibility rules should match the current message action behavior:
+
+- desktop: reveal on hover and focus within the block group
+- mobile and non-hover environments: keep the control visible
+
+The existing message-level copy button must remain unchanged and continue copying the full assistant answer text.
+
+## Language Resolution
+
+### Declared language
+
+If the markdown fence declares a language, use it first.
+
+Normalize common aliases before passing them into the highlighter so the UI behaves consistently for frequent model outputs. This should include common mappings such as:
+
+- `js` -> `javascript`
+- `ts` -> `typescript`
+- `py` -> `python`
+- `sh` or `zsh` -> `bash` or shell-compatible highlighting
+- `yml` -> `yaml`
+
+The displayed label can remain compact and human-readable, such as `tsx`, `python`, or `sql`.
+
+### Auto-detection
+
+If no language is declared, attempt best-effort auto-detection across the supported language set.
+
+Auto-detection should only affect the rendering choice for that block. It should not change the source markdown, store metadata, or mutate message content.
+
+### Fallback behavior
+
+If the declared language is unsupported, or auto-detection is weak or unavailable:
+
+- render the code block as plain text code
+- keep the same code block chrome and copy button
+- do not throw or break rendering
+
+Unknown languages must degrade gracefully instead of failing the message render path.
+
+## Styling Direction
+
+The code block should feel like a natural extension of the current dark assistant bubble styling:
+
+- compact top bar with subtle separation from the code body
+- dark background with readable contrast
+- restrained border and radius values consistent with the rest of the chat UI
+- token colors driven by the syntax theme rather than extra decorative UI
+
+Do not:
+
+- add large floating shells
+- add oversized rounded corners
+- add decorative badges or extra labels
+- restyle the whole markdown surface around the code block
+
+The change should improve scanability and utility, not create a new visual subsystem.
+
+## Scope
+
+In scope:
+
+- custom fenced-code rendering for assistant answer bubbles
+- syntax highlighting for supported languages
+- best-effort auto-detection for untagged fenced blocks
+- per-block copy button for fenced multi-line code blocks
+- supporting styles and tests
+
+Out of scope:
+
+- changing inline code behavior
+- changing the expanded thinking panel
+- changing tool output log styling
+- changing the existing message-level copy action
+- rewriting the overall markdown system
+
+## Testing
+
+Follow TDD for the behavior change in [tests/unit/message-bubble.test.ts](/Users/charles/conductor/workspaces/Eidon-AI/atlanta/tests/unit/message-bubble.test.ts).
+
+Coverage should include:
+
+- fenced assistant code blocks rendering through the custom block renderer
+- declared language labels rendering correctly
+- untagged blocks taking the auto-detect path without breaking
+- unsupported or unknown languages degrading to plain code rendering
+- block copy writing only the code content for that block
+- thinking markdown remaining unchanged
+- message-level copy continuing to work
+
+After implementation:
+
+- run targeted unit tests first
+- run the full test suite with coverage
+- verify any required typecheck or lint commands
+- validate the UI in the browser
+- capture a screenshot of the updated assistant answer bubble with highlighted code
+- verify the per-block copy interaction in the browser
+
+## Risks And Mitigations
+
+### Bundle growth
+
+Real syntax highlighting and auto-detection can increase client bundle weight.
+
+Mitigation:
+
+- choose a highlighting path with broad language support but controlled footprint
+- keep the custom renderer scoped to fenced assistant blocks only
+
+### Detection ambiguity
+
+Auto-detection can guess incorrectly for short or generic snippets.
+
+Mitigation:
+
+- prefer declared fence languages over detection
+- fall back to plain text rendering when confidence or support is weak
+
+### UI clutter
+
+Adding another copy control risks visual noise inside already dense message bubbles.
+
+Mitigation:
+
+- keep the button small
+- match existing hover/focus behavior
+- avoid extra helper text or ornamental chrome

--- a/lib/clipboard.ts
+++ b/lib/clipboard.ts
@@ -1,0 +1,88 @@
+"use client";
+
+function prefersLegacyCopyGesture() {
+  if (typeof navigator === "undefined") {
+    return false;
+  }
+
+  const userAgent = navigator.userAgent ?? "";
+  const maxTouchPoints = navigator.maxTouchPoints ?? 0;
+  const isiPhoneOrIPod = /iPhone|iPod/i.test(userAgent);
+  const isiPad = /iPad/i.test(userAgent);
+  const isIPadDesktopMode = /Macintosh/i.test(userAgent) && maxTouchPoints > 1;
+
+  return isiPhoneOrIPod || isiPad || isIPadDesktopMode;
+}
+
+function legacyWriteTextToClipboard(text: string) {
+  if (typeof document === "undefined") {
+    throw new Error("Clipboard unavailable");
+  }
+
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.top = "0";
+  textarea.style.left = "0";
+  textarea.style.opacity = "0";
+  textarea.style.pointerEvents = "none";
+
+  document.body.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+  textarea.setSelectionRange(0, text.length);
+
+  try {
+    if (typeof document.execCommand !== "function" || !document.execCommand("copy")) {
+      throw new Error("Clipboard unavailable");
+    }
+  } finally {
+    textarea.remove();
+  }
+}
+
+export async function writeTextToClipboard(text: string) {
+  if (prefersLegacyCopyGesture()) {
+    try {
+      legacyWriteTextToClipboard(text);
+      return;
+    } catch {}
+  }
+
+  try {
+    if (typeof navigator === "undefined" || !navigator.clipboard) {
+      throw new Error("Clipboard unavailable");
+    }
+
+    await navigator.clipboard.writeText(text);
+  } catch {
+    legacyWriteTextToClipboard(text);
+  }
+}
+
+export async function writeRichTextToClipboard(input: { html: string; text: string }) {
+  try {
+    if (typeof navigator === "undefined" || !navigator.clipboard) {
+      throw new Error("Clipboard unavailable");
+    }
+
+    if (
+      typeof ClipboardItem !== "undefined" &&
+      typeof navigator.clipboard.write === "function" &&
+      input.html
+    ) {
+      await navigator.clipboard.write([
+        new ClipboardItem({
+          "text/plain": new Blob([input.text], { type: "text/plain" }),
+          "text/html": new Blob([input.html], { type: "text/html" })
+        })
+      ]);
+      return;
+    }
+
+    await navigator.clipboard.writeText(input.text);
+  } catch {
+    legacyWriteTextToClipboard(input.text);
+  }
+}

--- a/lib/code-highlighting.ts
+++ b/lib/code-highlighting.ts
@@ -42,7 +42,11 @@ const HTML_ESCAPE_MAP: Record<string, string> = {
   "'": "&#39;"
 };
 
-const AUTO_DETECT_MIN_RELEVANCE = 3;
+const AUTO_DETECT_MIN_RELEVANCE: Record<string, number> = {
+  bash: 1,
+  sql: 2,
+  yaml: 3
+};
 
 const highlighter = createHighlighter();
 
@@ -73,7 +77,7 @@ export function detectCodeLanguage(code: string): string | null {
 
   if (
     !normalizedLanguage ||
-    detection.relevance < AUTO_DETECT_MIN_RELEVANCE ||
+    detection.relevance < getAutoDetectMinRelevance(normalizedLanguage) ||
     isAmbiguousAutoDetection(detection) ||
     !isSupportedAutoDetection(normalizedLanguage, code)
   ) {
@@ -198,11 +202,18 @@ function isSqlLike(code: string) {
 }
 
 function isYamlLike(code: string) {
-  const lines = code.split("\n").map((line) => line.trim()).filter(Boolean);
+  const lines = code
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith("#"));
 
   if (lines.length < 2) {
     return false;
   }
 
   return lines.every((line) => /^(?:-\s+)?[a-z0-9_-]+\s*:/.test(line));
+}
+
+function getAutoDetectMinRelevance(language: string) {
+  return AUTO_DETECT_MIN_RELEVANCE[language] ?? 3;
 }

--- a/lib/code-highlighting.ts
+++ b/lib/code-highlighting.ts
@@ -42,9 +42,12 @@ const HTML_ESCAPE_MAP: Record<string, string> = {
   "'": "&#39;"
 };
 
+const AUTO_DETECT_MIN_RELEVANCE = 3;
+
 const highlighter = createHighlighter();
 
 export type HighlightedCodeResult = {
+  displayLanguage: string | null;
   html: string;
   language: string | null;
   usedFallback: boolean;
@@ -65,9 +68,13 @@ export function normalizeCodeFenceLanguage(language?: string | null): string | n
 }
 
 export function detectCodeLanguage(code: string): string | null {
-  const detectedLanguage = highlighter.highlightAuto(code, [...REGISTERED_LANGUAGES]).language;
+  const detection = highlighter.highlightAuto(code, [...REGISTERED_LANGUAGES]);
 
-  return normalizeCodeFenceLanguage(detectedLanguage);
+  if (detection.relevance < AUTO_DETECT_MIN_RELEVANCE) {
+    return null;
+  }
+
+  return normalizeCodeFenceLanguage(detection.language);
 }
 
 export function renderHighlightedCode(language: string | null | undefined, code: string): HighlightedCodeResult {
@@ -75,19 +82,19 @@ export function renderHighlightedCode(language: string | null | undefined, code:
 
   if (normalizedLanguage) {
     if (!highlighter.getLanguage(normalizedLanguage)) {
-      return createFallbackResult(code);
+      return createFallbackResult(code, normalizedLanguage);
     }
 
-    return highlightCode(normalizedLanguage, code);
+    return highlightCode(normalizedLanguage, code, normalizedLanguage);
   }
 
   const detectedLanguage = detectCodeLanguage(code);
 
   if (!detectedLanguage) {
-    return createFallbackResult(code);
+    return createFallbackResult(code, null);
   }
 
-  return highlightCode(detectedLanguage, code);
+  return highlightCode(detectedLanguage, code, detectedLanguage);
 }
 
 function createHighlighter() {
@@ -103,32 +110,29 @@ function createHighlighter() {
   instance.registerLanguage("xml", xml);
   instance.registerLanguage("yaml", yaml);
 
-  instance.registerAliases(["js"], { languageName: "javascript" });
-  instance.registerAliases(["jsx"], { languageName: "javascript" });
-  instance.registerAliases(["py"], { languageName: "python" });
-  instance.registerAliases(["sh", "shell", "zsh"], { languageName: "bash" });
-  instance.registerAliases(["ts"], { languageName: "typescript" });
-  instance.registerAliases(["tsx"], { languageName: "typescript" });
-  instance.registerAliases(["html"], { languageName: "xml" });
-  instance.registerAliases(["yml"], { languageName: "yaml" });
+  for (const [languageName, aliases] of Object.entries(groupAliasesByLanguage())) {
+    instance.registerAliases(aliases, { languageName });
+  }
 
   return instance;
 }
 
-function highlightCode(language: string, code: string): HighlightedCodeResult {
+function highlightCode(language: string, code: string, displayLanguage: string): HighlightedCodeResult {
   try {
     return {
+      displayLanguage,
       language,
       html: highlighter.highlight(code, { ignoreIllegals: true, language }).value,
       usedFallback: false
     };
   } catch {
-    return createFallbackResult(code);
+    return createFallbackResult(code, displayLanguage);
   }
 }
 
-function createFallbackResult(code: string): HighlightedCodeResult {
+function createFallbackResult(code: string, displayLanguage: string | null): HighlightedCodeResult {
   return {
+    displayLanguage,
     html: escapeHtml(code),
     language: null,
     usedFallback: true
@@ -137,4 +141,15 @@ function createFallbackResult(code: string): HighlightedCodeResult {
 
 function escapeHtml(value: string): string {
   return value.replace(/[&<>"']/g, (character) => HTML_ESCAPE_MAP[character]);
+}
+
+function groupAliasesByLanguage() {
+  const aliasesByLanguage: Record<string, string[]> = {};
+
+  for (const [alias, language] of Object.entries(LANGUAGE_ALIASES)) {
+    aliasesByLanguage[language] ??= [];
+    aliasesByLanguage[language].push(alias);
+  }
+
+  return aliasesByLanguage;
 }

--- a/lib/code-highlighting.ts
+++ b/lib/code-highlighting.ts
@@ -1,0 +1,140 @@
+import hljs from "highlight.js/lib/core";
+import bash from "highlight.js/lib/languages/bash";
+import css from "highlight.js/lib/languages/css";
+import javascript from "highlight.js/lib/languages/javascript";
+import json from "highlight.js/lib/languages/json";
+import python from "highlight.js/lib/languages/python";
+import sql from "highlight.js/lib/languages/sql";
+import typescript from "highlight.js/lib/languages/typescript";
+import xml from "highlight.js/lib/languages/xml";
+import yaml from "highlight.js/lib/languages/yaml";
+
+const REGISTERED_LANGUAGES = [
+  "bash",
+  "css",
+  "javascript",
+  "json",
+  "python",
+  "sql",
+  "typescript",
+  "xml",
+  "yaml"
+] as const;
+
+const LANGUAGE_ALIASES: Record<string, (typeof REGISTERED_LANGUAGES)[number]> = {
+  html: "xml",
+  js: "javascript",
+  jsx: "javascript",
+  py: "python",
+  sh: "bash",
+  shell: "bash",
+  ts: "typescript",
+  tsx: "typescript",
+  yml: "yaml",
+  zsh: "bash"
+};
+
+const HTML_ESCAPE_MAP: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&#39;"
+};
+
+const highlighter = createHighlighter();
+
+export type HighlightedCodeResult = {
+  html: string;
+  language: string | null;
+  usedFallback: boolean;
+};
+
+export function normalizeCodeFenceLanguage(language?: string | null): string | null {
+  if (typeof language !== "string") {
+    return null;
+  }
+
+  const normalized = language.trim().toLowerCase();
+
+  if (!normalized) {
+    return null;
+  }
+
+  return LANGUAGE_ALIASES[normalized] ?? normalized;
+}
+
+export function detectCodeLanguage(code: string): string | null {
+  const detectedLanguage = highlighter.highlightAuto(code, [...REGISTERED_LANGUAGES]).language;
+
+  return normalizeCodeFenceLanguage(detectedLanguage);
+}
+
+export function renderHighlightedCode(language: string | null | undefined, code: string): HighlightedCodeResult {
+  const normalizedLanguage = normalizeCodeFenceLanguage(language);
+
+  if (normalizedLanguage) {
+    if (!highlighter.getLanguage(normalizedLanguage)) {
+      return createFallbackResult(code);
+    }
+
+    return highlightCode(normalizedLanguage, code);
+  }
+
+  const detectedLanguage = detectCodeLanguage(code);
+
+  if (!detectedLanguage) {
+    return createFallbackResult(code);
+  }
+
+  return highlightCode(detectedLanguage, code);
+}
+
+function createHighlighter() {
+  const instance = hljs.newInstance();
+
+  instance.registerLanguage("bash", bash);
+  instance.registerLanguage("css", css);
+  instance.registerLanguage("javascript", javascript);
+  instance.registerLanguage("json", json);
+  instance.registerLanguage("python", python);
+  instance.registerLanguage("sql", sql);
+  instance.registerLanguage("typescript", typescript);
+  instance.registerLanguage("xml", xml);
+  instance.registerLanguage("yaml", yaml);
+
+  instance.registerAliases(["js"], { languageName: "javascript" });
+  instance.registerAliases(["jsx"], { languageName: "javascript" });
+  instance.registerAliases(["py"], { languageName: "python" });
+  instance.registerAliases(["sh", "shell", "zsh"], { languageName: "bash" });
+  instance.registerAliases(["ts"], { languageName: "typescript" });
+  instance.registerAliases(["tsx"], { languageName: "typescript" });
+  instance.registerAliases(["html"], { languageName: "xml" });
+  instance.registerAliases(["yml"], { languageName: "yaml" });
+
+  return instance;
+}
+
+function highlightCode(language: string, code: string): HighlightedCodeResult {
+  try {
+    return {
+      language,
+      html: highlighter.highlight(code, { ignoreIllegals: true, language }).value,
+      usedFallback: false
+    };
+  } catch {
+    return createFallbackResult(code);
+  }
+}
+
+function createFallbackResult(code: string): HighlightedCodeResult {
+  return {
+    html: escapeHtml(code),
+    language: null,
+    usedFallback: true
+  };
+}
+
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, (character) => HTML_ESCAPE_MAP[character]);
+}

--- a/lib/code-highlighting.ts
+++ b/lib/code-highlighting.ts
@@ -69,12 +69,18 @@ export function normalizeCodeFenceLanguage(language?: string | null): string | n
 
 export function detectCodeLanguage(code: string): string | null {
   const detection = highlighter.highlightAuto(code, [...REGISTERED_LANGUAGES]);
+  const normalizedLanguage = normalizeCodeFenceLanguage(detection.language);
 
-  if (detection.relevance < AUTO_DETECT_MIN_RELEVANCE) {
+  if (
+    !normalizedLanguage ||
+    detection.relevance < AUTO_DETECT_MIN_RELEVANCE ||
+    isAmbiguousAutoDetection(detection) ||
+    !isSupportedAutoDetection(normalizedLanguage, code)
+  ) {
     return null;
   }
 
-  return normalizeCodeFenceLanguage(detection.language);
+  return normalizedLanguage;
 }
 
 export function renderHighlightedCode(language: string | null | undefined, code: string): HighlightedCodeResult {
@@ -152,4 +158,51 @@ function groupAliasesByLanguage() {
   }
 
   return aliasesByLanguage;
+}
+
+function isAmbiguousAutoDetection(detection: { relevance: number; secondBest?: { relevance: number } | undefined }) {
+  return detection.secondBest?.relevance === detection.relevance;
+}
+
+function isSupportedAutoDetection(language: string, code: string) {
+  switch (language) {
+    case "bash":
+      return isBashLike(code);
+    case "css":
+      return isCssLike(code);
+    case "sql":
+      return isSqlLike(code);
+    case "yaml":
+      return isYamlLike(code);
+    default:
+      return true;
+  }
+}
+
+function isBashLike(code: string) {
+  return /(^|\n)\s*(\$|#!\/|(?:[A-Za-z_][\w-]*=)|(?:echo|cat|grep|curl|wget|npm|pnpm|yarn|git|cd|ls|mkdir|rm|cp|mv|node|python|bash|sh|zsh)\b)/.test(
+    code
+  ) || /(?:\|\||&&|>>?|<<|`)/.test(code);
+}
+
+function isCssLike(code: string) {
+  return /[{}]/.test(code) || /(^|\n)\s*[.#@a-zA-Z][^{}\n]*:\s*[^;\n]+;/.test(code);
+}
+
+function isSqlLike(code: string) {
+  const keywordMatches = code.match(
+    /\b(select|from|where|join|insert|into|values|update|set|delete|create|table|alter|drop|with|group\s+by|order\s+by|having|limit)\b/gi
+  );
+
+  return new Set(keywordMatches?.map((match) => match.toLowerCase()) ?? []).size >= 2;
+}
+
+function isYamlLike(code: string) {
+  const lines = code.split("\n").map((line) => line.trim()).filter(Boolean);
+
+  if (lines.length < 2) {
+    return false;
+  }
+
+  return lines.every((line) => /^(?:-\s+)?[a-z0-9_-]+\s*:/.test(line));
 }

--- a/lib/code-highlighting.ts
+++ b/lib/code-highlighting.ts
@@ -72,9 +72,16 @@ export function normalizeCodeFenceLanguage(language?: string | null): string | n
 }
 
 export function detectCodeLanguage(code: string): string | null {
+  const patternLanguage = detectPatternLanguage(code);
+
+  if (patternLanguage) {
+    return patternLanguage;
+  }
+
   const detection = highlighter.highlightAuto(code, [...REGISTERED_LANGUAGES]);
   const normalizedLanguage = normalizeCodeFenceLanguage(detection.language);
 
+  // highlightAuto is intentionally filtered here because plain prose often scores as a language.
   if (
     !normalizedLanguage ||
     detection.relevance < getAutoDetectMinRelevance(normalizedLanguage) ||
@@ -202,18 +209,54 @@ function isSqlLike(code: string) {
 }
 
 function isYamlLike(code: string) {
-  const lines = code
-    .split("\n")
+  const lines = code.split("\n");
+  const contentLines = lines
     .map((line) => line.trim())
     .filter((line) => line.length > 0 && !line.startsWith("#"));
 
-  if (lines.length < 2) {
+  if (contentLines.length < 2) {
     return false;
   }
 
-  return lines.every((line) => /^(?:-\s+)?[a-z0-9_-]+\s*:/.test(line));
+  if (!contentLines.every((line) => /^(?:-\s+)?[A-Za-z0-9_-]+\s*:/.test(line))) {
+    return false;
+  }
+
+  const hasYamlStructure = lines.some((line) => /^\s+/.test(line)) || lines.some((line) => line.trim().startsWith("#"));
+
+  if (hasYamlStructure) {
+    return true;
+  }
+
+  const keys = contentLines
+    .map((line) => line.match(/^(?:-\s+)?([A-Za-z0-9_-]+)\s*:/)?.[1]?.toLowerCase())
+    .filter((key): key is string => Boolean(key));
+
+  return !keys.every((key) => COMMON_LABEL_LIKE_YAML_KEYS.has(key));
 }
 
 function getAutoDetectMinRelevance(language: string) {
   return AUTO_DETECT_MIN_RELEVANCE[language] ?? 3;
 }
+
+function detectPatternLanguage(code: string) {
+  if (isLikelySqlSnippet(code)) {
+    return "sql";
+  }
+
+  if (isLikelyBashSnippet(code)) {
+    return "bash";
+  }
+
+  return null;
+}
+
+function isLikelySqlSnippet(code: string) {
+  return /^(?:\s*)(select\b.+\bfrom\b|update\b.+\bset\b|delete\b.+\bfrom\b|insert\b.+\binto\b)/i.test(code.trim());
+}
+
+function isLikelyBashSnippet(code: string) {
+  return /^\s*(?:git|npm|pnpm|yarn|curl|wget|node|python|bash|sh|zsh)\b/.test(code.trim());
+}
+
+const COMMON_LABEL_LIKE_YAML_KEYS = new Set(["name", "role", "status", "title", "email", "phone", "user"]);

--- a/lib/code-highlighting.ts
+++ b/lib/code-highlighting.ts
@@ -201,11 +201,7 @@ function isCssLike(code: string) {
 }
 
 function isSqlLike(code: string) {
-  const keywordMatches = code.match(
-    /\b(select|from|where|join|insert|into|values|update|set|delete|create|table|alter|drop|with|group\s+by|order\s+by|having|limit)\b/gi
-  );
-
-  return new Set(keywordMatches?.map((match) => match.toLowerCase()) ?? []).size >= 2;
+  return matchesSqlStatement(code.trim());
 }
 
 function isYamlLike(code: string) {
@@ -252,7 +248,7 @@ function detectPatternLanguage(code: string) {
 }
 
 function isLikelySqlSnippet(code: string) {
-  return /^(?:\s*)(select\b.+\bfrom\b|update\b.+\bset\b|delete\b.+\bfrom\b|insert\b.+\binto\b)/i.test(code.trim());
+  return matchesSqlStatement(code.trim());
 }
 
 function isLikelyBashSnippet(code: string) {
@@ -260,3 +256,27 @@ function isLikelyBashSnippet(code: string) {
 }
 
 const COMMON_LABEL_LIKE_YAML_KEYS = new Set(["name", "role", "status", "title", "email", "phone", "user"]);
+
+function matchesSqlStatement(code: string) {
+  return matchesSelectStatement(code) || matchesUpdateStatement(code) || matchesDeleteStatement(code) || matchesInsertStatement(code);
+}
+
+function matchesSelectStatement(code: string) {
+  const match = code.match(
+    /^select\s+([A-Za-z_][\w.]*|\*)(?:\s*,\s*([A-Za-z_][\w.]*|\*))*\s+from\s+([A-Za-z_][\w.]*)(?:\s+(where|join|group\s+by|order\s+by|limit)\b.*)?;?$/i
+  );
+
+  return Boolean(match);
+}
+
+function matchesUpdateStatement(code: string) {
+  return /^update\s+[A-Za-z_][\w.]*\s+set\s+[A-Za-z_][\w.]*\s*=.+$/i.test(code);
+}
+
+function matchesDeleteStatement(code: string) {
+  return /^delete\s+from\s+[A-Za-z_][\w.]*?(?:\s+where\b.+)?;?$/i.test(code);
+}
+
+function matchesInsertStatement(code: string) {
+  return /^insert\s+into\s+[A-Za-z_][\w.]*\s*(?:\([^)]*\))?\s+values\s*\(.+\);?$/i.test(code);
+}

--- a/lib/code-highlighting.ts
+++ b/lib/code-highlighting.ts
@@ -96,13 +96,14 @@ export function detectCodeLanguage(code: string): string | null {
 
 export function renderHighlightedCode(language: string | null | undefined, code: string): HighlightedCodeResult {
   const normalizedLanguage = normalizeCodeFenceLanguage(language);
+  const explicitDisplayLanguage = getExplicitDisplayLanguage(language);
 
   if (normalizedLanguage) {
     if (!highlighter.getLanguage(normalizedLanguage)) {
-      return createFallbackResult(code, normalizedLanguage);
+      return createFallbackResult(code, explicitDisplayLanguage ?? normalizedLanguage);
     }
 
-    return highlightCode(normalizedLanguage, code, normalizedLanguage);
+    return highlightCode(normalizedLanguage, code, explicitDisplayLanguage ?? normalizedLanguage);
   }
 
   const detectedLanguage = detectCodeLanguage(code);
@@ -158,6 +159,16 @@ function createFallbackResult(code: string, displayLanguage: string | null): Hig
 
 function escapeHtml(value: string): string {
   return value.replace(/[&<>"']/g, (character) => HTML_ESCAPE_MAP[character]);
+}
+
+function getExplicitDisplayLanguage(language?: string | null) {
+  if (typeof language !== "string") {
+    return null;
+  }
+
+  const trimmedLanguage = language.trim();
+
+  return trimmedLanguage || null;
 }
 
 function groupAliasesByLanguage() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "clsx": "^2.1.1",
         "framer-motion": "^12.38.0",
         "gpt-tokenizer": "^3.4.0",
+        "highlight.js": "^11.11.1",
         "jose": "^6.0.8",
         "lucide-react": "^0.511.0",
         "next": "15.5.14",
@@ -6699,6 +6700,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/hono": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "clsx": "^2.1.1",
     "framer-motion": "^12.38.0",
     "gpt-tokenizer": "^3.4.0",
+    "highlight.js": "^11.11.1",
     "jose": "^6.0.8",
     "lucide-react": "^0.511.0",
     "next": "15.5.14",

--- a/tests/unit/clipboard.test.ts
+++ b/tests/unit/clipboard.test.ts
@@ -1,0 +1,191 @@
+// @vitest-environment jsdom
+
+import { writeRichTextToClipboard, writeTextToClipboard } from "@/lib/clipboard";
+
+describe("clipboard helpers", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("prefers the synchronous legacy copy path on iPhone-class devices", async () => {
+    const execCommand = vi.fn().mockReturnValue(true);
+    const writeText = vi.fn().mockResolvedValue(undefined);
+
+    Object.defineProperty(document, "execCommand", {
+      value: execCommand,
+      configurable: true
+    });
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true
+    });
+    Object.defineProperty(navigator, "userAgent", {
+      value: "Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1",
+      configurable: true
+    });
+    Object.defineProperty(navigator, "maxTouchPoints", {
+      value: 5,
+      configurable: true
+    });
+
+    await writeTextToClipboard("print('hello')");
+
+    expect(execCommand).toHaveBeenCalledWith("copy");
+    expect(writeText).not.toHaveBeenCalled();
+  });
+
+  it("uses navigator.clipboard.writeText on non-iPhone browsers", async () => {
+    const execCommand = vi.fn().mockReturnValue(true);
+    const writeText = vi.fn().mockResolvedValue(undefined);
+
+    Object.defineProperty(document, "execCommand", {
+      value: execCommand,
+      configurable: true
+    });
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true
+    });
+    Object.defineProperty(navigator, "userAgent", {
+      value: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
+      configurable: true
+    });
+    Object.defineProperty(navigator, "maxTouchPoints", {
+      value: 0,
+      configurable: true
+    });
+
+    await writeTextToClipboard("print('hello')");
+
+    expect(writeText).toHaveBeenCalledWith("print('hello')");
+    expect(execCommand).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the legacy path when writeText rejects on non-iPhone browsers", async () => {
+    const execCommand = vi.fn().mockReturnValue(true);
+    const writeText = vi.fn().mockRejectedValue(new Error("denied"));
+
+    Object.defineProperty(document, "execCommand", {
+      value: execCommand,
+      configurable: true
+    });
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true
+    });
+    Object.defineProperty(navigator, "userAgent", {
+      value: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
+      configurable: true
+    });
+    Object.defineProperty(navigator, "maxTouchPoints", {
+      value: 0,
+      configurable: true
+    });
+
+    await writeTextToClipboard("print('hello')");
+
+    expect(writeText).toHaveBeenCalledWith("print('hello')");
+    expect(execCommand).toHaveBeenCalledWith("copy");
+  });
+
+  it("uses rich clipboard writes when html copy is available on non-iPhone browsers", async () => {
+    const execCommand = vi.fn().mockReturnValue(true);
+    const write = vi.fn().mockResolvedValue(undefined);
+
+    class MockClipboardItem {
+      constructor(public items: Record<string, Blob>) {}
+    }
+
+    Object.defineProperty(document, "execCommand", {
+      value: execCommand,
+      configurable: true
+    });
+    Object.defineProperty(navigator, "clipboard", {
+      value: { write, writeText: vi.fn() },
+      configurable: true
+    });
+    Object.defineProperty(navigator, "userAgent", {
+      value: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
+      configurable: true
+    });
+    Object.defineProperty(navigator, "maxTouchPoints", {
+      value: 0,
+      configurable: true
+    });
+    vi.stubGlobal("ClipboardItem", MockClipboardItem as unknown as typeof ClipboardItem);
+
+    await writeRichTextToClipboard({
+      html: "<p>Hello</p>",
+      text: "Hello"
+    });
+
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(execCommand).not.toHaveBeenCalled();
+  });
+
+  it("uses plain writeText when rich clipboard writes are unavailable", async () => {
+    const execCommand = vi.fn().mockReturnValue(true);
+    const writeText = vi.fn().mockResolvedValue(undefined);
+
+    Object.defineProperty(document, "execCommand", {
+      value: execCommand,
+      configurable: true
+    });
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true
+    });
+    Object.defineProperty(navigator, "userAgent", {
+      value: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
+      configurable: true
+    });
+    Object.defineProperty(navigator, "maxTouchPoints", {
+      value: 0,
+      configurable: true
+    });
+    vi.stubGlobal("ClipboardItem", undefined);
+
+    await writeRichTextToClipboard({
+      html: "",
+      text: "Hello"
+    });
+
+    expect(writeText).toHaveBeenCalledWith("Hello");
+    expect(execCommand).not.toHaveBeenCalled();
+  });
+
+  it("keeps rich clipboard writes enabled for iPhone-class devices when available", async () => {
+    const execCommand = vi.fn().mockReturnValue(true);
+    const write = vi.fn().mockResolvedValue(undefined);
+
+    class MockClipboardItem {
+      constructor(public items: Record<string, Blob>) {}
+    }
+
+    Object.defineProperty(document, "execCommand", {
+      value: execCommand,
+      configurable: true
+    });
+    Object.defineProperty(navigator, "clipboard", {
+      value: { write, writeText: vi.fn() },
+      configurable: true
+    });
+    Object.defineProperty(navigator, "userAgent", {
+      value: "Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1",
+      configurable: true
+    });
+    Object.defineProperty(navigator, "maxTouchPoints", {
+      value: 5,
+      configurable: true
+    });
+    vi.stubGlobal("ClipboardItem", MockClipboardItem as unknown as typeof ClipboardItem);
+
+    await writeRichTextToClipboard({
+      html: "<p>Hello</p>",
+      text: "Hello"
+    });
+
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(execCommand).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/code-highlighting.test.ts
+++ b/tests/unit/code-highlighting.test.ts
@@ -18,19 +18,24 @@ describe("code highlighting helpers", () => {
     it("detects simple shell command chains as bash", () => {
       expect(detectCodeLanguage("curl https://example.com && echo ok")).toBe("bash");
       expect(detectCodeLanguage("git status && npm test")).toBe("bash");
+      expect(detectCodeLanguage("git status")).toBe("bash");
+      expect(detectCodeLanguage("npm install react")).toBe("bash");
     });
 
     it("detects sql from common query syntax", () => {
       expect(detectCodeLanguage("SELECT id, email FROM users WHERE active = 1;")).toBe("sql");
       expect(detectCodeLanguage("UPDATE users SET active = 1")).toBe("sql");
+      expect(detectCodeLanguage("SELECT id FROM users")).toBe("sql");
     });
 
-    it("detects yaml with comments between mappings", () => {
+    it("detects yaml with comments or nesting", () => {
       expect(detectCodeLanguage("foo: bar\n# comment\nbaz: qux")).toBe("yaml");
+      expect(detectCodeLanguage("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: demo")).toBe("yaml");
     });
 
     it("does not auto-detect plain label/value text as yaml", () => {
       expect(detectCodeLanguage("Name: John\nRole: admin\nStatus: active")).toBeNull();
+      expect(detectCodeLanguage("name: John\nrole: admin\nstatus: active")).toBeNull();
     });
 
     it("does not auto-detect account-like text as sql", () => {

--- a/tests/unit/code-highlighting.test.ts
+++ b/tests/unit/code-highlighting.test.ts
@@ -25,7 +25,17 @@ describe("code highlighting helpers", () => {
       const result = renderHighlightedCode("customlang", "hello <world>");
 
       expect(result.language).toBeNull();
+      expect(result.displayLanguage).toBe("customlang");
       expect(result.html).toContain("&lt;world&gt;");
+      expect(result.usedFallback).toBe(true);
+    });
+
+    it("keeps ordinary plain text unhighlighted when auto-detection confidence is weak", () => {
+      const result = renderHighlightedCode(null, "Step 1: click save");
+
+      expect(result.language).toBeNull();
+      expect(result.displayLanguage).toBeNull();
+      expect(result.html).toBe("Step 1: click save");
       expect(result.usedFallback).toBe(true);
     });
   });

--- a/tests/unit/code-highlighting.test.ts
+++ b/tests/unit/code-highlighting.test.ts
@@ -1,0 +1,32 @@
+import {
+  detectCodeLanguage,
+  normalizeCodeFenceLanguage,
+  renderHighlightedCode
+} from "@/lib/code-highlighting";
+
+describe("code highlighting helpers", () => {
+  describe("normalizeCodeFenceLanguage", () => {
+    it("normalizes supported aliases to canonical highlight.js language names", () => {
+      expect(normalizeCodeFenceLanguage("py")).toBe("python");
+      expect(normalizeCodeFenceLanguage("ts")).toBe("typescript");
+      expect(normalizeCodeFenceLanguage("yml")).toBe("yaml");
+      expect(normalizeCodeFenceLanguage("zsh")).toBe("bash");
+    });
+  });
+
+  describe("detectCodeLanguage", () => {
+    it("detects sql from common query syntax", () => {
+      expect(detectCodeLanguage("SELECT id, email FROM users WHERE active = 1;")).toBe("sql");
+    });
+  });
+
+  describe("renderHighlightedCode", () => {
+    it("falls back to escaped plain text for unsupported languages", () => {
+      const result = renderHighlightedCode("customlang", "hello <world>");
+
+      expect(result.language).toBeNull();
+      expect(result.html).toContain("&lt;world&gt;");
+      expect(result.usedFallback).toBe(true);
+    });
+  });
+});

--- a/tests/unit/code-highlighting.test.ts
+++ b/tests/unit/code-highlighting.test.ts
@@ -15,8 +15,18 @@ describe("code highlighting helpers", () => {
   });
 
   describe("detectCodeLanguage", () => {
+    it("detects simple shell command chains as bash", () => {
+      expect(detectCodeLanguage("curl https://example.com && echo ok")).toBe("bash");
+      expect(detectCodeLanguage("git status && npm test")).toBe("bash");
+    });
+
     it("detects sql from common query syntax", () => {
       expect(detectCodeLanguage("SELECT id, email FROM users WHERE active = 1;")).toBe("sql");
+      expect(detectCodeLanguage("UPDATE users SET active = 1")).toBe("sql");
+    });
+
+    it("detects yaml with comments between mappings", () => {
+      expect(detectCodeLanguage("foo: bar\n# comment\nbaz: qux")).toBe("yaml");
     });
 
     it("does not auto-detect plain label/value text as yaml", () => {

--- a/tests/unit/code-highlighting.test.ts
+++ b/tests/unit/code-highlighting.test.ts
@@ -18,6 +18,22 @@ describe("code highlighting helpers", () => {
     it("detects sql from common query syntax", () => {
       expect(detectCodeLanguage("SELECT id, email FROM users WHERE active = 1;")).toBe("sql");
     });
+
+    it("does not auto-detect plain label/value text as yaml", () => {
+      expect(detectCodeLanguage("Name: John\nRole: admin\nStatus: active")).toBeNull();
+    });
+
+    it("does not auto-detect account-like text as sql", () => {
+      expect(detectCodeLanguage("user: alice@example.com\nactive: true")).toBeNull();
+    });
+
+    it("does not auto-detect urls as bash", () => {
+      expect(detectCodeLanguage("http://localhost:3000/api/users?id=1")).toBeNull();
+    });
+
+    it("does not auto-detect plain multiline text as css", () => {
+      expect(detectCodeLanguage("line one\nline two\nline three")).toBeNull();
+    });
   });
 
   describe("renderHighlightedCode", () => {
@@ -37,6 +53,24 @@ describe("code highlighting helpers", () => {
       expect(result.displayLanguage).toBeNull();
       expect(result.html).toBe("Step 1: click save");
       expect(result.usedFallback).toBe(true);
+    });
+
+    it("falls back for the known plain-text false positives", () => {
+      const samples = [
+        "Name: John\nRole: admin\nStatus: active",
+        "user: alice@example.com\nactive: true",
+        "http://localhost:3000/api/users?id=1",
+        "line one\nline two\nline three"
+      ];
+
+      for (const sample of samples) {
+        const result = renderHighlightedCode(null, sample);
+
+        expect(result.language).toBeNull();
+        expect(result.displayLanguage).toBeNull();
+        expect(result.html).toBe(sample);
+        expect(result.usedFallback).toBe(true);
+      }
     });
   });
 });

--- a/tests/unit/code-highlighting.test.ts
+++ b/tests/unit/code-highlighting.test.ts
@@ -28,6 +28,12 @@ describe("code highlighting helpers", () => {
       expect(detectCodeLanguage("SELECT id FROM users")).toBe("sql");
     });
 
+    it("does not auto-detect plain english verb phrases as sql", () => {
+      expect(detectCodeLanguage("select the option from the menu")).toBeNull();
+      expect(detectCodeLanguage("delete the file from your desktop")).toBeNull();
+      expect(detectCodeLanguage("for each item, delete it from the list")).toBeNull();
+    });
+
     it("detects yaml with comments or nesting", () => {
       expect(detectCodeLanguage("foo: bar\n# comment\nbaz: qux")).toBe("yaml");
       expect(detectCodeLanguage("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: demo")).toBe("yaml");
@@ -86,6 +92,14 @@ describe("code highlighting helpers", () => {
         expect(result.html).toBe(sample);
         expect(result.usedFallback).toBe(true);
       }
+    });
+
+    it("uses the detected sql path for undeclared sql snippets", () => {
+      const result = renderHighlightedCode(null, "SELECT id FROM users");
+
+      expect(result.language).toBe("sql");
+      expect(result.displayLanguage).toBe("sql");
+      expect(result.usedFallback).toBe(false);
     });
   });
 });

--- a/tests/unit/code-highlighting.test.ts
+++ b/tests/unit/code-highlighting.test.ts
@@ -58,6 +58,24 @@ describe("code highlighting helpers", () => {
   });
 
   describe("renderHighlightedCode", () => {
+    it("preserves explicit fence aliases for display while normalizing lookup internally", () => {
+      const htmlResult = renderHighlightedCode("html", "<div>Hello</div>");
+      const zshResult = renderHighlightedCode("zsh", "echo hello");
+      const tsxResult = renderHighlightedCode("tsx", "const view = <div />;");
+
+      expect(htmlResult.language).toBe("xml");
+      expect(htmlResult.displayLanguage).toBe("html");
+      expect(htmlResult.usedFallback).toBe(false);
+
+      expect(zshResult.language).toBe("bash");
+      expect(zshResult.displayLanguage).toBe("zsh");
+      expect(zshResult.usedFallback).toBe(false);
+
+      expect(tsxResult.language).toBe("typescript");
+      expect(tsxResult.displayLanguage).toBe("tsx");
+      expect(tsxResult.usedFallback).toBe(false);
+    });
+
     it("falls back to escaped plain text for unsupported languages", () => {
       const result = renderHighlightedCode("customlang", "hello <world>");
 

--- a/tests/unit/message-bubble.test.ts
+++ b/tests/unit/message-bubble.test.ts
@@ -1013,6 +1013,54 @@ describe("message bubble", () => {
     expect(container.querySelector('[data-testid="assistant-message-bubble"] p code')).toBeNull();
   });
 
+  it("keeps the copy action hidden for a trailing assistant code block while its closing fence is still streaming", () => {
+    render(
+      React.createElement(StreamingPlaceholder, {
+        createdAt: new Date().toISOString(),
+        thinking: "",
+        answer: ["```python", "print('still streaming')"].join("\n"),
+        awaitingFirstToken: false,
+        thinkingInProgress: false,
+        timeline: []
+      })
+    );
+
+    const codeBlock = screen.getByTestId("assistant-code-block");
+
+    expect(codeBlock).toBeInTheDocument();
+    expect(codeBlock).toHaveTextContent("print('still streaming')");
+    expect(screen.queryByRole("button", { name: "Copy code block" })).toBeNull();
+  });
+
+  it("keeps earlier completed assistant code blocks copyable while a later block is still streaming", () => {
+    render(
+      React.createElement(StreamingPlaceholder, {
+        createdAt: new Date().toISOString(),
+        thinking: "",
+        answer: [
+          "```python",
+          "print('done')",
+          "```",
+          "",
+          "Still working on the next snippet.",
+          "",
+          "```javascript",
+          "const pending = true;"
+        ].join("\n"),
+        awaitingFirstToken: false,
+        thinkingInProgress: false,
+        timeline: []
+      })
+    );
+
+    const codeBlocks = screen.getAllByTestId("assistant-code-block");
+
+    expect(codeBlocks).toHaveLength(2);
+    expect(codeBlocks[0]).toHaveTextContent("print('done')");
+    expect(codeBlocks[1]).toHaveTextContent("const pending = true;");
+    expect(screen.getAllByRole("button", { name: "Copy code block" })).toHaveLength(1);
+  });
+
   it("keeps assistant inline code inline instead of rendering the dedicated block component", () => {
     const { container } = render(
       React.createElement(MessageBubble, {

--- a/tests/unit/message-bubble.test.ts
+++ b/tests/unit/message-bubble.test.ts
@@ -816,6 +816,21 @@ describe("message bubble", () => {
     expect(screen.getByRole("button", { name: "Copy code block" })).toBeInTheDocument();
   });
 
+  it("renders single-line untagged fenced assistant code blocks through the dedicated block renderer", () => {
+    render(
+      React.createElement(MessageBubble, {
+        message: {
+          ...createAssistantMessage(),
+          content: ["```", "foo", "```"].join("\n")
+        }
+      })
+    );
+
+    expect(screen.getByTestId("assistant-code-block")).toBeInTheDocument();
+    expect(screen.getByText("foo")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Copy code block" })).toBeInTheDocument();
+  });
+
   it("copies only the fenced code payload from the block action", async () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
 

--- a/tests/unit/message-bubble.test.ts
+++ b/tests/unit/message-bubble.test.ts
@@ -1086,6 +1086,26 @@ describe("message bubble", () => {
     expect(screen.queryByRole("button", { name: "Copy message" })).toBeNull();
   });
 
+  it("keeps code-block copy hidden while streamed display text is still animating after the message snapshot is completed", () => {
+    render(
+      React.createElement(MessageBubble, {
+        message: {
+          ...createAssistantMessage(),
+          status: "completed",
+          content: ["```python", "print('final')", "```"].join("\n")
+        },
+        streamingAnswer: ["```python", "print('still painting')", "```"].join("\n")
+      })
+    );
+
+    const codeBlock = screen.getByTestId("assistant-code-block");
+
+    expect(codeBlock).toHaveAttribute("data-complete", "false");
+    expect(codeBlock).toHaveTextContent("print('still painting')");
+    expect(screen.queryByRole("button", { name: "Copy code block" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Copy message" })).toBeNull();
+  });
+
   it("keeps assistant inline code inline instead of rendering the dedicated block component", () => {
     const { container } = render(
       React.createElement(MessageBubble, {

--- a/tests/unit/message-bubble.test.ts
+++ b/tests/unit/message-bubble.test.ts
@@ -832,6 +832,21 @@ describe("message bubble", () => {
     expect(screen.getByRole("button", { name: "Copy code block" })).toBeInTheDocument();
   });
 
+  it("caps assistant bubbles at the container width so fenced code blocks can scroll internally on narrow screens", () => {
+    render(
+      React.createElement(MessageBubble, {
+        message: {
+          ...createAssistantMessage(),
+          content: ["```python", "print('hello')", "```"].join("\n")
+        }
+      })
+    );
+
+    expect(screen.getByTestId("assistant-message-bubble").className).toContain("max-w-full");
+    expect(screen.getByTestId("assistant-message-bubble").parentElement?.parentElement?.className).toContain("w-full");
+    expect(screen.getByTestId("assistant-message-bubble").parentElement?.parentElement?.className).toContain("min-w-0");
+  });
+
   it("renders assistant fenced code blocks without an extra outer pre wrapper", () => {
     render(
       React.createElement(MessageBubble, {
@@ -1086,6 +1101,26 @@ describe("message bubble", () => {
     expect(screen.queryByRole("button", { name: "Copy message" })).toBeNull();
   });
 
+  it("keeps a trailing closed blockquoted assistant code block non-copyable until streaming finishes", () => {
+    render(
+      React.createElement(StreamingPlaceholder, {
+        createdAt: new Date().toISOString(),
+        thinking: "",
+        answer: ["> ```python", "> print('quoted')", "> ```"].join("\n"),
+        awaitingFirstToken: false,
+        thinkingInProgress: false,
+        timeline: []
+      })
+    );
+
+    const codeBlock = screen.getByTestId("assistant-code-block");
+
+    expect(codeBlock).toHaveAttribute("data-complete", "false");
+    expect(codeBlock).toHaveTextContent("print('quoted')");
+    expect(screen.queryByRole("button", { name: "Copy code block" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Copy message" })).toBeNull();
+  });
+
   it("keeps code-block copy hidden while streamed display text is still animating after the message snapshot is completed", () => {
     render(
       React.createElement(MessageBubble, {
@@ -1104,6 +1139,34 @@ describe("message bubble", () => {
     expect(codeBlock).toHaveTextContent("print('still painting')");
     expect(screen.queryByRole("button", { name: "Copy code block" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Copy message" })).toBeNull();
+  });
+
+  it("keeps a completed code-block copy button mounted while later streamed prose changes", () => {
+    const { rerender } = render(
+      React.createElement(MessageBubble, {
+        message: {
+          ...createAssistantMessage(),
+          status: "streaming",
+          content: ""
+        },
+        streamingAnswer: ["```python", "print('done')", "```", "", "tail a"].join("\n")
+      })
+    );
+
+    const initialCopyButton = screen.getByRole("button", { name: "Copy code block" });
+
+    rerender(
+      React.createElement(MessageBubble, {
+        message: {
+          ...createAssistantMessage(),
+          status: "streaming",
+          content: ""
+        },
+        streamingAnswer: ["```python", "print('done')", "```", "", "tail ab"].join("\n")
+      })
+    );
+
+    expect(screen.getByRole("button", { name: "Copy code block" })).toBe(initialCopyButton);
   });
 
   it("keeps assistant inline code inline instead of rendering the dedicated block component", () => {
@@ -1152,6 +1215,37 @@ describe("message bubble", () => {
     await waitFor(() => {
       expect(writeText).toHaveBeenCalledWith("print('hello')");
     });
+  });
+
+  it("falls back to legacy copy when the code-block clipboard writeText call rejects", async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error("clipboard denied"));
+    const execCommand = vi.fn().mockReturnValue(true);
+
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true
+    });
+    Object.defineProperty(document, "execCommand", {
+      value: execCommand,
+      configurable: true
+    });
+    vi.stubGlobal("ClipboardItem", undefined);
+
+    render(
+      React.createElement(MessageBubble, {
+        message: {
+          ...createAssistantMessage(),
+          content: ["```python", "print('hello')", "```"].join("\n")
+        }
+      })
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy code block" }));
+
+    await waitFor(() => {
+      expect(execCommand).toHaveBeenCalledWith("copy");
+    });
+    expect(screen.getByRole("button", { name: "Copied code block" })).toBeInTheDocument();
   });
 
   it("copies assistant output through the clipboard fallback", async () => {

--- a/tests/unit/message-bubble.test.ts
+++ b/tests/unit/message-bubble.test.ts
@@ -698,6 +698,22 @@ describe("message bubble", () => {
     expect(assistantMarkdown).not.toBeNull();
   });
 
+  it("keeps fenced code inside thinking content on the plain markdown path", () => {
+    const { container } = render(
+      React.createElement(MessageBubble, {
+        message: {
+          ...createAssistantMessage(),
+          thinkingContent: ["```python", "print('thought')", "```"].join("\n")
+        }
+      })
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Thought/i }));
+
+    expect(container.querySelector(".thinking-markdown-body [data-testid='assistant-code-block']")).toBeNull();
+    expect(container.querySelector(".thinking-markdown-body pre code")).not.toBeNull();
+  });
+
   it("keeps persisted thinking content collapsed by default", () => {
     render(
       React.createElement(MessageBubble, {
@@ -816,6 +832,20 @@ describe("message bubble", () => {
     expect(screen.getByRole("button", { name: "Copy code block" })).toBeInTheDocument();
   });
 
+  it("preserves symbol-containing assistant fence labels instead of truncating them", () => {
+    render(
+      React.createElement(MessageBubble, {
+        message: {
+          ...createAssistantMessage(),
+          content: ["```c++", "std::cout << 1;", "```"].join("\n")
+        }
+      })
+    );
+
+    expect(screen.getByTestId("assistant-code-block")).toBeInTheDocument();
+    expect(screen.getByText("c++")).toBeInTheDocument();
+  });
+
   it("renders single-line untagged fenced assistant code blocks through the dedicated block renderer", () => {
     render(
       React.createElement(MessageBubble, {
@@ -829,6 +859,21 @@ describe("message bubble", () => {
     expect(screen.getByTestId("assistant-code-block")).toBeInTheDocument();
     expect(screen.getByText("foo")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Copy code block" })).toBeInTheDocument();
+  });
+
+  it("keeps assistant inline code inline instead of rendering the dedicated block component", () => {
+    const { container } = render(
+      React.createElement(MessageBubble, {
+        message: {
+          ...createAssistantMessage(),
+          content: "Inline `token` should stay inline."
+        }
+      })
+    );
+
+    expect(screen.getByText("token")).toBeInTheDocument();
+    expect(container.querySelector('[data-testid="assistant-code-block"]')).toBeNull();
+    expect(container.querySelector('[data-testid="assistant-message-bubble"] p code')).not.toBeNull();
   });
 
   it("copies only the fenced code payload from the block action", async () => {

--- a/tests/unit/message-bubble.test.ts
+++ b/tests/unit/message-bubble.test.ts
@@ -832,6 +832,19 @@ describe("message bubble", () => {
     expect(screen.getByRole("button", { name: "Copy code block" })).toBeInTheDocument();
   });
 
+  it("renders assistant fenced code blocks without an extra outer pre wrapper", () => {
+    render(
+      React.createElement(MessageBubble, {
+        message: {
+          ...createAssistantMessage(),
+          content: ["```python", "print('hello')", "```"].join("\n")
+        }
+      })
+    );
+
+    expect(screen.getByTestId("assistant-code-block").closest("pre")).toBeNull();
+  });
+
   it("preserves symbol-containing assistant fence labels instead of truncating them", () => {
     render(
       React.createElement(MessageBubble, {

--- a/tests/unit/message-bubble.test.ts
+++ b/tests/unit/message-bubble.test.ts
@@ -890,8 +890,9 @@ describe("message bubble", () => {
     const assistantCodeBlock = screen.getByTestId("assistant-code-block");
 
     expect(assistantCodeBlock).toBeInTheDocument();
-    expect(screen.getByText("text")).toBeInTheDocument();
     expect(assistantCodeBlock).toHaveTextContent("SELECT id,");
+    expect(assistantCodeBlock.querySelector(".assistant-code-block__header")).not.toBeNull();
+    expect(assistantCodeBlock.querySelector(".assistant-code-block__copy")).not.toBeNull();
     expect(container.querySelector(".thinking-markdown-body [data-testid='assistant-code-block']")).toBeNull();
     expect(container.querySelector(".thinking-markdown-body pre code")).not.toBeNull();
   });
@@ -937,6 +938,31 @@ describe("message bubble", () => {
     expect(language).not.toBeNull();
     expect(copyButton).not.toBeNull();
     expect(body).not.toBeNull();
+  });
+
+  it("keeps long unsupported language labels inside the dedicated header without displacing copy controls", () => {
+    const longLanguage = "unsupported-language-label-with-a-very-long-fallback-name-that-should-not-overflow";
+    const { container } = render(
+      React.createElement(MessageBubble, {
+        message: {
+          ...createAssistantMessage(),
+          content: [`\`\`\`${longLanguage}`, "opaque => still visible", "```"].join("\n")
+        }
+      })
+    );
+
+    const codeBlock = screen.getByTestId("assistant-code-block");
+    const header = container.querySelector(".assistant-code-block__header");
+    const language = container.querySelector(".assistant-code-block__language");
+    const copyButton = container.querySelector(".assistant-code-block__copy");
+
+    expect(codeBlock).toBeInTheDocument();
+    expect(header).not.toBeNull();
+    expect(language).toHaveTextContent(longLanguage);
+    expect(language).toHaveAttribute("title", longLanguage);
+    expect(copyButton).not.toBeNull();
+    expect(header?.contains(language)).toBe(true);
+    expect(header?.contains(copyButton)).toBe(true);
   });
 
   it("renders empty tagged fenced assistant blocks without leaking undefined", () => {

--- a/tests/unit/message-bubble.test.ts
+++ b/tests/unit/message-bubble.test.ts
@@ -859,6 +859,26 @@ describe("message bubble", () => {
     expect(screen.getByText("c++")).toBeInTheDocument();
   });
 
+  it("preserves explicit assistant fence aliases in the visible label while still highlighting them", () => {
+    const { container } = render(
+      React.createElement(MessageBubble, {
+        message: {
+          ...createAssistantMessage(),
+          content: ["```html", "<div>Hello</div>", "```", "", "```zsh", "echo hello", "```"].join("\n")
+        }
+      })
+    );
+
+    const languageLabels = Array.from(container.querySelectorAll(".assistant-code-block__language")).map(
+      (element) => element.textContent
+    );
+    const codeElements = Array.from(container.querySelectorAll(".assistant-code-block__body code"));
+
+    expect(languageLabels).toEqual(["html", "zsh"]);
+    expect(codeElements[0]).toHaveClass("language-xml");
+    expect(codeElements[1]).toHaveClass("language-bash");
+  });
+
   it("renders single-line untagged fenced assistant code blocks through the dedicated block renderer", () => {
     render(
       React.createElement(MessageBubble, {

--- a/tests/unit/message-bubble.test.ts
+++ b/tests/unit/message-bubble.test.ts
@@ -1028,8 +1028,10 @@ describe("message bubble", () => {
     const codeBlock = screen.getByTestId("assistant-code-block");
 
     expect(codeBlock).toBeInTheDocument();
+    expect(codeBlock).toHaveAttribute("data-complete", "false");
     expect(codeBlock).toHaveTextContent("print('still streaming')");
     expect(screen.queryByRole("button", { name: "Copy code block" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Copy message" })).toBeNull();
   });
 
   it("keeps earlier completed assistant code blocks copyable while a later block is still streaming", () => {
@@ -1056,9 +1058,32 @@ describe("message bubble", () => {
     const codeBlocks = screen.getAllByTestId("assistant-code-block");
 
     expect(codeBlocks).toHaveLength(2);
+    expect(codeBlocks[0]).toHaveAttribute("data-complete", "true");
+    expect(codeBlocks[1]).toHaveAttribute("data-complete", "false");
     expect(codeBlocks[0]).toHaveTextContent("print('done')");
     expect(codeBlocks[1]).toHaveTextContent("const pending = true;");
     expect(screen.getAllByRole("button", { name: "Copy code block" })).toHaveLength(1);
+    expect(screen.queryByRole("button", { name: "Copy message" })).toBeNull();
+  });
+
+  it("keeps a trailing closed assistant code block non-copyable until streaming finishes", () => {
+    render(
+      React.createElement(StreamingPlaceholder, {
+        createdAt: new Date().toISOString(),
+        thinking: "",
+        answer: ["```python", "print('closed but still streaming')", "```"].join("\n"),
+        awaitingFirstToken: false,
+        thinkingInProgress: false,
+        timeline: []
+      })
+    );
+
+    const codeBlock = screen.getByTestId("assistant-code-block");
+
+    expect(codeBlock).toHaveAttribute("data-complete", "false");
+    expect(codeBlock).toHaveTextContent("print('closed but still streaming')");
+    expect(screen.queryByRole("button", { name: "Copy code block" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Copy message" })).toBeNull();
   });
 
   it("keeps assistant inline code inline instead of rendering the dedicated block component", () => {

--- a/tests/unit/message-bubble.test.ts
+++ b/tests/unit/message-bubble.test.ts
@@ -874,6 +874,71 @@ describe("message bubble", () => {
     expect(screen.getByRole("button", { name: "Copy code block" })).toBeInTheDocument();
   });
 
+  it("keeps untagged assistant code blocks on the dedicated block path without changing the thinking bubble", () => {
+    const { container } = render(
+      React.createElement(MessageBubble, {
+        message: {
+          ...createAssistantMessage(),
+          content: ["```", "SELECT id,", "  email FROM users;", "```"].join("\n"),
+          thinkingContent: ["```", "SELECT thought FROM steps;", "```"].join("\n")
+        }
+      })
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Thought/i }));
+
+    const assistantCodeBlock = screen.getByTestId("assistant-code-block");
+
+    expect(assistantCodeBlock).toBeInTheDocument();
+    expect(screen.getByText("text")).toBeInTheDocument();
+    expect(assistantCodeBlock).toHaveTextContent("SELECT id,");
+    expect(container.querySelector(".thinking-markdown-body [data-testid='assistant-code-block']")).toBeNull();
+    expect(container.querySelector(".thinking-markdown-body pre code")).not.toBeNull();
+  });
+
+  it("renders unsupported fenced languages as readable plain code in the dedicated block chrome", () => {
+    const { container } = render(
+      React.createElement(MessageBubble, {
+        message: {
+          ...createAssistantMessage(),
+          content: ["```mermadeidon", "opaque => still visible", "```"].join("\n")
+        }
+      })
+    );
+
+    const codeBlock = screen.getByTestId("assistant-code-block");
+    const codeElement = container.querySelector(".assistant-code-block__body code");
+
+    expect(codeBlock).toBeInTheDocument();
+    expect(screen.getByText("mermadeidon")).toBeInTheDocument();
+    expect(screen.getByText("opaque => still visible")).toBeInTheDocument();
+    expect(codeElement).toHaveClass("hljs");
+    expect(codeElement).not.toHaveClass("language-mermadeidon");
+  });
+
+  it("renders assistant fenced code blocks with scoped structural hooks for styling and copy behavior", () => {
+    const { container } = render(
+      React.createElement(MessageBubble, {
+        message: {
+          ...createAssistantMessage(),
+          content: ["```python", "print('hello')", "```"].join("\n")
+        }
+      })
+    );
+
+    const codeBlock = screen.getByTestId("assistant-code-block");
+    const header = container.querySelector(".assistant-code-block__header");
+    const language = container.querySelector(".assistant-code-block__language");
+    const copyButton = container.querySelector(".assistant-code-block__copy");
+    const body = container.querySelector(".assistant-code-block__body");
+
+    expect(codeBlock).toHaveClass("assistant-code-block");
+    expect(header).not.toBeNull();
+    expect(language).not.toBeNull();
+    expect(copyButton).not.toBeNull();
+    expect(body).not.toBeNull();
+  });
+
   it("renders empty tagged fenced assistant blocks without leaking undefined", () => {
     const { container } = render(
       React.createElement(MessageBubble, {

--- a/tests/unit/message-bubble.test.ts
+++ b/tests/unit/message-bubble.test.ts
@@ -801,6 +801,54 @@ describe("message bubble", () => {
     expect(container.querySelector("hr")).not.toBeNull();
   });
 
+  it("renders fenced assistant code blocks with a language label and block-local copy action", () => {
+    render(
+      React.createElement(MessageBubble, {
+        message: {
+          ...createAssistantMessage(),
+          content: ["```python", "print('hello')", "```"].join("\n")
+        }
+      })
+    );
+
+    expect(screen.getByTestId("assistant-code-block")).toBeInTheDocument();
+    expect(screen.getByText("python")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Copy code block" })).toBeInTheDocument();
+  });
+
+  it("copies only the fenced code payload from the block action", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true
+    });
+    vi.stubGlobal("ClipboardItem", undefined);
+
+    render(
+      React.createElement(MessageBubble, {
+        message: {
+          ...createAssistantMessage(),
+          content: [
+            "Before",
+            "",
+            "```python",
+            "print('hello')",
+            "```",
+            "",
+            "After"
+          ].join("\n")
+        }
+      })
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy code block" }));
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith("print('hello')");
+    });
+  });
+
   it("copies assistant output through the clipboard fallback", async () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
 

--- a/tests/unit/message-bubble.test.ts
+++ b/tests/unit/message-bubble.test.ts
@@ -874,6 +874,34 @@ describe("message bubble", () => {
     expect(screen.getByRole("button", { name: "Copy code block" })).toBeInTheDocument();
   });
 
+  it("renders empty tagged fenced assistant blocks without leaking undefined", () => {
+    const { container } = render(
+      React.createElement(MessageBubble, {
+        message: {
+          ...createAssistantMessage(),
+          content: ["```python", "```"].join("\n")
+        }
+      })
+    );
+
+    expect(screen.getByTestId("assistant-code-block")).toBeInTheDocument();
+    expect(container).not.toHaveTextContent("undefined");
+  });
+
+  it("renders empty untagged fenced assistant blocks without collapsing to inline code", () => {
+    const { container } = render(
+      React.createElement(MessageBubble, {
+        message: {
+          ...createAssistantMessage(),
+          content: ["```", "```"].join("\n")
+        }
+      })
+    );
+
+    expect(screen.getByTestId("assistant-code-block")).toBeInTheDocument();
+    expect(container.querySelector('[data-testid="assistant-message-bubble"] p code')).toBeNull();
+  });
+
   it("keeps assistant inline code inline instead of rendering the dedicated block component", () => {
     const { container } = render(
       React.createElement(MessageBubble, {


### PR DESCRIPTION
Adds syntax-highlighted fenced code blocks to assistant answers with a dedicated renderer and language-aware highlighting. Introduces per-block copy controls with stable streaming behavior while leaving thinking bubbles on the plain markdown path. Improves mobile layout so code blocks stay within the bubble and scroll internally. Fixes clipboard handling for iPhone-class devices while preserving rich-text message copy. Adds regression coverage for highlighting, streaming completion, mobile layout, and clipboard fallbacks.