### PR TITLE
Replace attachment raw link with download

### DIFF
--- a/app/api/attachments/[attachmentId]/route.ts
+++ b/app/api/attachments/[attachmentId]/route.ts
@@ -37,6 +37,7 @@ export async function GET(
   }
 
   const format = new URL(request.url).searchParams.get("format");
+  const download = new URL(request.url).searchParams.get("download") === "1";
 
   if (format === "text") {
     try {
@@ -62,7 +63,7 @@ export async function GET(
       headers: {
         "Content-Type": attachment.mimeType,
         "Content-Length": String(buffer.length),
-        "Content-Disposition": `inline; filename="${attachment.filename}"`
+        "Content-Disposition": `${download ? "attachment" : "inline"}; filename="${attachment.filename}"`
       }
     });
   } catch {

--- a/components/attachment-preview-modal.tsx
+++ b/components/attachment-preview-modal.tsx
@@ -201,14 +201,12 @@ export function AttachmentPreviewModal({
           </div>
 
           <a
-            href={`/api/attachments/${attachment.id}`}
-            target="_blank"
-            rel="noreferrer"
+            href={`/api/attachments/${attachment.id}?download=1`}
             className="inline-flex items-center gap-2 rounded-lg border border-white/10 px-3 py-2 text-xs text-white/70"
-            aria-label="Open raw attachment"
+            aria-label="Download attachment"
           >
             <Download className="h-3.5 w-3.5" />
-            <span>Open raw</span>
+            <span>Download</span>
           </a>
         </div>
 

--- a/docs/superpowers/specs/2026-04-16-attachment-download-design.md
+++ b/docs/superpowers/specs/2026-04-16-attachment-download-design.md
@@ -1,0 +1,66 @@
+# Attachment Modal Download Design
+
+## Goal
+
+Replace the attachment preview modal's `Open raw` action with a download action that prompts the browser to download the attachment instead of opening it inline. The behavior must work for image and text attachments on desktop and mobile.
+
+## Current State
+
+- The modal header action in `components/attachment-preview-modal.tsx` is an anchor labeled `Open raw`.
+- The attachment route in `app/api/attachments/[attachmentId]/route.ts` serves attachment bytes with `Content-Disposition: inline`, which favors opening content in-browser instead of downloading it.
+- Existing unit tests assert the presence of the raw-link action, and e2e coverage currently validates modal open/close behavior but not the header action semantics.
+
+## Decision
+
+Use the existing attachment `GET` route and add a download mode via the query string.
+
+The modal action will link to `/api/attachments/<attachmentId>?download=1`. When `download=1` is present, the route will respond with `Content-Disposition: attachment; filename="..."`. Without that flag, the route will preserve its current inline behavior so image previews inside the modal continue to work.
+
+This is the smallest change that preserves the preview path, keeps authentication behavior unchanged, avoids duplicating route logic, and gives mobile browsers the strongest signal to download rather than render inline.
+
+## Route Changes
+
+Update `app/api/attachments/[attachmentId]/route.ts` so the default binary response remains unchanged except for the addition of conditional content disposition logic:
+
+- `format=text` continues to return JSON preview content exactly as it does today.
+- Binary attachment responses inspect `download` from the request query string.
+- If `download=1`, respond with `Content-Disposition: attachment; filename="<attachment.filename>"`, using the stored attachment filename.
+- Otherwise, continue responding with `Content-Disposition: inline; filename="<attachment.filename>"`, again using the stored attachment filename.
+
+No new route is needed. Authentication, ownership checks, and missing-file handling remain as-is.
+
+## UI Changes
+
+Update `components/attachment-preview-modal.tsx`:
+
+- Replace the `Open raw` header action with a download action.
+- The control text becomes `Download`.
+- The accessible name becomes `Download attachment`.
+- The control targets `/api/attachments/<attachmentId>?download=1`.
+- Keep the control visible for all attachment types shown in the modal.
+
+The modal layout stays otherwise unchanged. This is a behavior update, not a visual redesign.
+
+## Mobile Behavior
+
+Mobile support is achieved through the server response, not CSS or device-specific logic.
+
+- Browsers that honor `Content-Disposition: attachment` will download directly.
+- Browsers with stricter handling, especially mobile Safari, still receive the correct attachment response instead of an inline-only asset URL.
+- No `target="_blank"` behavior should remain on the action, because the desired outcome is download, not opening a new tab.
+
+## Testing Plan
+
+Follow TDD for implementation:
+
+1. Add or update a route-level test covering `download=1` and asserting the `Content-Disposition` header uses `attachment`.
+2. Update the modal unit test in `tests/unit/message-bubble.test.ts` to assert the renamed action and new href.
+3. Extend e2e coverage in `tests/e2e/features.spec.ts` so the modal action is asserted in at least one transcript attachment flow.
+4. Run the targeted tests first, then the full required test suite to confirm no regressions and coverage compliance.
+
+## Non-Goals
+
+- No change to upload flows.
+- No change to how inline image previews are loaded inside the modal.
+- No new download manager UI, progress state, or toast.
+- No change to attachment authorization rules.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "eidon",
       "version": "0.1.0",
+      "license": "AGPL-3.0-only",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/tests/e2e/features.spec.ts
+++ b/tests/e2e/features.spec.ts
@@ -1163,6 +1163,10 @@ test.describe("Feature: Chat attachments", () => {
     await page.getByRole("button", { name: "Preview notes.txt" }).last().click();
     await expect(page.getByRole("dialog", { name: "Attachment preview" })).toBeVisible();
     await expect(page.getByText("hello")).toBeVisible();
+    await expect(page.getByRole("link", { name: "Download attachment" })).toHaveAttribute(
+      "href",
+      /\/api\/attachments\/att_notes\?download=1$/
+    );
   });
 });
 

--- a/tests/unit/attachment-preview-route.test.ts
+++ b/tests/unit/attachment-preview-route.test.ts
@@ -239,6 +239,35 @@ describe("attachment preview route", () => {
     await expect(response.text()).resolves.toBe("# Notes\nRaw body");
   });
 
+  it("switches the binary response into download mode when requested", async () => {
+    const user = await createLocalUser({
+      username: "attachment-download-response-user",
+      password: "Password123!",
+      role: "user"
+    });
+    const conversation = createConversation("Download attachment response", null, undefined, user.id);
+    const [attachment] = createAttachments(conversation.id, [
+      {
+        filename: "notes.md",
+        mimeType: "text/markdown",
+        bytes: Buffer.from("# Notes\nDownload body", "utf8")
+      }
+    ]);
+
+    requireUserMock.mockResolvedValue(user);
+
+    const { GET } = await import("@/app/api/attachments/[attachmentId]/route");
+    const response = await GET(
+      new Request(`http://localhost/api/attachments/${attachment.id}?download=1`),
+      { params: Promise.resolve({ attachmentId: attachment.id }) }
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("text/markdown");
+    expect(response.headers.get("Content-Disposition")).toBe('attachment; filename="notes.md"');
+    await expect(response.text()).resolves.toBe("# Notes\nDownload body");
+  });
+
   it("requires authentication for text preview access", async () => {
     requireUserMock.mockResolvedValue(null);
 

--- a/tests/unit/message-bubble.test.ts
+++ b/tests/unit/message-bubble.test.ts
@@ -1495,9 +1495,9 @@ describe("message bubble", () => {
     });
 
     expect(global.fetch).toHaveBeenCalledWith("/api/attachments/att_text?format=text");
-    expect(screen.getByRole("link", { name: "Open raw attachment" })).toHaveAttribute(
+    expect(screen.getByRole("link", { name: "Download attachment" })).toHaveAttribute(
       "href",
-      "/api/attachments/att_text"
+      "/api/attachments/att_text?download=1"
     );
   });
 


### PR DESCRIPTION
## Summary
- Replace the attachment preview modal's raw-open action with a download link backed by `?download=1` on the existing attachment route.
- Add unit and e2e coverage for the new download behavior and include the approved design spec in `docs/superpowers/specs/2026-04-16-attachment-download-design.md`.
- Sync the root `package-lock.json` metadata with the existing package license field.

## Test Plan
- `npx vitest run tests/unit/attachment-preview-route.test.ts tests/unit/message-bubble.test.ts --coverage.enabled false`
- `npx playwright test tests/e2e/features.spec.ts --grep "opens transcript text attachments in a modal and renders preview content"`
- `npm test`