### PR TITLE
Improve browser tool labeling and ansi command logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,10 @@ ENV NODE_ENV=production
 ENV PORT=3000
 ENV EIDON_DATA_DIR=/app/data
 ENV EIDON_PASSWORD_LOGIN_ENABLED=true
+ENV HOME=/app/data/home
+ENV TMPDIR=/app/data/tmp
+ENV XDG_RUNTIME_DIR=/app/data/runtime
+ENV AGENT_BROWSER_SOCKET_DIR=/app/data/runtime/agent-browser
 
 # Install uv for uvx (Python-based MCP servers)
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
@@ -40,7 +44,8 @@ COPY --from=builder /app/public ./public
 COPY --from=builder /app/server.cjs ./server.cjs
 COPY --from=builder /app/ws-handler-compiled.cjs ./ws-handler-compiled.cjs
 COPY --from=prod-deps /app/node_modules ./node_modules
-RUN mkdir -p /app/data && chown -R eidon:eidon /app
+RUN install -d -m 700 /app/data /app/data/home /app/data/tmp /app/data/runtime /app/data/runtime/agent-browser \
+    && chown -R eidon:eidon /app
 USER eidon
 EXPOSE 3000
 VOLUME ["/app/data"]

--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/attachment-preview-modal";
 import { CompactionIndicator } from "@/components/compaction-indicator";
 import { Textarea } from "@/components/ui/textarea";
+import { parseAnsiText } from "@/lib/ansi";
 import { writeRichTextToClipboard } from "@/lib/clipboard";
 import type {
   MemoryCategory,
@@ -26,6 +27,58 @@ import { normalizeMarkdownLineBreaks } from "@/lib/text-utils";
 const MARKDOWN_PLUGINS = [remarkGfm, remarkBreaks];
 const COPY_RESET_DELAY_MS = 1600;
 const AssistantMarkdownCopyReadyContext = React.createContext<Map<number, boolean> | null>(null);
+
+function getAnsiForegroundClassName(foregroundColor: ReturnType<typeof parseAnsiText>[number]["foregroundColor"]) {
+  switch (foregroundColor) {
+    case "black":
+      return "text-white/55";
+    case "red":
+      return "text-red-300";
+    case "green":
+      return "text-emerald-300";
+    case "yellow":
+      return "text-amber-300";
+    case "blue":
+      return "text-sky-300";
+    case "magenta":
+      return "text-fuchsia-300";
+    case "cyan":
+      return "text-cyan-300";
+    case "white":
+      return "text-white/90";
+    default:
+      return null;
+  }
+}
+
+function AnsiText({
+  text,
+  defaultTextClassName
+}: {
+  text: string;
+  defaultTextClassName: string;
+}) {
+  const segments = parseAnsiText(text);
+
+  return (
+    <>
+      {segments.map((segment, index) => {
+        const segmentClassName = [
+          getAnsiForegroundClassName(segment.foregroundColor) ?? defaultTextClassName,
+          segment.bold ? "font-semibold" : null
+        ]
+          .filter(Boolean)
+          .join(" ");
+
+        return (
+          <span key={`${index}:${segment.text.length}`} className={segmentClassName}>
+            {segment.text}
+          </span>
+        );
+      })}
+    </>
+  );
+}
 
 function getMarkdownCodeValue(children: React.ReactNode) {
   return React.Children.toArray(children)
@@ -265,10 +318,14 @@ function CollapsibleActionRow({
       {isOpen && (action.detail || action.resultSummary) ? (
         <div className="px-2.5 pb-2">
           {action.detail ? (
-            <pre className="overflow-x-auto rounded-md bg-black/30 p-2 text-[11px] leading-5 text-white/45 whitespace-pre-wrap break-words font-mono">{action.detail}</pre>
+            <pre className="overflow-x-auto rounded-md bg-black/30 p-2 text-[11px] leading-5 whitespace-pre-wrap break-words font-mono">
+              <AnsiText text={action.detail} defaultTextClassName="text-white/45" />
+            </pre>
           ) : null}
           {action.resultSummary ? (
-            <p className="mt-1.5 text-[11px] text-white/35 break-words">{action.resultSummary}</p>
+            <div className="mt-1.5 text-[11px] break-words whitespace-pre-wrap font-mono">
+              <AnsiText text={action.resultSummary} defaultTextClassName="text-white/35" />
+            </div>
           ) : null}
         </div>
       ) : null}

--- a/lib/ansi.ts
+++ b/lib/ansi.ts
@@ -1,0 +1,123 @@
+export type AnsiTextSegment = {
+  text: string;
+  foregroundColor:
+    | "black"
+    | "red"
+    | "green"
+    | "yellow"
+    | "blue"
+    | "magenta"
+    | "cyan"
+    | "white"
+    | null;
+  bold: boolean;
+};
+
+const ANSI_SGR_PATTERN = /\u001b\[([0-9;]*)m/g;
+
+const STANDARD_FOREGROUND_COLOR_CODES = new Map<number, NonNullable<AnsiTextSegment["foregroundColor"]>>([
+  [30, "black"],
+  [31, "red"],
+  [32, "green"],
+  [33, "yellow"],
+  [34, "blue"],
+  [35, "magenta"],
+  [36, "cyan"],
+  [37, "white"],
+  [90, "black"],
+  [91, "red"],
+  [92, "green"],
+  [93, "yellow"],
+  [94, "blue"],
+  [95, "magenta"],
+  [96, "cyan"],
+  [97, "white"]
+]);
+
+type AnsiRenderState = Pick<AnsiTextSegment, "foregroundColor" | "bold">;
+
+const DEFAULT_ANSI_STATE: AnsiRenderState = {
+  foregroundColor: null,
+  bold: false
+};
+
+function pushAnsiTextSegment(
+  segments: AnsiTextSegment[],
+  text: string,
+  state: AnsiRenderState
+) {
+  if (!text) {
+    return;
+  }
+
+  const previousSegment = segments[segments.length - 1];
+
+  if (
+    previousSegment &&
+    previousSegment.foregroundColor === state.foregroundColor &&
+    previousSegment.bold === state.bold
+  ) {
+    previousSegment.text += text;
+    return;
+  }
+
+  segments.push({
+    text,
+    foregroundColor: state.foregroundColor,
+    bold: state.bold
+  });
+}
+
+function applyAnsiSgrCode(state: AnsiRenderState, code: number) {
+  if (code === 0) {
+    state.foregroundColor = null;
+    state.bold = false;
+    return;
+  }
+
+  if (code === 1) {
+    state.bold = true;
+    return;
+  }
+
+  if (code === 22) {
+    state.bold = false;
+    return;
+  }
+
+  if (code === 39) {
+    state.foregroundColor = null;
+    return;
+  }
+
+  const nextForegroundColor = STANDARD_FOREGROUND_COLOR_CODES.get(code);
+
+  if (nextForegroundColor) {
+    state.foregroundColor = nextForegroundColor;
+  }
+}
+
+export function parseAnsiText(input: string) {
+  const segments: AnsiTextSegment[] = [];
+  const state: AnsiRenderState = { ...DEFAULT_ANSI_STATE };
+  let lastIndex = 0;
+
+  for (const match of input.matchAll(ANSI_SGR_PATTERN)) {
+    const matchIndex = match.index ?? 0;
+    pushAnsiTextSegment(segments, input.slice(lastIndex, matchIndex), state);
+
+    const codes = match[1]
+      ? match[1].split(";").map((code) => Number.parseInt(code, 10)).filter((code) => Number.isFinite(code))
+      : [0];
+
+    for (const code of codes) {
+      applyAnsiSgrCode(state, code);
+    }
+
+    lastIndex = matchIndex + match[0].length;
+  }
+
+  pushAnsiTextSegment(segments, input.slice(lastIndex), state);
+
+  return segments;
+}

--- a/lib/assistant-runtime.ts
+++ b/lib/assistant-runtime.ts
@@ -9,7 +9,7 @@ import {
 } from "@/lib/memory-proposals";
 import { getSettings } from "@/lib/settings";
 import { parseSkillContentMetadata } from "@/lib/skill-metadata";
-import { executeLocalShellCommand, summarizeShellResult } from "@/lib/local-shell";
+import { executeLocalShellCommand, getShellCommandLabel, summarizeShellResult } from "@/lib/local-shell";
 import { callMcpTool, getToolResultText } from "@/lib/mcp-client";
 import { searchSearxng } from "@/lib/searxng";
 import { extractEnumHints, coerceEnumValues } from "@/lib/tool-schema-helpers";
@@ -653,7 +653,7 @@ async function executeShellCommand(
 
   const handle = await context.input.onActionStart?.({
     kind: "shell_command",
-    label: "Local command",
+    label: getShellCommandLabel(command),
     detail: buildShellDetail(command),
     arguments: { command, timeoutMs }
   });

--- a/lib/copilot-tools.ts
+++ b/lib/copilot-tools.ts
@@ -8,7 +8,7 @@ import {
   normalizeMemoryCategory
 } from "@/lib/memory-proposals";
 import { getSettings } from "@/lib/settings";
-import { executeLocalShellCommand, summarizeShellResult } from "@/lib/local-shell";
+import { executeLocalShellCommand, getShellCommandLabel, summarizeShellResult } from "@/lib/local-shell";
 import { searchSearxng } from "@/lib/searxng";
 import { parseSkillContentMetadata } from "@/lib/skill-metadata";
 import { coerceEnumValues } from "@/lib/tool-schema-helpers";
@@ -143,7 +143,7 @@ function buildShellCopilotTool(ctx: CopilotToolContext): Tool {
 
       const handle = await ctx.onActionStart?.({
         kind: "shell_command",
-        label: "Local command",
+        label: getShellCommandLabel(command),
         detail: command.length > 140 ? `${command.slice(0, 137)}...` : command,
         arguments: { command, timeoutMs: timeout_ms }
       });

--- a/lib/local-shell.ts
+++ b/lib/local-shell.ts
@@ -3,6 +3,9 @@ import { accessSync, constants as fsConstants } from "node:fs";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 const MAX_OUTPUT_CHARS = 8_000;
+const SHELL_SEGMENT_SEPARATOR_PATTERN = /&&|\|\||[;|\n]/;
+const WEB_BROWSER_COMMAND_SEGMENT_PATTERN =
+  /^(?:(?:env)\s+)?(?:(?:[A-Z_][A-Z0-9_]*=(?:"[^"]*"|'[^']*'|[^\s]+))\s+)*(?:(?:npx|bunx)\s+|pnpm\s+(?:exec|dlx)\s+|yarn\s+dlx\s+)?(?:(?:\.{1,2}\/|\/)?(?:[^\s/]+\/)*agent-browser)(?:\s|$)/i;
 
 export type ShellCallPayload = {
   command: string;
@@ -116,6 +119,15 @@ export async function executeLocalShellCommand(input: {
       });
     });
   });
+}
+
+export function getShellCommandLabel(command: string) {
+  const invokesWebBrowser = command
+    .split(SHELL_SEGMENT_SEPARATOR_PATTERN)
+    .map((segment) => segment.trim())
+    .some((segment) => WEB_BROWSER_COMMAND_SEGMENT_PATTERN.test(segment));
+
+  return invokesWebBrowser ? "Web browser" : "Local command";
 }
 
 export function summarizeShellResult(result: ShellExecutionResult) {

--- a/tests/unit/ansi.test.ts
+++ b/tests/unit/ansi.test.ts
@@ -1,0 +1,38 @@
+import { parseAnsiText } from "@/lib/ansi";
+
+describe("ansi text parser", () => {
+  it("parses foreground colors and reset sequences into styled segments", () => {
+    expect(parseAnsiText("\u001b[32m✓\u001b[0m ok \u001b[31mnope\u001b[0m")).toEqual([
+      {
+        text: "✓",
+        foregroundColor: "green",
+        bold: false
+      },
+      {
+        text: " ok ",
+        foregroundColor: null,
+        bold: false
+      },
+      {
+        text: "nope",
+        foregroundColor: "red",
+        bold: false
+      }
+    ]);
+  });
+
+  it("tracks bold independently from foreground colors", () => {
+    expect(parseAnsiText("\u001b[1mstrong\u001b[22m plain")).toEqual([
+      {
+        text: "strong",
+        foregroundColor: null,
+        bold: true
+      },
+      {
+        text: " plain",
+        foregroundColor: null,
+        bold: false
+      }
+    ]);
+  });
+});

--- a/tests/unit/assistant-runtime.test.ts
+++ b/tests/unit/assistant-runtime.test.ts
@@ -3,8 +3,10 @@ import type { ChatStreamEvent, ProviderProfileWithApiKey, Skill } from "@/lib/ty
 const streamProviderResponse = vi.fn();
 const callMcpTool = vi.fn();
 const getToolResultText = vi.fn();
-const executeLocalShellCommand = vi.fn();
-const summarizeShellResult = vi.fn();
+const localShellMocks = vi.hoisted(() => ({
+  executeLocalShellCommand: vi.fn(),
+  summarizeShellResult: vi.fn()
+}));
 const getMemoryRecord = vi.fn();
 const createMemoryFn = vi.fn();
 const updateMemoryRecord = vi.fn();
@@ -22,10 +24,14 @@ vi.mock("@/lib/mcp-client", () => ({
   getToolResultText
 }));
 
-vi.mock("@/lib/local-shell", () => ({
-  executeLocalShellCommand,
-  summarizeShellResult
-}));
+vi.mock("@/lib/local-shell", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/local-shell")>();
+  return {
+    ...actual,
+    executeLocalShellCommand: localShellMocks.executeLocalShellCommand,
+    summarizeShellResult: localShellMocks.summarizeShellResult
+  };
+});
 
 vi.mock("@/lib/memories", () => ({
   getMemory: getMemoryRecord,
@@ -122,8 +128,8 @@ describe("assistant runtime", () => {
     streamProviderResponse.mockReset();
     callMcpTool.mockReset();
     getToolResultText.mockReset();
-    executeLocalShellCommand.mockReset();
-    summarizeShellResult.mockReset();
+    localShellMocks.executeLocalShellCommand.mockReset();
+    localShellMocks.summarizeShellResult.mockReset();
     getMemoryRecord.mockReset();
     createMemoryFn.mockReset();
     updateMemoryRecord.mockReset();
@@ -136,7 +142,7 @@ describe("assistant runtime", () => {
     getToolResultText.mockImplementation((result: { content?: Array<{ text?: string }> }) => {
       return result.content?.[0]?.text ?? "done";
     });
-    summarizeShellResult.mockImplementation((result: { stdout?: string; stderr?: string }) => {
+    localShellMocks.summarizeShellResult.mockImplementation((result: { stdout?: string; stderr?: string }) => {
       return result.stdout || result.stderr || "done";
     });
   });
@@ -425,7 +431,7 @@ describe("assistant runtime", () => {
           usage: { inputTokens: 8, outputTokens: 2 }
         })
       );
-    executeLocalShellCommand.mockResolvedValue({
+    localShellMocks.executeLocalShellCommand.mockResolvedValue({
       stdout: "HTTP/2 200",
       stderr: "",
       exitCode: 0,
@@ -448,11 +454,62 @@ describe("assistant runtime", () => {
     expect(started).toEqual([
       expect.objectContaining({ kind: "shell_command", label: "Local command", detail: "curl -I https://example.com" })
     ]);
-    expect(executeLocalShellCommand).toHaveBeenCalledWith({
+    expect(localShellMocks.executeLocalShellCommand).toHaveBeenCalledWith({
       command: "curl -I https://example.com",
       timeoutMs: undefined
     });
     expect(result.answer).toBe("Probed the endpoint.");
+  });
+
+  it("labels agent-browser shell commands as Web browser", async () => {
+    streamProviderResponse
+      .mockReturnValueOnce(
+        createProviderStream([], {
+          answer: "",
+          thinking: "",
+          toolCalls: [{
+            id: "call_1",
+            name: "execute_shell_command",
+            arguments: JSON.stringify({ command: "agent-browser open https://example.com" })
+          }],
+          usage: { inputTokens: 7 }
+        })
+      )
+      .mockReturnValueOnce(
+        createProviderStream([{ type: "answer_delta", text: "Opened the page." }], {
+          answer: "Opened the page.",
+          thinking: "",
+          usage: { inputTokens: 8, outputTokens: 2 }
+        })
+      );
+    localShellMocks.executeLocalShellCommand.mockResolvedValue({
+      stdout: "Page opened",
+      stderr: "",
+      exitCode: 0,
+      timedOut: false,
+      isError: false
+    });
+
+    const started: Array<{ kind: string; label: string; detail?: string }> = [];
+    const { resolveAssistantTurn } = await import("@/lib/assistant-runtime");
+
+    const result = await resolveAssistantTurn({
+      settings: createSettings(),
+      promptMessages: [{ role: "user", content: "Open example.com in the browser" }],
+      skills: [],
+      mcpToolSets: [],
+      onActionStart: (action) => { started.push(action); return "act_shell"; },
+      onActionComplete: () => undefined
+    });
+
+    expect(started).toEqual([
+      expect.objectContaining({
+        kind: "shell_command",
+        label: "Web browser",
+        detail: "agent-browser open https://example.com"
+      })
+    ]);
+    expect(result.answer).toBe("Opened the page.");
   });
 
   it("keeps load_skill hidden for ordinary factual chat turns while shell remains available", async () => {
@@ -804,7 +861,7 @@ Run browser commands.`
       onActionStart: () => "act_shell"
     });
 
-    expect(executeLocalShellCommand).not.toHaveBeenCalled();
+    expect(localShellMocks.executeLocalShellCommand).not.toHaveBeenCalled();
     expect(result.answer).toBe("Need a command.");
   });
 

--- a/tests/unit/copilot-tools.test.ts
+++ b/tests/unit/copilot-tools.test.ts
@@ -2,15 +2,7 @@ import { beforeEach, describe, it, expect, vi } from "vitest";
 import { buildCopilotTools } from "@/lib/copilot-tools";
 import type { McpServer, McpTool, Skill } from "@/lib/types";
 
-vi.mock("@/lib/mcp-client", () => ({
-  callMcpTool: vi.fn().mockResolvedValue({
-    content: [{ type: "text", text: "mock result" }],
-    isError: false
-  }),
-  getToolResultText: vi.fn().mockReturnValue("mock result")
-}));
-
-vi.mock("@/lib/local-shell", () => ({
+const localShellMocks = vi.hoisted(() => ({
   executeLocalShellCommand: vi.fn().mockResolvedValue({
     exitCode: 0,
     stdout: "ok",
@@ -20,6 +12,23 @@ vi.mock("@/lib/local-shell", () => ({
   }),
   summarizeShellResult: vi.fn().mockReturnValue("ok")
 }));
+
+vi.mock("@/lib/mcp-client", () => ({
+  callMcpTool: vi.fn().mockResolvedValue({
+    content: [{ type: "text", text: "mock result" }],
+    isError: false
+  }),
+  getToolResultText: vi.fn().mockReturnValue("mock result")
+}));
+
+vi.mock("@/lib/local-shell", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/local-shell")>();
+  return {
+    ...actual,
+    executeLocalShellCommand: localShellMocks.executeLocalShellCommand,
+    summarizeShellResult: localShellMocks.summarizeShellResult
+  };
+});
 
 vi.mock("@/lib/searxng", () => ({
   searchSearxng: vi.fn().mockResolvedValue("SearXNG result")
@@ -464,6 +473,35 @@ describe("buildCopilotTools", () => {
       detail: "echo ready",
       resultSummary: "ready"
     });
+  });
+
+  it("labels agent-browser shell commands as Web browser", async () => {
+    const { executeLocalShellCommand, summarizeShellResult } = await import("@/lib/local-shell");
+    vi.mocked(executeLocalShellCommand).mockResolvedValueOnce({
+      exitCode: 0,
+      stdout: "page loaded",
+      stderr: "",
+      timedOut: false,
+      isError: false
+    });
+    vi.mocked(summarizeShellResult).mockReturnValueOnce("page loaded");
+
+    const onActionStart = vi.fn().mockResolvedValue("shell_1");
+    const ctx = makeCtx({ onActionStart });
+
+    const tools = buildCopilotTools(ctx);
+    const shellTool = tools.find((t) => t.name === "execute_shell_command")!;
+
+    await shellTool.handler!(
+      { command: "agent-browser open https://example.com" },
+      { sessionId: "s1", toolCallId: "tc1", toolName: "execute_shell_command", arguments: {} }
+    );
+
+    expect(onActionStart).toHaveBeenCalledWith(expect.objectContaining({
+      kind: "shell_command",
+      label: "Web browser",
+      detail: "agent-browser open https://example.com"
+    }));
   });
 
   it("records shell command error results", async () => {

--- a/tests/unit/dockerfile.test.ts
+++ b/tests/unit/dockerfile.test.ts
@@ -1,0 +1,19 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const dockerfile = fs.readFileSync(path.join(process.cwd(), "Dockerfile"), "utf8");
+
+describe("Dockerfile", () => {
+  it("provisions writable browser runtime directories for the non-root user", () => {
+    expect(dockerfile).toContain("ENV HOME=/app/data/home");
+    expect(dockerfile).toContain("ENV TMPDIR=/app/data/tmp");
+    expect(dockerfile).toContain("ENV XDG_RUNTIME_DIR=/app/data/runtime");
+    expect(dockerfile).toContain("ENV AGENT_BROWSER_SOCKET_DIR=/app/data/runtime/agent-browser");
+    expect(dockerfile).toContain(
+      "install -d -m 700 /app/data /app/data/home /app/data/tmp /app/data/runtime /app/data/runtime/agent-browser"
+    );
+    expect(dockerfile).toContain("chown -R eidon:eidon /app");
+  });
+});

--- a/tests/unit/local-shell.test.ts
+++ b/tests/unit/local-shell.test.ts
@@ -191,6 +191,26 @@ describe("local shell", () => {
     });
   });
 
+  it("labels direct and wrapped agent-browser commands as Web browser", async () => {
+    const { getShellCommandLabel } = await import("@/lib/local-shell");
+
+    expect(getShellCommandLabel("agent-browser open https://example.com")).toBe("Web browser");
+    expect(getShellCommandLabel("npx agent-browser open https://example.com")).toBe("Web browser");
+    expect(getShellCommandLabel("pnpm exec agent-browser open https://example.com")).toBe("Web browser");
+    expect(getShellCommandLabel('FOO="a b" agent-browser open https://example.com')).toBe("Web browser");
+    expect(getShellCommandLabel("env FOO=1 agent-browser open https://example.com")).toBe("Web browser");
+    expect(getShellCommandLabel("/usr/local/bin/agent-browser open https://example.com")).toBe("Web browser");
+    expect(getShellCommandLabel("sleep 3 && agent-browser snapshot")).toBe("Web browser");
+    expect(getShellCommandLabel("sleep 3 && ./agent-browser snapshot")).toBe("Web browser");
+  });
+
+  it("keeps non-invocation agent-browser text labeled as Local command", async () => {
+    const { getShellCommandLabel } = await import("@/lib/local-shell");
+
+    expect(getShellCommandLabel("echo agent-browser open https://example.com")).toBe("Local command");
+    expect(getShellCommandLabel("printf 'agent-browser snapshot'")).toBe("Local command");
+  });
+
   it("returns a structured error when spawn fails before close", async () => {
     const { executeLocalShellCommand, summarizeShellResult } = await import("@/lib/local-shell");
     const child = new MockChild();

--- a/tests/unit/message-bubble.test.ts
+++ b/tests/unit/message-bubble.test.ts
@@ -200,6 +200,34 @@ describe("message bubble", () => {
     expect(screen.getByText("Found MCP documentation")).toBeInTheDocument();
   });
 
+  it("renders ANSI-colored tool logs without showing raw escape codes", () => {
+    const { container } = render(
+      React.createElement(MessageBubble, {
+        message: {
+          ...createAssistantMessage(),
+          actions: [
+            createToolAction({
+              id: "act_ansi",
+              messageId: "msg_assistant",
+              kind: "shell_command",
+              label: "Web browser",
+              detail: "agent-browser screenshot /tmp/example.png",
+              resultSummary:
+                "\u001b[32m✓\u001b[0m Screenshot saved to \u001b[32m/tmp/example.png\u001b[0m"
+            })
+          ]
+        }
+      })
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Web browser" }));
+
+    expect(screen.getByText("✓")).toBeInTheDocument();
+    expect(screen.getByText("/tmp/example.png")).toBeInTheDocument();
+    expect(container.textContent).not.toContain("[32m");
+    expect(container.querySelector(".text-emerald-300")).not.toBeNull();
+  });
+
   it("renders pending create proposals with operation-specific copy", () => {
     render(
       React.createElement(MessageBubble, {


### PR DESCRIPTION
## Summary
This PR updates shell command tool labels so any command invoking `agent-browser` is shown as `Web browser` across both copilot tool execution and assistant runtime. It also adds command-segment detection for chained shell expressions so nested invocations like `sleep 3 && agent-browser ...` are correctly classified. Tool card expansion now renders ANSI color output via a lightweight parser, converting escape codes into visible colored spans instead of raw text. Runtime and frontend behavior for local commands now uses the shared shell label helper for consistent naming while preserving existing local-command behavior. It also includes container runtime hardening by provisioning writable `HOME/TMPDIR/XDG_RUNTIME_DIR` and agent-browser socket directories for the non-root `eidon` user in the Docker image.
