### PR TITLE
Fix worktree .data copy to always source from main worktree

### DIFF
--- a/scripts/setup-worktree.sh
+++ b/scripts/setup-worktree.sh
@@ -79,8 +79,8 @@ copy_data_dir() {
     local dest_dir="$2"
 
     if [ ! -e "$src_dir" ]; then
-        echo "error: source data directory $src_dir does not exist; refusing to launch with seeded default providers only" >&2
-        return 1
+        echo "warning: $src_dir does not exist; launching with seeded default providers" >&2
+        return 0
     fi
 
     if [ -e "$dest_dir" ]; then
@@ -100,13 +100,10 @@ copy_data_dir() {
     echo "copied: $dest_dir <- $src_dir"
 }
 
-SOURCE_DATA_DIR="$SOURCE_WT/.data"
-DEST_DATA_DIR="$WORKTREE_DIR/.data"
-
 echo "Setting up worktree from $SOURCE_LABEL: $SOURCE_WT"
 
 copy_file_replace "$SOURCE_WT/.env" "$WORKTREE_DIR/.env"
-copy_data_dir "$SOURCE_DATA_DIR" "$DEST_DATA_DIR"
+copy_data_dir "$MAIN_WT/.data" "$WORKTREE_DIR/.data"
 
 if [ ! -e "$WORKTREE_DIR/node_modules" ]; then
     echo "Installing npm dependencies..."

--- a/tests/unit/setup-worktree.test.ts
+++ b/tests/unit/setup-worktree.test.ts
@@ -17,16 +17,6 @@ function run(command: string, args: string[], cwd: string, env: NodeJS.ProcessEn
   });
 }
 
-function runSetupExpectFailure(cwd: string, env: NodeJS.ProcessEnv = {}) {
-  try {
-    run("./scripts/setup-worktree.sh", [], cwd, env);
-  } catch (error) {
-    return error as { status: number; stderr?: Buffer | string; stdout?: Buffer | string };
-  }
-
-  throw new Error("Expected setup-worktree.sh to fail");
-}
-
 function createSqliteDatabase(dbPath: string, label: string) {
   run(
     "sqlite3",
@@ -134,7 +124,7 @@ describe("scripts/setup-worktree.sh", () => {
     expect(fs.existsSync(path.join(worktreeDir, ".data/destination-only.txt"))).toBe(false);
   });
 
-  it("copies env and data from EIDON_SETUP_SOURCE_DIR when provided", () => {
+  it("copies env from EIDON_SETUP_SOURCE_DIR but data always from main", () => {
     const { worktreeDir } = createWorktreeFixture();
     const sourceDir = createSourceCheckoutFixture(path.dirname(worktreeDir));
 
@@ -143,33 +133,31 @@ describe("scripts/setup-worktree.sh", () => {
     expect(fs.readFileSync(path.join(worktreeDir, ".env"), "utf8")).toBe(
       "EIDON_DATA_DIR=.data\nSOURCE_CHECKOUT=true\n"
     );
-    expect(readSqliteLabel(path.join(worktreeDir, ".data/eidon.db"))).toBe("source-checkout");
-    expect(fs.readFileSync(path.join(worktreeDir, ".data/attachments/source-checkout.txt"), "utf8")).toBe(
-      "source checkout"
+    expect(readSqliteLabel(path.join(worktreeDir, ".data/eidon.db"))).toBe("source");
+    expect(fs.readFileSync(path.join(worktreeDir, ".data/attachments/source.txt"), "utf8")).toBe(
+      "source attachment"
     );
   });
 
-  it("fails explicitly when the selected source checkout has no data directory", () => {
-    const { worktreeDir } = createWorktreeFixture();
-    const sourceDir = path.join(path.dirname(worktreeDir), "empty-source");
-    fs.mkdirSync(sourceDir, { recursive: true });
-    fs.writeFileSync(path.join(sourceDir, ".env"), "EIDON_DATA_DIR=.data\n");
+  it("succeeds when main has no .data directory", () => {
+    const { mainDir, worktreeDir } = createWorktreeFixture();
+    fs.rmSync(path.join(mainDir, ".data"), { recursive: true, force: true });
 
-    const error = runSetupExpectFailure(worktreeDir, { EIDON_SETUP_SOURCE_DIR: sourceDir });
+    run("./scripts/setup-worktree.sh", [], worktreeDir);
 
-    expect(error.status).not.toBe(0);
-    expect(String(error.stderr)).toContain("error:");
-    expect(String(error.stderr)).toContain(".data");
+    expect(fs.existsSync(path.join(worktreeDir, ".data"))).toBe(false);
   });
 
-  it("does not delete source data when source and destination .data are the same", () => {
-    const { worktreeDir } = createWorktreeFixture();
+  it("does not delete source data when main and worktree .data are the same", () => {
+    const { mainDir, worktreeDir } = createWorktreeFixture();
     fs.writeFileSync(path.join(worktreeDir, ".env"), "EIDON_DATA_DIR=.data\n");
     fs.mkdirSync(path.join(worktreeDir, ".data", "attachments"), { recursive: true });
     createSqliteDatabase(path.join(worktreeDir, ".data/eidon.db"), "same-source");
     fs.writeFileSync(path.join(worktreeDir, ".data/attachments/source.txt"), "same source");
+    fs.rmSync(path.join(mainDir, ".data"), { recursive: true, force: true });
+    fs.symlinkSync(path.join(worktreeDir, ".data"), path.join(mainDir, ".data"));
 
-    const output = run("./scripts/setup-worktree.sh", [], worktreeDir, { EIDON_SETUP_SOURCE_DIR: worktreeDir });
+    const output = run("./scripts/setup-worktree.sh", [], worktreeDir);
 
     expect(output).toContain("source and destination data directories are the same");
     expect(readSqliteLabel(path.join(worktreeDir, ".data/eidon.db"))).toBe("same-source");


### PR DESCRIPTION
## Summary
- Always copy `.data` from the main worktree (`$MAIN_WT/.data`) instead of the source worktree, since `.data` is gitignored and only exists locally in the main checkout
- Make `.data` copy non-fatal — warn instead of erroring when it doesn't exist yet, so new worktrees can still set up successfully
- Removes intermediate variables that were no longer needed

## Test plan
- [x] Ran script with `.data` present at main worktree — copies successfully
- [x] Ran script without `.data` at main worktree — warns and continues without error
- [x] Re-ran script (idempotent) — overwrites cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)