### PR TITLE
ci: publish docker image only on release

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,8 +3,8 @@ name: Docker Build
 on:
   pull_request:
     branches: [main]
-  push:
-    branches: [main]
+  release:
+    types: [published]
 
 jobs:
   build:
@@ -48,11 +48,14 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build full production image
-        if: github.event_name == 'push' || steps.changes.outputs.deployment == 'true'
+        if: github.event_name == 'pull_request' && steps.changes.outputs.deployment == 'true' || github.event_name == 'release'
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: false
+          push: ${{ github.event_name == 'release' }}
+          tags: |
+            ghcr.io/${{ env.REPO_LOWERCASE }}:latest
+            ghcr.io/${{ env.REPO_LOWERCASE }}:${{ github.event.release.tag_name }}
           cache-from: |
             type=gha
             type=registry,ref=ghcr.io/${{ env.REPO_LOWERCASE }}/buildcache:main


### PR DESCRIPTION
Updated the Docker workflow to stop publishing images on every push to main.\nThe workflow now publishes only on GitHub release events and keeps PR validation for deployment-related changes targeting main.\nWhen a release is published, the image is pushed to GHCR with latest and the release tag name.\nThis PR only changes .github/workflows/docker.yml.