### PR TITLE
feat: add desktop sidebar toggle button

### DIFF
--- a/components/shell.tsx
+++ b/components/shell.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useState, type PropsWithChildren } from "react";
+import { useEffect, useState, type PropsWithChildren } from "react";
 import { usePathname, useRouter } from "next/navigation";
-import { Menu, Plus } from "lucide-react";
+import { ChevronLeft, ChevronRight, Menu, Plus } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 import { AutomationsNav } from "@/components/automations/automations-nav";
 import { Sidebar } from "@/components/sidebar";
@@ -27,6 +27,13 @@ export function Shell({
   automations?: Automation[];
 }>) {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+
+  useEffect(() => {
+    if (typeof window !== "undefined" && window.innerWidth >= 768) {
+      setIsSidebarOpen(true);
+    }
+  }, []);
+
   const pathname = usePathname();
   const router = useRouter();
   useGlobalWebSocket();
@@ -54,8 +61,8 @@ export function Shell({
       </AnimatePresence>
 
       <div
-        className={`fixed inset-y-0 left-0 z-50 w-[280px] transform transition-transform duration-300 ease-out md:relative md:z-0 md:translate-x-0 border-r border-white/5 ${
-          isSidebarOpen ? "translate-x-0" : "-translate-x-full"
+        className={`fixed inset-y-0 left-0 z-50 w-[280px] transform transition-transform duration-300 ease-out border-r border-white/5 ${
+          isSidebarOpen ? "translate-x-0 md:translate-x-0" : "-translate-x-full md:-translate-x-full"
         }`}
       >
         {isSettingsPage ? (
@@ -71,7 +78,24 @@ export function Shell({
         )}
       </div>
 
-      <div className="relative flex min-h-0 min-w-0 flex-1 flex-col w-full overflow-hidden pt-14 md:pt-0">
+      <button
+        type="button"
+        onClick={() => setIsSidebarOpen((prev) => !prev)}
+        className={`hidden md:flex fixed top-1/2 -translate-y-1/2 z-50 w-6 h-12 items-center justify-center rounded-full bg-[var(--background)] border border-white/10 hover:border-white/20 hover:bg-white/5 transition-all duration-300 ease-out ${
+          isSidebarOpen ? "left-[280px]" : "left-0"
+        }`}
+        aria-label={isSidebarOpen ? "Collapse sidebar" : "Expand sidebar"}
+      >
+        {isSidebarOpen ? (
+          <ChevronLeft className="h-4 w-4 text-[var(--text-muted)]" />
+        ) : (
+          <ChevronRight className="h-4 w-4 text-[var(--text-muted)]" />
+        )}
+      </button>
+
+      <div className={`relative flex min-h-0 min-w-0 flex-1 flex-col w-full overflow-hidden pt-14 md:pt-0 transition-all duration-300 ease-out ${
+        isSidebarOpen ? "md:pl-[280px]" : "md:pl-0"
+      }`}>
         <div className="fixed top-0 left-0 right-0 z-30 flex h-14 items-center justify-between px-4 md:hidden bg-[var(--background)]/80 backdrop-blur-xl border-b border-white/4">
           <button
             type="button"

--- a/docs/superpowers/specs/2026-04-21-desktop-sidebar-toggle-design.md
+++ b/docs/superpowers/specs/2026-04-21-desktop-sidebar-toggle-design.md
@@ -1,0 +1,35 @@
+# Desktop Sidebar Toggle
+
+## Overview
+Add a show/hide toggle button to the desktop sidebar so it can slide in and out from the left, giving the conversation viewport more width.
+
+## Current State
+- The `Shell` component (`components/shell.tsx`) renders a 280px sidebar on the left and a flex-1 main content area.
+- Sidebar visibility is controlled by `isSidebarOpen` state (currently mobile-only).
+- On desktop (`md:` breakpoints), the sidebar is always visible (`md:translate-x-0`).
+- Mobile uses a hamburger menu + overlay (`bg-black/70 backdrop-blur-sm`).
+
+## Proposed Design
+
+### Layout Behavior
+- Extend `isSidebarOpen` state to also control desktop visibility.
+- Sidebar defaults to **open** on desktop (preserves existing behavior).
+- When toggled off, sidebar slides out to the left using `md:-translate-x-full` with the existing `transition-transform duration-300 ease-out` classes.
+- The main content area is `flex-1` and automatically expands to fill the freed space.
+
+### Toggle Button
+- **Position**: fixed/absolute at the sidebar's right edge, vertically centered.
+- **Size**: ~28px wide, ~48px tall (pill shape).
+- **Icon**: `ChevronLeft` when open, `ChevronRight` when closed.
+- **Style**: subtle background (`bg-white/5`), border on the right edge, hover highlight.
+- **Accessibility**: `aria-label="Collapse sidebar"` / `"Expand sidebar"`.
+- **Visibility**: `hidden md:flex` so it only appears on desktop.
+
+### State & Behavior
+- Mobile behavior is **unchanged** — hamburger menu still controls the overlay sidebar.
+- Desktop toggle is independent and hidden from mobile view.
+- `isSidebarOpen` drives both mobile and desktop visibility.
+
+### Testing
+- Unit test: verify toggle button renders, toggles `isSidebarOpen`, and applies correct translate class.
+- E2E: open a chat, click toggle → sidebar hides and viewport widens; click again → sidebar reappears.

--- a/tests/e2e/features.spec.ts
+++ b/tests/e2e/features.spec.ts
@@ -937,6 +937,31 @@ test.describe("Feature: Mobile settings navigation", () => {
   });
 });
 
+test.describe("Feature: Desktop sidebar toggle", () => {
+  test("collapses and expands sidebar on desktop", async ({ page }) => {
+    await signIn(page);
+    await page.setViewportSize({ width: 1280, height: 844 });
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    // Sidebar should be visible by default
+    await expect(page.locator("aside")).toBeVisible();
+
+    // Toggle button should be visible
+    const toggleButton = page.getByRole("button", { name: "Collapse sidebar" });
+    await expect(toggleButton).toBeVisible();
+
+    // Click to collapse
+    await toggleButton.click();
+    await expect(page.getByRole("button", { name: "Expand sidebar" })).toBeVisible();
+
+    // Click to expand back
+    await page.getByRole("button", { name: "Expand sidebar" }).click();
+    await expect(page.locator("aside")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Collapse sidebar" })).toBeVisible();
+  });
+});
+
 test.describe("Feature: Skills in settings", () => {
   test("adds and removes a skill", async ({ page }) => {
     await signIn(page);

--- a/tests/unit/shell-desktop-toggle.test.tsx
+++ b/tests/unit/shell-desktop-toggle.test.tsx
@@ -70,8 +70,8 @@ describe("Desktop Sidebar Toggle", () => {
     render(<Shell {...mockProps} />);
     const toggle = screen.getByRole("button", { name: /collapse sidebar|expand sidebar/i });
     expect(toggle).toBeInTheDocument();
-    expect(toggle.parentElement).toHaveClass("hidden");
-    expect(toggle.parentElement).toHaveClass("md:flex");
+    expect(toggle).toHaveClass("hidden");
+    expect(toggle).toHaveClass("md:flex");
   });
 
   it("shows aria-label 'Collapse sidebar' when sidebar is open by default", () => {

--- a/tests/unit/shell-desktop-toggle.test.tsx
+++ b/tests/unit/shell-desktop-toggle.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { Shell } from "@/components/shell";
+
+const mockPush = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/",
+  useRouter: () => ({ push: mockPush }),
+}));
+
+vi.mock("framer-motion", () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  motion: {
+    div: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement> & { children: React.ReactNode }) => (
+      <div {...props}>{children}</div>
+    ),
+  },
+}));
+
+vi.mock("@/components/sidebar", () => ({
+  Sidebar: () => <aside data-testid="sidebar">Sidebar</aside>,
+}));
+
+vi.mock("@/components/settings/settings-nav", () => ({
+  SettingsNav: () => <aside data-testid="settings-nav">SettingsNav</aside>,
+}));
+
+vi.mock("@/components/automations/automations-nav", () => ({
+  AutomationsNav: () => <aside data-testid="automations-nav">AutomationsNav</aside>,
+}));
+
+vi.mock("@/lib/context-tokens-context", () => ({
+  ContextTokensProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/lib/conversation-drafts", () => ({
+  deleteConversationIfStillEmpty: vi.fn(),
+}));
+
+vi.mock("@/lib/ws-client", () => ({
+  useGlobalWebSocket: vi.fn(),
+}));
+
+const mockProps = {
+  currentUser: {
+    id: "u1",
+    username: "testuser",
+    role: "user" as const,
+    authSource: "local" as const,
+    passwordManagedBy: "local" as const,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  },
+  passwordLoginEnabled: true,
+  conversationPage: { conversations: [], nextCursor: null, hasMore: false },
+  folders: [],
+  automations: [],
+  children: <div data-testid="main">Main Content</div>,
+};
+
+describe("Desktop Sidebar Toggle", () => {
+  beforeEach(() => {
+    mockPush.mockReset();
+  });
+
+  it("renders toggle button on desktop viewport", () => {
+    render(<Shell {...mockProps} />);
+    const toggle = screen.getByRole("button", { name: /collapse sidebar|expand sidebar/i });
+    expect(toggle).toBeInTheDocument();
+    expect(toggle.parentElement).toHaveClass("hidden");
+    expect(toggle.parentElement).toHaveClass("md:flex");
+  });
+
+  it("shows aria-label 'Collapse sidebar' when sidebar is open by default", () => {
+    render(<Shell {...mockProps} />);
+    const toggle = screen.getByRole("button", { name: "Collapse sidebar" });
+    expect(toggle).toBeInTheDocument();
+  });
+
+  it("collapses sidebar and shows 'Expand sidebar' on click", () => {
+    render(<Shell {...mockProps} />);
+    const toggle = screen.getByRole("button", { name: "Collapse sidebar" });
+    fireEvent.click(toggle);
+
+    expect(screen.getByRole("button", { name: "Expand sidebar" })).toBeInTheDocument();
+
+    const sidebar = screen.getByRole("complementary");
+    expect(sidebar.parentElement).toHaveClass("md:-translate-x-full");
+    expect(sidebar.parentElement).not.toHaveClass("md:translate-x-0");
+  });
+
+  it("expands sidebar back on second click", () => {
+    render(<Shell {...mockProps} />);
+    const toggle = screen.getByRole("button", { name: "Collapse sidebar" });
+    fireEvent.click(toggle); // close
+    fireEvent.click(toggle); // open
+
+    expect(screen.getByRole("button", { name: "Collapse sidebar" })).toBeInTheDocument();
+
+    const sidebar = screen.getByRole("complementary");
+    expect(sidebar.parentElement).toHaveClass("md:translate-x-0");
+    expect(sidebar.parentElement).not.toHaveClass("md:-translate-x-full");
+  });
+});


### PR DESCRIPTION
Add a show/hide toggle button to the desktop sidebar so users can collapse it and gain more horizontal space for the conversation viewport. The sidebar slides from the left with smooth CSS transitions and defaults to open on desktop. The toggle button uses ChevronLeft/ChevronRight icons and is hidden on mobile to preserve the existing hamburger menu behavior. Includes unit and E2E tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)