### PR TITLE
Refine sidebar handle styling

### DIFF
--- a/components/home-view.tsx
+++ b/components/home-view.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 
 import { ChatComposer } from "@/components/chat-composer";
-import { storeChatBootstrap } from "@/lib/chat-bootstrap";
+import { markHomeSubmitSidebarAutoHide, storeChatBootstrap } from "@/lib/chat-bootstrap";
 import { appendTranscriptToDraft } from "@/lib/speech/append-transcript-to-draft";
 import { useSpeechInput } from "@/lib/speech/use-speech-input";
 import { shouldAutofocusTextInput } from "@/lib/utils";
@@ -259,6 +259,7 @@ export function HomeView({
         attachments: pendingAttachments,
         personaId: personaId ?? undefined
       });
+      markHomeSubmitSidebarAutoHide(conversationId);
       router.push(`/chat/${conversationId}`);
     } catch (caughtError) {
       setError(

--- a/components/shell.tsx
+++ b/components/shell.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useEffect, useState, type PropsWithChildren } from "react";
+import { useEffect, useRef, useState, type PropsWithChildren } from "react";
 import { usePathname, useRouter } from "next/navigation";
-import { ChevronLeft, ChevronRight, Menu, Plus } from "lucide-react";
+import { Menu, PanelLeftClose, PanelLeftOpen, Plus } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 import { AutomationsNav } from "@/components/automations/automations-nav";
 import { Sidebar } from "@/components/sidebar";
@@ -10,6 +10,7 @@ import { SettingsNav } from "@/components/settings/settings-nav";
 import { ContextTokensProvider } from "@/lib/context-tokens-context";
 import type { AuthUser, Automation, Conversation, ConversationListPage, Folder } from "@/lib/types";
 import { deleteConversationIfStillEmpty } from "@/lib/conversation-drafts";
+import { consumeHomeSubmitSidebarAutoHide } from "@/lib/chat-bootstrap";
 import { useGlobalWebSocket } from "@/lib/ws-client";
 
 export function Shell({
@@ -27,12 +28,8 @@ export function Shell({
   automations?: Automation[];
 }>) {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
-
-  useEffect(() => {
-    if (typeof window !== "undefined" && window.innerWidth >= 768) {
-      setIsSidebarOpen(true);
-    }
-  }, []);
+  const consumedHomeSubmitAutoHideConversationIdRef = useRef<string | null>(null);
+  const hasAppliedDesktopDefaultRef = useRef(false);
 
   const pathname = usePathname();
   const router = useRouter();
@@ -42,7 +39,52 @@ export function Shell({
     : null;
   const isSettingsPage = pathname.startsWith("/settings");
   const isAutomationsPage = pathname.startsWith("/automations");
+  const isDesktopSidebarOpen = isSettingsPage || isSidebarOpen;
   const mobileMenuLabel = isSettingsPage ? "Open settings menu" : "Open menu";
+  const sidebarToggleLabel = isSidebarOpen ? "Collapse sidebar" : "Expand sidebar";
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const isDesktop = window.innerWidth >= 768;
+    let shouldAutoHideActiveConversation = false;
+
+    if (activeConversationId) {
+      if (consumedHomeSubmitAutoHideConversationIdRef.current === activeConversationId) {
+        shouldAutoHideActiveConversation = true;
+      } else if (consumeHomeSubmitSidebarAutoHide(activeConversationId)) {
+        consumedHomeSubmitAutoHideConversationIdRef.current = activeConversationId;
+        shouldAutoHideActiveConversation = true;
+      }
+    }
+
+    if (!isDesktop) {
+      return;
+    }
+
+    if (pathname === "/") {
+      hasAppliedDesktopDefaultRef.current = true;
+      setIsSidebarOpen(true);
+      return;
+    }
+
+    if (isSettingsPage) {
+      return;
+    }
+
+    if (shouldAutoHideActiveConversation) {
+      hasAppliedDesktopDefaultRef.current = true;
+      setIsSidebarOpen(false);
+      return;
+    }
+
+    if (!hasAppliedDesktopDefaultRef.current) {
+      hasAppliedDesktopDefaultRef.current = true;
+      setIsSidebarOpen(true);
+    }
+  }, [activeConversationId, isSettingsPage, pathname]);
 
   return (
     <div className="flex h-[100dvh] w-full bg-[var(--background)] overflow-hidden">
@@ -62,7 +104,9 @@ export function Shell({
 
       <div
         className={`fixed inset-y-0 left-0 z-50 w-[280px] transform transition-transform duration-300 ease-out border-r border-white/5 ${
-          isSidebarOpen ? "translate-x-0 md:translate-x-0" : "-translate-x-full md:-translate-x-full"
+          isSidebarOpen ? "translate-x-0" : "-translate-x-full"
+        } ${
+          isDesktopSidebarOpen ? "md:translate-x-0" : "md:-translate-x-full"
         }`}
       >
         {isSettingsPage ? (
@@ -78,23 +122,35 @@ export function Shell({
         )}
       </div>
 
-      <button
-        type="button"
-        onClick={() => setIsSidebarOpen((prev) => !prev)}
-        className={`hidden md:flex fixed top-1/2 -translate-y-1/2 z-50 w-6 h-12 items-center justify-center rounded-full bg-[var(--background)] border border-white/10 hover:border-white/20 hover:bg-white/5 transition-all duration-300 ease-out ${
-          isSidebarOpen ? "left-[280px]" : "left-0"
-        }`}
-        aria-label={isSidebarOpen ? "Collapse sidebar" : "Expand sidebar"}
-      >
-        {isSidebarOpen ? (
-          <ChevronLeft className="h-4 w-4 text-[var(--text-muted)]" />
-        ) : (
-          <ChevronRight className="h-4 w-4 text-[var(--text-muted)]" />
-        )}
-      </button>
+      {!isSettingsPage ? (
+        <button
+          type="button"
+          onClick={() => setIsSidebarOpen((prev) => !prev)}
+          className={`group/sidebar-toggle hidden md:flex fixed top-[72px] z-50 h-9 w-9 items-center justify-center rounded-lg border border-white/10 bg-[var(--background)]/95 text-white/45 shadow-[0_2px_8px_rgba(0,0,0,0.18)] backdrop-blur-sm transition-[left,background-color,border-color,color] duration-200 ease-out hover:border-white/18 hover:bg-[#171717] hover:text-white/75 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/20 ${
+            isSidebarOpen ? "left-[262px]" : "left-3"
+          }`}
+          aria-label={sidebarToggleLabel}
+          aria-pressed={isSidebarOpen}
+          title={sidebarToggleLabel}
+        >
+          <span className="absolute left-1.5 top-2 h-5 w-px rounded bg-white/12 transition-colors duration-150 group-hover/sidebar-toggle:bg-white/24" />
+          {isSidebarOpen ? (
+            <PanelLeftClose className="h-4 w-4" />
+          ) : (
+            <PanelLeftOpen className="h-4 w-4" />
+          )}
+          <span
+            className={`pointer-events-none absolute top-1/2 -translate-y-1/2 whitespace-nowrap rounded-md border border-white/10 bg-[#161616] px-2 py-1 text-[11px] font-medium text-white/70 opacity-0 shadow-[0_2px_8px_rgba(0,0,0,0.22)] transition-opacity duration-150 group-hover/sidebar-toggle:opacity-100 group-focus-visible/sidebar-toggle:opacity-100 ${
+              isSidebarOpen ? "right-11" : "left-11"
+            }`}
+          >
+            {isSidebarOpen ? "Hide sidebar" : "Show sidebar"}
+          </span>
+        </button>
+      ) : null}
 
       <div className={`relative flex min-h-0 min-w-0 flex-1 flex-col w-full overflow-hidden pt-14 md:pt-0 transition-all duration-300 ease-out ${
-        isSidebarOpen ? "md:pl-[280px]" : "md:pl-0"
+        isDesktopSidebarOpen ? "md:pl-[280px]" : "md:pl-0"
       }`}>
         <div className="fixed top-0 left-0 right-0 z-30 flex h-14 items-center justify-between px-4 md:hidden bg-[var(--background)]/80 backdrop-blur-xl border-b border-white/4">
           <button

--- a/lib/chat-bootstrap.ts
+++ b/lib/chat-bootstrap.ts
@@ -10,6 +10,8 @@ function getChatBootstrapStorageKey(conversationId: string) {
   return `eidon:chat-bootstrap:${conversationId}`;
 }
 
+const HOME_SUBMIT_SIDEBAR_AUTO_HIDE_KEY = "eidon:shell:auto-hide-sidebar-conversation";
+
 export function storeChatBootstrap(
   conversationId: string,
   payload: ChatBootstrapPayload
@@ -36,4 +38,17 @@ export function readChatBootstrap(conversationId: string) {
 
 export function clearChatBootstrap(conversationId: string) {
   sessionStorage.removeItem(getChatBootstrapStorageKey(conversationId));
+}
+
+export function markHomeSubmitSidebarAutoHide(conversationId: string) {
+  sessionStorage.setItem(HOME_SUBMIT_SIDEBAR_AUTO_HIDE_KEY, conversationId);
+}
+
+export function consumeHomeSubmitSidebarAutoHide(conversationId: string) {
+  if (sessionStorage.getItem(HOME_SUBMIT_SIDEBAR_AUTO_HIDE_KEY) !== conversationId) {
+    return false;
+  }
+
+  sessionStorage.removeItem(HOME_SUBMIT_SIDEBAR_AUTO_HIDE_KEY);
+  return true;
 }

--- a/tests/unit/home-view.test.tsx
+++ b/tests/unit/home-view.test.tsx
@@ -266,6 +266,9 @@ describe("home view", () => {
     expect(sessionStorage.getItem("eidon:chat-bootstrap:conv_new")).toContain(
       "Start this thread"
     );
+    expect(sessionStorage.getItem("eidon:shell:auto-hide-sidebar-conversation")).toBe(
+      "conv_new"
+    );
     expect(screen.queryByText("Help me brainstorm ideas")).toBeNull();
   });
 

--- a/tests/unit/shell-desktop-toggle.test.tsx
+++ b/tests/unit/shell-desktop-toggle.test.tsx
@@ -1,13 +1,15 @@
 // @vitest-environment jsdom
 
 import { describe, expect, it, vi, beforeEach } from "vitest";
+import { StrictMode } from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { Shell } from "@/components/shell";
 
 const mockPush = vi.fn();
+let mockPathname = "/";
 
 vi.mock("next/navigation", () => ({
-  usePathname: () => "/",
+  usePathname: () => mockPathname,
   useRouter: () => ({ push: mockPush }),
 }));
 
@@ -61,9 +63,20 @@ const mockProps = {
   children: <div data-testid="main">Main Content</div>,
 };
 
+function setViewportWidth(width: number) {
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    writable: true,
+    value: width,
+  });
+}
+
 describe("Desktop Sidebar Toggle", () => {
   beforeEach(() => {
     mockPush.mockReset();
+    mockPathname = "/";
+    sessionStorage.clear();
+    setViewportWidth(1024);
   });
 
   it("renders toggle button on desktop viewport", () => {
@@ -103,5 +116,94 @@ describe("Desktop Sidebar Toggle", () => {
     const sidebar = screen.getByRole("complementary");
     expect(sidebar.parentElement).toHaveClass("md:translate-x-0");
     expect(sidebar.parentElement).not.toHaveClass("md:-translate-x-full");
+  });
+
+  it("does not render the desktop sidebar toggle on settings routes", () => {
+    mockPathname = "/settings/general";
+
+    render(<Shell {...mockProps} />);
+
+    expect(screen.getByTestId("settings-nav")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /collapse sidebar|expand sidebar/i })
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId("settings-nav").parentElement).toHaveClass("md:translate-x-0");
+  });
+
+  it("opens the automations nav by default on direct desktop automations routes", () => {
+    mockPathname = "/automations";
+
+    render(<Shell {...mockProps} />);
+
+    expect(screen.getByTestId("automations-nav")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Collapse sidebar" })).toBeInTheDocument();
+    expect(screen.getByTestId("automations-nav").parentElement).toHaveClass("md:translate-x-0");
+  });
+
+  it("keeps the chat sidebar collapsed after visiting desktop settings", () => {
+    mockPathname = "/chat/conv_existing";
+    const { rerender } = render(<Shell {...mockProps} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Collapse sidebar" }));
+    expect(screen.getByRole("button", { name: "Expand sidebar" })).toBeInTheDocument();
+    expect(screen.getByTestId("sidebar").parentElement).toHaveClass("md:-translate-x-full");
+
+    mockPathname = "/settings/general";
+    rerender(<Shell {...mockProps} />);
+
+    expect(screen.getByTestId("settings-nav")).toBeInTheDocument();
+    expect(screen.getByTestId("settings-nav").parentElement).toHaveClass("md:translate-x-0");
+    expect(
+      screen.queryByRole("button", { name: /collapse sidebar|expand sidebar/i })
+    ).not.toBeInTheDocument();
+
+    mockPathname = "/chat/conv_existing";
+    rerender(<Shell {...mockProps} />);
+
+    expect(screen.getByRole("button", { name: "Expand sidebar" })).toBeInTheDocument();
+    expect(screen.getByTestId("sidebar").parentElement).toHaveClass("md:-translate-x-full");
+  });
+
+  it("auto-hides the desktop sidebar once after home submits the first message", () => {
+    mockPathname = "/chat/conv_new";
+    sessionStorage.setItem("eidon:shell:auto-hide-sidebar-conversation", "conv_new");
+
+    render(<Shell {...mockProps} />);
+
+    expect(screen.getByRole("button", { name: "Expand sidebar" })).toBeInTheDocument();
+    expect(screen.getByTestId("sidebar").parentElement).toHaveClass("md:-translate-x-full");
+    expect(sessionStorage.getItem("eidon:shell:auto-hide-sidebar-conversation")).toBeNull();
+  });
+
+  it("keeps the home-submit auto-hide after StrictMode replays mount effects", () => {
+    mockPathname = "/chat/conv_new";
+    sessionStorage.setItem("eidon:shell:auto-hide-sidebar-conversation", "conv_new");
+
+    render(
+      <StrictMode>
+        <Shell {...mockProps} />
+      </StrictMode>
+    );
+
+    expect(screen.getByRole("button", { name: "Expand sidebar" })).toBeInTheDocument();
+    expect(screen.getByTestId("sidebar").parentElement).toHaveClass("md:-translate-x-full");
+    expect(sessionStorage.getItem("eidon:shell:auto-hide-sidebar-conversation")).toBeNull();
+  });
+
+  it("consumes the home-submit auto-hide marker on narrow viewports without leaving stale desktop state", () => {
+    mockPathname = "/chat/conv_new";
+    setViewportWidth(390);
+    sessionStorage.setItem("eidon:shell:auto-hide-sidebar-conversation", "conv_new");
+
+    const { unmount } = render(<Shell {...mockProps} />);
+
+    expect(sessionStorage.getItem("eidon:shell:auto-hide-sidebar-conversation")).toBeNull();
+
+    unmount();
+    setViewportWidth(1024);
+    render(<Shell {...mockProps} />);
+
+    expect(screen.getByRole("button", { name: "Collapse sidebar" })).toBeInTheDocument();
+    expect(screen.getByTestId("sidebar").parentElement).toHaveClass("md:translate-x-0");
   });
 });


### PR DESCRIPTION
## Summary
- Rework the desktop sidebar toggle into a compact seam handle with panel icons, hover/focus treatment, and inline tooltip text
- Keep the handle hidden on settings routes and preserve the current sidebar visibility rules
- Add and update unit coverage for the handle behavior across desktop routes

## Testing
- `npx vitest run --coverage=false tests/unit/shell-desktop-toggle.test.tsx`
- `npm test`
- `npm run typecheck`
- Local browser validation of the home, chat, and settings routes