### PR TITLE
Fix chat auto-scroll on send

### DIFF
--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -722,14 +722,29 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
     });
   }, [payload.conversation.id]);
 
-  function jumpToBottom() {
+  function scrollQueueToBottom(behavior: ScrollBehavior = "smooth") {
     if (!queueRef.current) {
       return;
     }
 
     shouldAutoScrollRef.current = true;
     setIsConversationAtBottom(true);
-    queueRef.current.scrollTo({ top: queueRef.current.scrollHeight, behavior: "smooth" });
+    if (queueRef.current.scrollTo) {
+      queueRef.current.scrollTo({ top: queueRef.current.scrollHeight, behavior });
+    } else {
+      queueRef.current.scrollTop = queueRef.current.scrollHeight;
+    }
+  }
+
+  function jumpToBottom() {
+    scrollQueueToBottom("smooth");
+  }
+
+  function ensureQueueAtBottomAfterSubmit() {
+    scrollQueueToBottom("auto");
+    requestAnimationFrame(() => {
+      scrollQueueToBottom("auto");
+    });
   }
 
   useEffect(() => {
@@ -751,7 +766,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
       if (!queueRef.current || !shouldAutoScrollRef.current) return;
       setIsConversationAtBottom(true);
       if (queueRef.current.scrollTo) {
-        queueRef.current.scrollTo({ top: queueRef.current.scrollHeight, behavior: "instant" });
+        queueRef.current.scrollTo({ top: queueRef.current.scrollHeight, behavior: "auto" });
       } else {
         queueRef.current.scrollTop = queueRef.current.scrollHeight;
       }
@@ -1737,6 +1752,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
         return;
       }
 
+      ensureQueueAtBottomAfterSubmit();
       setError("");
       setInput("");
       wsSend({
@@ -1751,6 +1767,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
       return;
     }
 
+    ensureQueueAtBottomAfterSubmit();
     setError("");
     setInput("");
     setPendingAttachments([]);

--- a/tests/unit/chat-view.test.ts
+++ b/tests/unit/chat-view.test.ts
@@ -2511,6 +2511,78 @@ describe("chat view", () => {
     });
   });
 
+  it("jumps back to the latest messages when a scrolled-up user queues another prompt", async () => {
+    const { container } = renderWithProvider(
+      React.createElement(ChatView, {
+        payload: createPayload({
+          conversation: {
+            ...createPayload().conversation,
+            isActive: true
+          }
+        })
+      })
+    );
+    const queue = container.querySelector(".no-scrollbar.overflow-y-auto") as HTMLDivElement;
+    const textarea = screen.getByPlaceholderText(
+      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
+    );
+
+    let scrollTop = 700;
+    const scrollTo = vi.fn(({ top }: { top?: number }) => {
+      if (typeof top === "number") {
+        scrollTop = top;
+      }
+    });
+
+    Object.defineProperty(queue, "clientHeight", {
+      configurable: true,
+      get: () => 300
+    });
+    Object.defineProperty(queue, "scrollHeight", {
+      configurable: true,
+      get: () => 1000
+    });
+    Object.defineProperty(queue, "scrollTop", {
+      configurable: true,
+      get: () => scrollTop,
+      set: (value: number) => {
+        scrollTop = value;
+      }
+    });
+    Object.defineProperty(queue, "scrollTo", {
+      configurable: true,
+      value: scrollTo
+    });
+
+    act(() => {
+      wsMock.onMessage!({
+        type: "delta",
+        conversationId: "conv_1",
+        event: { type: "message_start", messageId: "msg_assistant" }
+      });
+    });
+
+    await flushAnimationFrame();
+
+    scrollTop = 120;
+    fireEvent.scroll(queue);
+    scrollTo.mockClear();
+
+    fireEvent.change(textarea, { target: { value: "Queued follow-up" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(wsMock.send).toHaveBeenCalledWith({
+        type: "queue_message",
+        conversationId: "conv_1",
+        content: "Queued follow-up"
+      });
+    });
+
+    expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ top: 1000 }));
+    expect(scrollTop).toBe(1000);
+  });
+
   it("does not force-scroll streaming updates when the user has scrolled away from the bottom", async () => {
     const { container } = renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
     const queue = container.querySelector(".no-scrollbar.overflow-y-auto") as HTMLDivElement;
@@ -2566,6 +2638,65 @@ describe("chat view", () => {
 
     expect(scrollTo).not.toHaveBeenCalled();
     expect(scrollTop).toBe(120);
+  });
+
+  it("hides the scroll-to-newest pill when the user sends from a scrolled-up conversation", async () => {
+    const { container } = renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
+    const queue = container.querySelector(".no-scrollbar.overflow-y-auto") as HTMLDivElement;
+    const textarea = screen.getByPlaceholderText(
+      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
+    );
+
+    let scrollTop = 700;
+    const scrollTo = vi.fn(({ top }: { top?: number }) => {
+      if (typeof top === "number") {
+        scrollTop = top;
+      }
+    });
+
+    Object.defineProperty(queue, "clientHeight", {
+      configurable: true,
+      get: () => 300
+    });
+    Object.defineProperty(queue, "scrollHeight", {
+      configurable: true,
+      get: () => 1000
+    });
+    Object.defineProperty(queue, "scrollTop", {
+      configurable: true,
+      get: () => scrollTop,
+      set: (value: number) => {
+        scrollTop = value;
+      }
+    });
+    Object.defineProperty(queue, "scrollTo", {
+      configurable: true,
+      value: scrollTo
+    });
+
+    await flushAnimationFrame();
+
+    scrollTop = 120;
+    fireEvent.scroll(queue);
+    scrollTo.mockClear();
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Scroll to newest messages" })).toBeInTheDocument();
+    });
+
+    fireEvent.change(textarea, { target: { value: "Follow the latest reply" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    await flushAnimationFrame();
+
+    expect(wsMock.send).toHaveBeenCalledWith({
+      type: "message",
+      conversationId: "conv_1",
+      content: "Follow the latest reply",
+      attachmentIds: [],
+      personaId: undefined
+    });
+    expect(screen.queryByRole("button", { name: "Scroll to newest messages" })).toBeNull();
   });
 
   it("renders tool actions and answer text while streaming", async () => {


### PR DESCRIPTION
## Summary
- Re-anchor the conversation queue when a send originates from a scrolled-up view so the streaming reply stays visible.
- Factor queue scrolling into a shared helper and use browser-safe `auto` scrolling for submit-triggered jumps.
- Add regression coverage for queued follow-ups and scroll-to-newest visibility after sending from scrolled up.

## Testing
- `npx vitest run --coverage.enabled false tests/unit/chat-view.test.ts`
- `npm test`
- Local browser validation with `agent-browser` against the running dev server