### PR TITLE
Fix provider preset switching to Manual on field changes

### DIFF
--- a/components/settings/sections/providers-section.tsx
+++ b/components/settings/sections/providers-section.tsx
@@ -22,10 +22,9 @@ import { DEFAULT_PROVIDER_SETTINGS } from "@/lib/constants";
 import {
   applyProviderPreset,
   getMatchingProviderPresetId,
-  PROVIDER_PRESETS,
-  type ProviderPresetId
+  PROVIDER_PRESETS
 } from "@/lib/provider-presets";
-import type { AppSettings, ApiMode, McpServer, ReasoningEffort, VisionMode } from "@/lib/types";
+import type { AppSettings, ApiMode, McpServer, ProviderPresetId, ReasoningEffort, VisionMode } from "@/lib/types";
 
 import { SettingsSplitPane } from "../settings-split-pane";
 import { ProfileCard } from "../profile-card";
@@ -55,6 +54,7 @@ type SettingsPayload = AppSettings & {
     mergedTargetTokens: number;
     visionMode: VisionMode;
     visionMcpServerId: string | null;
+    providerPresetId: ProviderPresetId | null;
     githubAccountLogin: string | null;
     githubAccountName: string | null;
     githubTokenExpiresAt: string | null;
@@ -112,7 +112,7 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
     [providerProfiles, selectedProviderProfileId]
   );
   const activeProviderPresetId = activeProviderProfile
-    ? getMatchingProviderPresetId(activeProviderProfile)
+    ? activeProviderProfile.providerPresetId ?? getMatchingProviderPresetId(activeProviderProfile)
     : null;
   const isCopilot = activeProviderProfile?.providerKind === "github_copilot";
 
@@ -166,6 +166,7 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
         mergedTargetTokens: 1600,
         visionMode: "native" as VisionMode,
         visionMcpServerId: null,
+        providerPresetId: null,
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
         hasApiKey: false,
@@ -198,7 +199,10 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
       return;
     }
 
-    updateActiveProviderProfile(applyProviderPreset(activeProviderProfile, presetId));
+    updateActiveProviderProfile({
+      ...applyProviderPreset(activeProviderProfile, presetId),
+      providerPresetId: presetId
+    });
   }
 
   function resetActiveProviderAdvancedSettings() {
@@ -283,6 +287,7 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
         mergedTargetTokens: profile.mergedTargetTokens,
         visionMode: profile.visionMode ?? "native",
         visionMcpServerId: profile.visionMcpServerId ?? null,
+        providerPresetId: profile.providerPresetId ?? null,
         githubAccountLogin: profile.githubAccountLogin ?? null,
         githubAccountName: profile.githubAccountName ?? null,
         githubTokenExpiresAt: profile.githubTokenExpiresAt ?? null,
@@ -468,13 +473,15 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
                             model: "",
                             apiMode: "responses",
                             systemPrompt: "",
-                            tokenizerModel: "off"
+                            tokenizerModel: "off",
+                            providerPresetId: null
                           });
                         } else {
                           updateActiveProviderProfile({
                             providerKind: "openai_compatible",
                             apiBaseUrl: activeProviderProfile.apiBaseUrl || "https://api.openai.com/v1",
-                            apiKey: ""
+                            apiKey: "",
+                            providerPresetId: null
                           });
                         }
                       }
@@ -576,7 +583,7 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
                             autoComplete="url"
                             value={activeProviderProfile.apiBaseUrl}
                             onChange={(event) =>
-                              updateActiveProviderProfile({ apiBaseUrl: event.target.value })
+                              updateActiveProviderProfile({ apiBaseUrl: event.target.value, providerPresetId: null })
                             }
                             required
                           />

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -646,6 +646,17 @@ function migrate(db: Database.Database) {
     }
   }
 
+  const presetCols = {
+    provider_preset_id: "TEXT"
+  };
+  const presetProfileCols = db.prepare("PRAGMA table_info(provider_profiles)").all() as Array<{ name: string }>;
+  const presetProfileColNames = presetProfileCols.map((c) => c.name);
+  for (const [colName, colDef] of Object.entries(presetCols)) {
+    if (!presetProfileColNames.includes(colName)) {
+      db.exec(`ALTER TABLE provider_profiles ADD COLUMN ${colName} ${colDef}`);
+    }
+  }
+
   try {
     db.exec(`ALTER TABLE compaction_events RENAME TO compaction_events_old`);
     db.exec(`

--- a/lib/provider-presets.ts
+++ b/lib/provider-presets.ts
@@ -1,11 +1,7 @@
 import { DEFAULT_PROVIDER_SETTINGS } from "@/lib/constants";
-import type { ApiMode, ReasoningEffort } from "@/lib/types";
+import type { ApiMode, ProviderPresetId, ReasoningEffort } from "@/lib/types";
 
-export type ProviderPresetId =
-  | "ollama_cloud"
-  | "glm_coding_plan"
-  | "openrouter"
-  | "custom_openai_compatible";
+export type { ProviderPresetId } from "@/lib/types";
 
 type ProviderPresetValues = {
   name: string;

--- a/lib/settings.ts
+++ b/lib/settings.ts
@@ -38,6 +38,7 @@ const runtimeSettingsSchema = z.object({
   mergedTargetTokens: z.coerce.number().int().min(128).max(16000).default(1600),
   visionMode: z.enum(["none", "native", "mcp"]).default("native"),
   visionMcpServerId: z.string().nullable().default(null),
+  providerPresetId: z.enum(["ollama_cloud", "glm_coding_plan", "openrouter", "custom_openai_compatible"]).nullable().default(null),
   githubUserAccessTokenEncrypted: z.string().default(""),
   githubRefreshTokenEncrypted: z.string().default(""),
   githubAccountLogin: z.string().nullable().default(null),
@@ -229,6 +230,7 @@ type ProviderProfileRow = {
   vision_mode: string;
   vision_mcp_server_id: string | null;
   provider_kind: string;
+  provider_preset_id: string | null;
   github_user_access_token_encrypted: string;
   github_refresh_token_encrypted: string;
   github_token_expires_at: string | null;
@@ -370,6 +372,7 @@ function rowToProviderProfile(row: ProviderProfileRow): ProviderProfile {
     mergedTargetTokens: row.merged_target_tokens,
     visionMode: row.vision_mode as VisionMode,
     visionMcpServerId: row.vision_mcp_server_id,
+    providerPresetId: row.provider_preset_id as ProviderProfile["providerPresetId"],
     githubUserAccessTokenEncrypted: row.github_user_access_token_encrypted,
     githubRefreshTokenEncrypted: row.github_refresh_token_encrypted,
     githubTokenExpiresAt: row.github_token_expires_at,
@@ -408,6 +411,7 @@ function listProviderProfileRows() {
         vision_mode,
         vision_mcp_server_id,
         provider_kind,
+        provider_preset_id,
         github_user_access_token_encrypted,
         github_refresh_token_encrypted,
         github_token_expires_at,
@@ -449,6 +453,7 @@ function getProviderProfileRow(profileId: string) {
         vision_mode,
         vision_mcp_server_id,
         provider_kind,
+        provider_preset_id,
         github_user_access_token_encrypted,
         github_refresh_token_encrypted,
         github_token_expires_at,
@@ -848,6 +853,7 @@ export function updateSettings(input: unknown) {
         vision_mode,
         vision_mcp_server_id,
         provider_kind,
+        provider_preset_id,
         github_user_access_token_encrypted,
         github_refresh_token_encrypted,
         github_token_expires_at,
@@ -880,6 +886,7 @@ export function updateSettings(input: unknown) {
         @visionMode,
         @visionMcpServerId,
         @providerKind,
+        @providerPresetId,
         @githubUserAccessTokenEncrypted,
         @githubRefreshTokenEncrypted,
         @githubTokenExpiresAt,
@@ -912,6 +919,7 @@ export function updateSettings(input: unknown) {
         vision_mode = excluded.vision_mode,
         vision_mcp_server_id = excluded.vision_mcp_server_id,
         provider_kind = excluded.provider_kind,
+        provider_preset_id = excluded.provider_preset_id,
         github_user_access_token_encrypted = excluded.github_user_access_token_encrypted,
         github_refresh_token_encrypted = excluded.github_refresh_token_encrypted,
         github_token_expires_at = excluded.github_token_expires_at,
@@ -955,6 +963,7 @@ export function updateSettings(input: unknown) {
         visionMode: profile.visionMode ?? "native",
         visionMcpServerId: profile.visionMcpServerId ?? null,
         providerKind: profile.providerKind,
+        providerPresetId: profile.providerPresetId ?? null,
         githubUserAccessTokenEncrypted,
         githubRefreshTokenEncrypted,
         githubTokenExpiresAt,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -58,6 +58,8 @@ export type MemoryNodeType = "leaf_summary" | "merged_summary";
 
 export type SystemMessageKind = "compaction_notice";
 
+export type ProviderPresetId = "ollama_cloud" | "glm_coding_plan" | "openrouter" | "custom_openai_compatible";
+
 export type ProviderProfile = {
   id: string;
   providerKind: ProviderKind;
@@ -82,6 +84,7 @@ export type ProviderProfile = {
   mergedTargetTokens: number;
   visionMode: VisionMode;
   visionMcpServerId: string | null;
+  providerPresetId: ProviderPresetId | null;
   githubUserAccessTokenEncrypted: string;
   githubRefreshTokenEncrypted: string;
   githubTokenExpiresAt: string | null;

--- a/tests/unit/assistant-runtime.test.ts
+++ b/tests/unit/assistant-runtime.test.ts
@@ -90,6 +90,7 @@ function createSettings(): ProviderProfileWithApiKey {
     mergedTargetTokens: 1600,
     visionMode: "native" as const,
     visionMcpServerId: null,
+    providerPresetId: null,
     providerKind: "openai_compatible",
     githubUserAccessTokenEncrypted: "",
     githubRefreshTokenEncrypted: "",

--- a/tests/unit/automation-scheduler.test.ts
+++ b/tests/unit/automation-scheduler.test.ts
@@ -44,6 +44,7 @@ function createProviderProfile(id = "profile_scheduler"): ProviderProfileWithApi
     mergedTargetTokens: 1600,
     visionMode: "none",
     visionMcpServerId: null,
+    providerPresetId: null,
     providerKind: "openai_compatible",
     githubUserAccessTokenEncrypted: "",
     githubRefreshTokenEncrypted: "",

--- a/tests/unit/chat-turn.test.ts
+++ b/tests/unit/chat-turn.test.ts
@@ -54,6 +54,7 @@ function setupProviderProfile(): { profileId: string; profile: ProviderProfileWi
     mergedTargetTokens: 1600,
     visionMode: "native" as const,
     visionMcpServerId: null,
+    providerPresetId: null,
     providerKind: "openai_compatible",
     githubUserAccessTokenEncrypted: "",
     githubRefreshTokenEncrypted: "",

--- a/tests/unit/chat-view.test.ts
+++ b/tests/unit/chat-view.test.ts
@@ -219,6 +219,7 @@ function createPayload(overrides: Partial<ChatViewPayload> = {}): ChatViewPayloa
         mergedTargetTokens: 1600,
         visionMode: "native" as const,
         visionMcpServerId: null,
+        providerPresetId: null,
         providerKind: "openai_compatible" as "openai_compatible" | "github_copilot",
         githubTokenExpiresAt: null,
         githubRefreshTokenExpiresAt: null,

--- a/tests/unit/conversation-title-generator.test.ts
+++ b/tests/unit/conversation-title-generator.test.ts
@@ -31,6 +31,7 @@ function createSettings(): ProviderProfileWithApiKey {
     mergedTargetTokens: 1600,
     visionMode: "native",
     visionMcpServerId: null,
+    providerPresetId: null,
     providerKind: "openai_compatible",
     githubUserAccessTokenEncrypted: "",
     githubRefreshTokenEncrypted: "",

--- a/tests/unit/github-copilot.test.ts
+++ b/tests/unit/github-copilot.test.ts
@@ -65,6 +65,7 @@ function createProfile(overrides: Record<string, unknown> = {}) {
     mergedTargetTokens: 1600,
     visionMode: "native" as const,
     visionMcpServerId: null,
+    providerPresetId: null,
     githubUserAccessTokenEncrypted: encryptValue("ghu_access"),
     githubRefreshTokenEncrypted: encryptValue("ghr_refresh"),
     githubTokenExpiresAt: new Date(Date.now() + 10 * 60_000).toISOString(),

--- a/tests/unit/home-view.test.tsx
+++ b/tests/unit/home-view.test.tsx
@@ -116,6 +116,7 @@ function createProviderProfile() {
     mergedTargetTokens: 1600,
     visionMode: "native" as const,
     visionMcpServerId: null,
+    providerPresetId: null,
     providerKind: "openai_compatible" as "openai_compatible" | "github_copilot",
     githubTokenExpiresAt: null,
     githubRefreshTokenExpiresAt: null,

--- a/tests/unit/provider.test.ts
+++ b/tests/unit/provider.test.ts
@@ -86,6 +86,7 @@ function createSettings(
     mergedTargetTokens: 1600,
     visionMode: "native" as const,
     visionMcpServerId: null,
+    providerPresetId: null,
     githubUserAccessTokenEncrypted: "",
     githubRefreshTokenEncrypted: "",
     githubTokenExpiresAt: null,

--- a/tests/unit/providers-section.test.tsx
+++ b/tests/unit/providers-section.test.tsx
@@ -34,6 +34,7 @@ type ProviderProfileFixture = {
   mergedTargetTokens: number;
   visionMode: "none" | "native" | "mcp";
   visionMcpServerId: string | null;
+  providerPresetId: "ollama_cloud" | "glm_coding_plan" | "openrouter" | "custom_openai_compatible" | null;
   githubAccountLogin: string | null;
   githubAccountName: string | null;
   githubTokenExpiresAt: string | null;
@@ -95,6 +96,7 @@ function makeSettings(overrides: Partial<SettingsFixture> = {}): SettingsFixture
         safetyMarginTokens: 1200,
         leafSourceTokenLimit: 12000,
         leafMinMessageCount: 6,
+        providerPresetId: null,
         mergedMinNodeCount: 4,
         mergedTargetTokens: 1600,
         visionMode: "native",
@@ -176,6 +178,7 @@ describe("providers section", () => {
               mergedTargetTokens: 1600,
               visionMode: "native",
               visionMcpServerId: null,
+              providerPresetId: null,
               githubAccountLogin: null,
               githubAccountName: null,
               githubTokenExpiresAt: null,
@@ -252,6 +255,7 @@ describe("providers section", () => {
               mergedTargetTokens: 1600,
               visionMode: "native",
               visionMcpServerId: null,
+              providerPresetId: null,
               githubAccountLogin: "octocat",
               githubAccountName: "The Octocat",
               githubTokenExpiresAt: new Date(Date.now() + 60_000).toISOString(),
@@ -298,6 +302,40 @@ describe("providers section", () => {
     expect(profileNameInput).toHaveValue("OpenRouter");
     expect(apiBaseUrlInput).toHaveValue("https://openrouter.ai/api/v1");
     expect(modelInput).toHaveValue("");
+  });
+
+  it("keeps the selected preset when the model changes", async () => {
+    const { container } = render(React.createElement(ProvidersSection, { settings: makeSettings() }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith("/api/mcp-servers");
+    });
+
+    const presetSelect = screen.getByDisplayValue("Manual configuration");
+    const modelInput = container.querySelector<HTMLInputElement>('input[name="provider-model"]');
+
+    fireEvent.change(presetSelect, { target: { value: "openrouter" } });
+    expect(presetSelect).toHaveValue("openrouter");
+
+    fireEvent.change(modelInput!, { target: { value: "custom-model" } });
+    expect(presetSelect).toHaveValue("openrouter");
+  });
+
+  it("switches to Manual configuration when the API base URL changes", async () => {
+    const { container } = render(React.createElement(ProvidersSection, { settings: makeSettings() }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith("/api/mcp-servers");
+    });
+
+    const presetSelect = screen.getByDisplayValue("Manual configuration");
+    const apiBaseUrlInput = screen.getByDisplayValue("https://api.example.com/v1");
+
+    fireEvent.change(presetSelect, { target: { value: "openrouter" } });
+    expect(presetSelect).toHaveValue("openrouter");
+
+    fireEvent.change(apiBaseUrlInput, { target: { value: "https://custom.api.com/v1" } });
+    expect(presetSelect).toHaveValue("");
   });
 
   it("shows compaction threshold as a percent and preserves top-level settings on save", async () => {
@@ -455,6 +493,7 @@ describe("providers section", () => {
           mergedTargetTokens: 1600,
           visionMode: "native",
           visionMcpServerId: null,
+          providerPresetId: null,
           githubTokenExpiresAt: null,
           githubRefreshTokenExpiresAt: null,
           githubAccountLogin: null,
@@ -487,6 +526,7 @@ describe("providers section", () => {
           mergedTargetTokens: 1600,
           visionMode: "native",
           visionMcpServerId: null,
+          providerPresetId: null,
           githubTokenExpiresAt: null,
           githubRefreshTokenExpiresAt: null,
           githubAccountLogin: null,

--- a/tests/unit/settings.test.ts
+++ b/tests/unit/settings.test.ts
@@ -38,6 +38,7 @@ function buildProfile(
     modelContextLimit: number;
     compactionThreshold: number;
     freshTailCount: number;
+    providerPresetId: "ollama_cloud" | "glm_coding_plan" | "openrouter" | "custom_openai_compatible" | null;
   }> = {}
 ) {
   return {
@@ -54,7 +55,8 @@ function buildProfile(
     reasoningSummaryEnabled: overrides.reasoningSummaryEnabled ?? true,
     modelContextLimit: overrides.modelContextLimit ?? 16384,
     compactionThreshold: overrides.compactionThreshold ?? 0.8,
-    freshTailCount: overrides.freshTailCount ?? 12
+    freshTailCount: overrides.freshTailCount ?? 12,
+    providerPresetId: overrides.providerPresetId ?? null
   };
 }
 


### PR DESCRIPTION
The provider preset dropdown was re-computed from profile values on every render, matching all seven fields exactly. Changing the model or any other setting caused the preset to immediately revert to "Manual configuration." This PR stores the user's explicit preset selection as `providerPresetId` on the profile, so the preset stays selected until the API base URL is changed (at which point it correctly switches to Manual configuration).

Changes:
- Add `providerPresetId` field to `ProviderProfile` type and DB schema
- Dropdown uses stored `providerPresetId`, falling back to computed match for backward compat
- Changing model/apiMode/etc. preserves the selected preset
- Changing the API base URL clears the preset to Manual
- Added DB migration for `provider_preset_id` column
- Added 2 new unit tests for the sticky preset behavior

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>