### PR TITLE
Harden sidebar, mobile actions, and reliability warnings

### DIFF
--- a/app/api/attachments/route.ts
+++ b/app/api/attachments/route.ts
@@ -114,7 +114,13 @@ export async function POST(request: Request) {
     return badRequest("Authentication required", 401);
   }
 
-  const multipart = await parseMultipartRequest(request);
+  let multipart: Awaited<ReturnType<typeof parseMultipartRequest>>;
+
+  try {
+    multipart = await parseMultipartRequest(request);
+  } catch {
+    return badRequest("Invalid attachment upload");
+  }
   const parsed = formSchema.safeParse({
     conversationId: multipart.fields.get("conversationId")
   });

--- a/app/api/auth/account/route.ts
+++ b/app/api/auth/account/route.ts
@@ -23,17 +23,28 @@ export async function PUT(request: Request) {
     return badRequest("Invalid account payload");
   }
 
-  await updateUsername(user.id, body.data.username);
+  try {
+    await updateUsername(user.id, body.data.username);
 
-  if (body.data.password) {
-    await updatePassword(user.id, body.data.password);
-    await invalidateAllSessionsForUser(user.id);
+    if (body.data.password) {
+      await updatePassword(user.id, body.data.password);
+      await invalidateAllSessionsForUser(user.id);
 
-    const session = await getSessionPayload();
+      const session = await getSessionPayload();
 
-    if (session) {
-      await clearSessionCookie();
+      if (session) {
+        await clearSessionCookie();
+      }
     }
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message === "Env-managed credentials cannot be changed in the UI"
+    ) {
+      return badRequest(error.message);
+    }
+
+    throw error;
   }
 
   return ok({ success: true });

--- a/app/api/conversations/[conversationId]/route.ts
+++ b/app/api/conversations/[conversationId]/route.ts
@@ -59,9 +59,15 @@ export async function DELETE(
 
   const onlyIfEmptyParam = new URL(request.url).searchParams.get("onlyIfEmpty");
   const onlyIfEmpty = onlyIfEmptyParam === "1" || onlyIfEmptyParam === "true";
+  const conversation = getConversation(params.data.conversationId, user.id);
+
+  if (!conversation) {
+    return badRequest("Conversation not found", 404);
+  }
+
   const deleted = onlyIfEmpty
     ? deleteConversationIfEmpty(params.data.conversationId, user.id)
-    : (deleteConversation(params.data.conversationId, user.id), true);
+    : deleteConversation(params.data.conversationId, user.id);
 
   if (deleted) {
     try {

--- a/components/attachment-preview-modal.tsx
+++ b/components/attachment-preview-modal.tsx
@@ -212,6 +212,7 @@ export function AttachmentPreviewModal({
 
         <div className="min-h-0 flex-1 overflow-auto p-4">
           {state.kind === "image" ? (
+            // eslint-disable-next-line @next/next/no-img-element -- Attachment previews are API-served user files that next/image cannot safely optimize.
             <img
               src={`/api/attachments/${attachment.id}`}
               alt={attachment.filename}

--- a/components/chat-composer.tsx
+++ b/components/chat-composer.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import React, { useState, useRef, useEffect } from "react";
-import Image from "next/image";
 import {
   AlertCircle,
   ArrowUp,
@@ -293,11 +292,11 @@ export function ChatComposer({
               >
                 {attachment.kind === "image" ? (
                   <div className="relative h-9 w-9 overflow-hidden rounded-xl border border-white/10">
-                    <Image
+                    {/* eslint-disable-next-line @next/next/no-img-element -- Pending attachment thumbnails are API-served user files that next/image cannot safely optimize. */}
+                    <img
                       src={`/api/attachments/${attachment.id}`}
                       alt={attachment.filename}
-                      fill
-                      className="object-cover"
+                      className="h-full w-full object-cover"
                     />
                   </div>
                 ) : (

--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -477,6 +477,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
   const router = useRouter();
   const { getTokenUsage, setTokenUsage } = useContextTokens();
   const previewController = useAttachmentPreviewController();
+  const { closeAttachmentPreview } = previewController;
   const activeConversationIdRef = useRef(payload.conversation.id);
   const [messages, setMessages] = useState(() => sanitizeMessages(payload.messages));
   const [queuedMessages, setQueuedMessages] = useState(() => payload.queuedMessages);
@@ -516,8 +517,8 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
     }
 
     activeConversationIdRef.current = payload.conversation.id;
-    previewController.closeAttachmentPreview();
-  }, [payload.conversation.id, previewController.closeAttachmentPreview]);
+    closeAttachmentPreview();
+  }, [payload.conversation.id, closeAttachmentPreview]);
 
   const compactionInProgressRef = useRef(false);
   const thinkingStartTimeRef = useRef<number | null>(null);

--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -709,6 +709,7 @@ function AttachmentTile({
         onClick={() => onPreview(attachment)}
         className={`overflow-hidden rounded-xl border border-white/10 bg-black/20 ${compact ? "w-16" : "w-28"}`}
       >
+        {/* eslint-disable-next-line @next/next/no-img-element -- Attachment thumbnails are API-served user files that next/image cannot safely optimize. */}
         <img
           src={`/api/attachments/${attachment.id}`}
           alt=""
@@ -804,6 +805,7 @@ function AssistantInlineImageAttachments({
           onClick={() => onPreview(attachment)}
           className="max-w-full overflow-hidden rounded-xl border border-white/10 bg-black/20"
         >
+          {/* eslint-disable-next-line @next/next/no-img-element -- Attachment previews are API-served user files that next/image cannot safely optimize. */}
           <img
             src={`/api/attachments/${attachment.id}`}
             alt=""
@@ -1207,6 +1209,7 @@ export function MessageBubble({
     <div data-message-id={message.id} className="w-full">
       <div className="flex gap-3.5">
         <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-white/[0.06] border border-white/6 text-[10px] font-bold text-white/60 overflow-hidden mt-1">
+          {/* eslint-disable-next-line @next/next/no-img-element -- Static assistant avatar is deliberately tiny and unoptimized. */}
           <img src="/agent-icon.png" alt="" width={28} height={28} className="h-full w-full object-cover" />
         </div>
 

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -28,6 +28,7 @@ import {
   useSensor,
   useSensors,
   type DragEndEvent,
+  type DragMoveEvent,
   type DragStartEvent,
   type CollisionDetection
 } from "@dnd-kit/core";
@@ -205,6 +206,10 @@ function ConversationItem({
     trimmedSearchQuery && conversation.matchSnippet
       ? highlightMatch(conversation.matchSnippet, trimmedSearchQuery)
       : null;
+  const titlePaddingClass = active ? "pr-8" : "pr-8 md:pr-0 md:group-hover:pr-8";
+  const actionVisibilityClass = active
+    ? "opacity-100"
+    : "opacity-100 md:opacity-0 md:group-hover:opacity-100";
 
   function handleNavigate(event: ReactMouseEvent<HTMLAnchorElement>) {
     if (
@@ -272,6 +277,7 @@ function ConversationItem({
       className="relative mb-0.5"
       {...(dragEnabled ? attributes : {})}
       {...(dragEnabled ? listeners : {})}
+      aria-label={`${conversation.title} conversation`}
     >
       <Link
         href={`/chat/${conversation.id}`}
@@ -291,11 +297,11 @@ function ConversationItem({
         <div className="relative min-w-0 flex-1 overflow-hidden">
           {highlightedTitle ? (
             <div
-              className={`truncate ${active ? "pr-8" : "group-hover:pr-8"}`}
+              className={`truncate ${titlePaddingClass}`}
               dangerouslySetInnerHTML={{ __html: highlightedTitle }}
             />
           ) : (
-            <div className={`truncate ${active ? "pr-8" : "group-hover:pr-8"}`}>
+            <div className={`truncate ${titlePaddingClass}`}>
               {conversation.title}
             </div>
           )}
@@ -308,12 +314,14 @@ function ConversationItem({
           ) : null}
 
           <div
-            className={`absolute right-0 top-0 bottom-0 flex items-center bg-gradient-to-l from-transparent via-transparent to-transparent pl-4 pr-1 transition-opacity duration-300 ${
-              active ? "opacity-100" : "opacity-0 group-hover:opacity-100"
-            }`}
+            data-sidebar-row-actions="conversation"
+            className={`absolute right-0 top-0 bottom-0 flex items-center bg-gradient-to-l from-transparent via-transparent to-transparent pl-4 pr-1 transition-opacity duration-300 ${actionVisibilityClass}`}
             onClick={(e) => e.preventDefault()}
           >
             <button
+              type="button"
+              aria-label={`Conversation actions for ${conversation.title}`}
+              title={`Conversation actions for ${conversation.title}`}
               className="text-white/20 hover:text-white transition-colors duration-200 p-1 rounded-lg hover:bg-white/5"
               onClick={(e) => {
                 e.preventDefault();
@@ -401,7 +409,6 @@ function FolderItem({
   onCreateInFolder,
   dragEnabled,
   showCount,
-  isDraggingConversation,
   searchQuery
 }: {
   folder: Folder;
@@ -414,7 +421,6 @@ function FolderItem({
   onCreateInFolder: (folderId: string) => void;
   dragEnabled: boolean;
   showCount: boolean;
-  isDraggingConversation: boolean;
   searchQuery: string;
 }) {
   const [collapsed, setCollapsed] = useState(true);
@@ -432,7 +438,7 @@ function FolderItem({
     setNodeRef,
     transform,
     transition
-  } = useSortable({ id: folder.id, disabled: isDraggingConversation });
+  } = useSortable({ id: folder.id });
   const {
     setNodeRef: setFolderDropRef,
     isOver: isOverFolderDrop
@@ -440,7 +446,7 @@ function FolderItem({
     id: `${FOLDER_DROP_PREFIX}${folder.id}`
   });
 
-  const style = isDraggingConversation ? undefined : {
+  const style = {
     transform: CSS.Transform.toString(transform),
     transition
   };
@@ -499,7 +505,12 @@ function FolderItem({
         aria-label={`${folder.name} folder`}
         {...(dragEnabled ? listeners : {})}
       >
-        <button onClick={() => setCollapsed(!collapsed)} className="p-0.5 opacity-30 hover:opacity-100 transition-opacity">
+        <button
+          type="button"
+          aria-label={collapsed ? `Expand ${folder.name}` : `Collapse ${folder.name}`}
+          onClick={() => setCollapsed(!collapsed)}
+          className="p-0.5 opacity-30 hover:opacity-100 transition-opacity"
+        >
           {collapsed ? <ChevronRight className="h-3.5 w-3.5" /> : <ChevronDown className="h-3.5 w-3.5" />}
         </button>
         {collapsed ? (
@@ -531,18 +542,24 @@ function FolderItem({
           <span className="text-[10px] font-bold text-white/10 group-hover:text-white/20 transition-colors mr-1 tabular-nums">{conversations.length}</span>
         ) : null}
         <div
-          className="opacity-0 group-hover:opacity-100 flex items-center gap-1 transition-opacity duration-300"
+          data-sidebar-row-actions="folder"
+          className="flex items-center gap-1 opacity-100 transition-opacity duration-300 md:opacity-0 md:group-hover:opacity-100"
           onClick={(e) => e.stopPropagation()}
         >
           <button
+            type="button"
+            aria-label={`New chat in ${folder.name}`}
             onClick={() => onCreateInFolder(folder.id)}
             className="p-1 text-white/20 hover:text-white transition-colors duration-200"
-            title="New chat in folder"
+            title={`New chat in ${folder.name}`}
           >
             <Plus className="h-3.5 w-3.5" />
           </button>
           <div className="relative">
             <button
+              type="button"
+              aria-label={`Folder actions for ${folder.name}`}
+              title={`Folder actions for ${folder.name}`}
               onClick={() => { setFolderMenuOpen(!folderMenuOpen); setConfirmDeleteFolder(false); }}
               className="p-1 text-white/20 hover:text-white transition-colors duration-200"
             >
@@ -642,8 +659,10 @@ export function Sidebar({
   const [newFolderName, setNewFolderName] = useState("");
   const [showNewFolder, setShowNewFolder] = useState(false);
   const [mounted, setMounted] = useState(false);
+  const [activeDragId, setActiveDragId] = useState<string | null>(null);
   const searchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const dragPointerRef = useRef<{ x: number; y: number } | null>(null);
 
   const navigateToHref = useCallback(
     async (href: string, nextConversationId?: string) => {
@@ -953,12 +972,33 @@ export function Sidebar({
   }
 
   const handleDragEnd = useCallback((event: DragEndEvent) => {
-    setActiveDragId(null);
     const { active, over } = event;
-    if (!over || active.id === over.id || searchResults) return;
-
     const activeId = String(active.id);
-    const overId = String(over.id);
+    const isConversationDrag = localConversations.some((conversation) => conversation.id === activeId);
+    const dragPointer = dragPointerRef.current;
+    const fallbackFolderId =
+      isConversationDrag && dragPointer && (!over || active.id === over.id)
+        ? document
+            .elementFromPoint(dragPointer.x, dragPointer.y)
+            ?.closest<HTMLElement>("[data-folder-drop-id]")
+            ?.dataset.folderDropId ?? null
+        : null;
+    const rawOverId = fallbackFolderId
+      ? `${FOLDER_DROP_PREFIX}${fallbackFolderId}`
+      : over && active.id !== over.id
+        ? String(over.id)
+        : null;
+    const isRawFolderDrop =
+      isConversationDrag &&
+      rawOverId &&
+      localFolders.some((folder) => folder.id === rawOverId);
+    const overId = isRawFolderDrop ? `${FOLDER_DROP_PREFIX}${rawOverId}` : rawOverId;
+
+    setActiveDragId(null);
+    dragPointerRef.current = null;
+
+    if (!overId || searchResults) return;
+
     const reorderedFolders = reorderSidebarFolders(localFolders, activeId, overId);
 
     if (reorderedFolders) {
@@ -999,6 +1039,36 @@ export function Sidebar({
     setActiveDragId(String(event.active.id));
   }, []);
 
+  const handleDragMove = useCallback((event: DragMoveEvent) => {
+    const rect = event.active.rect.current.translated ?? event.active.rect.current.initial;
+
+    if (!rect) {
+      return;
+    }
+
+    dragPointerRef.current = {
+      x: rect.left + rect.width / 2,
+      y: rect.top + rect.height / 2
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!activeDragId) {
+      dragPointerRef.current = null;
+      return;
+    }
+
+    function handleMouseMove(event: MouseEvent) {
+      dragPointerRef.current = {
+        x: event.clientX,
+        y: event.clientY
+      };
+    }
+
+    window.addEventListener("mousemove", handleMouseMove);
+    return () => window.removeEventListener("mousemove", handleMouseMove);
+  }, [activeDragId]);
+
   const displayedConversations = searchResults ?? localConversations;
   const unfiled = displayedConversations.filter((c) => !c.folderId);
   const unfiledSections = buildConversationSections(unfiled);
@@ -1021,13 +1091,11 @@ export function Sidebar({
   });
   const dragEnabled = mounted && !searchResults;
   const showFolderCounts = !hasMoreConversations && !searchResults;
-  const [activeDragId, setActiveDragId] = useState<string | null>(null);
-  const isDraggingConversation = activeDragId ? !localFolders.some((f) => f.id === activeDragId) : false;
   const activeDragConversation = activeDragId
     ? localConversations.find((c) => c.id === activeDragId)
     : null;
 
-  function renderConversationSections(enableDrag: boolean, draggingConversation: boolean) {
+  function renderConversationSections(enableDrag: boolean) {
     return (
       <>
         {localFolders.map((folder) => {
@@ -1045,7 +1113,6 @@ export function Sidebar({
                 onCreateInFolder={(fId) => handleCreate(fId)}
                 dragEnabled={enableDrag}
                 showCount={showFolderCounts}
-                isDraggingConversation={draggingConversation}
                 searchQuery={searchQuery}
               />
             </div>
@@ -1259,13 +1326,13 @@ export function Sidebar({
           </div>
 
           {dragEnabled ? (
-            <DndContext sensors={sensors} collisionDetection={collisionDetection} onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
+            <DndContext sensors={sensors} collisionDetection={collisionDetection} onDragStart={handleDragStart} onDragMove={handleDragMove} onDragEnd={handleDragEnd}>
               <SortableContext items={sortableIds} strategy={verticalListSortingStrategy}>
-                {renderConversationSections(true, isDraggingConversation)}
+                {renderConversationSections(true)}
               </SortableContext>
               <DragOverlay>
                 {activeDragConversation ? (
-                  <div className="flex items-center gap-3 rounded-2xl px-4 py-3 text-sm bg-white/[0.08] text-white font-medium shadow-2xl backdrop-blur-xl border border-white/10 opacity-90">
+                  <div className="pointer-events-none flex items-center gap-3 rounded-2xl px-4 py-3 text-sm bg-white/[0.08] text-white font-medium shadow-2xl backdrop-blur-xl border border-white/10 opacity-90">
                     <MessageSquare className="h-4 w-4 shrink-0 opacity-60" />
                     <span className="truncate max-w-[200px]">{activeDragConversation.title}</span>
                   </div>
@@ -1273,7 +1340,7 @@ export function Sidebar({
               </DragOverlay>
             </DndContext>
           ) : (
-            renderConversationSections(false, false)
+            renderConversationSections(false)
           )}
         </div>
 

--- a/lib/automation-scheduler.ts
+++ b/lib/automation-scheduler.ts
@@ -35,6 +35,7 @@ type SchedulerHandle = {
 };
 
 const DEFAULT_POLL_INTERVAL_MS = 5 * 60_000;
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
 const SCHEDULER_REGISTRY_KEY = Symbol.for("eidon.automation.schedulers");
 
 function getActiveSchedulers() {
@@ -327,9 +328,10 @@ export function createAutomationScheduler(dependencies: SchedulerDependencies = 
 
   function scheduleNextCycle() {
     const nextWakeAt = getNextWakeAt();
-    const delayMs = nextWakeAt
+    const rawDelayMs = nextWakeAt
       ? Math.max(0, new Date(nextWakeAt).getTime() - now().getTime())
       : pollIntervalMs;
+    const delayMs = Math.min(rawDelayMs, MAX_TIMER_DELAY_MS);
 
     timer = setTimeout(() => {
       void runCycle();

--- a/lib/conversations.ts
+++ b/lib/conversations.ts
@@ -547,14 +547,14 @@ function deleteConversationRecord(conversationId: string) {
 
 export function deleteConversation(conversationId: string, userId?: string) {
   if (userId && !getConversation(conversationId, userId)) {
-    return;
+    return false;
   }
 
   const transaction = getDb().transaction((id: string) => {
-    deleteConversationRecord(id);
+    return deleteConversationRecord(id);
   });
 
-  transaction(conversationId);
+  return transaction(conversationId);
 }
 
 export function deleteConversationIfEmpty(conversationId: string, userId?: string) {
@@ -2400,21 +2400,20 @@ export async function generateConversationTitleFromFirstUserMessage(
 }
 
 export function moveConversationToFolder(conversationId: string, folderId: string | null, userId?: string) {
-  const timestamp = nowIso();
   if (userId) {
     getDb()
       .prepare(
-        `UPDATE conversations SET folder_id = ?, updated_at = ? WHERE id = ? AND user_id = ?`
+        `UPDATE conversations SET folder_id = ? WHERE id = ? AND user_id = ?`
       )
-      .run(folderId, timestamp, conversationId, userId);
+      .run(folderId, conversationId, userId);
     return;
   }
 
   getDb()
     .prepare(
-      `UPDATE conversations SET folder_id = ?, updated_at = ? WHERE id = ?`
+      `UPDATE conversations SET folder_id = ? WHERE id = ?`
     )
-    .run(folderId, timestamp, conversationId);
+    .run(folderId, conversationId);
 }
 
 export function updateConversationProviderProfile(
@@ -2450,21 +2449,20 @@ export function reorderConversations(
   const statement = userId
     ? getDb()
         .prepare(
-          "UPDATE conversations SET sort_order = ?, folder_id = ?, updated_at = ? WHERE id = ? AND user_id = ?"
+          "UPDATE conversations SET sort_order = ?, folder_id = ? WHERE id = ? AND user_id = ?"
         )
     : getDb()
-        .prepare("UPDATE conversations SET sort_order = ?, folder_id = ?, updated_at = ? WHERE id = ?");
+        .prepare("UPDATE conversations SET sort_order = ?, folder_id = ? WHERE id = ?");
 
-  const timestamp = nowIso();
   const transaction = getDb().transaction(
     (entries: Array<{ id: string; folderId: string | null; sortOrder: number }>) => {
       entries.forEach((entry) => {
         if (userId) {
-          statement.run(entry.sortOrder, entry.folderId, timestamp, entry.id, userId);
+          statement.run(entry.sortOrder, entry.folderId, entry.id, userId);
           return;
         }
 
-        statement.run(entry.sortOrder, entry.folderId, timestamp, entry.id);
+        statement.run(entry.sortOrder, entry.folderId, entry.id);
       });
     }
   );

--- a/lib/edge-session-token.ts
+++ b/lib/edge-session-token.ts
@@ -1,0 +1,97 @@
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+function base64UrlDecode(value: string) {
+  if (!/^[A-Za-z0-9_-]*$/.test(value)) {
+    return null;
+  }
+
+  const padded = value + "=".repeat((4 - (value.length % 4)) % 4);
+
+  try {
+    const binary = atob(padded.replace(/-/g, "+").replace(/_/g, "/"));
+    const bytes = new Uint8Array(binary.length);
+
+    for (let index = 0; index < binary.length; index += 1) {
+      bytes[index] = binary.charCodeAt(index);
+    }
+
+    return bytes;
+  } catch {
+    return null;
+  }
+}
+
+function parseJsonSegment(value: string) {
+  const decoded = base64UrlDecode(value);
+
+  if (!decoded) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(decoder.decode(decoded)) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function hasValidTemporalClaims(payload: Record<string, unknown>) {
+  const now = Math.floor(Date.now() / 1000);
+
+  if (typeof payload.exp === "number" && payload.exp <= now) {
+    return false;
+  }
+
+  if (typeof payload.nbf === "number" && payload.nbf > now) {
+    return false;
+  }
+
+  return true;
+}
+
+function copyToArrayBuffer(bytes: Uint8Array) {
+  const copy = new Uint8Array(bytes.byteLength);
+  copy.set(bytes);
+  return copy.buffer;
+}
+
+export async function verifyHs256Jwt(token: string, secret: Uint8Array) {
+  const [encodedHeader, encodedPayload, encodedSignature, extra] = token.split(".");
+
+  if (!encodedHeader || !encodedPayload || !encodedSignature || extra !== undefined) {
+    return null;
+  }
+
+  const header = parseJsonSegment(encodedHeader);
+  const payload = parseJsonSegment(encodedPayload);
+  const signature = base64UrlDecode(encodedSignature);
+
+  if (!header || !payload || !signature || header.alg !== "HS256") {
+    return null;
+  }
+
+  if (!hasValidTemporalClaims(payload)) {
+    return null;
+  }
+
+  try {
+    const key = await globalThis.crypto.subtle.importKey(
+      "raw",
+      copyToArrayBuffer(secret),
+      { name: "HMAC", hash: "SHA-256" },
+      false,
+      ["verify"]
+    );
+    const verified = await globalThis.crypto.subtle.verify(
+      "HMAC",
+      key,
+      signature,
+      encoder.encode(`${encodedHeader}.${encodedPayload}`)
+    );
+
+    return verified ? payload : null;
+  } catch {
+    return null;
+  }
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
-import { jwtVerify } from "jose";
 
 import { SESSION_COOKIE_NAME } from "@/lib/constants";
+import { verifyHs256Jwt } from "@/lib/edge-session-token";
 import { env, isPasswordLoginEnabled } from "@/lib/env";
 
 const publicPaths = ["/login"];
@@ -44,7 +44,10 @@ export async function middleware(request: NextRequest) {
   }
 
   try {
-    await jwtVerify(token, getSecret());
+    const payload = await verifyHs256Jwt(token, getSecret());
+    if (!payload) {
+      throw new Error("Invalid session token");
+    }
   } catch {
     if (isPublic) {
       return NextResponse.next();

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "typecheck": "next typegen && tsc --noEmit",
     "test": "vitest run --coverage",
     "test:watch": "vitest",
-    "test:e2e": "playwright test"
+    "test:e2e": "env -u NO_COLOR playwright test"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     trace: "on-first-retry"
   },
   webServer: {
-    command: "rm -rf .e2e-data test-results && PORT=3117 npm run dev",
+    command: "rm -rf .e2e-data test-results && env -u NO_COLOR PORT=3117 npm run dev",
     url: "http://localhost:3117",
     reuseExistingServer: false,
     env: {

--- a/tests/e2e/features.spec.ts
+++ b/tests/e2e/features.spec.ts
@@ -64,6 +64,24 @@ async function mockChatResponse(
 async function createNewChat(page: import("@playwright/test").Page) {
   const newChatButtons = page.getByRole("button", { name: "New chat", exact: true });
   await expect(newChatButtons.first()).toBeVisible({ timeout: 10000 });
+  await expect
+    .poll(
+      async () => {
+        const buttonCount = await newChatButtons.count();
+
+        for (let index = 0; index < buttonCount; index += 1) {
+          const candidate = newChatButtons.nth(index);
+
+          if ((await candidate.isVisible()) && (await candidate.isEnabled())) {
+            return index;
+          }
+        }
+
+        return -1;
+      },
+      { timeout: 10000 }
+    )
+    .not.toBe(-1);
 
   let newChatButton: import("@playwright/test").Locator | null = null;
   const buttonCount = await newChatButtons.count();
@@ -92,6 +110,34 @@ async function createNewChat(page: import("@playwright/test").Page) {
       await page.waitForTimeout(500);
     }
   }
+}
+
+async function resetSidebarData(page: import("@playwright/test").Page) {
+  const conversationsResponse = await page.request.get("/api/conversations?limit=50");
+
+  if (conversationsResponse.ok()) {
+    const conversationsPayload = (await conversationsResponse.json()) as {
+      conversations?: Array<{ id: string }>;
+    };
+
+    for (const conversation of conversationsPayload.conversations ?? []) {
+      await page.request.delete(`/api/conversations/${conversation.id}`);
+    }
+  }
+
+  const foldersResponse = await page.request.get("/api/folders");
+
+  if (foldersResponse.ok()) {
+    const foldersPayload = (await foldersResponse.json()) as {
+      folders?: Array<{ id: string }>;
+    };
+
+    for (const folder of foldersPayload.folders ?? []) {
+      await page.request.delete(`/api/folders/${folder.id}`);
+    }
+  }
+
+  await page.goto("/", { waitUntil: "domcontentloaded" });
 }
 
 type MockChatRequest = {
@@ -813,24 +859,36 @@ test.describe("Feature: Folders", () => {
 test.describe("Feature: Move conversation to folder", () => {
   test("moves a conversation into a folder by dragging it onto the folder", async ({ page }) => {
     await signIn(page);
+    await resetSidebarData(page);
+    const folderName = `Projects ${Date.now()}`;
 
     // Create a folder first
     await page.getByRole("button", { name: "New folder" }).click();
-    await page.getByPlaceholder("Folder name").fill("Projects");
+    await page.getByPlaceholder("Folder name").fill(folderName);
     await page.getByPlaceholder("Folder name").press("Enter");
-    await expect(page.getByRole("button", { name: "Projects folder" }).first()).toBeVisible({
-      timeout: 3000
-    });
+    const folderDropTarget = page.locator(`[data-folder-name="${folderName}"]`);
+    await expect(folderDropTarget).toBeVisible({ timeout: 3000 });
+
+    const foldersResponse = await page.request.get("/api/folders");
+    expect(foldersResponse.ok()).toBeTruthy();
+    const foldersPayload = (await foldersResponse.json()) as {
+      folders: Array<{ id: string; name: string }>;
+    };
+    const folderId = foldersPayload.folders.find((folder) => folder.name === folderName)?.id;
+    expect(folderId).toBeTruthy();
 
     // Create a chat
     await createNewChat(page);
     await expect(page).toHaveURL(/\/chat\//, { timeout: 10000 });
+    const conversationId = page.url().match(/\/chat\/([^/?#]+)/)?.[1];
+    expect(conversationId).toBeTruthy();
 
-    const convLink = page.locator('aside a[href*="/chat/"]').first();
-    const folderRow = page.getByRole("button", { name: "Projects folder" }).first();
-
-    const convBox = await convLink.boundingBox();
-    const folderBox = await folderRow.boundingBox();
+    const convLink = page.locator(`aside a[href="/chat/${conversationId}"]`);
+    await expect(convLink).toBeVisible({ timeout: 5000 });
+    const convDragSource = convLink.locator("xpath=..");
+    await expect(convDragSource).toHaveAttribute("role", "button", { timeout: 5000 });
+    const convBox = await convDragSource.boundingBox();
+    const folderBox = await folderDropTarget.boundingBox();
 
     if (!convBox || !folderBox) {
       throw new Error("Could not find drag source or folder target");
@@ -838,13 +896,101 @@ test.describe("Feature: Move conversation to folder", () => {
 
     await page.mouse.move(convBox.x + convBox.width / 2, convBox.y + convBox.height / 2);
     await page.mouse.down();
-    await page.mouse.move(folderBox.x + folderBox.width / 2, folderBox.y + folderBox.height / 2, {
-      steps: 20
+    await page.mouse.move(convBox.x + convBox.width / 2 + 16, convBox.y + convBox.height / 2, {
+      steps: 5
     });
+    await page.waitForTimeout(150);
+    await page.mouse.move(folderBox.x + folderBox.width / 2, folderBox.y + folderBox.height / 2, {
+      steps: 50
+    });
+    await page.waitForTimeout(100);
     await page.mouse.up();
 
-    const projectsFolder = page.getByRole("button", { name: "Projects folder" }).first();
-    await expect(projectsFolder.getByText("1")).toBeVisible({ timeout: 5000 });
+    await expect.poll(
+      async () => {
+        const response = await page.request.get(`/api/conversations/${conversationId}`);
+        const payload = (await response.json()) as {
+          conversation?: { folderId: string | null };
+        };
+        return payload.conversation?.folderId ?? null;
+      },
+      { timeout: 5000 }
+    ).toBe(folderId);
+  });
+
+  test("keeps sidebar actions discoverable and usable on mobile", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await signIn(page);
+    await resetSidebarData(page);
+
+    const folderName = `Mobile Projects ${Date.now()}`;
+    const conversationTitle = `Mobile action chat ${Date.now()}`;
+    const folderResponse = await page.request.post("/api/folders", {
+      data: { name: folderName }
+    });
+    expect(folderResponse.status()).toBe(201);
+    const folderPayload = (await folderResponse.json()) as {
+      folder: { id: string; name: string };
+    };
+
+    const conversationResponse = await page.request.post("/api/conversations", {
+      data: { title: conversationTitle }
+    });
+    expect(conversationResponse.status()).toBe(201);
+    const conversationPayload = (await conversationResponse.json()) as {
+      conversation: { id: string; title: string };
+    };
+
+    await page.goto(`/chat/${conversationPayload.conversation.id}`, {
+      waitUntil: "domcontentloaded"
+    });
+    await page.waitForLoadState("networkidle");
+    await page.getByRole("button", { name: "Open menu" }).click();
+
+    const sidebar = page.locator("aside");
+    const conversationActions = sidebar.getByRole("button", {
+      name: `Conversation actions for ${conversationTitle}`,
+      exact: true
+    });
+    const folderNewChat = sidebar.getByRole("button", {
+      name: `New chat in ${folderName}`,
+      exact: true
+    });
+    const folderActions = sidebar.getByRole("button", {
+      name: `Folder actions for ${folderName}`,
+      exact: true
+    });
+
+    await expect(conversationActions).toBeVisible({ timeout: 5000 });
+    await expect(conversationActions).toBeInViewport({ timeout: 5000 });
+    await expect(folderNewChat).toBeVisible({ timeout: 5000 });
+    await expect(folderActions).toBeVisible({ timeout: 5000 });
+    await expect(sidebar.locator('[data-sidebar-row-actions="conversation"]').first()).toHaveCSS(
+      "opacity",
+      "1"
+    );
+    await expect(sidebar.locator('[data-sidebar-row-actions="folder"]').first()).toHaveCSS(
+      "opacity",
+      "1"
+    );
+
+    await conversationActions.click();
+    await sidebar.getByRole("button", { name: folderName, exact: true }).click();
+
+    await expect
+      .poll(
+        async () => {
+          const response = await page.request.get(
+            `/api/conversations/${conversationPayload.conversation.id}`
+          );
+          const payload = (await response.json()) as {
+            conversation?: { folderId: string | null };
+          };
+          return payload.conversation?.folderId ?? null;
+        },
+        { timeout: 5000 }
+      )
+      .toBe(folderPayload.folder.id);
   });
 });
 
@@ -976,10 +1122,11 @@ test.describe("Feature: Skills in settings", () => {
     await page.getByPlaceholder("Enter the full skill instructions...").fill("Always respond in French.");
     await page.getByRole("button", { name: "Add skill" }).last().click();
 
-    await expect(page.getByText("Test Skill")).toBeVisible({ timeout: 5000 });
+    await expect(page.getByRole("heading", { name: "Test Skill", exact: true })).toBeVisible({
+      timeout: 5000
+    });
 
     // Delete it
-    await page.getByText("Test Skill", { exact: true }).click();
     await page.getByRole("button", { name: "Delete", exact: true }).click();
     await expect(page.locator("span").filter({ hasText: "Test Skill" })).toHaveCount(0, {
       timeout: 3000
@@ -1354,13 +1501,13 @@ test.describe("Feature: Chat attachments", () => {
       await expect(page.getByRole("button", { name: "Preview screenshot.png" })).toHaveCount(1);
       await expect(page.getByRole("button", { name: "Preview report.txt" })).toHaveCount(1);
       await expect(page.getByRole("link", { name: "Report" })).toHaveCount(0);
-      await expect(page.getByRole("img", { name: "Screenshot" })).toHaveCount(0);
+      await expect(page.getByRole("img", { name: "Screenshot", exact: true })).toHaveCount(0);
       await expect(page.locator(`a[href="${reportPath}"]`)).toHaveCount(0);
       await expect(page.locator(`img[src="${screenshotPath}"]`)).toHaveCount(0);
 
       await page.getByRole("button", { name: "Preview screenshot.png" }).last().click();
       await expect(page.getByRole("dialog", { name: "Attachment preview" })).toBeVisible();
-      await expect(page.getByRole("img", { name: "Screenshot" })).toHaveCount(0);
+      await expect(page.getByRole("img", { name: "Screenshot", exact: true })).toHaveCount(0);
       await expect(page.getByRole("link", { name: "Download attachment" })).toHaveAttribute(
         "href",
         /\/api\/attachments\/[^/]+\?download=1$/
@@ -1543,14 +1690,16 @@ test.describe("Feature: Queued chat follow-ups", () => {
       await expect(queueHeader).toBeVisible({ timeout: 10000 });
 
       const thirdQueuedRow = page
-        .getByText("Third queued follow-up", { exact: true })
-        .locator("xpath=..");
+        .locator('[data-testid^="queued-message-body-"]')
+        .filter({ hasText: "Third queued follow-up" });
+      await expect(thirdQueuedRow).toBeVisible({ timeout: 10000 });
       await thirdQueuedRow.getByRole("button", { name: "Delete" }).click();
       await expect(page.getByText("Third queued follow-up", { exact: true })).toHaveCount(0);
 
       const secondQueuedRow = page
-        .getByText("Second queued follow-up", { exact: true })
-        .locator("xpath=..");
+        .locator('[data-testid^="queued-message-body-"]')
+        .filter({ hasText: "Second queued follow-up" });
+      await expect(secondQueuedRow).toBeVisible({ timeout: 10000 });
       await secondQueuedRow.getByRole("button", { name: "Send now" }).click();
 
       await expect.poll(
@@ -1575,12 +1724,12 @@ test.describe("Feature: Queued chat follow-ups", () => {
       ]);
       expect(dispatchedMessages).not.toContain("Third queued follow-up");
 
-      await expect(page.getByText("Second queued follow-up", { exact: true })).toHaveCount(0, {
-        timeout: 10000
-      });
-      await expect(page.getByText("First queued follow-up", { exact: true })).toHaveCount(0, {
-        timeout: 10000
-      });
+      await expect(
+        page.locator('[data-testid^="queued-message-body-"]').filter({ hasText: "Second queued follow-up" })
+      ).toHaveCount(0, { timeout: 10000 });
+      await expect(
+        page.locator('[data-testid^="queued-message-body-"]').filter({ hasText: "First queued follow-up" })
+      ).toHaveCount(0, { timeout: 10000 });
       await expect(page.getByText("Handled Second queued follow-up")).toBeVisible({
         timeout: 10000
       });

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -17,7 +17,10 @@ test("redirects to login, signs in, opens settings, and creates a chat", async (
   await page.getByRole("link", { name: "Back to chat" }).click();
   await page.waitForURL("http://localhost:3117/", { timeout: 15000 });
 
-  await page.getByRole("button", { name: "New chat" }).click();
+  const newChatButton = page.getByRole("button", { name: "New chat", exact: true });
+  await expect(newChatButton).toBeVisible({ timeout: 10000 });
+  await expect(newChatButton).toBeEnabled({ timeout: 10000 });
+  await newChatButton.click();
 
   await expect(page).toHaveURL(/\/chat\//, { timeout: 10000 });
 });

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -16,6 +16,13 @@ Object.assign(process.env, {
   EIDON_ENCRYPTION_SECRET: "test-encryption-secret-which-is-long-enough"
 });
 
+if (typeof window !== "undefined") {
+  Object.defineProperty(window, "scrollTo", {
+    configurable: true,
+    value: () => undefined
+  });
+}
+
 beforeEach(async () => {
   const { resetDbForTests } = await import("@/lib/db");
   resetDbForTests();

--- a/tests/unit/automation-scheduler.test.ts
+++ b/tests/unit/automation-scheduler.test.ts
@@ -473,6 +473,57 @@ describe("automation scheduler", () => {
     }
   });
 
+  it("clamps long scheduler sleeps to the maximum timer delay", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-10T13:04:00.000Z"));
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    let scheduler: { start: () => void; stop: () => void } | null = null;
+
+    try {
+      const { updateSettings } = await import("@/lib/settings");
+      updateSettings({
+        defaultProviderProfileId: "profile_scheduler",
+        skillsEnabled: false,
+        providerProfiles: [createProviderProfile()]
+      });
+
+      createAutomation({
+        name: "Long interval",
+        prompt: "Run later",
+        providerProfileId: "profile_scheduler",
+        personaId: null,
+        scheduleKind: "interval",
+        intervalMinutes: 30 * 24 * 60,
+        calendarFrequency: null,
+        timeOfDay: null,
+        daysOfWeek: []
+      });
+
+      const { createAutomationScheduler } = await import("@/lib/automation-scheduler");
+      scheduler = createAutomationScheduler({
+        now: () => new Date(),
+        timeZone: "UTC",
+        manager: createConversationManager(),
+        startChatTurn: vi.fn().mockResolvedValue({ status: "completed" })
+      });
+
+      scheduler.start();
+      await vi.runAllTicks();
+      await Promise.resolve();
+
+      const delays = setTimeoutSpy.mock.calls
+        .map((call) => Number(call[1]))
+        .filter((delay) => Number.isFinite(delay));
+
+      expect(delays).toContain(2_147_483_647);
+      expect(Math.max(...delays)).toBeLessThanOrEqual(2_147_483_647);
+    } finally {
+      scheduler?.stop();
+      setTimeoutSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
   it("resyncs future next-run timestamps to the scheduler timezone without touching overdue or disabled work", async () => {
     const previousTz = process.env.TZ;
     vi.useFakeTimers();

--- a/tests/unit/conversations-extended.test.ts
+++ b/tests/unit/conversations-extended.test.ts
@@ -35,6 +35,24 @@ describe("conversations extended", () => {
     expect(results2[0].folderId).toBeNull();
   });
 
+  it("preserves activity timestamps when moving conversations between folders", () => {
+    const folder1 = createFolder("Stable Folder 1");
+    const folder2 = createFolder("Stable Folder 2");
+    const conv = createConversation("Stable folder chat", folder1.id);
+    const originalUpdatedAt = "2026-04-01T10:00:00.000Z";
+
+    getDb()
+      .prepare("UPDATE conversations SET updated_at = ? WHERE id = ?")
+      .run(originalUpdatedAt, conv.id);
+
+    moveConversationToFolder(conv.id, folder2.id);
+
+    const row = getDb()
+      .prepare("SELECT updated_at FROM conversations WHERE id = ?")
+      .get(conv.id) as { updated_at: string };
+    expect(row.updated_at).toBe(originalUpdatedAt);
+  });
+
   it("moves conversations between folders only for the requested user", async () => {
     const userA = await createLocalUser({
       username: "conversation-folder-a",
@@ -70,6 +88,34 @@ describe("conversations extended", () => {
 
     // The reorder updates sort_order, and listConversations uses updated_at DESC
     // but the reorder function persists the new sort_order
+  });
+
+  it("preserves activity timestamps when reordering conversations", () => {
+    const c1 = createConversation("Stable C1");
+    const c2 = createConversation("Stable C2");
+    const timestamps = new Map([
+      [c1.id, "2026-04-01T10:00:00.000Z"],
+      [c2.id, "2026-04-02T10:00:00.000Z"]
+    ]);
+
+    for (const [id, updatedAt] of timestamps) {
+      getDb()
+        .prepare("UPDATE conversations SET updated_at = ? WHERE id = ?")
+        .run(updatedAt, id);
+    }
+
+    reorderConversations([
+      { id: c2.id, folderId: null },
+      { id: c1.id, folderId: null }
+    ]);
+
+    const rows = getDb()
+      .prepare("SELECT id, updated_at FROM conversations WHERE id IN (?, ?)")
+      .all(c1.id, c2.id) as Array<{ id: string; updated_at: string }>;
+
+    for (const row of rows) {
+      expect(row.updated_at).toBe(timestamps.get(row.id));
+    }
   });
 
   it("scopes conversation search results to the requested user", async () => {

--- a/tests/unit/edge-session-token.test.ts
+++ b/tests/unit/edge-session-token.test.ts
@@ -1,0 +1,46 @@
+import { SignJWT } from "jose";
+
+import { verifyHs256Jwt } from "@/lib/edge-session-token";
+
+const secret = new TextEncoder().encode("edge-session-token-test-secret");
+
+async function signSessionToken(
+  payload: Record<string, unknown>,
+  options: { expiresAt?: number; secretOverride?: Uint8Array } = {}
+) {
+  const signer = new SignJWT(payload).setProtectedHeader({ alg: "HS256" });
+
+  if (options.expiresAt !== undefined) {
+    signer.setExpirationTime(options.expiresAt);
+  } else {
+    signer.setExpirationTime(Math.floor(Date.now() / 1000) + 60);
+  }
+
+  return signer.sign(options.secretOverride ?? secret);
+}
+
+describe("edge session token verifier", () => {
+  it("verifies a signed HS256 token and returns its payload", async () => {
+    const token = await signSessionToken({ sid: "session_123", uid: "user_123" });
+
+    await expect(verifyHs256Jwt(token, secret)).resolves.toMatchObject({
+      sid: "session_123",
+      uid: "user_123"
+    });
+  });
+
+  it("rejects invalid signatures and expired tokens", async () => {
+    const badSignatureToken = await signSessionToken(
+      { sid: "session_123", uid: "user_123" },
+      { secretOverride: new TextEncoder().encode("wrong-secret") }
+    );
+    const expiredToken = await signSessionToken(
+      { sid: "session_123", uid: "user_123" },
+      { expiresAt: Math.floor(Date.now() / 1000) - 1 }
+    );
+
+    await expect(verifyHs256Jwt(badSignatureToken, secret)).resolves.toBeNull();
+    await expect(verifyHs256Jwt(expiredToken, secret)).resolves.toBeNull();
+    await expect(verifyHs256Jwt("not-a-jwt", secret)).resolves.toBeNull();
+  });
+});

--- a/tests/unit/reliability-routes.test.ts
+++ b/tests/unit/reliability-routes.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createConversation } from "@/lib/conversations";
+import { createLocalUser } from "@/lib/users";
+
+const { requireUserMock } = vi.hoisted(() => ({
+  requireUserMock: vi.fn()
+}));
+
+vi.mock("@/lib/auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/auth")>();
+
+  return {
+    ...actual,
+    requireUser: requireUserMock
+  };
+});
+
+describe("reliability route hardening", () => {
+  beforeEach(() => {
+    requireUserMock.mockReset();
+  });
+
+  it("returns a client error for malformed multipart attachment uploads", async () => {
+    const user = await createLocalUser({
+      username: "malformed-upload-user",
+      password: "Password123!",
+      role: "user"
+    });
+    requireUserMock.mockResolvedValue(user);
+
+    const { POST } = await import("@/app/api/attachments/route");
+    const response = await POST(
+      new Request("http://localhost/api/attachments", {
+        method: "POST",
+        headers: { "content-type": "multipart/form-data" },
+        body: "not a multipart body"
+      })
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Invalid attachment upload"
+    });
+  });
+
+  it("returns a client error when env-managed account credentials are updated", async () => {
+    const auth = await import("@/lib/auth");
+    await auth.ensureAdminBootstrap();
+    const admin = await auth.findUserByUsername("admin");
+    requireUserMock.mockResolvedValue(admin!.user);
+
+    const { PUT } = await import("@/app/api/auth/account/route");
+    const response = await PUT(
+      new Request("http://localhost/api/auth/account", {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          username: "admin-renamed",
+          password: "new-secret-123"
+        })
+      })
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Env-managed credentials cannot be changed in the UI"
+    });
+  });
+
+  it("returns not found when deleting a missing conversation id", async () => {
+    const user = await createLocalUser({
+      username: "delete-missing-conversation-user",
+      password: "Password123!",
+      role: "user"
+    });
+    requireUserMock.mockResolvedValue(user);
+
+    const { DELETE } = await import("@/app/api/conversations/[conversationId]/route");
+    const response = await DELETE(
+      new Request("http://localhost/api/conversations/conv_missing", {
+        method: "DELETE"
+      }),
+      { params: Promise.resolve({ conversationId: "conv_missing" }) }
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: "Conversation not found"
+    });
+  });
+
+  it("still reports success when deleting an existing conversation", async () => {
+    const user = await createLocalUser({
+      username: "delete-existing-conversation-user",
+      password: "Password123!",
+      role: "user"
+    });
+    const conversation = createConversation("Delete me", null, undefined, user.id);
+    requireUserMock.mockResolvedValue(user);
+
+    const { DELETE } = await import("@/app/api/conversations/[conversationId]/route");
+    const response = await DELETE(
+      new Request(`http://localhost/api/conversations/${conversation.id}`, {
+        method: "DELETE"
+      }),
+      { params: Promise.resolve({ conversationId: conversation.id }) }
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      success: true,
+      deleted: true
+    });
+  });
+
+  it("preserves onlyIfEmpty delete semantics for nonempty conversations", async () => {
+    const user = await createLocalUser({
+      username: "delete-nonempty-conversation-user",
+      password: "Password123!",
+      role: "user"
+    });
+    const conversation = createConversation("Keep me", null, undefined, user.id);
+    requireUserMock.mockResolvedValue(user);
+
+    const { createMessage } = await import("@/lib/conversations");
+    createMessage({
+      conversationId: conversation.id,
+      role: "user",
+      content: "Do not delete this populated conversation"
+    });
+
+    const { DELETE } = await import("@/app/api/conversations/[conversationId]/route");
+    const response = await DELETE(
+      new Request(`http://localhost/api/conversations/${conversation.id}?onlyIfEmpty=1`, {
+        method: "DELETE"
+      }),
+      { params: Promise.resolve({ conversationId: conversation.id }) }
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      success: true,
+      deleted: false
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Fix sidebar drag/drop so conversations reliably move into folders and keep recency ordering clean.
- Make sidebar row actions usable on mobile, with stable labels and touch-friendly visibility.
- Tighten API error handling for malformed uploads, env-managed account updates, and missing conversations.
- Remove noisy warning sources by clamping scheduler delays, replacing the Edge middleware JWT check, and reducing browser/image warnings.
- Add regression coverage for the new reliability and mobile paths.

## Testing
- `npm test` passed with global coverage above the 85% threshold.
- `npm run typecheck` passed.
- `npm run build` passed.
- `npm run test:e2e` passed, including the mobile sidebar action flow and attachment/search regressions.
- Performed live browser validation of the mobile sidebar and settings flows against the local dev server.