### PR TITLE
Generate Eidon design context files

### DIFF
--- a/DESIGN.json
+++ b/DESIGN.json
@@ -1,0 +1,273 @@
+{
+  "schemaVersion": 2,
+  "generatedAt": "2026-05-06T19:37:05Z",
+  "title": "Design System: Eidon",
+  "extensions": {
+    "colorMeta": {
+      "abyss-background": {
+        "role": "neutral",
+        "displayName": "Abyss Background",
+        "canonical": "#0a0a0a",
+        "tonalRamp": ["oklch(15% 0.006 285)", "oklch(24% 0.006 285)", "oklch(34% 0.006 285)", "oklch(44% 0.006 285)", "oklch(56% 0.006 285)", "oklch(68% 0.006 285)", "oklch(82% 0.006 285)", "oklch(95% 0.006 285)"]
+      },
+      "sidebar-charcoal": {
+        "role": "neutral",
+        "displayName": "Sidebar Charcoal",
+        "canonical": "#0f0f0f",
+        "tonalRamp": ["oklch(16% 0.006 285)", "oklch(25% 0.006 285)", "oklch(35% 0.006 285)", "oklch(45% 0.006 285)", "oklch(57% 0.006 285)", "oklch(69% 0.006 285)", "oklch(83% 0.006 285)", "oklch(96% 0.006 285)"]
+      },
+      "panel-zinc": {
+        "role": "neutral",
+        "displayName": "Panel Zinc",
+        "canonical": "#18181b",
+        "tonalRamp": ["oklch(17% 0.01 285)", "oklch(26% 0.01 285)", "oklch(36% 0.01 285)", "oklch(46% 0.01 285)", "oklch(58% 0.01 285)", "oklch(70% 0.01 285)", "oklch(84% 0.01 285)", "oklch(96% 0.01 285)"]
+      },
+      "eidon-violet": {
+        "role": "primary",
+        "displayName": "Eidon Violet",
+        "canonical": "#8b5cf6",
+        "tonalRamp": ["oklch(18% 0.06 295)", "oklch(28% 0.09 295)", "oklch(38% 0.12 295)", "oklch(50% 0.16 295)", "oklch(62% 0.19 295)", "oklch(74% 0.15 295)", "oklch(86% 0.09 295)", "oklch(95% 0.04 295)"]
+      },
+      "provider-cyan": {
+        "role": "secondary",
+        "displayName": "Provider Cyan",
+        "canonical": "#22d3ee",
+        "tonalRamp": ["oklch(18% 0.04 220)", "oklch(28% 0.06 220)", "oklch(40% 0.08 220)", "oklch(54% 0.1 220)", "oklch(68% 0.11 220)", "oklch(79% 0.08 220)", "oklch(89% 0.05 220)", "oklch(96% 0.025 220)"]
+      },
+      "persona-violet": {
+        "role": "secondary",
+        "displayName": "Persona Violet",
+        "canonical": "#a78bfa",
+        "tonalRamp": ["oklch(18% 0.05 295)", "oklch(29% 0.07 295)", "oklch(41% 0.09 295)", "oklch(55% 0.12 295)", "oklch(70% 0.13 295)", "oklch(80% 0.1 295)", "oklch(90% 0.06 295)", "oklch(96% 0.03 295)"]
+      },
+      "success-green": {
+        "role": "status",
+        "displayName": "Success Green",
+        "canonical": "#22c55e",
+        "tonalRamp": ["oklch(18% 0.05 150)", "oklch(28% 0.07 150)", "oklch(40% 0.09 150)", "oklch(54% 0.11 150)", "oklch(66% 0.13 150)", "oklch(78% 0.1 150)", "oklch(89% 0.06 150)", "oklch(96% 0.03 150)"]
+      },
+      "warning-amber": {
+        "role": "status",
+        "displayName": "Warning Amber",
+        "canonical": "#eab308",
+        "tonalRamp": ["oklch(18% 0.04 80)", "oklch(30% 0.06 80)", "oklch(43% 0.09 80)", "oklch(58% 0.12 80)", "oklch(74% 0.14 80)", "oklch(84% 0.1 80)", "oklch(92% 0.06 80)", "oklch(97% 0.03 80)"]
+      },
+      "danger-red": {
+        "role": "status",
+        "displayName": "Danger Red",
+        "canonical": "#ef4444",
+        "tonalRamp": ["oklch(18% 0.05 25)", "oklch(29% 0.08 25)", "oklch(41% 0.11 25)", "oklch(55% 0.15 25)", "oklch(68% 0.17 25)", "oklch(80% 0.12 25)", "oklch(90% 0.07 25)", "oklch(96% 0.035 25)"]
+      }
+    },
+    "typographyMeta": {
+      "display": {
+        "displayName": "Display",
+        "purpose": "Rare editorial or brand moments only."
+      },
+      "body": {
+        "displayName": "Body",
+        "purpose": "Operational product UI and assistant prose."
+      },
+      "label": {
+        "displayName": "Label",
+        "purpose": "Metadata, compact controls, and small status labels."
+      },
+      "mono": {
+        "displayName": "Mono",
+        "purpose": "Code, identifiers, command output, and machine-readable values."
+      },
+      "wordmark": {
+        "displayName": "Wordmark",
+        "purpose": "Eidon brand mark only."
+      }
+    },
+    "shadows": [
+      {
+        "name": "workspace-shadow",
+        "value": "0 8px 32px rgba(0, 0, 0, 0.5)",
+        "purpose": "Login form and substantial floating panels."
+      },
+      {
+        "name": "composer-shadow",
+        "value": "0 0 40px rgba(0,0,0,0.5)",
+        "purpose": "Chat composer shell at rest."
+      },
+      {
+        "name": "composer-focus-glow",
+        "value": "0 0 50px rgba(0,0,0,0.6), 0 0 20px var(--accent-soft)",
+        "purpose": "Composer focus state only."
+      },
+      {
+        "name": "primary-action-glow",
+        "value": "0 0 20px var(--accent-glow)",
+        "purpose": "Send and primary action buttons."
+      }
+    ],
+    "motion": [
+      {
+        "name": "fade-in",
+        "value": "0.3s ease-out",
+        "purpose": "Small reveal states."
+      },
+      {
+        "name": "slide-up",
+        "value": "0.4s ease-out from translateY(12px)",
+        "purpose": "Panels and login form entry."
+      },
+      {
+        "name": "compact-control-transition",
+        "value": "120ms to 300ms ease-out",
+        "purpose": "Hover, focus, and icon control states."
+      }
+    ],
+    "breakpoints": [
+      {
+        "name": "mobile",
+        "value": "< 768px"
+      },
+      {
+        "name": "desktop-sidebar",
+        "value": "768px"
+      }
+    ]
+  },
+  "components": [
+    {
+      "name": "Primary Button",
+      "kind": "button",
+      "refersTo": "button-primary",
+      "description": "Compact violet command for save, send, and decisive actions.",
+      "html": "<button class=\"ds-btn-primary\">Save changes</button>",
+      "css": ".ds-btn-primary { display: inline-flex; align-items: center; justify-content: center; min-height: 40px; border: 0; border-radius: 999px; background: var(--accent, #8b5cf6); color: var(--text, #f4f4f5); padding: 8px 16px; font: 600 14px/1.2 Inter, ui-sans-serif, system-ui, sans-serif; box-shadow: 0 0 20px var(--accent-glow, rgba(139,92,246,0.25)); transition: transform 200ms ease-out, filter 200ms ease-out, box-shadow 200ms ease-out; } .ds-btn-primary:hover { filter: brightness(1.1); } .ds-btn-primary:active { transform: scale(0.97); } .ds-btn-primary:focus-visible { outline: 2px solid rgba(244,244,245,0.22); outline-offset: 2px; }"
+    },
+    {
+      "name": "Secondary Button",
+      "kind": "button",
+      "refersTo": "button-secondary",
+      "description": "Quiet command button for secondary settings and modal actions.",
+      "html": "<button class=\"ds-btn-secondary\">Cancel</button>",
+      "css": ".ds-btn-secondary { display: inline-flex; align-items: center; justify-content: center; min-height: 40px; border: 1px solid rgba(255,255,255,0.08); border-radius: 999px; background: rgba(255,255,255,0.05); color: var(--text, #f4f4f5); padding: 8px 16px; font: 500 14px/1.2 Inter, ui-sans-serif, system-ui, sans-serif; transition: background-color 200ms ease-out, border-color 200ms ease-out, transform 200ms ease-out; } .ds-btn-secondary:hover { background: rgba(255,255,255,0.1); border-color: rgba(255,255,255,0.14); } .ds-btn-secondary:active { transform: scale(0.97); } .ds-btn-secondary:focus-visible { outline: 2px solid rgba(139,92,246,0.35); outline-offset: 2px; }"
+    },
+    {
+      "name": "Ghost Icon Button",
+      "kind": "button",
+      "refersTo": "button-ghost",
+      "description": "Small tool button for attach, menu, settings, copy, and navigation controls.",
+      "html": "<button class=\"ds-icon-button\" aria-label=\"Attach files\"><svg viewBox=\"0 0 24 24\" aria-hidden=\"true\"><path d=\"M21.4 11.6 12 21a6 6 0 0 1-8.5-8.5l9.8-9.8a4 4 0 0 1 5.7 5.7L9.2 18.2a2 2 0 1 1-2.8-2.8l9.2-9.2\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"/></svg></button>",
+      "css": ".ds-icon-button { display: inline-flex; align-items: center; justify-content: center; height: 36px; width: 36px; border: 0; border-radius: 12px; background: transparent; color: rgba(244,244,245,0.35); transition: background-color 200ms ease-out, color 200ms ease-out, transform 200ms ease-out; } .ds-icon-button svg { height: 18px; width: 18px; } .ds-icon-button:hover { background: rgba(255,255,255,0.05); color: rgba(244,244,245,0.7); } .ds-icon-button:active { transform: scale(0.97); } .ds-icon-button:focus-visible { outline: 2px solid rgba(139,92,246,0.35); outline-offset: 2px; }"
+    },
+    {
+      "name": "Input Field",
+      "kind": "input",
+      "refersTo": "input-field",
+      "description": "Integrated dark field with a soft violet focus state.",
+      "html": "<label class=\"ds-field\"><span>Provider name</span><input value=\"OpenAI\" /></label>",
+      "css": ".ds-field { display: grid; gap: 6px; color: var(--text, #f4f4f5); font-family: Inter, ui-sans-serif, system-ui, sans-serif; } .ds-field span { color: rgba(244,244,245,0.64); font-size: 12px; font-weight: 600; } .ds-field input { width: 100%; border: 1px solid rgba(255,255,255,0.06); border-radius: 12px; background: rgba(255,255,255,0.04); color: var(--text, #f4f4f5); padding: 12px 16px; font: 400 14px/1.4 Inter, ui-sans-serif, system-ui, sans-serif; outline: none; transition: background-color 200ms ease-out, border-color 200ms ease-out, box-shadow 200ms ease-out; } .ds-field input:focus { border-color: rgba(139,92,246,0.4); background: rgba(255,255,255,0.06); box-shadow: 0 0 0 3px var(--accent-soft, rgba(139,92,246,0.1)); }"
+    },
+    {
+      "name": "Settings Card",
+      "kind": "card",
+      "refersTo": "settings-card",
+      "description": "Flat grouped setting surface for related controls.",
+      "html": "<section class=\"ds-settings-card\"><div><h3>Providers</h3><p>Connect the model access you want to use.</p></div><div class=\"ds-row\"><span>Default provider</span><strong>OpenAI</strong></div></section>",
+      "css": ".ds-settings-card { display: grid; gap: 20px; border: 1px solid rgba(255,255,255,0.06); border-radius: 12px; background: rgba(255,255,255,0.02); color: var(--text, #f4f4f5); padding: 24px; font-family: Inter, ui-sans-serif, system-ui, sans-serif; } .ds-settings-card h3 { margin: 0; font-size: 14px; font-weight: 600; line-height: 1.3; } .ds-settings-card p { margin: 4px 0 0; color: var(--muted, #71717a); font-size: 12px; line-height: 1.5; } .ds-row { display: flex; align-items: center; justify-content: space-between; gap: 16px; color: rgba(244,244,245,0.72); font-size: 13px; } .ds-row strong { color: var(--text, #f4f4f5); font-size: 13px; font-weight: 600; }"
+    },
+    {
+      "name": "Active Profile Row",
+      "kind": "custom",
+      "refersTo": "profile-card-active",
+      "description": "Selectable settings row with a quiet violet active state.",
+      "html": "<button class=\"ds-profile-row\"><span class=\"ds-dot\"></span><span class=\"ds-profile-main\"><strong>OpenAI</strong><small>gpt-5-mini</small></span><span class=\"ds-badge\">Default</span></button>",
+      "css": ".ds-profile-row { display: flex; width: 100%; align-items: center; gap: 8px; border: 1px solid rgba(139,92,246,0.2); border-radius: 12px; background: rgba(139,92,246,0.08); color: var(--text, #f4f4f5); padding: 12px; text-align: left; font-family: Inter, ui-sans-serif, system-ui, sans-serif; transition: background-color 200ms ease-out, border-color 200ms ease-out; } .ds-profile-row:hover { background: rgba(139,92,246,0.11); border-color: rgba(139,92,246,0.28); } .ds-dot { height: 8px; width: 8px; flex: none; border-radius: 999px; background: var(--accent, #8b5cf6); } .ds-profile-main { display: grid; min-width: 0; gap: 2px; flex: 1; } .ds-profile-main strong { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 13px; font-weight: 600; } .ds-profile-main small { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: rgba(244,244,245,0.62); font-size: 11px; } .ds-badge { border-radius: 6px; background: rgba(167,139,250,0.1); color: #a78bfa; padding: 2px 6px; font-size: 10px; font-weight: 700; }"
+    },
+    {
+      "name": "Sidebar Footer Link",
+      "kind": "nav",
+      "refersTo": "sidebar-link",
+      "description": "Persistent navigation row for automations and settings.",
+      "html": "<a class=\"ds-sidebar-link\" href=\"#\"><svg viewBox=\"0 0 24 24\" aria-hidden=\"true\"><path d=\"M12 8v5l3 2\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\"/><circle cx=\"12\" cy=\"12\" r=\"9\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\"/></svg><span>Automations</span></a>",
+      "css": ".ds-sidebar-link { display: flex; width: 100%; align-items: center; gap: 12px; border-radius: 16px; color: rgba(244,244,245,0.3); padding: 12px 16px; text-decoration: none; font: 500 14px/1.2 Inter, ui-sans-serif, system-ui, sans-serif; transition: background-color 300ms ease-out, color 300ms ease-out; } .ds-sidebar-link svg { height: 18px; width: 18px; opacity: 0.6; } .ds-sidebar-link:hover { background: rgba(255,255,255,0.03); color: rgba(244,244,245,0.6); } .ds-sidebar-link:focus-visible { outline: 2px solid rgba(139,92,246,0.35); outline-offset: 2px; }"
+    },
+    {
+      "name": "Status Badge",
+      "kind": "chip",
+      "refersTo": "badge",
+      "description": "Tiny semibold state marker for transport, built-in, key, and provider state.",
+      "html": "<span class=\"ds-badge-success\">stdio</span>",
+      "css": ".ds-badge-success { display: inline-flex; align-items: center; border-radius: 6px; background: rgba(34,197,94,0.1); color: #22c55e; padding: 2px 6px; font: 700 10px/1.2 Inter, ui-sans-serif, system-ui, sans-serif; }"
+    },
+    {
+      "name": "Chat Composer Shell",
+      "kind": "custom",
+      "refersTo": "chat-composer",
+      "description": "Signature input surface that holds drafting, attachments, provider context, and send state.",
+      "html": "<div class=\"ds-composer\"><textarea placeholder=\"Ask, create, or start a task\"></textarea><div class=\"ds-composer-bar\"><button>Attach</button><span>Provider</span><button class=\"ds-send\" aria-label=\"Send\"><svg viewBox=\"0 0 24 24\"><path d=\"M12 19V5m0 0-6 6m6-6 6 6\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"/></svg></button></div></div>",
+      "css": ".ds-composer { display: grid; gap: 8px; border: 1px solid rgba(255,255,255,0.1); border-radius: 26px; background: rgba(24,24,27,0.7); color: var(--text, #f4f4f5); padding: 8px; box-shadow: 0 0 40px rgba(0,0,0,0.5); backdrop-filter: blur(32px); transition: border-color 300ms ease-out, box-shadow 300ms ease-out; } .ds-composer:focus-within { border-color: rgba(139,92,246,0.3); box-shadow: 0 0 50px rgba(0,0,0,0.6), 0 0 20px var(--accent-soft, rgba(139,92,246,0.1)); } .ds-composer textarea { min-height: 52px; max-height: 300px; resize: none; border: 0; background: transparent; color: var(--text, #f4f4f5); padding: 14px 16px; font: 400 15px/1.5 Inter, ui-sans-serif, system-ui, sans-serif; outline: none; } .ds-composer textarea::placeholder { color: rgba(255,255,255,0.2); } .ds-composer-bar { display: flex; align-items: center; gap: 8px; border-top: 1px solid rgba(255,255,255,0.05); padding: 6px; color: rgba(244,244,245,0.45); font: 600 11px/1.2 Inter, ui-sans-serif, system-ui, sans-serif; } .ds-composer-bar button { border: 0; border-radius: 12px; background: transparent; color: rgba(244,244,245,0.35); padding: 8px; transition: background-color 200ms ease-out, color 200ms ease-out; } .ds-composer-bar button:hover { background: rgba(255,255,255,0.05); color: rgba(244,244,245,0.7); } .ds-send { margin-left: auto; display: inline-flex; height: 40px; width: 40px; align-items: center; justify-content: center; border-radius: 999px !important; background: var(--accent, #8b5cf6) !important; color: var(--text, #f4f4f5) !important; box-shadow: 0 0 20px var(--accent-glow, rgba(139,92,246,0.25)); } .ds-send svg { height: 20px; width: 20px; }"
+    }
+  ],
+  "narrative": {
+    "northStar": "The Private Control Room",
+    "overview": "Eidon's interface should feel like a focused control room for an AI workspace the user owns. It is dark because the product is used for long-running text work, configuration, and monitoring in concentrated sessions, not because dark mode is a shortcut to looking technical. The surface should stay quiet, legible, and immediate.\n\nThe system is dense but not cramped. Controls sit close to the work so capability feels available, while the main chat path stays obvious within seconds. Power should reveal through split panes, compact controls, durable tool states, and restrained accents rather than through marketing spectacle.\n\nThe visual language explicitly rejects a too-corporate SaaS dashboard, childish assistant styling, generic AI product cliches, huge gradient hero text, identical feature-card grids, and decorative complexity that makes the product harder to read.",
+    "keyCharacteristics": [
+      "Dark, near-black workspace with tonal depth.",
+      "Violet as a scarce commitment color, not a background wash.",
+      "Compact controls with readable labels and icon-first actions.",
+      "Soft borders, low-glow focus states, and rounded but not playful surfaces.",
+      "Mobile-safe density that keeps admin workflows usable on phones."
+    ],
+    "rules": [
+      {
+        "name": "The Scarce Signal Rule",
+        "body": "Eidon Violet is for commitment, selection, and focus. If more than 10% of a screen is violet, the screen is shouting.",
+        "section": "colors"
+      },
+      {
+        "name": "The Tonal Depth Rule",
+        "body": "Use near-black layers and faint borders for structure. Do not create depth with decorative purple gradients, blue fog, or large color washes.",
+        "section": "colors"
+      },
+      {
+        "name": "The Status Honesty Rule",
+        "body": "Green, amber, and red mean real system state. They are forbidden as decorative palette fillers.",
+        "section": "colors"
+      },
+      {
+        "name": "The App Scale Rule",
+        "body": "Most product UI lives between 11px and 15px. Large type must signal a real change in context, not fill space.",
+        "section": "typography"
+      },
+      {
+        "name": "The Wordmark Containment Rule",
+        "body": "Orbitron is for the Eidon mark. It is not a general display font for headings, buttons, or cards.",
+        "section": "typography"
+      },
+      {
+        "name": "The Flat Until Active Rule",
+        "body": "Surfaces do not float unless the user is interacting with them or they are temporarily above the main plane.",
+        "section": "elevation"
+      },
+      {
+        "name": "The Glow Has A Job Rule",
+        "body": "Glow means focus, active work, or a primary action. Decorative glow is prohibited.",
+        "section": "elevation"
+      }
+    ],
+    "dos": [
+      "Do make the first path obvious within seconds: new chat, type, send, provider, persona.",
+      "Do keep Eidon Violet scarce and meaningful. Primary actions, active rows, and focus rings get it first.",
+      "Do use tonal layers, hairline borders, and compact spacing to show hierarchy.",
+      "Do keep controls close to the work, especially in the chat composer and settings detail panes.",
+      "Do preserve pragmatic accessibility: readable contrast, keyboard focus, reduced-motion support, and mobile-safe layouts.",
+      "Do use personal, direct language that respects capable users."
+    ],
+    "donts": [
+      "Don't make Eidon feel like a too-corporate SaaS dashboard full of jargon, upsell framing, sterile admin panels, or abstract productivity promises.",
+      "Don't make it childish, toy-like, mascot-led, gamified, or visually loud for its own sake.",
+      "Don't use generic AI product cliches: huge gradient hero text, vague magic language, empty agent metaphors, identical feature-card grids, or decorative complexity.",
+      "Don't put cards inside cards. Use full-width panes, split views, or simple grouped rows instead.",
+      "Don't use side-stripe borders as accent decoration.",
+      "Don't let violet, cyan, or status colors become background themes. They are signals, not wallpaper.",
+      "Don't use Orbitron outside the Eidon wordmark."
+    ]
+  }
+}

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,294 @@
+---
+name: Eidon
+description: Self-hosted AI workspace with clear, powerful, personal controls.
+colors:
+  abyss-background: "#0a0a0a"
+  sidebar-charcoal: "#0f0f0f"
+  panel-zinc: "#18181b"
+  panel-zinc-strong: "#27272a"
+  signal-text: "#f4f4f5"
+  muted-ash: "#71717a"
+  hairline-faint: "#ffffff0f"
+  hairline-strong: "#ffffff1a"
+  eidon-violet: "#8b5cf6"
+  eidon-violet-soft: "#8b5cf61a"
+  eidon-violet-glow: "#8b5cf640"
+  thinking-indigo: "#818cf8"
+  provider-cyan: "#22d3ee"
+  persona-violet: "#a78bfa"
+  success-green: "#22c55e"
+  warning-amber: "#eab308"
+  danger-red: "#ef4444"
+  translucent-surface: "#ffffff08"
+typography:
+  display:
+    fontFamily: "Instrument Serif, Georgia, serif"
+    fontSize: "clamp(2.5rem, 7vw, 4.5rem)"
+    fontWeight: 400
+    lineHeight: 1
+    letterSpacing: "0"
+  headline:
+    fontFamily: "Inter, ui-sans-serif, system-ui, sans-serif"
+    fontSize: "1.375rem"
+    fontWeight: 600
+    lineHeight: 1.25
+    letterSpacing: "0"
+  title:
+    fontFamily: "Inter, ui-sans-serif, system-ui, sans-serif"
+    fontSize: "0.95rem"
+    fontWeight: 600
+    lineHeight: 1.35
+    letterSpacing: "0"
+  body:
+    fontFamily: "Inter, ui-sans-serif, system-ui, sans-serif"
+    fontSize: "14.5px"
+    fontWeight: 400
+    lineHeight: 1.75
+    letterSpacing: "0"
+  label:
+    fontFamily: "Inter, ui-sans-serif, system-ui, sans-serif"
+    fontSize: "11px"
+    fontWeight: 600
+    lineHeight: 1.2
+    letterSpacing: "0.08em"
+  mono:
+    fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace"
+    fontSize: "0.92em"
+    fontWeight: 400
+    lineHeight: 1.5
+    letterSpacing: "0"
+  wordmark:
+    fontFamily: "Orbitron, Eurostile, Space Grotesk, sans-serif"
+    fontSize: "1.125rem"
+    fontWeight: 600
+    lineHeight: 1
+    letterSpacing: "0.12em"
+rounded:
+  sm: "8px"
+  md: "12px"
+  lg: "16px"
+  xl: "22px"
+  composer: "26px"
+  pill: "999px"
+spacing:
+  xs: "4px"
+  sm: "8px"
+  md: "12px"
+  lg: "16px"
+  xl: "24px"
+  xxl: "32px"
+components:
+  button-primary:
+    backgroundColor: "{colors.eidon-violet}"
+    textColor: "{colors.signal-text}"
+    typography: "{typography.body}"
+    rounded: "{rounded.pill}"
+    padding: "8px 16px"
+  button-secondary:
+    backgroundColor: "{colors.translucent-surface}"
+    textColor: "{colors.signal-text}"
+    typography: "{typography.body}"
+    rounded: "{rounded.pill}"
+    padding: "8px 16px"
+  button-ghost:
+    backgroundColor: "transparent"
+    textColor: "{colors.muted-ash}"
+    typography: "{typography.body}"
+    rounded: "{rounded.md}"
+    padding: "8px 12px"
+  input-field:
+    backgroundColor: "{colors.translucent-surface}"
+    textColor: "{colors.signal-text}"
+    typography: "{typography.body}"
+    rounded: "{rounded.md}"
+    padding: "12px 16px"
+  settings-card:
+    backgroundColor: "{colors.translucent-surface}"
+    textColor: "{colors.signal-text}"
+    rounded: "{rounded.md}"
+    padding: "24px"
+  chat-composer:
+    backgroundColor: "{colors.panel-zinc}"
+    textColor: "{colors.signal-text}"
+    rounded: "{rounded.composer}"
+    padding: "8px"
+---
+
+# Design System: Eidon
+
+## 1. Overview
+
+**Creative North Star: "The Private Control Room"**
+
+Eidon's interface should feel like a focused control room for an AI workspace the user owns. It is dark because the product is used for long-running text work, configuration, and monitoring in concentrated sessions, not because dark mode is a shortcut to looking technical. The surface should stay quiet, legible, and immediate.
+
+The system is dense but not cramped. Controls sit close to the work so capability feels available, while the main chat path stays obvious within seconds. Power should reveal through split panes, compact controls, durable tool states, and restrained accents rather than through marketing spectacle.
+
+The visual language explicitly rejects a too-corporate SaaS dashboard, childish assistant styling, generic AI product cliches, huge gradient hero text, identical feature-card grids, and decorative complexity that makes the product harder to read.
+
+**Key Characteristics:**
+- Dark, near-black workspace with tonal depth.
+- Violet as a scarce commitment color, not a background wash.
+- Compact controls with readable labels and icon-first actions.
+- Soft borders, low-glow focus states, and rounded but not playful surfaces.
+- Mobile-safe density that keeps admin workflows usable on phones.
+
+## 2. Colors
+
+The palette is a restrained private-workspace palette: near-black neutrals carry the product, violet marks decisive action, and cyan/violet utility accents distinguish model and persona controls.
+
+### Primary
+- **Eidon Violet**: The primary action and selection color. Use it for send, save, active profile, focus glow, and the most important current state.
+- **Eidon Violet Soft**: The tinted selection fill behind active rows, focus rings, and quiet affirmative states.
+
+### Secondary
+- **Provider Cyan**: The model/provider control accent. Use only where provider identity or runtime context needs to be found quickly.
+- **Persona Violet**: The persona control accent. It is related to the primary violet, but softer and more personal.
+
+### Tertiary
+- **Thinking Indigo**: Agent activity, tool progress, and streaming intelligence cues. Keep it subordinate to Eidon Violet.
+- **Success Green**, **Warning Amber**, and **Danger Red**: Operational status colors. Use them for state and feedback, never decoration.
+
+### Neutral
+- **Abyss Background**: The page background and deepest workspace layer.
+- **Sidebar Charcoal**: Navigation and persistent side surfaces.
+- **Panel Zinc**: Cards, composer shells, menus, and modal interiors.
+- **Panel Zinc Strong**: Tooltips, code headers, elevated menus, and stronger hover surfaces.
+- **Signal Text**: Primary text on dark surfaces.
+- **Muted Ash**: Secondary text, placeholders, dormant icons, and metadata.
+- **Hairline Faint** and **Hairline Strong**: Dividers, strokes, and subtle containment.
+- **Translucent Surface**: Low-emphasis fills for icon buttons, settings sections, and disabled affordances.
+
+### Named Rules
+
+**The Scarce Signal Rule.** Eidon Violet is for commitment, selection, and focus. If more than 10% of a screen is violet, the screen is shouting.
+
+**The Tonal Depth Rule.** Use near-black layers and faint borders for structure. Do not create depth with decorative purple gradients, blue fog, or large color washes.
+
+**The Status Honesty Rule.** Green, amber, and red mean real system state. They are forbidden as decorative palette fillers.
+
+## 3. Typography
+
+**Display Font:** Instrument Serif, with Georgia fallback.
+**Body Font:** Inter, with system sans fallback.
+**Label/Mono Font:** Inter for labels; ui-monospace for code and machine output.
+**Wordmark Font:** Orbitron, with Eurostile and Space Grotesk fallbacks.
+
+**Character:** The type system is direct and compact. Inter carries the app because most screens are operational; Instrument Serif is reserved for rare editorial or empty-state moments; Orbitron belongs to the Eidon wordmark only.
+
+### Hierarchy
+- **Display** (400, clamp(2.5rem, 7vw, 4.5rem), 1): Brand and landing-scale moments only. Do not use inside dense app panels.
+- **Headline** (600, 1.375rem, 1.25): Markdown h1, page titles, and high-level app headings.
+- **Title** (600, 0.95rem, 1.35): Settings sections, modal titles, list group headers, and compact panels.
+- **Body** (400, 14.5px, 1.75): Assistant prose, settings descriptions, and normal explanatory text. Cap long prose at 65 to 75 characters.
+- **Label** (600, 11px, 0.08em where uppercase): Metadata, code-block language tags, compact field hints, and small status labels.
+- **Mono** (400, 0.92em, 1.5): Inline code, code blocks, identifiers, command output, and machine-readable values.
+
+### Named Rules
+
+**The App Scale Rule.** Most product UI lives between 11px and 15px. Large type must signal a real change in context, not fill space.
+
+**The Wordmark Containment Rule.** Orbitron is for the Eidon mark. It is not a general display font for headings, buttons, or cards.
+
+## 4. Elevation
+
+Eidon uses a hybrid of tonal layering, translucent surfaces, faint borders, and selective shadows. Most surfaces are flat at rest. Elevation appears when a control opens, a composer receives focus, or a surface must clearly float above the workspace.
+
+### Shadow Vocabulary
+- **Workspace Shadow** (`0 8px 32px rgba(0, 0, 0, 0.5)`): Login form and substantial floating panels.
+- **Composer Shadow** (`0 0 40px rgba(0,0,0,0.5)`): Chat composer shell at rest.
+- **Composer Focus Glow** (`0 0 50px rgba(0,0,0,0.6), 0 0 20px var(--accent-soft)`): Composer focus state only.
+- **Primary Action Glow** (`0 0 20px var(--accent-glow)`): Send and primary action buttons.
+- **Tooltip Shadow** (`0 2px 8px rgba(0,0,0,0.22)`): Small hover descriptions and compact tooltips.
+
+### Named Rules
+
+**The Flat Until Active Rule.** Surfaces do not float unless the user is interacting with them or they are temporarily above the main plane.
+
+**The Glow Has A Job Rule.** Glow means focus, active work, or a primary action. Decorative glow is prohibited.
+
+## 5. Components
+
+### Buttons
+
+Eidon buttons are compact, icon-aware, and stateful. Text buttons are for clear commands; icon buttons are preferred for common tools where the symbol is familiar.
+
+- **Shape:** Fully rounded for primary action buttons (999px radius); gently rounded for ghost tools (12px radius).
+- **Primary:** Eidon Violet fill, Signal Text, 8px 16px padding, and a soft violet glow.
+- **Hover / Focus:** Increase brightness or surface fill; use a 2px focus ring or a 3px soft violet focus shadow.
+- **Secondary:** Faint white fill with a subtle border. It should feel available but quieter than primary.
+- **Ghost:** Transparent at rest, muted text, and a white 5% hover fill.
+- **Danger:** Red tint with a faint red border. It must remain readable, not alarming by default.
+
+### Chips
+
+Chips are small state markers for provider types, built-in status, key state, and transport types.
+
+- **Style:** 10px semibold type, 6px radius, 6px horizontal padding, and tinted backgrounds at about 10% opacity.
+- **State:** Green means active or stdio, amber means missing key or built-in caution, sky means HTTP, violet means product-owned identity.
+
+### Cards / Containers
+
+Cards exist for repeated records, settings groups, menus, and framed tools. Do not nest cards.
+
+- **Corner Style:** Gently rounded (12px), with larger radii only for the composer or floating menus.
+- **Background:** Use translucent white fills or Panel Zinc, never plain black.
+- **Shadow Strategy:** Flat by default; shadow only for floating or focused surfaces.
+- **Border:** Hairline Faint for containment, Hairline Strong for hover and selected states.
+- **Internal Padding:** 16px for compact panels, 24px for settings cards, 8px for dense list shells.
+
+### Inputs / Fields
+
+Inputs should feel integrated with the dark surface rather than pasted on top.
+
+- **Style:** 12px radius, faint white border, translucent white background, 14px to 15px text.
+- **Focus:** Violet 40% border and a 3px Eidon Violet Soft ring.
+- **Error / Disabled:** Red or muted text with tinted background. Disabled fields stay readable enough to confirm a stored value exists.
+
+### Navigation
+
+Navigation is compact and persistent, with stronger state than decoration.
+
+- **Sidebar:** Charcoal surface, faint dividers, 280px desktop width, grouped conversations, and muted inactive rows.
+- **Active Rows:** Soft Eidon Violet fill, faint violet border, and Signal Text.
+- **Footer Navigation:** Rounded 16px rows with icons, muted text at rest, and translucent hover fill.
+- **Mobile Treatment:** Top bar with menu, centered wordmark or page title, and one right-side action. Do not add explanatory text to the bar.
+
+### Chat Composer
+
+The composer is the signature component. It carries text input, provider selection, persona selection, attachment controls, speech controls, context usage, queueing, and send/stop state without becoming a dashboard.
+
+- **Shape:** Large rounded shell (22px mobile, 26px desktop).
+- **Background:** Zinc 900 at 70% opacity with backdrop blur and faint white border.
+- **Focus:** Border shifts toward Eidon Violet and adds a soft focus glow.
+- **Action Cluster:** Send/stop remains a 40px circular button. Provider and persona controls stay compact below the draft field.
+- **Attachments:** Small rounded chips with thumbnails or file icons, metadata, and a remove icon.
+
+### Markdown And Code Blocks
+
+Assistant content is readable prose first, with code blocks designed as compact work surfaces.
+
+- **Markdown:** 14.5px body, 1.75 line height, softened headings, and generous paragraph rhythm.
+- **Inline Code:** Small translucent pill with mono type.
+- **Code Blocks:** Darker panel, 14px radius, faint border, header strip, language tag, and icon-only copy action.
+
+## 6. Do's and Don'ts
+
+### Do:
+
+- **Do** make the first path obvious within seconds: new chat, type, send, provider, persona.
+- **Do** keep Eidon Violet scarce and meaningful. Primary actions, active rows, and focus rings get it first.
+- **Do** use tonal layers, hairline borders, and compact spacing to show hierarchy.
+- **Do** keep controls close to the work, especially in the chat composer and settings detail panes.
+- **Do** preserve pragmatic accessibility: readable contrast, keyboard focus, reduced-motion support, and mobile-safe layouts.
+- **Do** use personal, direct language that respects capable users.
+
+### Don't:
+
+- **Don't** make Eidon feel like a too-corporate SaaS dashboard full of jargon, upsell framing, sterile admin panels, or abstract productivity promises.
+- **Don't** make it childish, toy-like, mascot-led, gamified, or visually loud for its own sake.
+- **Don't** use generic AI product cliches: huge gradient hero text, vague magic language, empty agent metaphors, identical feature-card grids, or decorative complexity.
+- **Don't** put cards inside cards. Use full-width panes, split views, or simple grouped rows instead.
+- **Don't** use side-stripe borders as accent decoration.
+- **Don't** let violet, cyan, or status colors become background themes. They are signals, not wallpaper.
+- **Don't** use Orbitron outside the Eidon wordmark.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,43 @@
+# Product
+
+## Register
+
+product
+
+## Users
+
+Eidon is for self-hosters, power users, builders, small teams, and workspace admins who want an AI assistant they can run on infrastructure they control. They bring their own model providers, manage their own data, and expect the product to handle real daily work without requiring them to assemble a chat UI, auth, storage, tools, memory, browser automation, and scheduling from separate pieces.
+
+The product needs to work for first-time setup, routine chat, long-running agent work, mobile use, and admin configuration. Users should be able to understand the main path within seconds, then discover deeper controls only when they need them.
+
+## Product Purpose
+
+Eidon provides a self-hosted, single-container AI assistant workspace with bring-your-own-provider model routing, memory, tools, automations, web search, image generation, browser automation, and multi-user administration.
+
+Success means a user can deploy Eidon, connect the provider they trust, start chatting quickly, and keep using the same workspace for increasingly capable work without feeling trapped in a hosted platform or overwhelmed by configuration.
+
+## Brand Personality
+
+Clear, powerful, personal.
+
+Eidon should feel direct and understandable first, then reveal capability through thoughtful controls and reliable workflows. It should carry the confidence of a serious tool without becoming cold, enterprise-heavy, or generic. The product should feel owned by the user, not like a corporate portal or a novelty assistant.
+
+## Anti-references
+
+Eidon should not feel like a too-corporate SaaS dashboard full of jargon, upsell framing, sterile admin panels, or abstract productivity promises.
+
+It should not feel childish, toy-like, mascot-led, gamified, or visually loud for its own sake.
+
+It should avoid generic AI product cliches: huge gradient hero text, vague magic language, empty agent metaphors, identical feature-card grids, and decorative complexity that makes the product harder to read.
+
+## Design Principles
+
+1. Make the first path obvious within seconds.
+2. Keep power close, but never let configuration dominate the main workflow.
+3. Treat self-hosting as confidence and control, not as technical austerity.
+4. Use personal, direct language that respects capable users.
+5. Prefer durable product clarity over novelty or decorative polish.
+
+## Accessibility & Inclusion
+
+Accessibility should be pragmatic and mostly invisible in the product experience. Eidon should preserve readable contrast, keyboard access, focus states, reduced-motion support, mobile-safe layouts, and clear labels without making the interface feel clinical or compliance-driven.


### PR DESCRIPTION
## Summary
- Added `PRODUCT.md` to establish the app as a `product` surface with the brand personality `Clear, powerful, personal`.
- Added `DESIGN.md` and `DESIGN.json` to document the current visual system, including tokens, component patterns, and design rules for Eidon’s dark workspace.
- Kept the spec aligned with the existing UI: near-black layers, violet as a scarce primary signal, compact controls, and the chat composer as the signature component.

## Testing
- Not run (not requested)
- The design files were generated from the current codebase context and the existing UI tokens/components were scanned before writing them.