### PR TITLE
Show jumping dots indicator during agent idle gaps

### DIFF
--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -2046,7 +2046,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
                     isForking={forkingMessageId === message.id}
                   />
                   {isStreamingMessage && isAgentIdle && hasReceivedFirstToken && (
-                    <div className="animate-fade-in mt-[6px] inline-flex items-center overflow-hidden rounded-lg border border-white/5 bg-white/[0.015] px-2 py-1">
+                    <div className="animate-fade-in ml-[42px] mt-[6px] inline-flex items-center overflow-hidden rounded-lg border border-white/5 bg-white/[0.015] px-2 py-1">
                       <TypingIndicator compact />
                     </div>
                   )}

--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -1042,7 +1042,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
     setIsAgentIdle(false);
     idleTimerRef.current = setTimeout(() => {
       setIsAgentIdle(true);
-    }, 300);
+    }, 1200);
   }
 
   function clearIdleTimer() {

--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -9,7 +9,7 @@ import {
 } from "@/components/attachment-preview-modal";
 import { ChatComposer } from "@/components/chat-composer";
 import { QueuedMessageBanner } from "@/components/queued-message-banner";
-import { MessageBubble } from "@/components/message-bubble";
+import { MessageBubble, TypingIndicator } from "@/components/message-bubble";
 import { clearChatBootstrap, readChatBootstrap } from "@/lib/chat-bootstrap";
 import { useContextTokens } from "@/lib/context-tokens-context";
 import {
@@ -2045,6 +2045,11 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
                     onForkAssistantMessage={forkAssistantMessage}
                     isForking={forkingMessageId === message.id}
                   />
+                  {isStreamingMessage && isAgentIdle && hasReceivedFirstToken && (
+                    <div className="animate-fade-in pl-4 pt-1">
+                      <TypingIndicator compact />
+                    </div>
+                  )}
                 </div>
               );
             })()

--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -910,6 +910,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
     }
 
     if (event.type === "system_notice") {
+      resetIdleTimer();
       setMessages((current) => [
         ...current,
         {

--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -507,6 +507,8 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
   const [isConversationAtBottom, setIsConversationAtBottom] = useState(true);
   const queueBannerRef = useRef<HTMLDivElement>(null);
   const [queueBannerHeight, setQueueBannerHeight] = useState(0);
+  const [isAgentIdle, setIsAgentIdle] = useState(false);
+  const idleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const {
     speechSnapshot,
@@ -787,14 +789,24 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
     return () => window.cancelAnimationFrame(handle);
   }, [payload.conversation.id]);
 
+  useEffect(() => {
+    return () => {
+      if (idleTimerRef.current !== null) {
+        clearTimeout(idleTimerRef.current);
+      }
+    };
+  }, []);
+
   function handleDelta(event: ChatStreamEvent) {
     if (event.type === "compaction_start") {
       setCompactionInProgress(true);
+      resetIdleTimer();
       return;
     }
 
     if (event.type === "compaction_end") {
       setCompactionInProgress(false);
+      resetIdleTimer();
       return;
     }
 
@@ -802,6 +814,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
       setIsConversationActive(true);
       setStreamMessageId(event.messageId);
       setHasReceivedFirstToken(false);
+      resetIdleTimer();
       setStreamAnswerTarget("");
       setStreamAnswerDisplay("");
       setStreamThinkingTarget("");
@@ -874,6 +887,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
     if (event.type === "thinking_delta") {
       clearCompactionIndicator();
       setHasReceivedFirstToken(true);
+      resetIdleTimer();
       const nextThinking = `${streamThinkingTargetRef.current}${event.text}`;
       streamThinkingTargetRef.current = nextThinking;
       setStreamThinkingTarget(nextThinking);
@@ -885,6 +899,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
     if (event.type === "answer_delta") {
       clearCompactionIndicator();
       setHasReceivedFirstToken(true);
+      resetIdleTimer();
       const nextAnswer = `${streamAnswerTargetRef.current}${event.text}`;
       streamAnswerTargetRef.current = nextAnswer;
       setStreamAnswerTarget(nextAnswer);
@@ -914,6 +929,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
 
     if (event.type === "action_start") {
       clearCompactionIndicator();
+      resetIdleTimer();
       updateStreamTimeline((prev) => {
         const isExisting = prev.some((item) => item.timelineKind === "action" && item.id === event.action.id);
         if (isExisting) {
@@ -943,11 +959,13 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
 
     if (event.type === "action_complete" || event.type === "action_error") {
       clearCompactionIndicator();
+      resetIdleTimer();
       updateStreamTimeline((prev) => updateStreamingAction(prev, event.action));
     }
 
     if (event.type === "done") {
       clearCompactionIndicator();
+      clearIdleTimer();
       setIsConversationActive(false);
       const wasStopped = isStopPending;
       setIsStopPending(false);
@@ -996,6 +1014,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
 
     if (event.type === "error") {
       clearCompactionIndicator();
+      clearIdleTimer();
       setIsConversationActive(false);
       setIsStopPending(false);
       const activeStreamMessageId = streamMessageIdRef.current;
@@ -1013,6 +1032,24 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
       updateStreamTimeline([]);
       setIsSending(false);
     }
+  }
+
+  function resetIdleTimer() {
+    if (idleTimerRef.current !== null) {
+      clearTimeout(idleTimerRef.current);
+    }
+    setIsAgentIdle(false);
+    idleTimerRef.current = setTimeout(() => {
+      setIsAgentIdle(true);
+    }, 300);
+  }
+
+  function clearIdleTimer() {
+    if (idleTimerRef.current !== null) {
+      clearTimeout(idleTimerRef.current);
+      idleTimerRef.current = null;
+    }
+    setIsAgentIdle(false);
   }
 
   const {

--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -2046,7 +2046,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
                     isForking={forkingMessageId === message.id}
                   />
                   {isStreamingMessage && isAgentIdle && hasReceivedFirstToken && (
-                    <div className="animate-fade-in pl-4 pt-1">
+                    <div className="animate-fade-in mt-[6px] inline-flex items-center overflow-hidden rounded-lg border border-white/5 bg-white/[0.015] px-2 py-1">
                       <TypingIndicator compact />
                     </div>
                   )}

--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -249,7 +249,7 @@ function renderAssistantMarkdown(content: string, isStreaming: boolean) {
   );
 }
 
-function TypingIndicator({ compact = false }: { compact?: boolean }) {
+export function TypingIndicator({ compact = false }: { compact?: boolean }) {
   return (
     <div className={compact ? "flex items-center gap-1" : "flex items-center gap-1.5 px-1 py-2"}>
       {[0, 1, 2].map((i) => (

--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -1020,6 +1020,7 @@ export function MessageBubble({
   const showAssistantBubbleActions =
     Boolean(renderedAssistantText) &&
     !awaitingFirstToken &&
+    !isAssistantStreaming &&
     !hasIncompleteFencedCodeBlock(renderedAssistantText, isAssistantStreaming);
 
   useEffect(() => {

--- a/specs/2026-04-29-jumping-dots-idle-indicator-design.md
+++ b/specs/2026-04-29-jumping-dots-idle-indicator-design.md
@@ -1,0 +1,61 @@
+# Jumping Dots Idle Indicator
+
+## Problem
+
+When the agent is working but not actively streaming text (e.g. between tool call executions), the chat UI shows no activity indicator. The last message bubble sits idle with no visual feedback that the agent is still working. This makes the app feel frozen.
+
+## Solution
+
+Show the existing `TypingIndicator` (triple jumping dots) below the last assistant message bubble during gaps in streaming activity. The dots appear after a 300ms silence and disappear instantly when new streaming activity begins.
+
+## Mechanism
+
+### Gap Detection (ChatView-level)
+
+A timer-based approach in ChatView:
+
+- New state: `isAgentIdle: boolean`
+- A `useEffect` resets a 300ms timeout on every streaming event (thinking_delta, answer_delta, action_start, action_complete, compaction_start, compaction_end)
+- When the timeout fires, set `isAgentIdle = true`
+- When a new streaming event arrives, set `isAgentIdle = false` immediately
+
+### Condition for Showing Dots
+
+```
+isStreamingMessage && isAgentIdle && hasReceivedFirstToken
+```
+
+The `hasReceivedFirstToken` check ensures we don't double up with the existing `awaitingFirstToken` dots that appear inside MessageBubble for fresh messages.
+
+### Rendering
+
+The dots render as a sibling element below the streaming `MessageBubble` in the message list. Reuse the existing `TypingIndicator` component. Add a CSS fade-in (opacity 0 to 1 over 150ms) for smooth appearance. Instant hide on new activity.
+
+No changes to MessageBubble internals.
+
+## Lifecycle
+
+### Dots Appear When
+
+- Between tool call completions and the next event (> 300ms gap)
+- After compaction ends, before thinking/answer starts
+- Any mid-turn silence > 300ms
+
+### Dots Disappear When
+
+- Any new streaming event arrives
+- Turn completes (done event)
+- Turn stops (user clicks stop)
+- Turn errors out
+
+### No-Dots Cases
+
+- Pre-first-token on a fresh message (handled by existing awaitingFirstToken)
+- Text actively streaming (events reset timer continuously)
+- Tool call action row visible and in progress (action_start resets timer)
+
+## Files Changed
+
+- `components/chat-view.tsx` — add isAgentIdle state, timer logic, render dots below streaming MessageBubble
+- `components/message-bubble.tsx` — extract TypingIndicator to a standalone export so ChatView can import it
+- `app/globals.css` — add fade-in animation class for the dots container

--- a/specs/2026-04-29-jumping-dots-idle-indicator-plan.md
+++ b/specs/2026-04-29-jumping-dots-idle-indicator-plan.md
@@ -1,0 +1,250 @@
+# Jumping Dots Idle Indicator — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show jumping dots below the assistant's last message when the agent is working but not actively streaming visible output.
+
+**Architecture:** Timer-based gap detection in ChatView. A 300ms timeout resets on every streaming event; when it fires, `isAgentIdle` becomes true and the existing `TypingIndicator` component renders below the streaming MessageBubble. Instant hide on new activity. No changes to MessageBubble internals.
+
+**Tech Stack:** React (useState, useEffect, useRef), Tailwind CSS, existing TypingIndicator component
+
+---
+
+### Task 1: Export TypingIndicator from message-bubble.tsx
+
+**Files:**
+- Modify: `components/message-bubble.tsx:252`
+
+The `TypingIndicator` is currently a local function component inside `message-bubble.tsx`. Export it so `ChatView` can import it.
+
+- [ ] **Step 1: Export TypingIndicator**
+
+Change line 252 from:
+
+```tsx
+function TypingIndicator({ compact = false }: { compact?: boolean }) {
+```
+
+to:
+
+```tsx
+export function TypingIndicator({ compact = false }: { compact?: boolean }) {
+```
+
+- [ ] **Step 2: Verify no compile errors**
+
+Run: `npx tsc --noEmit 2>&1 | head -20`
+Expected: No errors related to TypingIndicator
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add components/message-bubble.tsx
+git commit -m "Export TypingIndicator component from message-bubble"
+```
+
+---
+
+### Task 2: Add isAgentIdle state and timer logic to ChatView
+
+**Files:**
+- Modify: `components/chat-view.tsx`
+
+Add the idle detection state and the timer effect that resets on every streaming event.
+
+- [ ] **Step 1: Add state declaration**
+
+Add after line 508 (after `const [queueBannerHeight, setQueueBannerHeight] = useState(0);`):
+
+```tsx
+const [isAgentIdle, setIsAgentIdle] = useState(false);
+const idleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+```
+
+- [ ] **Step 2: Add the idle timer reset effect**
+
+Add a new function after `handleDelta` (after line ~1016, before `useWebSocket`):
+
+```tsx
+function resetIdleTimer() {
+  if (idleTimerRef.current !== null) {
+    clearTimeout(idleTimerRef.current);
+  }
+  setIsAgentIdle(false);
+  idleTimerRef.current = setTimeout(() => {
+    setIsAgentIdle(true);
+  }, 300);
+}
+
+function clearIdleTimer() {
+  if (idleTimerRef.current !== null) {
+    clearTimeout(idleTimerRef.current);
+    idleTimerRef.current = null;
+  }
+  setIsAgentIdle(false);
+}
+```
+
+- [ ] **Step 3: Call resetIdleTimer on every streaming event in handleDelta**
+
+In the `handleDelta` function, add `resetIdleTimer()` calls at each event handler. Specifically, add it:
+
+1. Inside `compaction_start` handler (after `setCompactionInProgress(true);`, before `return;`)
+2. Inside `compaction_end` handler (after `setCompactionInProgress(false);`, before `return;`)
+3. Inside `message_start` handler (after `setHasReceivedFirstToken(false);`, before the other resets)
+4. Inside `thinking_delta` handler (after `setHasReceivedFirstToken(true);`)
+5. Inside `answer_delta` handler (after `setHasReceivedFirstToken(true);`)
+6. Inside `action_start` handler (at the top of the block, after `clearCompactionIndicator();`)
+7. Inside `action_complete` / `action_error` handler (after `clearCompactionIndicator();`)
+8. Inside `done` handler — call `clearIdleTimer()` instead of `resetIdleTimer()` (after `clearCompactionIndicator();`)
+9. Inside `error` handler — call `clearIdleTimer()` instead of `resetIdleTimer()` (after `clearCompactionIndicator();`)
+
+For `done` and `error`, use `clearIdleTimer()` because the turn is over — we want to clear the timer and reset idle state entirely, not start a new timer.
+
+- [ ] **Step 4: Add cleanup for the idle timer**
+
+Add a cleanup effect to clear the timer on unmount:
+
+```tsx
+useEffect(() => {
+  return () => {
+    if (idleTimerRef.current !== null) {
+      clearTimeout(idleTimerRef.current);
+    }
+  };
+}, []);
+```
+
+- [ ] **Step 5: Verify no compile errors**
+
+Run: `npx tsc --noEmit 2>&1 | head -20`
+Expected: No errors related to isAgentIdle or idleTimerRef
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add components/chat-view.tsx
+git commit -m "Add isAgentIdle state and timer-based gap detection"
+```
+
+---
+
+### Task 3: Render TypingIndicator below the streaming message
+
+**Files:**
+- Modify: `components/chat-view.tsx:1965-2013`
+
+Add the jumping dots as a sibling element below the streaming `MessageBubble` when idle conditions are met.
+
+- [ ] **Step 1: Add import at the top of the file**
+
+At the top of `components/chat-view.tsx`, add `TypingIndicator` to the import from `./message-bubble`:
+
+```tsx
+import { MessageBubble, TypingIndicator } from "./message-bubble";
+```
+
+(Find the existing `MessageBubble` import and add `TypingIndicator` to the named imports.)
+
+- [ ] **Step 2: Render dots below the streaming message bubble**
+
+Inside the message rendering loop (around line 2010, after the `</MessageBubble>` closing tag and before the closing `</div>`), add the dots. The current code renders each message like:
+
+```tsx
+return (
+  <div
+    key={message.id}
+    className="animate-slide-up"
+    style={{ animationFillMode: "forwards" }}
+  >
+    <MessageBubble ... />
+  </div>
+);
+```
+
+Change to:
+
+```tsx
+return (
+  <div
+    key={message.id}
+    className="animate-slide-up"
+    style={{ animationFillMode: "forwards" }}
+  >
+    <MessageBubble ... />
+    {isStreamingMessage && isAgentIdle && hasReceivedFirstToken && (
+      <div className="animate-fade-in pl-4 pt-1">
+        <TypingIndicator compact />
+      </div>
+    )}
+  </div>
+);
+```
+
+The condition `isStreamingMessage && isAgentIdle && hasReceivedFirstToken` ensures:
+- Only shows for the currently-streaming message
+- Only shows when the idle timer has fired (300ms gap)
+- Only shows after first token received (pre-first-token gap is already handled by `awaitingFirstToken` inside MessageBubble)
+
+The `compact` prop renders smaller dots with less padding, appropriate for appearing below existing content.
+
+- [ ] **Step 3: Verify no compile errors**
+
+Run: `npx tsc --noEmit 2>&1 | head -20`
+Expected: No errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add components/chat-view.tsx
+git commit -m "Render jumping dots below streaming message during idle gaps"
+```
+
+---
+
+### Task 4: Manual testing and verification
+
+**Files:** None (testing only)
+
+- [ ] **Step 1: Start the dev server**
+
+Run: `npm run dev`
+Wait for `.dev-server` file to appear, then read the URL.
+
+- [ ] **Step 2: Test the idle dots appear during tool call gaps**
+
+1. Open the chat in a browser
+2. Send a message that will trigger tool calls (e.g. "read the package.json file and explain the dependencies")
+3. Watch the assistant message during tool execution
+4. Verify: when a tool call completes and there's a >300ms gap before the next event, jumping dots appear below the message bubble
+5. Verify: dots disappear immediately when the next streaming event arrives
+
+- [ ] **Step 3: Test dots don't appear during active streaming**
+
+1. Send a simple question that produces a direct answer (no tool calls)
+2. Verify: no dots appear while text is streaming
+3. Verify: the existing `awaitingFirstToken` dots still work correctly before first token
+
+- [ ] **Step 4: Test dots disappear on turn completion**
+
+1. Send any message
+2. Wait for the turn to complete fully
+3. Verify: dots are not visible after completion
+
+- [ ] **Step 5: Test stop button clears dots**
+
+1. Send a message that will trigger tool calls
+2. Wait for idle dots to appear
+3. Click the stop button
+4. Verify: dots disappear immediately
+
+- [ ] **Step 6: Take a screenshot to confirm visual appearance**
+
+Use agent-browser to take a screenshot during an idle gap and verify the dots look correct — small, below the bubble, with smooth fade-in.
+
+- [ ] **Step 7: Final commit if any adjustments are needed**
+
+```bash
+git add -A
+git commit -m "Polish jumping dots idle indicator"
+```

--- a/tests/unit/message-bubble.test.ts
+++ b/tests/unit/message-bubble.test.ts
@@ -1318,7 +1318,7 @@ describe("message bubble", () => {
     ).toBeInTheDocument();
   });
 
-  it("keeps the copy action visible for non-completed assistant messages while hiding fork", () => {
+  it("hides copy and fork actions for streaming assistant messages", () => {
     render(
       React.createElement(MessageBubble as React.ComponentType<any>, {
         message: {
@@ -1330,7 +1330,9 @@ describe("message bubble", () => {
       })
     );
 
-    expect(screen.getByRole("button", { name: "Copy message" })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Copy message" })
+    ).toBeNull();
     expect(
       screen.queryByRole("button", { name: "Fork conversation from message" })
     ).toBeNull();


### PR DESCRIPTION
## Summary
- Adds a timer-based idle gap detector in ChatView that shows the existing `TypingIndicator` (triple jumping dots) below the assistant's last message bubble when the agent is working but not actively streaming output for >1.2s
- Hides the copy/fork action buttons on assistant bubbles until the message has fully finished streaming
- The dots render in the same small bubble style as the first-message typing indicator, aligned with the assistant bubble's content area, and disappear instantly on new streaming activity or turn completion

## Test plan
- [ ] Send a message that triggers tool calls and verify dots appear below the assistant bubble during gaps between tool executions
- [ ] Verify dots disappear immediately when the agent starts streaming again
- [ ] Verify dots do not appear during active text streaming or while tool call action rows are visible
- [ ] Verify copy/fork buttons only appear after the assistant message finishes streaming

🤖 Generated with [Claude Code](https://claude.com/claude-code)