### PR TITLE
Fix release-only Docker publishing tags

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,15 +47,30 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build full production image
-        if: github.event_name == 'pull_request' && steps.changes.outputs.deployment == 'true' || github.event_name == 'release'
+      - name: Build full production image (release)
+        if: github.event_name == 'release' && github.event.release.target_commitish == 'main'
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: ${{ github.event_name == 'release' }}
+          push: true
           tags: |
             ghcr.io/${{ env.REPO_LOWERCASE }}:latest
             ghcr.io/${{ env.REPO_LOWERCASE }}:${{ github.event.release.tag_name }}
+          cache-from: |
+            type=gha
+            type=registry,ref=ghcr.io/${{ env.REPO_LOWERCASE }}/buildcache:main
+          cache-to: |
+            type=gha,mode=max
+            type=registry,ref=ghcr.io/${{ env.REPO_LOWERCASE }}/buildcache:main,mode=max
+
+      - name: Build full production image (pull request)
+        if: github.event_name == 'pull_request' && steps.changes.outputs.deployment == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          tags: |
+            ghcr.io/${{ env.REPO_LOWERCASE }}:pr
           cache-from: |
             type=gha
             type=registry,ref=ghcr.io/${{ env.REPO_LOWERCASE }}/buildcache:main

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,8 +3,8 @@ name: Docker Build
 on:
   pull_request:
     branches: [main]
-  push:
-    branches: [main]
+  release:
+    types: [published]
 
 jobs:
   build:
@@ -48,11 +48,14 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build full production image
-        if: github.event_name == 'push' || steps.changes.outputs.deployment == 'true'
+        if: github.event_name == 'pull_request' && steps.changes.outputs.deployment == 'true' || github.event_name == 'release'
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: false
+          push: ${{ github.event_name == 'release' }}
+          tags: |
+            ghcr.io/${{ env.REPO_LOWERCASE }}:latest
+            ghcr.io/${{ env.REPO_LOWERCASE }}:${{ github.event.release.tag_name }}
           cache-from: |
             type=gha
             type=registry,ref=ghcr.io/${{ env.REPO_LOWERCASE }}/buildcache:main


### PR DESCRIPTION
## Changes\n- Change Docker workflow triggers so container publishing is release-only (published releases on main).\n- Split build steps by event: PRs do a non-push build, release events push images.\n- Guard release images with explicit tags using latest plus the release tag, avoiding empty tag generation in PR runs.\n\nThis fixes invalid tag failures and aligns image publishing to release lifecycle rather than branch merges.