### PR TITLE
Fix chat anchor-on-send scrolling and bottom clamp behavior

### DIFF
--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -721,6 +721,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
   }, []);
 
   useEffect(() => {
+    scrollModeRef.current = "idle";
     shouldAutoScrollRef.current = true;
     requestAnimationFrame(() => {
       if (!queueRef.current) {
@@ -837,6 +838,28 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
       performAnchorScroll(el);
     });
   }, [messages]);
+
+  useEffect(() => {
+    if (!streamMessageId) {
+      if (scrollModeRef.current === "following" || scrollModeRef.current === "anchored") {
+        scrollModeRef.current = "idle";
+      }
+      return;
+    }
+
+    if (scrollModeRef.current !== "anchored" || !queueRef.current) return;
+
+    requestAnimationFrame(() => {
+      if (scrollModeRef.current !== "anchored" || !queueRef.current) return;
+
+      const contentHeight = queueRef.current.scrollHeight - SCROLL_BOTTOM_PADDING;
+      if (contentHeight - anchorScrollTopRef.current > queueRef.current.clientHeight) {
+        scrollModeRef.current = "following";
+        shouldAutoScrollRef.current = true;
+        scrollQueueToBottom("auto");
+      }
+    });
+  }, [streamAnswerDisplay, streamTimeline, streamThinkingDisplay, streamMessageId]);
 
   useEffect(() => {
     if (!shouldAutofocusTextInput()) {
@@ -2063,8 +2086,18 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
             return;
           }
 
+          if (suppressNextScrollEventRef.current) {
+            suppressNextScrollEventRef.current = false;
+            return;
+          }
+
           const nextIsAtBottom = isNearQueueBottom(queueRef.current);
           setIsConversationAtBottom(nextIsAtBottom);
+
+          if (!nextIsAtBottom && scrollModeRef.current !== "idle") {
+            scrollModeRef.current = "idle";
+          }
+
           shouldAutoScrollRef.current = nextIsAtBottom;
         }}
       >

--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -757,31 +757,6 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
     });
   }
 
-  function anchorToUserMessage(messageId: string) {
-    scrollModeRef.current = "anchored";
-    shouldAutoScrollRef.current = false;
-    pendingAnchorMessageIdRef.current = messageId;
-
-    requestAnimationFrame(() => {
-      if (!queueRef.current || !pendingAnchorMessageIdRef.current) return;
-      const mid = pendingAnchorMessageIdRef.current;
-      const messageEl = queueRef.current.querySelector(`[data-message-id="${mid}"]`);
-      if (!messageEl) {
-        requestAnimationFrame(() => {
-          if (!queueRef.current || !pendingAnchorMessageIdRef.current) return;
-          const mid2 = pendingAnchorMessageIdRef.current;
-          const el = queueRef.current.querySelector(`[data-message-id="${mid2}"]`);
-          if (!el) return;
-          pendingAnchorMessageIdRef.current = null;
-          performAnchorScroll(el);
-        });
-        return;
-      }
-      pendingAnchorMessageIdRef.current = null;
-      performAnchorScroll(messageEl);
-    });
-  }
-
   function performAnchorScroll(messageEl: Element) {
     if (!queueRef.current) return;
     const containerRect = queueRef.current.getBoundingClientRect();

--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -50,6 +50,12 @@ type ConversationPayload = {
 };
 
 const AUTO_SCROLL_THRESHOLD_PX = 64;
+const ANCHOR_SCROLL_TOLERANCE_PX = 4;
+const ANCHOR_VISIBLE_TOP_GAP_PX = 16;
+const MESSAGE_SLIDE_UP_OFFSET_PX = 12;
+const ANCHOR_SCROLL_TOP_INSET_PX = ANCHOR_VISIBLE_TOP_GAP_PX + MESSAGE_SLIDE_UP_OFFSET_PX;
+const ANCHOR_LAYOUT_SCROLL_GRACE_MS = 300;
+const ANCHOR_PROGRAMMATIC_SCROLL_GRACE_MS = 900;
 
 type ScrollMode = "idle" | "anchored" | "following";
 const SCROLL_BOTTOM_PADDING = 260;
@@ -57,6 +63,7 @@ const SCROLL_BOTTOM_PADDING = 260;
 type SnapshotReconciliation = {
   messages: Message[];
   pendingLocalSubmissions: PendingLocalSubmission[];
+  anchorMessageIdRemap: Map<string, string>;
 };
 
 type PendingLocalSubmission = {
@@ -83,9 +90,23 @@ function isLooseImageActionMatch(
   );
 }
 
-function isNearQueueBottom(element: HTMLDivElement) {
-  const distanceFromBottom =
-    element.scrollHeight - element.clientHeight - element.scrollTop;
+function getComposerSafeVisibleHeight(element: HTMLDivElement) {
+  return Math.max(0, element.clientHeight - SCROLL_BOTTOM_PADDING);
+}
+
+function getQueueContentBottom(element: HTMLDivElement, scrollPadding: number) {
+  return Math.max(0, element.scrollHeight - scrollPadding);
+}
+
+function getComposerAwareBottomTarget(element: HTMLDivElement, scrollPadding: number) {
+  return Math.max(
+    0,
+    getQueueContentBottom(element, scrollPadding) - getComposerSafeVisibleHeight(element)
+  );
+}
+
+function isNearQueueBottom(element: HTMLDivElement, scrollPadding: number) {
+  const distanceFromBottom = getComposerAwareBottomTarget(element, scrollPadding) - element.scrollTop;
   return distanceFromBottom <= AUTO_SCROLL_THRESHOLD_PX;
 }
 
@@ -253,7 +274,8 @@ function reconcileSnapshotMessages(
   if (sanitizedSnapshot.length === 0) {
     return {
       messages: current.filter((message) => !isLegacyCompactionNotice(message)),
-      pendingLocalSubmissions
+      pendingLocalSubmissions,
+      anchorMessageIdRemap: new Map()
     };
   }
 
@@ -283,6 +305,7 @@ function reconcileSnapshotMessages(
   const nextPendingLocalSubmissions = pendingLocalSubmissions.map((submission) => ({
     ...submission
   }));
+  const anchorMessageIdRemap = new Map<string, string>();
 
   for (const submission of nextPendingLocalSubmissions) {
     if (
@@ -316,6 +339,7 @@ function reconcileSnapshotMessages(
 
       if (partialServerMessage) {
         submission.serverMessageId = partialServerMessage.id;
+        anchorMessageIdRemap.set(submission.localMessageId, partialServerMessage.id);
         claimedServerUserMessageIds.add(partialServerMessage.id);
       }
 
@@ -323,6 +347,7 @@ function reconcileSnapshotMessages(
     }
 
     submission.serverMessageId = matchedServerMessage.id;
+    anchorMessageIdRemap.set(submission.localMessageId, matchedServerMessage.id);
     confirmedLocalIds.add(submission.localMessageId);
     claimedServerUserMessageIds.add(matchedServerMessage.id);
   }
@@ -343,7 +368,8 @@ function reconcileSnapshotMessages(
     messages: [...merged, ...pendingLocalMessages],
     pendingLocalSubmissions: nextPendingLocalSubmissions.filter(
       (submission) => !confirmedLocalIds.has(submission.localMessageId)
-    )
+    ),
+    anchorMessageIdRemap
   };
 }
 
@@ -510,6 +536,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
   const [isConversationAtBottom, setIsConversationAtBottom] = useState(true);
   const queueBannerRef = useRef<HTMLDivElement>(null);
   const [queueBannerHeight, setQueueBannerHeight] = useState(0);
+  const [scrollPadding, setScrollPadding] = useState(SCROLL_BOTTOM_PADDING);
   const [isAgentIdle, setIsAgentIdle] = useState(false);
   const idleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -548,7 +575,12 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
   const scrollModeRef = useRef<ScrollMode>("idle");
   const pendingAnchorMessageIdRef = useRef<string | null>(null);
   const anchorScrollTopRef = useRef(0);
+  const anchorLayoutScrollGraceUntilRef = useRef(0);
+  const anchorProgrammaticScrollUntilRef = useRef(0);
   const suppressNextScrollEventRef = useRef(false);
+  const userScrollIntentRef = useRef(false);
+  const anchorInterruptedRef = useRef(false);
+  const wasStreamingRef = useRef(false);
   const bootstrapPayloadRef = useRef<{
     message: string;
     attachments: MessageAttachment[];
@@ -728,25 +760,43 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
         return;
       }
 
-      setIsConversationAtBottom(isNearQueueBottom(queueRef.current));
+      setIsConversationAtBottom(isNearQueueBottom(queueRef.current, scrollPadding));
     });
+  }, [payload.conversation.id, scrollPadding]);
+
+  useEffect(() => {
+    const el = queueRef.current;
+    if (!el) return;
+
+    const updateScrollPadding = () => {
+      setScrollPadding(Math.max(SCROLL_BOTTOM_PADDING, el.clientHeight));
+    };
+
+    updateScrollPadding();
+
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(updateScrollPadding);
+    observer.observe(el);
+    return () => observer.disconnect();
   }, [payload.conversation.id]);
 
-  function scrollQueueToBottom(behavior: ScrollBehavior = "smooth") {
+  const scrollQueueToBottom = useCallback((behavior: ScrollBehavior = "smooth") => {
     if (!queueRef.current) {
       return;
     }
 
     shouldAutoScrollRef.current = true;
     setIsConversationAtBottom(true);
+    const top = getComposerAwareBottomTarget(queueRef.current, scrollPadding);
     if (queueRef.current.scrollTo) {
-      queueRef.current.scrollTo({ top: queueRef.current.scrollHeight, behavior });
+      queueRef.current.scrollTo({ top, behavior });
     } else {
-      queueRef.current.scrollTop = queueRef.current.scrollHeight;
+      queueRef.current.scrollTop = top;
     }
-  }
+  }, [scrollPadding]);
 
   function jumpToBottom() {
+    scrollModeRef.current = streamMessageIdRef.current ? "following" : "idle";
     scrollQueueToBottom("smooth");
   }
 
@@ -762,16 +812,60 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
     const containerRect = queueRef.current.getBoundingClientRect();
     const messageRect = messageEl.getBoundingClientRect();
     const scrollOffset = messageRect.top - containerRect.top + queueRef.current.scrollTop;
+    const scrollTarget = Math.max(0, scrollOffset - ANCHOR_SCROLL_TOP_INSET_PX);
 
     suppressNextScrollEventRef.current = true;
     if (queueRef.current.scrollTo) {
-      queueRef.current.scrollTo({ top: Math.max(0, scrollOffset), behavior: "auto" });
+      queueRef.current.scrollTo({ top: scrollTarget, behavior: "smooth" });
     } else {
-      queueRef.current.scrollTop = Math.max(0, scrollOffset);
+      queueRef.current.scrollTop = scrollTarget;
     }
     setIsConversationAtBottom(true);
-    anchorScrollTopRef.current = Math.max(0, scrollOffset);
+    anchorScrollTopRef.current = scrollTarget;
+    anchorLayoutScrollGraceUntilRef.current = Date.now() + ANCHOR_LAYOUT_SCROLL_GRACE_MS;
+    anchorProgrammaticScrollUntilRef.current = Date.now() + ANCHOR_PROGRAMMATIC_SCROLL_GRACE_MS;
+    anchorInterruptedRef.current = false;
+    requestAnimationFrame(() => {
+      suppressNextScrollEventRef.current = false;
+    });
   }
+
+  function cancelAutoScrollForUserIntent() {
+    userScrollIntentRef.current = true;
+    anchorProgrammaticScrollUntilRef.current = 0;
+
+    if (scrollModeRef.current === "idle" && !shouldAutoScrollRef.current) {
+      return;
+    }
+
+    scrollModeRef.current = "idle";
+    shouldAutoScrollRef.current = false;
+    anchorInterruptedRef.current = true;
+    suppressNextScrollEventRef.current = false;
+  }
+
+  const followAnchoredOverflowIfNeeded = useCallback(() => {
+    const canFollowAnchor =
+      scrollModeRef.current === "anchored" ||
+      (wasStreamingRef.current && !anchorInterruptedRef.current);
+
+    if (!canFollowAnchor || !queueRef.current) {
+      return false;
+    }
+
+    const contentBottom = getQueueContentBottom(queueRef.current, scrollPadding);
+    if (
+      contentBottom - anchorScrollTopRef.current <=
+      getComposerSafeVisibleHeight(queueRef.current)
+    ) {
+      return false;
+    }
+
+    scrollModeRef.current = "following";
+    shouldAutoScrollRef.current = true;
+    scrollQueueToBottom("auto");
+    return true;
+  }, [scrollPadding, scrollQueueToBottom]);
 
   useEffect(() => {
     const el = queueBannerRef.current;
@@ -791,13 +885,14 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
     requestAnimationFrame(() => {
       if (!queueRef.current || !shouldAutoScrollRef.current) return;
       setIsConversationAtBottom(true);
+      const top = getComposerAwareBottomTarget(queueRef.current, scrollPadding);
       if (queueRef.current.scrollTo) {
-        queueRef.current.scrollTo({ top: queueRef.current.scrollHeight, behavior: "auto" });
+        queueRef.current.scrollTo({ top, behavior: "auto" });
       } else {
-        queueRef.current.scrollTop = queueRef.current.scrollHeight;
+        queueRef.current.scrollTop = top;
       }
     });
-  }, [messages, streamThinkingDisplay, streamAnswerDisplay, streamTimeline]);
+  }, [messages, streamThinkingDisplay, streamAnswerDisplay, streamTimeline, scrollPadding]);
 
   useEffect(() => {
     if (!pendingAnchorMessageIdRef.current || !queueRef.current) return;
@@ -816,25 +911,37 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
 
   useEffect(() => {
     if (!streamMessageId) {
-      if (scrollModeRef.current === "following" || scrollModeRef.current === "anchored") {
-        scrollModeRef.current = "idle";
+      if (wasStreamingRef.current) {
+        requestAnimationFrame(() => {
+          const didFollow = followAnchoredOverflowIfNeeded();
+          if (!didFollow && scrollModeRef.current === "anchored") {
+            scrollModeRef.current = "idle";
+          } else if (scrollModeRef.current === "following") {
+            scrollModeRef.current = "idle";
+          }
+          wasStreamingRef.current = false;
+        });
       }
       return;
     }
+
+    wasStreamingRef.current = true;
 
     if (scrollModeRef.current !== "anchored" || !queueRef.current) return;
 
     requestAnimationFrame(() => {
       if (scrollModeRef.current !== "anchored" || !queueRef.current) return;
 
-      const contentHeight = queueRef.current.scrollHeight - SCROLL_BOTTOM_PADDING;
-      if (contentHeight - anchorScrollTopRef.current > queueRef.current.clientHeight) {
-        scrollModeRef.current = "following";
-        shouldAutoScrollRef.current = true;
-        scrollQueueToBottom("auto");
-      }
+      followAnchoredOverflowIfNeeded();
     });
-  }, [streamAnswerDisplay, streamTimeline, streamThinkingDisplay, streamMessageId]);
+  }, [
+    streamAnswerDisplay,
+    streamTimeline,
+    streamThinkingDisplay,
+    streamMessageId,
+    scrollPadding,
+    followAnchoredOverflowIfNeeded
+  ]);
 
   useEffect(() => {
     if (!shouldAutofocusTextInput()) {
@@ -872,6 +979,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
     }
 
     if (event.type === "message_start") {
+      wasStreamingRef.current = true;
       setIsConversationActive(true);
       setStreamMessageId(event.messageId);
       setHasReceivedFirstToken(false);
@@ -1072,6 +1180,15 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
       streamAnswerTargetRef.current = "";
       streamThinkingTargetRef.current = "";
       setIsSending(false);
+      requestAnimationFrame(() => {
+        const didFollow = followAnchoredOverflowIfNeeded();
+        if (!didFollow && scrollModeRef.current === "anchored") {
+          scrollModeRef.current = "idle";
+        } else if (scrollModeRef.current === "following") {
+          scrollModeRef.current = "idle";
+        }
+        wasStreamingRef.current = false;
+      });
     }
 
     if (event.type === "error") {
@@ -1193,6 +1310,12 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
               streamMessageId,
               pendingLocalSubmissionsRef.current
             );
+            const remappedAnchorMessageId = pendingAnchorMessageIdRef.current
+              ? reconciliation.anchorMessageIdRemap.get(pendingAnchorMessageIdRef.current)
+              : undefined;
+            if (remappedAnchorMessageId) {
+              pendingAnchorMessageIdRef.current = remappedAnchorMessageId;
+            }
             pendingLocalSubmissionsRef.current = reconciliation.pendingLocalSubmissions;
             return reconciliation.messages;
           });
@@ -1432,6 +1555,12 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
             activeStreamMessageId,
             pendingLocalSubmissionsRef.current
           );
+          const remappedAnchorMessageId = pendingAnchorMessageIdRef.current
+            ? reconciliation.anchorMessageIdRemap.get(pendingAnchorMessageIdRef.current)
+            : undefined;
+          if (remappedAnchorMessageId) {
+            pendingAnchorMessageIdRef.current = remappedAnchorMessageId;
+          }
           pendingLocalSubmissionsRef.current = reconciliation.pendingLocalSubmissions;
           return reconciliation.messages;
         });
@@ -1619,6 +1748,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
     }
 
     scrollModeRef.current = "anchored";
+    anchorInterruptedRef.current = false;
     shouldAutoScrollRef.current = false;
     pendingAnchorMessageIdRef.current = messageId;
 
@@ -1871,6 +2001,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
     }
 
     scrollModeRef.current = "anchored";
+    anchorInterruptedRef.current = false;
     shouldAutoScrollRef.current = false;
     setError("");
     setInput("");
@@ -2066,17 +2197,86 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
             return;
           }
 
-          const nextIsAtBottom = isNearQueueBottom(queueRef.current);
+          const bottomTarget = getComposerAwareBottomTarget(queueRef.current, scrollPadding);
+          if (
+            scrollModeRef.current === "idle" &&
+            !isConversationActive &&
+            !streamMessageIdRef.current &&
+            queueRef.current.scrollTop > bottomTarget + ANCHOR_SCROLL_TOLERANCE_PX
+          ) {
+            suppressNextScrollEventRef.current = true;
+            queueRef.current.scrollTo?.({ top: bottomTarget, behavior: "auto" });
+            queueRef.current.scrollTop = bottomTarget;
+            setIsConversationAtBottom(true);
+            shouldAutoScrollRef.current = false;
+            userScrollIntentRef.current = false;
+            requestAnimationFrame(() => {
+              suppressNextScrollEventRef.current = false;
+            });
+            return;
+          }
+
+          const nextIsAtBottom = isNearQueueBottom(queueRef.current, scrollPadding);
           setIsConversationAtBottom(nextIsAtBottom);
+
+          if (scrollModeRef.current === "anchored") {
+            const movedAboveAnchor =
+              queueRef.current.scrollTop <
+              anchorScrollTopRef.current - ANCHOR_SCROLL_TOLERANCE_PX;
+            if (
+              movedAboveAnchor &&
+              !userScrollIntentRef.current &&
+              Date.now() <= anchorProgrammaticScrollUntilRef.current
+            ) {
+              return;
+            }
+            if (
+              movedAboveAnchor &&
+              (userScrollIntentRef.current || Date.now() > anchorLayoutScrollGraceUntilRef.current)
+            ) {
+              scrollModeRef.current = "idle";
+              shouldAutoScrollRef.current = false;
+              anchorInterruptedRef.current = true;
+            }
+            userScrollIntentRef.current = false;
+            return;
+          }
 
           if (!nextIsAtBottom && scrollModeRef.current !== "idle") {
             scrollModeRef.current = "idle";
+            shouldAutoScrollRef.current = false;
+            anchorInterruptedRef.current = true;
+            userScrollIntentRef.current = false;
+            return;
           }
 
           shouldAutoScrollRef.current = nextIsAtBottom;
+          userScrollIntentRef.current = false;
+        }}
+        onWheel={() => {
+          cancelAutoScrollForUserIntent();
+        }}
+        onTouchMove={() => {
+          cancelAutoScrollForUserIntent();
+        }}
+        onPointerDown={() => {
+          cancelAutoScrollForUserIntent();
+        }}
+        onKeyDown={(event) => {
+          if (
+            event.key === "ArrowUp" ||
+            event.key === "PageUp" ||
+            event.key === "Home" ||
+            event.key === " "
+          ) {
+            cancelAutoScrollForUserIntent();
+          }
         }}
       >
-        <div className="flex w-full flex-col gap-2.5 md:gap-4 px-2 md:px-0 pt-4 pb-[240px] md:pb-[260px]">
+        <div
+          className="flex w-full flex-col gap-2.5 md:gap-4 px-2 md:px-0 pt-4"
+          style={{ paddingBottom: scrollPadding }}
+        >
           {renderableMessages.map((message) => (
             (() => {
               const isStreamingMessage = message.id === streamMessageId;

--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -51,6 +51,9 @@ type ConversationPayload = {
 
 const AUTO_SCROLL_THRESHOLD_PX = 64;
 
+type ScrollMode = "idle" | "anchored" | "following";
+const SCROLL_BOTTOM_PADDING = 260;
+
 type SnapshotReconciliation = {
   messages: Message[];
   pendingLocalSubmissions: PendingLocalSubmission[];
@@ -542,6 +545,10 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
   const pendingLocalSubmissionsRef = useRef<PendingLocalSubmission[]>([]);
 
   const shouldAutoScrollRef = useRef(true);
+  const scrollModeRef = useRef<ScrollMode>("idle");
+  const pendingAnchorMessageIdRef = useRef<string | null>(null);
+  const anchorScrollTopRef = useRef(0);
+  const suppressNextScrollEventRef = useRef(false);
   const bootstrapPayloadRef = useRef<{
     message: string;
     attachments: MessageAttachment[];
@@ -749,6 +756,47 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
     });
   }
 
+  function anchorToUserMessage(messageId: string) {
+    scrollModeRef.current = "anchored";
+    shouldAutoScrollRef.current = false;
+    pendingAnchorMessageIdRef.current = messageId;
+
+    requestAnimationFrame(() => {
+      if (!queueRef.current || !pendingAnchorMessageIdRef.current) return;
+      const mid = pendingAnchorMessageIdRef.current;
+      const messageEl = queueRef.current.querySelector(`[data-message-id="${mid}"]`);
+      if (!messageEl) {
+        requestAnimationFrame(() => {
+          if (!queueRef.current || !pendingAnchorMessageIdRef.current) return;
+          const mid2 = pendingAnchorMessageIdRef.current;
+          const el = queueRef.current.querySelector(`[data-message-id="${mid2}"]`);
+          if (!el) return;
+          pendingAnchorMessageIdRef.current = null;
+          performAnchorScroll(el);
+        });
+        return;
+      }
+      pendingAnchorMessageIdRef.current = null;
+      performAnchorScroll(messageEl);
+    });
+  }
+
+  function performAnchorScroll(messageEl: Element) {
+    if (!queueRef.current) return;
+    const containerRect = queueRef.current.getBoundingClientRect();
+    const messageRect = messageEl.getBoundingClientRect();
+    const scrollOffset = messageRect.top - containerRect.top + queueRef.current.scrollTop;
+
+    suppressNextScrollEventRef.current = true;
+    if (queueRef.current.scrollTo) {
+      queueRef.current.scrollTo({ top: Math.max(0, scrollOffset), behavior: "auto" });
+    } else {
+      queueRef.current.scrollTop = Math.max(0, scrollOffset);
+    }
+    setIsConversationAtBottom(true);
+    anchorScrollTopRef.current = Math.max(0, scrollOffset);
+  }
+
   useEffect(() => {
     const el = queueBannerRef.current;
     if (!el || typeof ResizeObserver === "undefined") return;
@@ -774,6 +822,21 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
       }
     });
   }, [messages, streamThinkingDisplay, streamAnswerDisplay, streamTimeline]);
+
+  useEffect(() => {
+    if (!pendingAnchorMessageIdRef.current || !queueRef.current) return;
+    const messageId = pendingAnchorMessageIdRef.current;
+    const messageEl = queueRef.current.querySelector(`[data-message-id="${messageId}"]`);
+    if (!messageEl) return;
+
+    requestAnimationFrame(() => {
+      if (!queueRef.current) return;
+      const el = queueRef.current.querySelector(`[data-message-id="${messageId}"]`);
+      if (!el) return;
+      pendingAnchorMessageIdRef.current = null;
+      performAnchorScroll(el);
+    });
+  }, [messages]);
 
   useEffect(() => {
     if (!shouldAutofocusTextInput()) {
@@ -1557,6 +1620,10 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
       return;
     }
 
+    scrollModeRef.current = "anchored";
+    shouldAutoScrollRef.current = false;
+    pendingAnchorMessageIdRef.current = messageId;
+
     setError("");
     setUpdatingMessageId(messageId);
 
@@ -1805,7 +1872,8 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
       return;
     }
 
-    ensureQueueAtBottomAfterSubmit();
+    scrollModeRef.current = "anchored";
+    shouldAutoScrollRef.current = false;
     setError("");
     setInput("");
     setPendingAttachments([]);
@@ -1842,6 +1910,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
       serverMessageId: null
     });
     setMessages((current) => [...current, optimisticUserMessage]);
+    pendingAnchorMessageIdRef.current = optimisticUserMessage.id;
 
     wsSend({
       type: "message",

--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -49,7 +49,7 @@ type ConversationPayload = {
   };
 };
 
-const AUTO_SCROLL_THRESHOLD_PX = 32;
+const AUTO_SCROLL_THRESHOLD_PX = 64;
 
 type SnapshotReconciliation = {
   messages: Message[];
@@ -1999,7 +1999,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
           shouldAutoScrollRef.current = nextIsAtBottom;
         }}
       >
-        <div className="flex w-full flex-col gap-2.5 md:gap-4 px-2 md:px-0 pt-4 pb-[180px] md:pb-[200px]">
+        <div className="flex w-full flex-col gap-2.5 md:gap-4 px-2 md:px-0 pt-4 pb-[240px] md:pb-[260px]">
           {renderableMessages.map((message) => (
             (() => {
               const isStreamingMessage = message.id === streamMessageId;

--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -1104,7 +1104,7 @@ export function MessageBubble({
 
   if (message.role === "system") {
     return (
-      <div className="mx-auto max-w-lg rounded-full border border-white/6 bg-white/[0.03] px-5 py-2 text-center text-[11px] tracking-[0.12em] text-white/40 uppercase">
+      <div data-message-id={message.id} className="mx-auto max-w-lg rounded-full border border-white/6 bg-white/[0.03] px-5 py-2 text-center text-[11px] tracking-[0.12em] text-white/40 uppercase">
         {message.content}
       </div>
     );
@@ -1113,7 +1113,7 @@ export function MessageBubble({
   if (message.role === "user") {
     return (
       <>
-        <div className="flex w-full justify-end">
+        <div data-message-id={message.id} className="flex w-full justify-end">
           <div className="group flex max-w-[96%] flex-col items-end md:max-w-[95%]">
             <div className="w-full rounded-2xl border border-[var(--accent)]/10 bg-[var(--accent-soft)] px-4 py-3 text-[var(--text)]">
               {isEditing ? (
@@ -1204,7 +1204,7 @@ export function MessageBubble({
   }
 
   return (
-    <div className="w-full">
+    <div data-message-id={message.id} className="w-full">
       <div className="flex gap-3.5">
         <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-white/[0.06] border border-white/6 text-[10px] font-bold text-white/60 overflow-hidden mt-1">
           <img src="/agent-icon.png" alt="" width={28} height={28} className="h-full w-full object-cover" />

--- a/tests/unit/chat-view.test.ts
+++ b/tests/unit/chat-view.test.ts
@@ -2696,7 +2696,293 @@ describe("chat view", () => {
       attachmentIds: [],
       personaId: undefined
     });
+    await flushAnimationFrame();
+    await flushAnimationFrame();
     expect(screen.queryByRole("button", { name: "Scroll to newest messages" })).toBeNull();
+  });
+
+  it("scrolls to anchor the user message near the top after sending", async () => {
+    const { container } = renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
+    const queue = container.querySelector(".no-scrollbar.overflow-y-auto") as HTMLDivElement;
+    const textarea = screen.getByPlaceholderText(
+      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
+    );
+
+    let scrollTop = 500;
+    const scrollTo = vi.fn(({ top }: { top?: number }) => {
+      if (typeof top === "number") {
+        scrollTop = top;
+      }
+    });
+
+    Object.defineProperty(queue, "clientHeight", { configurable: true, get: () => 300 });
+    Object.defineProperty(queue, "scrollHeight", { configurable: true, get: () => 1000 });
+    Object.defineProperty(queue, "scrollTop", {
+      configurable: true,
+      get: () => scrollTop,
+      set: (value: number) => { scrollTop = value; }
+    });
+    Object.defineProperty(queue, "scrollTo", { configurable: true, value: scrollTo });
+
+    fireEvent.change(textarea, { target: { value: "Hello world" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Hello world")).toBeInTheDocument();
+    });
+
+    await flushAnimationFrame();
+    await flushAnimationFrame();
+
+    expect(scrollTo).toHaveBeenCalled();
+    const allTops = scrollTo.mock.calls.map((call) => call[0].top);
+    expect(allTops).not.toContain(1000);
+  });
+
+  it("scrolls to bottom when queuing a follow-up during an active turn", async () => {
+    const { container } = renderWithProvider(
+      React.createElement(ChatView, {
+        payload: createPayload({
+          conversation: {
+            ...createPayload().conversation,
+            isActive: true
+          }
+        })
+      })
+    );
+    const queue = container.querySelector(".no-scrollbar.overflow-y-auto") as HTMLDivElement;
+    const textarea = screen.getByPlaceholderText(
+      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
+    );
+
+    let scrollTop = 120;
+    const scrollTo = vi.fn(({ top }: { top?: number }) => {
+      if (typeof top === "number") {
+        scrollTop = top;
+      }
+    });
+
+    Object.defineProperty(queue, "clientHeight", { configurable: true, get: () => 300 });
+    Object.defineProperty(queue, "scrollHeight", { configurable: true, get: () => 1000 });
+    Object.defineProperty(queue, "scrollTop", {
+      configurable: true,
+      get: () => scrollTop,
+      set: (value: number) => { scrollTop = value; }
+    });
+    Object.defineProperty(queue, "scrollTo", { configurable: true, value: scrollTo });
+
+    act(() => {
+      wsMock.onMessage!({
+        type: "delta",
+        conversationId: "conv_1",
+        event: { type: "message_start", messageId: "msg_assistant" }
+      });
+    });
+
+    await flushAnimationFrame();
+
+    scrollTo.mockClear();
+
+    fireEvent.change(textarea, { target: { value: "Queued follow-up" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(wsMock.send).toHaveBeenCalledWith({
+        type: "queue_message",
+        conversationId: "conv_1",
+        content: "Queued follow-up"
+      });
+    });
+
+    await flushAnimationFrame();
+
+    expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ top: 1000 }));
+  });
+
+  it("returns to idle when the user manually scrolls during anchored mode", async () => {
+    const { container } = renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
+    const queue = container.querySelector(".no-scrollbar.overflow-y-auto") as HTMLDivElement;
+    const textarea = screen.getByPlaceholderText(
+      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
+    );
+
+    let scrollHeight = 200;
+    let scrollTop = 0;
+    const scrollTo = vi.fn(({ top }: { top?: number }) => {
+      if (typeof top === "number") {
+        scrollTop = top;
+      }
+    });
+
+    Object.defineProperty(queue, "clientHeight", { configurable: true, get: () => 300 });
+    Object.defineProperty(queue, "scrollHeight", { configurable: true, get: () => scrollHeight });
+    Object.defineProperty(queue, "scrollTop", {
+      configurable: true,
+      get: () => scrollTop,
+      set: (value: number) => { scrollTop = value; }
+    });
+    Object.defineProperty(queue, "scrollTo", { configurable: true, value: scrollTo });
+
+    fireEvent.change(textarea, { target: { value: "Hello" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Hello")).toBeInTheDocument();
+    });
+
+    await flushAnimationFrame();
+    await flushAnimationFrame();
+
+    scrollTo.mockClear();
+
+    scrollTop = 10;
+    fireEvent.scroll(queue);
+
+    scrollHeight = 700;
+    act(() => {
+      wsMock.onMessage!({
+        type: "delta",
+        conversationId: "conv_1",
+        event: { type: "message_start", messageId: "msg_assistant" }
+      });
+      wsMock.onMessage!({
+        type: "delta",
+        conversationId: "conv_1",
+        event: { type: "answer_delta", text: "Streaming content" }
+      });
+    });
+
+    await flushAnimationFrame();
+
+    expect(scrollTo).not.toHaveBeenCalled();
+  });
+
+  it("transitions to following mode when streaming content fills the viewport", async () => {
+    const { container } = renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
+    const queue = container.querySelector(".no-scrollbar.overflow-y-auto") as HTMLDivElement;
+
+    let scrollHeight = 700;
+    let scrollTop = 0;
+    const scrollTo = vi.fn(({ top }: { top?: number }) => {
+      if (typeof top === "number") {
+        scrollTop = top;
+      }
+    });
+
+    Object.defineProperty(queue, "clientHeight", { configurable: true, get: () => 300 });
+    Object.defineProperty(queue, "scrollHeight", { configurable: true, get: () => scrollHeight });
+    Object.defineProperty(queue, "scrollTop", {
+      configurable: true,
+      get: () => scrollTop,
+      set: (value: number) => { scrollTop = value; }
+    });
+    Object.defineProperty(queue, "scrollTo", { configurable: true, value: scrollTo });
+
+    const textarea = screen.getByPlaceholderText(
+      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
+    );
+
+    fireEvent.change(textarea, { target: { value: "Hello" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Hello")).toBeInTheDocument();
+    });
+
+    await flushAnimationFrame();
+    await flushAnimationFrame();
+
+    act(() => {
+      wsMock.onMessage!({
+        type: "delta",
+        conversationId: "conv_1",
+        event: { type: "message_start", messageId: "msg_assistant" }
+      });
+      wsMock.onMessage!({
+        type: "delta",
+        conversationId: "conv_1",
+        event: { type: "answer_delta", text: "A very long response that fills the viewport" }
+      });
+    });
+
+    await flushAnimationFrame();
+    await flushAnimationFrame();
+
+    expect(screen.queryByRole("button", { name: "Scroll to newest messages" })).toBeNull();
+  });
+
+  it("anchors to the edited message after edit-retry", async () => {
+    vi.mocked(global.fetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ personas: [] })
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          conversation: {
+            ...createPayload().conversation,
+            id: "conv_1"
+          },
+          messages: [
+            createMessage({
+              id: "msg_user",
+              role: "user",
+              content: "Edited prompt"
+            })
+          ]
+        })
+      } as Response);
+
+    const { container } = renderWithProvider(
+      React.createElement(ChatView, {
+        payload: {
+          ...createPayload(),
+          messages: [
+            createMessage({
+              id: "msg_user",
+              role: "user",
+              content: "Original prompt"
+            }),
+            createMessage({
+              id: "msg_assistant_old",
+              content: "Old answer"
+            })
+          ]
+        }
+      })
+    );
+    const queue = container.querySelector(".no-scrollbar.overflow-y-auto") as HTMLDivElement;
+
+    const scrollTo = vi.fn(({ top }: { top?: number }) => {
+      if (typeof top === "number") {
+        // noop
+      }
+    });
+    Object.defineProperty(queue, "scrollTo", { configurable: true, value: scrollTo });
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit message" }));
+    fireEvent.change(screen.getByDisplayValue("Original prompt"), {
+      target: { value: "Edited prompt" }
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save edit" }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith("/api/messages/msg_user/edit-restart", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ content: "Edited prompt" })
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Edited prompt")).toBeInTheDocument();
+    });
+
+    await flushAnimationFrame();
+    await flushAnimationFrame();
+
+    expect(scrollTo).toHaveBeenCalled();
   });
 
   it("renders tool actions and answer text while streaming", async () => {

--- a/tests/unit/chat-view.test.ts
+++ b/tests/unit/chat-view.test.ts
@@ -322,6 +322,8 @@ describe("chat view", () => {
   const originalMaxTouchPoints = Object.getOwnPropertyDescriptor(navigator, "maxTouchPoints");
   const originalMediaDevices = Object.getOwnPropertyDescriptor(navigator, "mediaDevices");
   const originalAudioContext = Object.getOwnPropertyDescriptor(window, "AudioContext");
+  const originalResizeObserver = window.ResizeObserver;
+  let resizeObserverCallbacks: Array<ResizeObserverCallback> = [];
 
   beforeEach(() => {
     push.mockReset();
@@ -342,6 +344,19 @@ describe("chat view", () => {
     speechMock.createSpeechEngine.mockClear();
     speechMock.audioMonitor.readLevel.mockReturnValue(0.42);
     speechMock.audioMonitor.dispose.mockReset();
+    resizeObserverCallbacks = [];
+    window.ResizeObserver = class {
+      private callback: ResizeObserverCallback;
+
+      constructor(callback: ResizeObserverCallback) {
+        this.callback = callback;
+        resizeObserverCallbacks.push(callback);
+      }
+
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as typeof ResizeObserver;
     Object.defineProperty(navigator, "mediaDevices", {
       configurable: true,
       value: {
@@ -415,6 +430,8 @@ describe("chat view", () => {
         value: undefined
       });
     }
+
+    window.ResizeObserver = originalResizeObserver;
   });
 
   function renderWithProvider(ui: React.ReactElement) {
@@ -429,6 +446,14 @@ describe("chat view", () => {
         React.createElement(ContextTokensProvider, null, ui)
       )
     );
+  }
+
+  async function flushResizeObservers() {
+    await act(async () => {
+      for (const callback of resizeObserverCallbacks) {
+        callback([], {} as ResizeObserver);
+      }
+    });
   }
 
   it("uploads an attachment from the file input and removes it from the pending list", async () => {
@@ -2579,8 +2604,8 @@ describe("chat view", () => {
       });
     });
 
-    expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ top: 1000 }));
-    expect(scrollTop).toBe(1000);
+    expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ top: 700 }));
+    expect(scrollTop).toBe(700);
   });
 
   it("does not force-scroll streaming updates when the user has scrolled away from the bottom", async () => {
@@ -2701,12 +2726,324 @@ describe("chat view", () => {
     expect(screen.queryByRole("button", { name: "Scroll to newest messages" })).toBeNull();
   });
 
+  it("sets dynamic bottom padding from the queue height with a 260px minimum", async () => {
+    const { container } = renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
+    const queue = container.querySelector(".no-scrollbar.overflow-y-auto") as HTMLDivElement;
+    const messageList = queue.firstElementChild as HTMLDivElement;
+
+    let clientHeight = 420;
+    Object.defineProperty(queue, "clientHeight", {
+      configurable: true,
+      get: () => clientHeight
+    });
+
+    await flushResizeObservers();
+
+    expect(messageList).toHaveStyle({ paddingBottom: "420px" });
+
+    clientHeight = 180;
+    await flushResizeObservers();
+
+    expect(messageList).toHaveStyle({ paddingBottom: "260px" });
+  });
+
+  it("follows streaming overflow to the composer-aware bottom target after sending", async () => {
+    const { container } = renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
+    const queue = container.querySelector(".no-scrollbar.overflow-y-auto") as HTMLDivElement;
+    const textarea = screen.getByPlaceholderText(
+      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
+    );
+
+    let scrollHeight = 720;
+    let scrollTop = 0;
+    const scrollTo = vi.fn(({ top }: { top?: number }) => {
+      if (typeof top === "number") {
+        scrollTop = top;
+      }
+    });
+
+    Object.defineProperty(queue, "clientHeight", { configurable: true, get: () => 360 });
+    Object.defineProperty(queue, "scrollHeight", { configurable: true, get: () => scrollHeight });
+    Object.defineProperty(queue, "scrollTop", {
+      configurable: true,
+      get: () => scrollTop,
+      set: (value: number) => { scrollTop = value; }
+    });
+    Object.defineProperty(queue, "scrollTo", { configurable: true, value: scrollTo });
+
+    await flushResizeObservers();
+
+    fireEvent.change(textarea, { target: { value: "Track the next reply" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Track the next reply")).toBeInTheDocument();
+    });
+
+    await flushAnimationFrame();
+    await flushAnimationFrame();
+
+    scrollTo.mockClear();
+    scrollHeight = 1080;
+
+    act(() => {
+      wsMock.onMessage!({
+        type: "delta",
+        conversationId: "conv_1",
+        event: { type: "message_start", messageId: "msg_assistant" }
+      });
+      wsMock.onMessage!({
+        type: "delta",
+        conversationId: "conv_1",
+        event: { type: "answer_delta", text: "A long response that overflows the composer-aware viewport" }
+      });
+    });
+
+    await flushAnimationFrame();
+    await flushAnimationFrame();
+
+    await waitFor(() => {
+      expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ top: 620 }));
+    });
+    expect(scrollTo).not.toHaveBeenCalledWith(expect.objectContaining({ top: 1080 }));
+  });
+
+  it("follows to the composer-aware bottom target when a stream completes before the overflow frame", async () => {
+    const { container } = renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
+    const queue = container.querySelector(".no-scrollbar.overflow-y-auto") as HTMLDivElement;
+    const textarea = screen.getByPlaceholderText(
+      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
+    );
+
+    let scrollHeight = 720;
+    let scrollTop = 0;
+    const scrollTo = vi.fn(({ top }: { top?: number }) => {
+      if (typeof top === "number") {
+        scrollTop = top;
+      }
+    });
+
+    Object.defineProperty(queue, "clientHeight", { configurable: true, get: () => 360 });
+    Object.defineProperty(queue, "scrollHeight", { configurable: true, get: () => scrollHeight });
+    Object.defineProperty(queue, "scrollTop", {
+      configurable: true,
+      get: () => scrollTop,
+      set: (value: number) => { scrollTop = value; }
+    });
+    Object.defineProperty(queue, "scrollTo", { configurable: true, value: scrollTo });
+
+    await flushResizeObservers();
+
+    fireEvent.change(textarea, { target: { value: "Track a fast reply" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Track a fast reply")).toBeInTheDocument();
+    });
+
+    await flushAnimationFrame();
+    await flushAnimationFrame();
+
+    scrollTo.mockClear();
+    scrollHeight = 1080;
+
+    act(() => {
+      wsMock.onMessage!({
+        type: "delta",
+        conversationId: "conv_1",
+        event: { type: "message_start", messageId: "msg_assistant" }
+      });
+      wsMock.onMessage!({
+        type: "delta",
+        conversationId: "conv_1",
+        event: { type: "answer_delta", text: "A long response that completes before the frame runs" }
+      });
+      wsMock.onMessage!({
+        type: "delta",
+        conversationId: "conv_1",
+        event: { type: "done", messageId: "msg_assistant" }
+      });
+    });
+
+    await flushAnimationFrame();
+    await flushAnimationFrame();
+
+    await waitFor(() => {
+      expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ top: 620 }));
+    });
+    expect(scrollTo).not.toHaveBeenCalledWith(expect.objectContaining({ top: 1080 }));
+  });
+
+  it("clamps back from padding-only max scroll when a followed stream completes", async () => {
+    const { container } = renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
+    const queue = container.querySelector(".no-scrollbar.overflow-y-auto") as HTMLDivElement;
+    const messageList = queue.firstElementChild as HTMLDivElement;
+    const textarea = screen.getByPlaceholderText(
+      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
+    );
+
+    let scrollHeight = 720;
+    let scrollTop = 0;
+    const scrollTo = vi.fn(({ top }: { top?: number }) => {
+      if (typeof top === "number") {
+        scrollTop = top;
+      }
+    });
+
+    Object.defineProperty(queue, "clientHeight", { configurable: true, get: () => 360 });
+    Object.defineProperty(queue, "scrollHeight", { configurable: true, get: () => scrollHeight });
+    Object.defineProperty(queue, "scrollTop", {
+      configurable: true,
+      get: () => scrollTop,
+      set: (value: number) => { scrollTop = value; }
+    });
+    Object.defineProperty(queue, "scrollTo", { configurable: true, value: scrollTo });
+
+    await flushResizeObservers();
+
+    fireEvent.change(textarea, { target: { value: "Track completion" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Track completion")).toBeInTheDocument();
+    });
+
+    await flushAnimationFrame();
+    await flushAnimationFrame();
+
+    scrollTo.mockClear();
+    scrollHeight = 1080;
+
+    act(() => {
+      wsMock.onMessage!({
+        type: "delta",
+        conversationId: "conv_1",
+        event: { type: "message_start", messageId: "msg_assistant" }
+      });
+      wsMock.onMessage!({
+        type: "delta",
+        conversationId: "conv_1",
+        event: { type: "answer_delta", text: "A long response that starts following" }
+      });
+    });
+
+    await waitFor(() => {
+      expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ top: 620 }));
+    });
+
+    scrollTo.mockClear();
+    scrollTop = 720;
+
+    act(() => {
+      wsMock.onMessage!({
+        type: "delta",
+        conversationId: "conv_1",
+        event: { type: "done", messageId: "msg_assistant" }
+      });
+    });
+
+    await flushAnimationFrame();
+    await flushAnimationFrame();
+
+    expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ top: 620 }));
+    expect(scrollTop).toBe(620);
+    expect(messageList).toHaveStyle({ paddingBottom: "360px" });
+  });
+
+  it("anchors to the reconciled server user message when the optimistic local message is removed first", async () => {
+    const serverUserMessage = createMessage({
+      id: "msg_server_user",
+      role: "user",
+      content: "Server-backed prompt"
+    });
+
+    vi.mocked(global.fetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ personas: [] })
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          conversation: {
+            ...createPayload().conversation,
+            isActive: true
+          },
+          messages: [serverUserMessage]
+        })
+      } as Response);
+
+    const originalGetBoundingClientRect = Element.prototype.getBoundingClientRect;
+    Element.prototype.getBoundingClientRect = function getBoundingClientRect() {
+      if (this instanceof HTMLElement && this.dataset.messageId === "msg_server_user") {
+        return {
+          x: 0,
+          y: 180,
+          top: 180,
+          right: 0,
+          bottom: 220,
+          left: 0,
+          width: 0,
+          height: 40,
+          toJSON: () => ({})
+        };
+      }
+
+      return originalGetBoundingClientRect.call(this);
+    };
+
+    const { container } = renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
+    const queue = container.querySelector(".no-scrollbar.overflow-y-auto") as HTMLDivElement;
+    const textarea = screen.getByPlaceholderText(
+      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
+    );
+
+    let scrollTop = 25;
+    const scrollTo = vi.fn(({ top }: { top?: number }) => {
+      if (typeof top === "number") {
+        scrollTop = top;
+      }
+    });
+
+    Object.defineProperty(queue, "clientHeight", { configurable: true, get: () => 300 });
+    Object.defineProperty(queue, "scrollHeight", { configurable: true, get: () => 900 });
+    Object.defineProperty(queue, "scrollTop", {
+      configurable: true,
+      get: () => scrollTop,
+      set: (value: number) => { scrollTop = value; }
+    });
+    Object.defineProperty(queue, "scrollTo", { configurable: true, value: scrollTo });
+
+    try {
+      fireEvent.change(textarea, { target: { value: "Server-backed prompt" } });
+      fireEvent.keyDown(textarea, { key: "Enter" });
+
+      await waitFor(() => {
+        expect(global.fetch).toHaveBeenCalledWith("/api/conversations/conv_1", {
+          cache: "no-store"
+        });
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("Server-backed prompt")).toBeInTheDocument();
+      });
+
+      await flushAnimationFrame();
+      await flushAnimationFrame();
+
+      expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ top: 177 }));
+    } finally {
+      Element.prototype.getBoundingClientRect = originalGetBoundingClientRect;
+    }
+  });
+
   it("scrolls to anchor the user message near the top after sending", async () => {
     const { container } = renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
     const queue = container.querySelector(".no-scrollbar.overflow-y-auto") as HTMLDivElement;
     const textarea = screen.getByPlaceholderText(
       "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
     );
+    const originalGetBoundingClientRect = Element.prototype.getBoundingClientRect;
 
     let scrollTop = 500;
     const scrollTo = vi.fn(({ top }: { top?: number }) => {
@@ -2723,20 +3060,56 @@ describe("chat view", () => {
       set: (value: number) => { scrollTop = value; }
     });
     Object.defineProperty(queue, "scrollTo", { configurable: true, value: scrollTo });
+    Element.prototype.getBoundingClientRect = function getBoundingClientRect() {
+      if (this === queue) {
+        return {
+          x: 0,
+          y: 100,
+          top: 100,
+          right: 0,
+          bottom: 400,
+          left: 0,
+          width: 0,
+          height: 300,
+          toJSON: () => ({})
+        };
+      }
 
-    fireEvent.change(textarea, { target: { value: "Hello world" } });
-    fireEvent.keyDown(textarea, { key: "Enter" });
+      if (this instanceof HTMLElement && this.dataset.messageId?.startsWith("local_")) {
+        return {
+          x: 0,
+          y: 140,
+          top: 140,
+          right: 0,
+          bottom: 180,
+          left: 0,
+          width: 0,
+          height: 40,
+          toJSON: () => ({})
+        };
+      }
 
-    await waitFor(() => {
-      expect(screen.getByText("Hello world")).toBeInTheDocument();
-    });
+      return originalGetBoundingClientRect.call(this);
+    };
 
-    await flushAnimationFrame();
-    await flushAnimationFrame();
+    try {
+      fireEvent.change(textarea, { target: { value: "Hello world" } });
+      fireEvent.keyDown(textarea, { key: "Enter" });
 
-    expect(scrollTo).toHaveBeenCalled();
-    const allTops = scrollTo.mock.calls.map((call) => call[0].top);
-    expect(allTops).not.toContain(1000);
+      await waitFor(() => {
+        expect(screen.getByText("Hello world")).toBeInTheDocument();
+      });
+
+      await flushAnimationFrame();
+      await flushAnimationFrame();
+
+      expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({
+        behavior: "smooth",
+        top: 512
+      }));
+    } finally {
+      Element.prototype.getBoundingClientRect = originalGetBoundingClientRect;
+    }
   });
 
   it("scrolls to bottom when queuing a follow-up during an active turn", async () => {
@@ -2796,7 +3169,7 @@ describe("chat view", () => {
 
     await flushAnimationFrame();
 
-    expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ top: 1000 }));
+    expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ top: 700 }));
   });
 
   it("returns to idle when the user manually scrolls during anchored mode", async () => {
@@ -2805,6 +3178,7 @@ describe("chat view", () => {
     const textarea = screen.getByPlaceholderText(
       "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
     );
+    const originalGetBoundingClientRect = Element.prototype.getBoundingClientRect;
 
     let scrollHeight = 200;
     let scrollTop = 0;
@@ -2822,23 +3196,116 @@ describe("chat view", () => {
       set: (value: number) => { scrollTop = value; }
     });
     Object.defineProperty(queue, "scrollTo", { configurable: true, value: scrollTo });
+    Element.prototype.getBoundingClientRect = function getBoundingClientRect() {
+      if (this === queue) {
+        return {
+          x: 0,
+          y: 0,
+          top: 0,
+          right: 0,
+          bottom: 300,
+          left: 0,
+          width: 0,
+          height: 300,
+          toJSON: () => ({})
+        };
+      }
 
-    fireEvent.change(textarea, { target: { value: "Hello" } });
+      if (this instanceof HTMLElement && this.dataset.messageId?.startsWith("local_")) {
+        return {
+          x: 0,
+          y: 120,
+          top: 120,
+          right: 0,
+          bottom: 160,
+          left: 0,
+          width: 0,
+          height: 40,
+          toJSON: () => ({})
+        };
+      }
+
+      return originalGetBoundingClientRect.call(this);
+    };
+
+    try {
+      fireEvent.change(textarea, { target: { value: "Hello" } });
+      fireEvent.keyDown(textarea, { key: "Enter" });
+
+      await waitFor(() => {
+        expect(screen.getByText("Hello")).toBeInTheDocument();
+      });
+
+      await flushAnimationFrame();
+      await flushAnimationFrame();
+
+      scrollTo.mockClear();
+
+      scrollHeight = 700;
+      scrollTop = 10;
+      fireEvent.wheel(queue, { deltaY: -120 });
+      fireEvent.scroll(queue);
+
+      act(() => {
+        wsMock.onMessage!({
+          type: "delta",
+          conversationId: "conv_1",
+          event: { type: "message_start", messageId: "msg_assistant" }
+        });
+        wsMock.onMessage!({
+          type: "delta",
+          conversationId: "conv_1",
+          event: { type: "answer_delta", text: "Streaming content" }
+        });
+      });
+
+      await flushAnimationFrame();
+
+      expect(scrollTo).not.toHaveBeenCalled();
+    } finally {
+      Element.prototype.getBoundingClientRect = originalGetBoundingClientRect;
+    }
+  });
+
+  it("cancels streaming follow immediately when the user wheels away", async () => {
+    const { container } = renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
+    const queue = container.querySelector(".no-scrollbar.overflow-y-auto") as HTMLDivElement;
+    const textarea = screen.getByPlaceholderText(
+      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
+    );
+
+    let scrollHeight = 720;
+    let scrollTop = 0;
+    const scrollTo = vi.fn(({ top }: { top?: number }) => {
+      if (typeof top === "number") {
+        scrollTop = top;
+      }
+    });
+
+    Object.defineProperty(queue, "clientHeight", { configurable: true, get: () => 360 });
+    Object.defineProperty(queue, "scrollHeight", { configurable: true, get: () => scrollHeight });
+    Object.defineProperty(queue, "scrollTop", {
+      configurable: true,
+      get: () => scrollTop,
+      set: (value: number) => { scrollTop = value; }
+    });
+    Object.defineProperty(queue, "scrollTo", { configurable: true, value: scrollTo });
+
+    await flushResizeObservers();
+
+    fireEvent.change(textarea, { target: { value: "Track then interrupt" } });
     fireEvent.keyDown(textarea, { key: "Enter" });
 
     await waitFor(() => {
-      expect(screen.getByText("Hello")).toBeInTheDocument();
+      expect(screen.getByText("Track then interrupt")).toBeInTheDocument();
     });
 
     await flushAnimationFrame();
     await flushAnimationFrame();
 
     scrollTo.mockClear();
+    scrollHeight = 1080;
 
-    scrollTop = 10;
-    fireEvent.scroll(queue);
-
-    scrollHeight = 700;
     act(() => {
       wsMock.onMessage!({
         type: "delta",
@@ -2848,13 +3315,94 @@ describe("chat view", () => {
       wsMock.onMessage!({
         type: "delta",
         conversationId: "conv_1",
-        event: { type: "answer_delta", text: "Streaming content" }
+        event: { type: "answer_delta", text: "A long response that starts following" }
+      });
+    });
+
+    await waitFor(() => {
+      expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ top: 620 }));
+    });
+
+    scrollTo.mockClear();
+    fireEvent.wheel(queue, { deltaY: -240 });
+    scrollTo.mockClear();
+
+    act(() => {
+      wsMock.onMessage!({
+        type: "delta",
+        conversationId: "conv_1",
+        event: { type: "answer_delta", text: "More streaming content after manual wheel" }
       });
     });
 
     await flushAnimationFrame();
+    await flushAnimationFrame();
 
-    expect(scrollTo).not.toHaveBeenCalled();
+    expect(scrollTo).not.toHaveBeenCalledWith(expect.objectContaining({ top: 620 }));
+  });
+
+  it("clamps idle scrolling before the padding-only blank area after streaming ends", async () => {
+    const { container } = renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
+    const queue = container.querySelector(".no-scrollbar.overflow-y-auto") as HTMLDivElement;
+    const textarea = screen.getByPlaceholderText(
+      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
+    );
+
+    let scrollHeight = 1080;
+    let scrollTop = 0;
+    const scrollTo = vi.fn(({ top }: { top?: number }) => {
+      if (typeof top === "number") {
+        scrollTop = top;
+      }
+    });
+
+    Object.defineProperty(queue, "clientHeight", { configurable: true, get: () => 360 });
+    Object.defineProperty(queue, "scrollHeight", { configurable: true, get: () => scrollHeight });
+    Object.defineProperty(queue, "scrollTop", {
+      configurable: true,
+      get: () => scrollTop,
+      set: (value: number) => { scrollTop = value; }
+    });
+    Object.defineProperty(queue, "scrollTo", { configurable: true, value: scrollTo });
+
+    await flushResizeObservers();
+
+    fireEvent.change(textarea, { target: { value: "Finish without blank space" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Finish without blank space")).toBeInTheDocument();
+    });
+
+    act(() => {
+      wsMock.onMessage!({
+        type: "delta",
+        conversationId: "conv_1",
+        event: { type: "message_start", messageId: "msg_assistant" }
+      });
+      wsMock.onMessage!({
+        type: "delta",
+        conversationId: "conv_1",
+        event: { type: "answer_delta", text: "Final response text" }
+      });
+      wsMock.onMessage!({
+        type: "delta",
+        conversationId: "conv_1",
+        event: { type: "done", messageId: "msg_assistant" }
+      });
+    });
+
+    await flushAnimationFrame();
+    await flushAnimationFrame();
+
+    scrollTo.mockClear();
+    scrollTop = 720;
+    fireEvent.scroll(queue);
+
+    expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({
+      behavior: "auto",
+      top: 620
+    }));
   });
 
   it("transitions to following mode when streaming content fills the viewport", async () => {

--- a/tests/unit/message-bubble.test.tsx
+++ b/tests/unit/message-bubble.test.tsx
@@ -125,3 +125,29 @@ describe("message bubble avatar", () => {
     expect(screen.queryByRole("img", { name: "Screenshot" })).toBeNull();
   });
 });
+
+describe("data-message-id attribute", () => {
+  it("renders data-message-id on user message root element", () => {
+    const message = {
+      ...createUserMessage(),
+      id: "msg_user_1"
+    };
+    const { container } = render(
+      React.createElement(MessageBubble, { message })
+    );
+    const userBubble = container.querySelector('[data-message-id="msg_user_1"]');
+    expect(userBubble).toBeInTheDocument();
+  });
+
+  it("renders data-message-id on assistant message root element", () => {
+    const message = {
+      ...createAssistantMessage(),
+      id: "msg_asst_1"
+    };
+    const { container } = render(
+      React.createElement(MessageBubble, { message })
+    );
+    const asstBubble = container.querySelector('[data-message-id="msg_asst_1"]');
+    expect(asstBubble).toBeInTheDocument();
+  });
+});

--- a/tests/unit/setup-worktree.test.ts
+++ b/tests/unit/setup-worktree.test.ts
@@ -9,7 +9,7 @@ const scriptSource = fs.readFileSync(path.join(process.cwd(), "scripts/setup-wor
 
 const tempDirs: string[] = [];
 
-function run(command: string, args: string[], cwd: string, env: NodeJS.ProcessEnv = {}) {
+function run(command: string, args: string[], cwd: string, env: Partial<NodeJS.ProcessEnv> = {}) {
   return execFileSync(command, args, {
     cwd,
     env: { ...process.env, ...env },


### PR DESCRIPTION
## Summary
- Smooth the anchor-on-send scroll so the user message lands cleanly instead of jumping.
- Prevent manual scroll-up during streaming from being pulled back to the bottom.
- Clamp idle scrolling so the transcript does not drift into empty padding below the final assistant message.
- Keep the composer-aware bottom target and anchor spacing intact for future sends.

## Testing
- Full `chat-view` unit coverage passed.
- Browser-validated the anchor animation, manual interruption behavior, and final-message bottom clamp in the live app.
- `npm test`, `npm run typecheck`, and `npm run lint` completed successfully, with lint reporting only the repo’s existing warnings.