### PR TITLE
Add shareable read-only conversation links

### DIFF
--- a/app/api/conversations/[conversationId]/share/route.ts
+++ b/app/api/conversations/[conversationId]/share/route.ts
@@ -1,0 +1,81 @@
+import { z } from "zod";
+
+import { requireUser } from "@/lib/auth";
+import {
+  disableConversationShare,
+  enableConversationShare,
+  getConversationShare
+} from "@/lib/conversations";
+import { badRequest, ok } from "@/lib/http";
+
+const paramsSchema = z.object({
+  conversationId: z.string().min(1)
+});
+
+const updateSchema = z.object({
+  enabled: z.boolean()
+});
+
+function buildSharePayload(request: Request, share: { enabled: boolean; token: string | null }) {
+  const forwardedProto = request.headers.get("x-forwarded-proto")?.split(",")[0]?.trim();
+  const forwardedHost = request.headers.get("x-forwarded-host")?.split(",")[0]?.trim();
+  const host = forwardedHost || request.headers.get("host");
+  const origin = host
+    ? `${forwardedProto || new URL(request.url).protocol.replace(":", "")}://${host}`
+    : new URL(request.url).origin;
+  const url = share.enabled && share.token ? `${origin}/share/${share.token}` : null;
+
+  return {
+    enabled: share.enabled,
+    token: share.token,
+    url
+  };
+}
+
+export async function GET(
+  request: Request,
+  context: { params: Promise<{ conversationId: string }> }
+) {
+  const user = await requireUser();
+  const params = paramsSchema.safeParse(await context.params);
+
+  if (!params.success) {
+    return badRequest("Invalid conversation id");
+  }
+
+  const share = getConversationShare(params.data.conversationId, user.id);
+
+  if (!share) {
+    return badRequest("Conversation not found", 404);
+  }
+
+  return ok(buildSharePayload(request, share));
+}
+
+export async function PATCH(
+  request: Request,
+  context: { params: Promise<{ conversationId: string }> }
+) {
+  const user = await requireUser();
+  const params = paramsSchema.safeParse(await context.params);
+
+  if (!params.success) {
+    return badRequest("Invalid conversation id");
+  }
+
+  const body = updateSchema.safeParse(await request.json());
+
+  if (!body.success) {
+    return badRequest("Invalid share update");
+  }
+
+  const share = body.data.enabled
+    ? enableConversationShare(params.data.conversationId, user.id)
+    : disableConversationShare(params.data.conversationId, user.id);
+
+  if (!share) {
+    return badRequest("Conversation not found", 404);
+  }
+
+  return ok(buildSharePayload(request, share));
+}

--- a/app/api/share/[shareToken]/attachments/[attachmentId]/route.ts
+++ b/app/api/share/[shareToken]/attachments/[attachmentId]/route.ts
@@ -1,0 +1,74 @@
+import { z } from "zod";
+
+import {
+  AttachmentTextPreviewUnsupportedError,
+  readAttachmentBuffer,
+  readAttachmentText
+} from "@/lib/attachments";
+import { getSharedConversationSnapshot } from "@/lib/conversations";
+import { badRequest } from "@/lib/http";
+
+const paramsSchema = z.object({
+  shareToken: z.string().min(16),
+  attachmentId: z.string().min(1)
+});
+
+export async function GET(
+  request: Request,
+  context: { params: Promise<{ shareToken: string; attachmentId: string }> }
+) {
+  const params = paramsSchema.safeParse(await context.params);
+
+  if (!params.success) {
+    return badRequest("Attachment not found", 404);
+  }
+
+  const snapshot = getSharedConversationSnapshot(params.data.shareToken);
+
+  if (!snapshot) {
+    return badRequest("Attachment not found", 404);
+  }
+
+  const attachment = snapshot.messages
+    .flatMap((message) => message.attachments ?? [])
+    .find((item) => item.id === params.data.attachmentId);
+
+  if (!attachment) {
+    return badRequest("Attachment not found", 404);
+  }
+
+  const url = new URL(request.url);
+  const format = url.searchParams.get("format");
+  const download = url.searchParams.get("download") === "1";
+
+  if (format === "text") {
+    try {
+      return Response.json({
+        id: attachment.id,
+        filename: attachment.filename,
+        mimeType: attachment.mimeType,
+        content: readAttachmentText(attachment)
+      });
+    } catch (error) {
+      if (error instanceof AttachmentTextPreviewUnsupportedError) {
+        return badRequest("Attachment cannot be previewed as text", 415);
+      }
+
+      return badRequest("Internal server error", 500);
+    }
+  }
+
+  try {
+    const buffer = readAttachmentBuffer(attachment);
+
+    return new Response(buffer, {
+      headers: {
+        "Content-Type": attachment.mimeType,
+        "Content-Length": String(buffer.length),
+        "Content-Disposition": `${download ? "attachment" : "inline"}; filename="${attachment.filename}"`
+      }
+    });
+  } catch {
+    return badRequest("Attachment file not found", 404);
+  }
+}

--- a/app/api/share/[shareToken]/route.ts
+++ b/app/api/share/[shareToken]/route.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+
+import { getSharedConversationSnapshot } from "@/lib/conversations";
+import { badRequest, ok } from "@/lib/http";
+
+const paramsSchema = z.object({
+  shareToken: z.string().min(16)
+});
+
+export async function GET(
+  _request: Request,
+  context: { params: Promise<{ shareToken: string }> }
+) {
+  const params = paramsSchema.safeParse(await context.params);
+
+  if (!params.success) {
+    return badRequest("Shared conversation not found", 404);
+  }
+
+  const snapshot = getSharedConversationSnapshot(params.data.shareToken);
+
+  if (!snapshot) {
+    return badRequest("Shared conversation not found", 404);
+  }
+
+  return ok(snapshot);
+}

--- a/app/automations/[automationId]/runs/[runId]/page.tsx
+++ b/app/automations/[automationId]/runs/[runId]/page.tsx
@@ -39,6 +39,7 @@ export default async function AutomationRunPage({
       conversationPage={listConversationsPage({ userId: user.id })}
       folders={listFolders(user.id)}
       automations={listAutomations(user.id)}
+      currentConversation={conversation}
     >
       <ChatView
         payload={{

--- a/app/chat/[conversationId]/page.tsx
+++ b/app/chat/[conversationId]/page.tsx
@@ -59,6 +59,7 @@ export default async function ConversationPage({
       passwordLoginEnabled={isPasswordLoginEnabled()}
       conversationPage={ensureConversationInPage(conversationPage, conversation)}
       folders={folders}
+      currentConversation={conversation}
     >
       <ChatView
         payload={{

--- a/app/share/[shareToken]/page.tsx
+++ b/app/share/[shareToken]/page.tsx
@@ -1,0 +1,25 @@
+import { notFound } from "next/navigation";
+
+import { SharedConversationView } from "@/components/shared-conversation-view";
+import { getSharedConversationSnapshot } from "@/lib/conversations";
+
+export default async function SharedConversationPage({
+  params
+}: {
+  params: Promise<{ shareToken: string }>;
+}) {
+  const { shareToken } = await params;
+  const snapshot = getSharedConversationSnapshot(shareToken);
+
+  if (!snapshot) {
+    notFound();
+  }
+
+  return (
+    <SharedConversationView
+      conversation={snapshot.conversation}
+      messages={snapshot.messages}
+      shareToken={shareToken}
+    />
+  );
+}

--- a/components/attachment-preview-modal.tsx
+++ b/components/attachment-preview-modal.tsx
@@ -5,6 +5,16 @@ import { Download, FileText, X } from "lucide-react";
 
 import type { MessageAttachment } from "@/lib/types";
 
+export type AttachmentUrlOptions = {
+  format?: "text";
+  download?: boolean;
+};
+
+export type AttachmentUrlBuilder = (
+  attachment: Pick<MessageAttachment, "id">,
+  options?: AttachmentUrlOptions
+) => string;
+
 export type AttachmentPreviewState =
   | { kind: "loading" }
   | { kind: "image" }
@@ -19,7 +29,50 @@ type AttachmentPreviewModalProps = {
   onRetry?: () => void;
 };
 
+function appendAttachmentUrlParams(baseUrl: string, options?: AttachmentUrlOptions) {
+  const params = new URLSearchParams();
+
+  if (options?.format) {
+    params.set("format", options.format);
+  }
+
+  if (options?.download) {
+    params.set("download", "1");
+  }
+
+  const query = params.toString();
+  return query ? `${baseUrl}?${query}` : baseUrl;
+}
+
+export function buildDefaultAttachmentUrl(
+  attachment: Pick<MessageAttachment, "id">,
+  options?: AttachmentUrlOptions
+) {
+  return appendAttachmentUrlParams(`/api/attachments/${attachment.id}`, options);
+}
+
+const AttachmentUrlContext = React.createContext<AttachmentUrlBuilder>(buildDefaultAttachmentUrl);
+
+export function AttachmentUrlProvider({
+  value,
+  children
+}: {
+  value: AttachmentUrlBuilder;
+  children: React.ReactNode;
+}) {
+  return (
+    <AttachmentUrlContext.Provider value={value}>
+      {children}
+    </AttachmentUrlContext.Provider>
+  );
+}
+
+export function useAttachmentUrlBuilder() {
+  return React.useContext(AttachmentUrlContext);
+}
+
 export function useAttachmentPreviewController() {
+  const buildAttachmentUrl = useAttachmentUrlBuilder();
   const [previewAttachment, setPreviewAttachment] = useState<MessageAttachment | null>(null);
   const [previewState, setPreviewState] = useState<AttachmentPreviewState>({
     kind: "unsupported"
@@ -85,7 +138,7 @@ export function useAttachmentPreviewController() {
             message: "Unable to load attachment preview."
           });
         };
-        image.src = `/api/attachments/${attachment.id}`;
+        image.src = buildAttachmentUrl(attachment);
         return;
       }
 
@@ -100,7 +153,7 @@ export function useAttachmentPreviewController() {
       }
 
       try {
-        const response = await fetch(`/api/attachments/${attachment.id}?format=text`);
+        const response = await fetch(buildAttachmentUrl(attachment, { format: "text" }));
         if (!isCurrentPreviewRequest(requestToken, attachment.id)) {
           return;
         }
@@ -144,7 +197,7 @@ export function useAttachmentPreviewController() {
         });
       }
     },
-    [textPreviewCache]
+    [buildAttachmentUrl, textPreviewCache]
   );
 
   return {
@@ -161,6 +214,8 @@ export function AttachmentPreviewModal({
   onClose,
   onRetry
 }: AttachmentPreviewModalProps) {
+  const buildAttachmentUrl = useAttachmentUrlBuilder();
+
   useEffect(() => {
     function handleKeyDown(event: KeyboardEvent) {
       if (event.key === "Escape") {
@@ -201,7 +256,7 @@ export function AttachmentPreviewModal({
           </div>
 
           <a
-            href={`/api/attachments/${attachment.id}?download=1`}
+            href={buildAttachmentUrl(attachment, { download: true })}
             className="inline-flex items-center gap-2 rounded-lg border border-white/10 px-3 py-2 text-xs text-white/70"
             aria-label="Download attachment"
           >
@@ -213,7 +268,7 @@ export function AttachmentPreviewModal({
         <div className="min-h-0 flex-1 overflow-auto p-4">
           {state.kind === "image" ? (
             <img
-              src={`/api/attachments/${attachment.id}`}
+              src={buildAttachmentUrl(attachment)}
               alt={attachment.filename}
               className="mx-auto max-h-[60vh] w-auto max-w-full rounded-xl"
             />

--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -2,6 +2,7 @@
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
+import { Share2 } from "lucide-react";
 
 import {
   AttachmentPreviewModal,
@@ -10,6 +11,7 @@ import {
 import { ChatComposer } from "@/components/chat-composer";
 import { QueuedMessageBanner } from "@/components/queued-message-banner";
 import { MessageBubble, TypingIndicator } from "@/components/message-bubble";
+import { useShareConversation } from "@/components/share-conversation-context";
 import { clearChatBootstrap, readChatBootstrap } from "@/lib/chat-bootstrap";
 import { useContextTokens } from "@/lib/context-tokens-context";
 import {
@@ -476,6 +478,7 @@ function isQueuedMessageOperationError(message: string) {
 export function ChatView({ payload }: { payload: ConversationPayload }) {
   const router = useRouter();
   const { getTokenUsage, setTokenUsage } = useContextTokens();
+  const { canShare, openShareModal } = useShareConversation();
   const previewController = useAttachmentPreviewController();
   const activeConversationIdRef = useRef(payload.conversation.id);
   const [messages, setMessages] = useState(() => sanitizeMessages(payload.messages));
@@ -2181,6 +2184,17 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
           <div className="min-w-0">
             <div className="font-medium text-[var(--text)] truncate text-sm">{conversationTitle}</div>
           </div>
+          {canShare ? (
+            <button
+              type="button"
+              className="-mr-1 hidden h-8 w-8 shrink-0 items-center justify-center rounded-md border border-white/6 bg-white/[0.02] text-white/40 transition-colors duration-150 hover:border-white/10 hover:bg-white/[0.05] hover:text-white/75 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/20 md:flex"
+              onClick={openShareModal}
+              aria-label="Share conversation"
+              title="Share conversation"
+            >
+              <Share2 className="h-3.5 w-3.5" />
+            </button>
+          ) : null}
         </div>
       </div>
 

--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -9,6 +9,7 @@ import remarkGfm from "remark-gfm";
 import { AssistantCodeBlock } from "@/components/assistant-code-block";
 import {
   AttachmentPreviewModal,
+  useAttachmentUrlBuilder,
   useAttachmentPreviewController
 } from "@/components/attachment-preview-modal";
 import { CompactionIndicator } from "@/components/compaction-indicator";
@@ -408,7 +409,8 @@ function MemorySnapshot({
 function MemoryProposalCard({
   action,
   onApprove,
-  onDismiss
+  onDismiss,
+  readOnly = false
 }: {
   action: Extract<MessageTimelineItem, { timelineKind: "action" }>;
   onApprove?: (
@@ -416,13 +418,14 @@ function MemoryProposalCard({
     overrides?: { content?: string; category?: MemoryCategory }
   ) => Promise<void>;
   onDismiss?: (actionId: string) => Promise<void>;
+  readOnly?: boolean;
 }) {
   const proposal = action.proposalPayload!;
   const editableMemory = proposal.proposedMemory;
   const displayMemory = proposal.proposedMemory ?? proposal.currentMemory ?? null;
   const currentMemory = proposal.currentMemory ?? null;
   const canEdit = action.kind !== "delete_memory" && Boolean(editableMemory);
-  const isPending = action.status === "pending" && action.proposalState === "pending";
+  const isPending = !readOnly && action.status === "pending" && action.proposalState === "pending";
   const isDelete = proposal.operation === "delete";
   const heading = getMemoryProposalHeading(action);
   const [isEditing, setIsEditing] = useState(false);
@@ -701,6 +704,8 @@ function AttachmentTile({
   compact?: boolean;
   onPreview: (attachment: MessageAttachment) => void;
 }) {
+  const buildAttachmentUrl = useAttachmentUrlBuilder();
+
   if (attachment.kind === "image") {
     return (
       <button
@@ -710,7 +715,7 @@ function AttachmentTile({
         className={`overflow-hidden rounded-xl border border-white/10 bg-black/20 ${compact ? "w-16" : "w-28"}`}
       >
         <img
-          src={`/api/attachments/${attachment.id}`}
+          src={buildAttachmentUrl(attachment)}
           alt=""
           aria-hidden="true"
           className={`w-full object-cover ${compact ? "h-16" : "h-28"}`}
@@ -790,6 +795,8 @@ function AssistantInlineImageAttachments({
   attachments: MessageAttachment[];
   onPreview: (attachment: MessageAttachment) => void;
 }) {
+  const buildAttachmentUrl = useAttachmentUrlBuilder();
+
   if (!attachments.length) {
     return null;
   }
@@ -805,7 +812,7 @@ function AssistantInlineImageAttachments({
           className="max-w-full overflow-hidden rounded-xl border border-white/10 bg-black/20"
         >
           <img
-            src={`/api/attachments/${attachment.id}`}
+            src={buildAttachmentUrl(attachment)}
             alt=""
             aria-hidden="true"
             className="block max-h-[28rem] w-auto max-w-full object-contain"
@@ -832,7 +839,8 @@ export function MessageBubble({
   isForking = false,
   onApproveMemoryProposal,
   onDismissMemoryProposal,
-  onPreviewAttachment
+  onPreviewAttachment,
+  readOnly = false
 }: {
   message: Message;
   streamingTimeline?: MessageTimelineItem[];
@@ -853,6 +861,7 @@ export function MessageBubble({
   onForkAssistantMessage?: (messageId: string) => void;
   isForking?: boolean;
   onPreviewAttachment?: (attachment: MessageAttachment) => void;
+  readOnly?: boolean;
 }) {
   const rawContent = streamingAnswer ?? message.content;
   const rawThinking = streamingThinking ?? message.thinkingContent;
@@ -1116,7 +1125,7 @@ export function MessageBubble({
         <div data-message-id={message.id} className="flex w-full justify-end">
           <div className="group flex max-w-[96%] flex-col items-end md:max-w-[95%]">
             <div className="w-full rounded-2xl border border-[var(--accent)]/10 bg-[var(--accent-soft)] px-4 py-3 text-[var(--text)]">
-              {isEditing ? (
+              {!readOnly && isEditing ? (
                 <Textarea
                   ref={editRef}
                   value={draft}
@@ -1140,7 +1149,7 @@ export function MessageBubble({
                 </div>
               ) : null}
               {message.attachments?.length ? (
-                <div className={content || isEditing ? "mt-3" : ""}>
+                <div className={content || (!readOnly && isEditing) ? "mt-3" : ""}>
                   <MessageAttachments
                     attachments={message.attachments}
                     compact
@@ -1165,7 +1174,7 @@ export function MessageBubble({
                   )}
                 </ActionButton>
 
-                {isEditing ? (
+                {!readOnly && isEditing ? (
                   <>
                     <ActionButton
                       label="Save edit"
@@ -1182,11 +1191,11 @@ export function MessageBubble({
                       <X className="h-3.5 w-3.5" />
                     </ActionButton>
                   </>
-                ) : (
+                ) : !readOnly ? (
                   <ActionButton label="Edit message" onClick={() => setIsEditing(true)}>
                     <Pencil className="h-3.5 w-3.5" />
                   </ActionButton>
-                )}
+                ) : null}
               </div>
             ) : null}
           </div>
@@ -1277,6 +1286,7 @@ export function MessageBubble({
                               action={item}
                               onApprove={onApproveMemoryProposal}
                               onDismiss={onDismissMemoryProposal}
+                              readOnly={readOnly}
                             />
                           ) : (
                             <CollapsibleActionRow

--- a/components/share-conversation-context.tsx
+++ b/components/share-conversation-context.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { createContext, useContext, type ReactNode } from "react";
+
+export type ShareConversationControl = {
+  canShare: boolean;
+  openShareModal: () => void;
+};
+
+const ShareConversationContext = createContext<ShareConversationControl>({
+  canShare: false,
+  openShareModal: () => undefined
+});
+
+export function ShareConversationProvider({
+  value,
+  children
+}: {
+  value: ShareConversationControl;
+  children?: ReactNode;
+}) {
+  return (
+    <ShareConversationContext.Provider value={value}>
+      {children}
+    </ShareConversationContext.Provider>
+  );
+}
+
+export function useShareConversation() {
+  return useContext(ShareConversationContext);
+}

--- a/components/shared-conversation-view.tsx
+++ b/components/shared-conversation-view.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import React, { useCallback } from "react";
+
+import {
+  AttachmentPreviewModal,
+  AttachmentUrlProvider,
+  type AttachmentUrlOptions,
+  useAttachmentPreviewController
+} from "@/components/attachment-preview-modal";
+import { MessageBubble } from "@/components/message-bubble";
+import type { Conversation, Message, MessageAttachment } from "@/lib/types";
+
+function buildSharedAttachmentUrl(
+  shareToken: string,
+  attachment: Pick<MessageAttachment, "id">,
+  options?: AttachmentUrlOptions
+) {
+  const params = new URLSearchParams();
+
+  if (options?.format) {
+    params.set("format", options.format);
+  }
+
+  if (options?.download) {
+    params.set("download", "1");
+  }
+
+  const query = params.toString();
+  const path = `/api/share/${shareToken}/attachments/${attachment.id}`;
+  return query ? `${path}?${query}` : path;
+}
+
+export function SharedConversationView({
+  conversation,
+  messages,
+  shareToken
+}: {
+  conversation: Conversation;
+  messages: Message[];
+  shareToken: string;
+}) {
+  const buildAttachmentUrl = useCallback(
+    (attachment: Pick<MessageAttachment, "id">, options?: AttachmentUrlOptions) =>
+      buildSharedAttachmentUrl(shareToken, attachment, options),
+    [shareToken]
+  );
+
+  return (
+    <AttachmentUrlProvider value={buildAttachmentUrl}>
+      <SharedConversationTranscript conversation={conversation} messages={messages} />
+    </AttachmentUrlProvider>
+  );
+}
+
+function SharedConversationTranscript({
+  conversation,
+  messages
+}: {
+  conversation: Conversation;
+  messages: Message[];
+}) {
+  const previewController = useAttachmentPreviewController();
+
+  return (
+    <main className="relative flex min-h-[100dvh] w-full flex-col bg-[var(--background)] text-[var(--text)]">
+      <header className="border-b border-white/4 px-4 py-3.5 md:px-6">
+        <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+          <div className="flex min-w-0 items-center gap-4">
+            <a
+              href="https://github.com/Quack6765/Eidon-AI"
+              aria-label="Eidon"
+              className="flex shrink-0 items-center transition-opacity hover:opacity-80"
+            >
+              <span
+                style={{
+                  filter: "drop-shadow(0 0 8px rgba(139,92,246,0.5)) drop-shadow(0 0 20px rgba(139,92,246,0.25)) drop-shadow(0 0 36px rgba(139,92,246,0.12))"
+                }}
+              >
+                <span
+                  className="inline-block text-[24px] font-bold leading-none tracking-[0.12em]"
+                  style={{
+                    fontFamily: "var(--font-wordmark), 'Eurostile', 'Space Grotesk', sans-serif",
+                    WebkitBackgroundClip: "text",
+                    backgroundClip: "text",
+                    WebkitTextFillColor: "transparent",
+                    backgroundImage: "linear-gradient(to bottom, #FFFFFF 0%, #D4C8FF 40%, #8b5cf6 100%)"
+                  }}
+                >
+                  Eidon
+                </span>
+              </span>
+            </a>
+            <div className="min-w-0">
+              <div className="truncate text-sm font-medium text-[var(--text)]">
+                {conversation.title}
+              </div>
+            </div>
+          </div>
+          <span className="w-fit rounded-full border border-white/8 px-2.5 py-1 text-[11px] font-medium text-white/45">
+            Read only
+          </span>
+        </div>
+      </header>
+
+      <section
+        className="no-scrollbar relative z-0 isolate min-h-0 flex-1 overflow-y-auto px-2 md:px-8"
+        aria-label="Shared transcript"
+      >
+        <div className="flex w-full flex-col gap-2.5 px-2 pt-4 pb-10 md:gap-4 md:px-0">
+          {messages.length > 0 ? (
+            messages.map((message) => (
+              <div
+                key={message.id}
+                className="animate-slide-up"
+                style={{ animationFillMode: "forwards" }}
+              >
+                <MessageBubble
+                  message={message}
+                  onPreviewAttachment={previewController.openAttachmentPreview}
+                  readOnly
+                />
+              </div>
+            ))
+          ) : (
+            <div className="rounded-2xl border border-white/8 bg-white/[0.025] px-4 py-5 text-sm text-[var(--muted)]">
+              This shared conversation has no visible messages.
+            </div>
+          )}
+        </div>
+      </section>
+
+      {previewController.previewAttachment ? (
+        <AttachmentPreviewModal
+          attachment={previewController.previewAttachment}
+          state={previewController.previewState}
+          onClose={previewController.closeAttachmentPreview}
+          onRetry={() => void previewController.openAttachmentPreview(previewController.previewAttachment!)}
+        />
+      ) : null}
+    </main>
+  );
+}

--- a/components/shell.tsx
+++ b/components/shell.tsx
@@ -1,17 +1,27 @@
 "use client";
 
-import { useEffect, useRef, useState, type PropsWithChildren } from "react";
+import { useEffect, useMemo, useRef, useState, type PropsWithChildren } from "react";
 import { usePathname, useRouter } from "next/navigation";
-import { Menu, PanelLeftClose, PanelLeftOpen, Plus } from "lucide-react";
+import { Check, Copy, Link2, Menu, PanelLeftClose, PanelLeftOpen, Plus, Share2, X } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 import { AutomationsNav } from "@/components/automations/automations-nav";
 import { Sidebar } from "@/components/sidebar";
 import { SettingsNav } from "@/components/settings/settings-nav";
+import { ShareConversationProvider } from "@/components/share-conversation-context";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { writeTextToClipboard } from "@/lib/clipboard";
 import { ContextTokensProvider } from "@/lib/context-tokens-context";
 import type { AuthUser, Automation, Conversation, ConversationListPage, Folder } from "@/lib/types";
 import { deleteConversationIfStillEmpty } from "@/lib/conversation-drafts";
 import { consumeHomeSubmitSidebarAutoHide } from "@/lib/chat-bootstrap";
 import { useGlobalWebSocket } from "@/lib/ws-client";
+
+type SharePayload = {
+  enabled: boolean;
+  token: string | null;
+  url: string | null;
+};
 
 export function Shell({
   currentUser,
@@ -19,6 +29,7 @@ export function Shell({
   conversationPage,
   folders,
   automations,
+  currentConversation,
   children
 }: PropsWithChildren<{
   currentUser: AuthUser;
@@ -26,8 +37,14 @@ export function Shell({
   conversationPage: ConversationListPage;
   folders?: Folder[];
   automations?: Automation[];
+  currentConversation?: Conversation;
 }>) {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+  const [shareModalOpen, setShareModalOpen] = useState(false);
+  const [shareState, setShareState] = useState<SharePayload | null>(null);
+  const [shareLoading, setShareLoading] = useState(false);
+  const [shareError, setShareError] = useState("");
+  const [shareCopied, setShareCopied] = useState(false);
   const consumedHomeSubmitAutoHideConversationIdRef = useRef<string | null>(null);
   const hasAppliedDesktopDefaultRef = useRef(false);
 
@@ -37,11 +54,121 @@ export function Shell({
   const activeConversationId = pathname.startsWith("/chat/")
     ? pathname.split("/chat/")[1]
     : null;
+  const shareConversation = useMemo(() => {
+    if (currentConversation) {
+      return currentConversation;
+    }
+
+    if (!activeConversationId) {
+      return null;
+    }
+
+    return conversationPage.conversations.find((conversation) => conversation.id === activeConversationId) ?? null;
+  }, [activeConversationId, conversationPage.conversations, currentConversation]);
   const isSettingsPage = pathname.startsWith("/settings");
   const isAutomationsPage = pathname.startsWith("/automations");
   const isDesktopSidebarOpen = isSettingsPage || isSidebarOpen;
   const mobileMenuLabel = isSettingsPage ? "Open settings menu" : "Open menu";
   const sidebarToggleLabel = isSidebarOpen ? "Collapse sidebar" : "Expand sidebar";
+
+  const normalizeSharePayload = (payload: SharePayload): SharePayload => {
+    if (!payload.token || !payload.enabled || typeof window === "undefined") {
+      return payload;
+    }
+
+    return {
+      ...payload,
+      url: `${window.location.origin}/share/${payload.token}`
+    };
+  };
+
+  const loadShareState = async () => {
+    if (!shareConversation) {
+      return;
+    }
+
+    setShareLoading(true);
+    setShareError("");
+
+    try {
+      const response = await fetch(`/api/conversations/${shareConversation.id}/share`);
+      if (!response.ok) {
+        throw new Error("Unable to load sharing");
+      }
+
+      setShareState(normalizeSharePayload(await response.json() as SharePayload));
+    } catch {
+      setShareError("Unable to load sharing.");
+    } finally {
+      setShareLoading(false);
+    }
+  };
+
+  const openShareModal = () => {
+    if (!shareConversation) {
+      return;
+    }
+
+    setShareModalOpen(true);
+    setShareCopied(false);
+    setShareState({
+      enabled: shareConversation.shareEnabled,
+      token: shareConversation.shareToken,
+      url: shareConversation.shareEnabled && shareConversation.shareToken
+        ? `${window.location.origin}/share/${shareConversation.shareToken}`
+        : null
+    });
+    void loadShareState();
+  };
+
+  const updateShare = async (enabled: boolean) => {
+    if (!shareConversation) {
+      return;
+    }
+
+    setShareLoading(true);
+    setShareError("");
+    setShareCopied(false);
+
+    try {
+      const response = await fetch(`/api/conversations/${shareConversation.id}/share`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ enabled })
+      });
+      if (!response.ok) {
+        throw new Error("Unable to update sharing");
+      }
+
+      const nextShare = normalizeSharePayload(await response.json() as SharePayload);
+      setShareState(nextShare);
+
+      if (nextShare.url) {
+        await writeTextToClipboard(nextShare.url);
+        setShareCopied(true);
+      }
+    } catch {
+      setShareError("Unable to update sharing.");
+    } finally {
+      setShareLoading(false);
+    }
+  };
+
+  const copyShareLink = async () => {
+    if (!shareState?.url) {
+      return;
+    }
+
+    setShareCopied(false);
+    setShareError("");
+
+    try {
+      await writeTextToClipboard(shareState.url);
+      setShareCopied(true);
+    } catch {
+      setShareError("Unable to copy link.");
+    }
+  };
 
   useEffect(() => {
     if (typeof window === "undefined") {
@@ -183,28 +310,156 @@ export function Shell({
           )}
 
           {isAutomationsPage ? (
-            <div className="h-9 w-9" />
+            <div className="flex h-9 w-9 items-center justify-end">
+              {shareConversation ? (
+                <button
+                  type="button"
+                  className="p-2 -mr-2 text-[var(--text)] hover:bg-white/5 rounded-lg transition-colors duration-200"
+                  onClick={openShareModal}
+                  aria-label="Share conversation"
+                  title="Share conversation"
+                >
+                  <Share2 className="h-[18px] w-[18px]" />
+                </button>
+              ) : null}
+            </div>
           ) : (
-            <button
-              type="button"
-              className="p-2 -mr-2 text-[var(--text)] hover:bg-white/5 rounded-lg transition-colors duration-200"
-              onClick={async () => {
-                try {
-                  await deleteConversationIfStillEmpty(activeConversationId);
-                  const res = await fetch("/api/conversations", { method: "POST" });
-                  const data = (await res.json()) as { conversation: Conversation };
-                  router.push(`/chat/${data.conversation.id}`);
-                } catch {}
-              }}
-              aria-label="New chat"
-            >
-              <Plus className="h-5 w-5" />
-            </button>
+            <div className="flex items-center gap-1">
+              {shareConversation ? (
+                <button
+                  type="button"
+                  className="p-2 text-[var(--text)] hover:bg-white/5 rounded-lg transition-colors duration-200"
+                  onClick={openShareModal}
+                  aria-label="Share conversation"
+                  title="Share conversation"
+                >
+                  <Share2 className="h-[18px] w-[18px]" />
+                </button>
+              ) : null}
+              <button
+                type="button"
+                className="p-2 -mr-2 text-[var(--text)] hover:bg-white/5 rounded-lg transition-colors duration-200"
+                onClick={async () => {
+                  try {
+                    await deleteConversationIfStillEmpty(activeConversationId);
+                    const res = await fetch("/api/conversations", { method: "POST" });
+                    const data = (await res.json()) as { conversation: Conversation };
+                    router.push(`/chat/${data.conversation.id}`);
+                  } catch {}
+                }}
+                aria-label="New chat"
+              >
+                <Plus className="h-5 w-5" />
+              </button>
+            </div>
           )}
         </div>
 
-        <ContextTokensProvider>{children}</ContextTokensProvider>
+        <ShareConversationProvider value={{ canShare: Boolean(shareConversation), openShareModal }}>
+          <ContextTokensProvider>{children}</ContextTokensProvider>
+        </ShareConversationProvider>
       </div>
+
+      <AnimatePresence>
+        {shareModalOpen && shareConversation ? (
+          <motion.div
+            key="share-modal-backdrop"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.16 }}
+            className="fixed inset-0 z-[60] flex items-center justify-center bg-black/70 px-4 backdrop-blur-sm"
+            onClick={() => setShareModalOpen(false)}
+          >
+            <motion.div
+              key="share-modal"
+              initial={{ opacity: 0, y: 14, scale: 0.98 }}
+              animate={{ opacity: 1, y: 0, scale: 1 }}
+              exit={{ opacity: 0, y: 10, scale: 0.98 }}
+              transition={{ duration: 0.18, ease: [0.22, 1, 0.36, 1] }}
+              role="dialog"
+              aria-modal="true"
+              aria-label="Share conversation"
+              className="w-full max-w-[420px] rounded-2xl border border-white/8 bg-[var(--panel)] p-5 shadow-[0_18px_60px_rgba(0,0,0,0.45)]"
+              onClick={(event) => event.stopPropagation()}
+            >
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <div className="flex h-9 w-9 items-center justify-center rounded-xl border border-[var(--accent)]/25 bg-[var(--accent)]/10 text-[var(--accent)]">
+                    <Link2 className="h-[18px] w-[18px]" />
+                  </div>
+                  <h2 className="mt-4 text-base font-semibold text-[var(--text)]">Share conversation</h2>
+                  <p className="mt-1 text-sm leading-5 text-[var(--muted)]">
+                    Anyone with the link can read this transcript.
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  className="-mr-2 -mt-2 rounded-lg p-2 text-white/45 transition-colors hover:bg-white/5 hover:text-white/75"
+                  onClick={() => setShareModalOpen(false)}
+                  aria-label="Close share dialog"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              </div>
+
+              {shareState?.url ? (
+                <div className="mt-5 flex gap-2">
+                  <Input
+                    value={shareState.url}
+                    readOnly
+                    aria-label="Share link"
+                    className="h-10 rounded-xl px-3 py-2 text-xs"
+                  />
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    className="h-10 w-10 shrink-0 rounded-md border border-white/6 bg-white/[0.02] px-0 text-white/35 hover:border-white/10 hover:bg-white/[0.05] hover:text-white/70"
+                    onClick={() => void copyShareLink()}
+                    aria-label={shareCopied ? "Copied share link" : "Copy share link"}
+                    title={shareCopied ? "Copied" : "Copy link"}
+                  >
+                    {shareCopied ? (
+                      <Check className="h-3.5 w-3.5 text-emerald-400" />
+                    ) : (
+                      <Copy className="h-3.5 w-3.5" />
+                    )}
+                  </Button>
+                </div>
+              ) : null}
+
+              {shareError ? (
+                <p className={`${shareState?.url ? "mt-3" : "mt-5"} text-xs text-red-300`}>{shareError}</p>
+              ) : null}
+
+              <div className="mt-5 flex items-center justify-between gap-4 rounded-xl border border-white/8 bg-white/[0.025] px-3 py-3">
+                <div className="min-w-0">
+                  <div className="text-sm font-medium text-[var(--text)]">Share this conversation</div>
+                </div>
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={Boolean(shareState?.enabled)}
+                  aria-label="Share this conversation"
+                  disabled={shareLoading}
+                  onClick={() => void updateShare(!shareState?.enabled)}
+                  className={`relative h-6 w-11 shrink-0 rounded-full border transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/20 disabled:cursor-not-allowed disabled:opacity-50 ${
+                    shareState?.enabled
+                      ? "border-[var(--accent)]/45 bg-[var(--accent)]"
+                      : "border-white/10 bg-white/[0.08]"
+                  }`}
+                >
+                  <span
+                    className={`absolute left-0 top-1/2 h-5 w-5 -translate-y-1/2 rounded-full bg-[var(--text)] shadow-[0_1px_5px_rgba(0,0,0,0.32)] transition-transform duration-150 ${
+                      shareState?.enabled ? "translate-x-[21px]" : "translate-x-[1px]"
+                    }`}
+                  />
+                </button>
+              </div>
+            </motion.div>
+          </motion.div>
+        ) : null}
+      </AnimatePresence>
     </div>
   );
 }

--- a/lib/conversations.ts
+++ b/lib/conversations.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 
@@ -63,6 +63,9 @@ type ConversationRow = {
   created_at: string;
   updated_at: string;
   is_active: number;
+  share_token: string | null;
+  share_enabled: number;
+  shared_at: string | null;
 };
 
 type ConversationCursor = {
@@ -96,8 +99,33 @@ function rowToConversation(row: ConversationRow): Conversation {
     sortOrder: row.sort_order,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
-    isActive: row.is_active === 1
+    isActive: row.is_active === 1,
+    shareEnabled: row.share_enabled === 1,
+    shareToken: row.share_token,
+    sharedAt: row.shared_at
   };
+}
+
+function selectConversationColumns(activityTimestamp: string) {
+  return `c.id,
+            c.title,
+            c.title_generation_status,
+            c.folder_id,
+            c.provider_profile_id,
+            c.automation_id,
+            c.automation_run_id,
+            c.conversation_origin,
+            c.sort_order,
+            c.created_at,
+            ${activityTimestamp} AS updated_at,
+            c.is_active,
+            c.share_token,
+            c.share_enabled,
+            c.shared_at`;
+}
+
+function generateShareToken() {
+  return randomBytes(32).toString("base64url");
 }
 
 function buildConversationMatchSnippet(content: string, query: string) {
@@ -288,18 +316,7 @@ export function listConversations(userId?: string) {
     ? getDb()
         .prepare(
           `SELECT
-            c.id,
-            c.title,
-            c.title_generation_status,
-            c.folder_id,
-            c.provider_profile_id,
-            c.automation_id,
-            c.automation_run_id,
-            c.conversation_origin,
-            c.sort_order,
-            c.created_at,
-            ${activityTimestamp} AS updated_at,
-            c.is_active
+            ${selectConversationColumns(activityTimestamp)}
            FROM conversations c
            WHERE c.user_id = ?
              AND c.conversation_origin = ?
@@ -309,18 +326,7 @@ export function listConversations(userId?: string) {
     : getDb()
         .prepare(
           `SELECT
-            c.id,
-            c.title,
-            c.title_generation_status,
-            c.folder_id,
-            c.provider_profile_id,
-            c.automation_id,
-            c.automation_run_id,
-            c.conversation_origin,
-            c.sort_order,
-            c.created_at,
-            ${activityTimestamp} AS updated_at,
-            c.is_active
+            ${selectConversationColumns(activityTimestamp)}
            FROM conversations c
            WHERE c.conversation_origin = ?
            ORDER BY ${activityTimestamp} DESC, c.id DESC`
@@ -344,18 +350,7 @@ export function listConversationsPage(input: {
     ? (getDb()
         .prepare(
           `SELECT
-            c.id,
-            c.title,
-            c.title_generation_status,
-            c.folder_id,
-            c.provider_profile_id,
-            c.automation_id,
-            c.automation_run_id,
-            c.conversation_origin,
-           c.sort_order,
-           c.created_at,
-           ${activityTimestamp} AS updated_at,
-           c.is_active
+            ${selectConversationColumns(activityTimestamp)}
            FROM conversations c
            WHERE ${userCondition}c.conversation_origin = ?
              AND (
@@ -376,18 +371,7 @@ export function listConversationsPage(input: {
     : (getDb()
         .prepare(
           `SELECT
-            c.id,
-            c.title,
-            c.title_generation_status,
-            c.folder_id,
-            c.provider_profile_id,
-            c.automation_id,
-            c.automation_run_id,
-            c.conversation_origin,
-            c.sort_order,
-            c.created_at,
-            ${activityTimestamp} AS updated_at,
-            c.is_active
+            ${selectConversationColumns(activityTimestamp)}
            FROM conversations c
            WHERE ${userCondition}c.conversation_origin = ?
            ORDER BY ${activityTimestamp} DESC, c.id DESC
@@ -417,18 +401,7 @@ export function getConversation(conversationId: string, userId?: string) {
     ? getDb()
         .prepare(
           `SELECT
-            c.id,
-            c.title,
-            c.title_generation_status,
-            c.folder_id,
-            c.provider_profile_id,
-            c.automation_id,
-            c.automation_run_id,
-            c.conversation_origin,
-            c.sort_order,
-            c.created_at,
-            ${activityTimestamp} AS updated_at,
-            c.is_active
+            ${selectConversationColumns(activityTimestamp)}
            FROM conversations c
            WHERE c.id = ? AND c.user_id = ?`
         )
@@ -436,18 +409,7 @@ export function getConversation(conversationId: string, userId?: string) {
     : getDb()
         .prepare(
           `SELECT
-            c.id,
-            c.title,
-            c.title_generation_status,
-            c.folder_id,
-            c.provider_profile_id,
-            c.automation_id,
-            c.automation_run_id,
-            c.conversation_origin,
-            c.sort_order,
-            c.created_at,
-            ${activityTimestamp} AS updated_at,
-            c.is_active
+            ${selectConversationColumns(activityTimestamp)}
            FROM conversations c
            WHERE c.id = ?`
         )
@@ -499,7 +461,10 @@ export function createConversation(
     sortOrder: maxOrder.max_order + 1,
     createdAt: timestamp,
     updatedAt: timestamp,
-    isActive: false
+    isActive: false,
+    shareEnabled: false,
+    shareToken: null,
+    sharedAt: null
   };
 
   getDb()
@@ -514,11 +479,14 @@ export function createConversation(
         automation_id,
         automation_run_id,
         conversation_origin,
+        share_enabled,
+        share_token,
+        shared_at,
         sort_order,
         created_at,
         updated_at,
         is_active
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     )
     .run(
       conversation.id,
@@ -530,6 +498,9 @@ export function createConversation(
       conversation.automationId,
       conversation.automationRunId,
       conversation.conversationOrigin,
+      0,
+      null,
+      null,
       conversation.sortOrder,
       conversation.createdAt,
       conversation.updatedAt,
@@ -1310,6 +1281,103 @@ export function getConversationSnapshot(conversationId: string, userId?: string)
   const messages = listVisibleMessages(conversationId);
   const queuedMessages = listQueuedMessages(conversationId);
   return { conversation, messages, queuedMessages };
+}
+
+export function getConversationShare(conversationId: string, userId?: string) {
+  const conversation = getConversation(conversationId, userId);
+
+  if (!conversation) {
+    return null;
+  }
+
+  return {
+    enabled: conversation.shareEnabled,
+    token: conversation.shareEnabled ? conversation.shareToken : null
+  };
+}
+
+export function enableConversationShare(conversationId: string, userId?: string) {
+  if (!getConversation(conversationId, userId)) {
+    return null;
+  }
+
+  const timestamp = nowIso();
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    const token = generateShareToken();
+
+    try {
+      getDb()
+        .prepare(
+          `UPDATE conversations
+           SET share_enabled = 1,
+               share_token = ?,
+               shared_at = ?,
+               updated_at = ?
+           WHERE id = ?`
+        )
+        .run(token, timestamp, timestamp, conversationId);
+
+      return {
+        enabled: true,
+        token
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "";
+      if (!message.includes("UNIQUE")) {
+        throw error;
+      }
+    }
+  }
+
+  throw new Error("Unable to generate unique share token");
+}
+
+export function disableConversationShare(conversationId: string, userId?: string) {
+  if (!getConversation(conversationId, userId)) {
+    return null;
+  }
+
+  getDb()
+    .prepare(
+      `UPDATE conversations
+       SET share_enabled = 0,
+           share_token = NULL,
+           shared_at = NULL,
+           updated_at = ?
+       WHERE id = ?`
+    )
+    .run(nowIso(), conversationId);
+
+  return {
+    enabled: false,
+    token: null
+  };
+}
+
+export function getSharedConversationSnapshot(shareToken: string): ConversationSnapshot | null {
+  const activityTimestamp = conversationActivityTimestampSql("c");
+  const row = getDb()
+    .prepare(
+      `SELECT
+        ${selectConversationColumns(activityTimestamp)}
+       FROM conversations c
+       WHERE c.share_enabled = 1
+         AND c.share_token = ?`
+    )
+    .get(shareToken) as ConversationRow | undefined;
+
+  if (!row) {
+    return null;
+  }
+
+  const conversation = rowToConversation(row);
+  const messages = listVisibleMessages(conversation.id);
+
+  return {
+    conversation,
+    messages,
+    queuedMessages: []
+  };
 }
 
 export function listActiveConversations(userId?: string): Array<{ id: string; title: string; isActive: boolean }> {
@@ -2486,18 +2554,7 @@ export function searchConversations(query: string, userId?: string): Conversatio
   const rows = getDb()
     .prepare(
       `SELECT
-        c.id,
-        c.title,
-        c.title_generation_status,
-        c.folder_id,
-        c.provider_profile_id,
-        c.automation_id,
-        c.automation_run_id,
-        c.conversation_origin,
-        c.sort_order,
-        c.created_at,
-        ${activityTimestamp} AS updated_at,
-        c.is_active,
+        ${selectConversationColumns(activityTimestamp)},
         m.content AS matched_message_content
        FROM conversations c
        LEFT JOIN messages m

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -190,6 +190,9 @@ function migrate(db: Database.Database) {
       folder_id TEXT,
       provider_profile_id TEXT,
       tool_execution_mode TEXT NOT NULL DEFAULT 'read_only',
+      share_token TEXT UNIQUE,
+      share_enabled INTEGER NOT NULL DEFAULT 0,
+      shared_at TEXT,
       sort_order INTEGER NOT NULL DEFAULT 0,
       created_at TEXT NOT NULL,
       updated_at TEXT NOT NULL,
@@ -415,6 +418,15 @@ function migrate(db: Database.Database) {
   }
   if (!convColNames.includes("is_active")) {
     db.exec("ALTER TABLE conversations ADD COLUMN is_active INTEGER NOT NULL DEFAULT 0");
+  }
+  if (!convColNames.includes("share_token")) {
+    db.exec("ALTER TABLE conversations ADD COLUMN share_token TEXT");
+  }
+  if (!convColNames.includes("share_enabled")) {
+    db.exec("ALTER TABLE conversations ADD COLUMN share_enabled INTEGER NOT NULL DEFAULT 0");
+  }
+  if (!convColNames.includes("shared_at")) {
+    db.exec("ALTER TABLE conversations ADD COLUMN shared_at TEXT");
   }
 
   const automationConversationCols = db
@@ -722,6 +734,7 @@ function migrate(db: Database.Database) {
   db.exec(`
     CREATE INDEX IF NOT EXISTS idx_conversations_updated_at ON conversations(updated_at DESC);
     CREATE INDEX IF NOT EXISTS idx_conversations_folder ON conversations(folder_id, sort_order);
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_conversations_share_token ON conversations(share_token);
     CREATE INDEX IF NOT EXISTS idx_messages_conversation_created_at ON messages(conversation_id, created_at ASC);
     CREATE INDEX IF NOT EXISTS idx_messages_compacted_at ON messages(conversation_id, compacted_at);
     CREATE INDEX IF NOT EXISTS idx_automations_enabled_next_run_at ON automations(enabled, next_run_at);

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -148,6 +148,9 @@ export type Conversation = {
   createdAt: string;
   updatedAt: string;
   isActive: boolean;
+  shareEnabled: boolean;
+  shareToken: string | null;
+  sharedAt: string | null;
 };
 
 export type ConversationSearchResult = Conversation & {

--- a/middleware.ts
+++ b/middleware.ts
@@ -5,7 +5,7 @@ import { jwtVerify } from "jose";
 import { SESSION_COOKIE_NAME } from "@/lib/constants";
 import { env, isPasswordLoginEnabled } from "@/lib/env";
 
-const publicPaths = ["/login"];
+const publicPaths = ["/login", "/share", "/api/share"];
 
 function getSecret() {
   return new TextEncoder().encode(env.EIDON_SESSION_SECRET);

--- a/tests/unit/chat-view.test.ts
+++ b/tests/unit/chat-view.test.ts
@@ -4,6 +4,7 @@ import React from "react";
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 import { ChatView } from "@/components/chat-view";
+import { ShareConversationProvider } from "@/components/share-conversation-context";
 import { ContextTokensProvider } from "@/lib/context-tokens-context";
 import type { SpeechSessionSnapshot, SttEngine, SttLanguage } from "@/lib/speech/types";
 import type { Message, MessageAttachment, MessageTimelineItem, QueuedMessage } from "@/lib/types";
@@ -189,7 +190,10 @@ function createPayload(overrides: Partial<ChatViewPayload> = {}): ChatViewPayloa
       sortOrder: 0,
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
-      isActive: false
+      isActive: false,
+      shareEnabled: false,
+      shareToken: null,
+      sharedAt: null
     },
     messages: [] as Message[],
     queuedMessages: [],
@@ -448,6 +452,19 @@ describe("chat view", () => {
     );
   }
 
+  function renderWithShareProvider(ui: React.ReactElement, openShareModal = vi.fn()) {
+    return {
+      openShareModal,
+      ...renderWithProvider(
+        React.createElement(
+          ShareConversationProvider,
+          { value: { canShare: true, openShareModal } },
+          ui
+        )
+      )
+    };
+  }
+
   async function flushResizeObservers() {
     await act(async () => {
       for (const callback of resizeObserverCallbacks) {
@@ -455,6 +472,21 @@ describe("chat view", () => {
       }
     });
   }
+
+  it("places the desktop share control in the conversation title header", () => {
+    const openShareModal = vi.fn();
+    renderWithShareProvider(
+      React.createElement(ChatView, { payload: createPayload() }),
+      openShareModal
+    );
+
+    const shareButton = screen.getByRole("button", { name: "Share conversation" });
+    expect(shareButton.className).not.toContain("fixed");
+    expect(shareButton.className).toContain("md:flex");
+
+    fireEvent.click(shareButton);
+    expect(openShareModal).toHaveBeenCalledTimes(1);
+  });
 
   it("uploads an attachment from the file input and removes it from the pending list", async () => {
     const attachment = createAttachment();

--- a/tests/unit/conversation-share-route.test.ts
+++ b/tests/unit/conversation-share-route.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createConversation } from "@/lib/conversations";
+import { createLocalUser } from "@/lib/users";
+
+const { requireUserMock } = vi.hoisted(() => ({
+  requireUserMock: vi.fn()
+}));
+
+vi.mock("@/lib/auth", () => ({
+  requireUser: requireUserMock
+}));
+
+describe("conversation share route", () => {
+  beforeEach(() => {
+    requireUserMock.mockReset();
+  });
+
+  it("enables and disables sharing for the authenticated owner", async () => {
+    const user = await createLocalUser({
+      username: "share-route-owner",
+      password: "Password123!",
+      role: "user"
+    });
+    requireUserMock.mockResolvedValue(user);
+    const conversation = createConversation("Route share", null, {}, user.id);
+    const { GET, PATCH } = await import("@/app/api/conversations/[conversationId]/share/route");
+
+    const enabled = await PATCH(
+      new Request(`http://localhost/api/conversations/${conversation.id}/share`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ enabled: true })
+      }),
+      { params: Promise.resolve({ conversationId: conversation.id }) }
+    );
+
+    expect(enabled.status).toBe(200);
+    const enabledBody = await enabled.json();
+    expect(enabledBody).toEqual({
+      enabled: true,
+      token: expect.any(String),
+      url: `http://localhost/share/${enabledBody.token}`
+    });
+
+    const current = await GET(
+      new Request(`http://localhost/api/conversations/${conversation.id}/share`),
+      { params: Promise.resolve({ conversationId: conversation.id }) }
+    );
+    await expect(current.json()).resolves.toEqual(enabledBody);
+
+    const disabled = await PATCH(
+      new Request(`http://localhost/api/conversations/${conversation.id}/share`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ enabled: false })
+      }),
+      { params: Promise.resolve({ conversationId: conversation.id }) }
+    );
+
+    expect(disabled.status).toBe(200);
+    await expect(disabled.json()).resolves.toEqual({
+      enabled: false,
+      token: null,
+      url: null
+    });
+  });
+
+  it("rejects invalid share updates and missing conversations", async () => {
+    const user = await createLocalUser({
+      username: "share-route-negative-owner",
+      password: "Password123!",
+      role: "user"
+    });
+    requireUserMock.mockResolvedValue(user);
+    const { GET, PATCH } = await import("@/app/api/conversations/[conversationId]/share/route");
+
+    const invalid = await PATCH(
+      new Request("http://localhost/api/conversations/conv_missing/share", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ enabled: "yes" })
+      }),
+      { params: Promise.resolve({ conversationId: "conv_missing" }) }
+    );
+    expect(invalid.status).toBe(400);
+
+    const missing = await GET(
+      new Request("http://localhost/api/conversations/conv_missing/share"),
+      { params: Promise.resolve({ conversationId: "conv_missing" }) }
+    );
+    expect(missing.status).toBe(404);
+  });
+});

--- a/tests/unit/conversation-sharing.test.ts
+++ b/tests/unit/conversation-sharing.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from "vitest";
+
+import { assignAttachmentsToMessage, createAttachments } from "@/lib/attachments";
+import {
+  createConversation,
+  createMessageAction,
+  createMessageTextSegment,
+  createMessage,
+  disableConversationShare,
+  enableConversationShare,
+  getConversationShare,
+  getSharedConversationSnapshot
+} from "@/lib/conversations";
+import { getDb } from "@/lib/db";
+import { createLocalUser } from "@/lib/users";
+
+describe("conversation sharing", () => {
+  it("creates an opaque share token and resolves a public transcript", async () => {
+    const user = await createLocalUser({
+      username: "share-owner",
+      password: "Password123!",
+      role: "user"
+    });
+    const conversation = createConversation("Shareable thread", null, {}, user.id);
+    createMessage({
+      conversationId: conversation.id,
+      role: "user",
+      content: "Visible prompt"
+    });
+    createMessage({
+      conversationId: conversation.id,
+      role: "assistant",
+      content: "Visible answer"
+    });
+    createMessage({
+      conversationId: conversation.id,
+      role: "system",
+      content: "Hidden background instruction"
+    });
+
+    const share = enableConversationShare(conversation.id, user.id);
+
+    expect(share).not.toBeNull();
+    expect(share).toEqual({
+      enabled: true,
+      token: expect.stringMatching(/^[A-Za-z0-9_-]{32,}$/)
+    });
+    expect(share!.token).not.toContain(conversation.id);
+    expect(getConversationShare(conversation.id, user.id)).toEqual(share);
+
+    const snapshot = getSharedConversationSnapshot(share!.token);
+    expect(snapshot?.conversation.title).toBe("Shareable thread");
+    expect(snapshot?.conversation.shareEnabled).toBe(true);
+    expect(snapshot?.conversation.shareToken).toBe(share!.token);
+    expect(snapshot?.messages.map((message) => message.content)).toEqual([
+      "Visible prompt",
+      "Visible answer"
+    ]);
+    expect(snapshot?.queuedMessages).toEqual([]);
+  });
+
+  it("keeps attachments, thinking, tool actions, and timeline items in public snapshots", async () => {
+    const user = await createLocalUser({
+      username: "share-full-transcript-owner",
+      password: "Password123!",
+      role: "user"
+    });
+    const conversation = createConversation("Full public transcript", null, {}, user.id);
+    const userMessage = createMessage({
+      conversationId: conversation.id,
+      role: "user",
+      content: "Look at this"
+    });
+    const [attachment] = createAttachments(conversation.id, [
+      {
+        filename: "receipt.txt",
+        mimeType: "text/plain",
+        bytes: Buffer.from("public attachment", "utf8")
+      }
+    ]);
+    assignAttachmentsToMessage(conversation.id, userMessage.id, [attachment.id]);
+    const assistantMessage = createMessage({
+      conversationId: conversation.id,
+      role: "assistant",
+      content: "I checked the file.",
+      thinkingContent: "Need to inspect the uploaded text."
+    });
+    createMessageTextSegment({
+      messageId: assistantMessage.id,
+      content: "I checked ",
+      sortOrder: 0
+    });
+    const action = createMessageAction({
+      messageId: assistantMessage.id,
+      kind: "mcp_tool_call",
+      status: "completed",
+      serverId: "filesystem",
+      toolName: "read_file",
+      label: "Read file",
+      detail: "receipt.txt",
+      resultSummary: "Read public attachment",
+      sortOrder: 1
+    });
+    createMessageTextSegment({
+      messageId: assistantMessage.id,
+      content: "the file.",
+      sortOrder: 2
+    });
+
+    const share = enableConversationShare(conversation.id, user.id);
+    expect(share).not.toBeNull();
+
+    const snapshot = getSharedConversationSnapshot(share!.token);
+    const sharedUserMessage = snapshot?.messages.find((message) => message.id === userMessage.id);
+    const sharedAssistantMessage = snapshot?.messages.find((message) => message.id === assistantMessage.id);
+
+    expect(sharedUserMessage?.attachments).toEqual([
+      expect.objectContaining({
+        id: attachment.id,
+        filename: "receipt.txt",
+        extractedText: "public attachment"
+      })
+    ]);
+    expect(sharedAssistantMessage).toEqual(
+      expect.objectContaining({
+        thinkingContent: "Need to inspect the uploaded text.",
+        actions: [
+          expect.objectContaining({
+            id: action.id,
+            label: "Read file",
+            resultSummary: "Read public attachment"
+          })
+        ],
+        timeline: [
+          expect.objectContaining({ timelineKind: "text", content: "I checked " }),
+          expect.objectContaining({ timelineKind: "action", id: action.id, label: "Read file" }),
+          expect.objectContaining({ timelineKind: "text", content: "the file." })
+        ]
+      })
+    );
+  });
+
+  it("invalidates the public link when sharing is disabled and rotates on re-enable", async () => {
+    const user = await createLocalUser({
+      username: "share-rotation-owner",
+      password: "Password123!",
+      role: "user"
+    });
+    const conversation = createConversation("Rotating share", null, {}, user.id);
+    createMessage({
+      conversationId: conversation.id,
+      role: "assistant",
+      content: "Previously public"
+    });
+
+    const firstShare = enableConversationShare(conversation.id, user.id);
+    expect(firstShare).not.toBeNull();
+    disableConversationShare(conversation.id, user.id);
+
+    expect(getConversationShare(conversation.id, user.id)).toEqual({
+      enabled: false,
+      token: null
+    });
+    expect(getSharedConversationSnapshot(firstShare!.token)).toBeNull();
+
+    const secondShare = enableConversationShare(conversation.id, user.id);
+    expect(secondShare).not.toBeNull();
+    expect(secondShare!.token).not.toBe(firstShare!.token);
+    expect(getSharedConversationSnapshot(secondShare!.token)?.conversation.id).toBe(conversation.id);
+  });
+
+  it("migrates share columns onto existing conversation tables", () => {
+    const columns = getDb()
+      .prepare("PRAGMA table_info(conversations)")
+      .all() as Array<{ name: string }>;
+
+    expect(columns.map((column) => column.name)).toEqual(
+      expect.arrayContaining(["share_token", "share_enabled", "shared_at"])
+    );
+  });
+
+  it("returns null for share operations on conversations outside the owner scope", async () => {
+    const owner = await createLocalUser({
+      username: "share-owner-scope",
+      password: "Password123!",
+      role: "user"
+    });
+    const otherUser = await createLocalUser({
+      username: "share-other-scope",
+      password: "Password123!",
+      role: "user"
+    });
+    const conversation = createConversation("Scoped share", null, {}, owner.id);
+
+    expect(getConversationShare(conversation.id, otherUser.id)).toBeNull();
+    expect(enableConversationShare(conversation.id, otherUser.id)).toBeNull();
+    expect(disableConversationShare(conversation.id, otherUser.id)).toBeNull();
+  });
+});

--- a/tests/unit/middleware-share.test.ts
+++ b/tests/unit/middleware-share.test.ts
@@ -1,0 +1,25 @@
+import { NextRequest } from "next/server";
+import { describe, expect, it } from "vitest";
+
+import { middleware } from "@/middleware";
+
+describe("middleware share public access", () => {
+  it.each(["/share/share_token", "/api/share/share_token"])(
+    "allows %s without a session",
+    async (pathname) => {
+      const response = await middleware(new NextRequest(`http://localhost${pathname}`));
+
+      expect(response.status).not.toBe(307);
+      expect(response.headers.get("location")).toBeNull();
+    }
+  );
+
+  it("continues to protect normal conversation APIs", async () => {
+    const response = await middleware(
+      new NextRequest("http://localhost/api/conversations/conv_123")
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe("http://localhost/login");
+  });
+});

--- a/tests/unit/public-share-attachment-route.test.ts
+++ b/tests/unit/public-share-attachment-route.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import { assignAttachmentsToMessage, createAttachments } from "@/lib/attachments";
+import { createConversation, createMessage, enableConversationShare } from "@/lib/conversations";
+import { createLocalUser } from "@/lib/users";
+
+describe("public shared attachment route", () => {
+  it("returns text previews for attachments that belong to a shared transcript", async () => {
+    const user = await createLocalUser({
+      username: "public-share-attachment-owner",
+      password: "Password123!",
+      role: "user"
+    });
+    const conversation = createConversation("Shared attachment", null, {}, user.id);
+    const message = createMessage({
+      conversationId: conversation.id,
+      role: "user",
+      content: "Attached"
+    });
+    const [attachment] = createAttachments(conversation.id, [
+      {
+        filename: "notes.txt",
+        mimeType: "text/plain",
+        bytes: Buffer.from("shared notes", "utf8")
+      }
+    ]);
+    assignAttachmentsToMessage(conversation.id, message.id, [attachment.id]);
+    const share = enableConversationShare(conversation.id, user.id);
+    expect(share).not.toBeNull();
+
+    const { GET } = await import("@/app/api/share/[shareToken]/attachments/[attachmentId]/route");
+    const response = await GET(
+      new Request(`http://localhost/api/share/${share!.token}/attachments/${attachment.id}?format=text`),
+      {
+        params: Promise.resolve({
+          shareToken: share!.token,
+          attachmentId: attachment.id
+        })
+      }
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      id: attachment.id,
+      filename: "notes.txt",
+      mimeType: "text/plain",
+      content: "shared notes"
+    });
+  });
+
+  it("does not expose attachments outside the shared transcript", async () => {
+    const user = await createLocalUser({
+      username: "public-share-attachment-scope-owner",
+      password: "Password123!",
+      role: "user"
+    });
+    const sharedConversation = createConversation("Shared scope", null, {}, user.id);
+    createMessage({
+      conversationId: sharedConversation.id,
+      role: "assistant",
+      content: "Visible"
+    });
+    const privateConversation = createConversation("Private scope", null, {}, user.id);
+    const [privateAttachment] = createAttachments(privateConversation.id, [
+      {
+        filename: "private.txt",
+        mimeType: "text/plain",
+        bytes: Buffer.from("private notes", "utf8")
+      }
+    ]);
+    const share = enableConversationShare(sharedConversation.id, user.id);
+    expect(share).not.toBeNull();
+
+    const { GET } = await import("@/app/api/share/[shareToken]/attachments/[attachmentId]/route");
+    const response = await GET(
+      new Request(`http://localhost/api/share/${share!.token}/attachments/${privateAttachment.id}?format=text`),
+      {
+        params: Promise.resolve({
+          shareToken: share!.token,
+          attachmentId: privateAttachment.id
+        })
+      }
+    );
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/tests/unit/public-share-route.test.ts
+++ b/tests/unit/public-share-route.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import { createConversation, createMessage, enableConversationShare } from "@/lib/conversations";
+import { createLocalUser } from "@/lib/users";
+
+describe("public shared conversation route", () => {
+  it("returns a shared read-only snapshot without requiring auth", async () => {
+    const user = await createLocalUser({
+      username: "public-share-owner",
+      password: "Password123!",
+      role: "user"
+    });
+    const conversation = createConversation("Public route", null, {}, user.id);
+    createMessage({
+      conversationId: conversation.id,
+      role: "assistant",
+      content: "Public answer"
+    });
+    const share = enableConversationShare(conversation.id, user.id);
+    expect(share).not.toBeNull();
+
+    const { GET } = await import("@/app/api/share/[shareToken]/route");
+    const response = await GET(new Request(`http://localhost/api/share/${share!.token}`), {
+      params: Promise.resolve({ shareToken: share!.token })
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      conversation: expect.objectContaining({
+        id: conversation.id,
+        title: "Public route",
+        shareEnabled: true,
+        shareToken: share!.token
+      }),
+      messages: [
+        expect.objectContaining({
+          role: "assistant",
+          content: "Public answer",
+          attachments: []
+        })
+      ],
+      queuedMessages: []
+    });
+  });
+
+  it("returns not found for disabled or malformed share tokens", async () => {
+    const user = await createLocalUser({
+      username: "public-share-disabled-owner",
+      password: "Password123!",
+      role: "user"
+    });
+    const conversation = createConversation("Disabled public route", null, {}, user.id);
+    const share = enableConversationShare(conversation.id, user.id);
+    expect(share).not.toBeNull();
+
+    const { disableConversationShare } = await import("@/lib/conversations");
+    disableConversationShare(conversation.id, user.id);
+
+    const { GET } = await import("@/app/api/share/[shareToken]/route");
+    const disabled = await GET(new Request(`http://localhost/api/share/${share!.token}`), {
+      params: Promise.resolve({ shareToken: share!.token })
+    });
+    expect(disabled.status).toBe(404);
+
+    const malformed = await GET(new Request("http://localhost/api/share/short"), {
+      params: Promise.resolve({ shareToken: "short" })
+    });
+    expect(malformed.status).toBe(404);
+  });
+});

--- a/tests/unit/shared-conversation-view.test.tsx
+++ b/tests/unit/shared-conversation-view.test.tsx
@@ -1,0 +1,185 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SharedConversationView } from "@/components/shared-conversation-view";
+import type { Conversation, Message, MessageAttachment, MessageTimelineItem } from "@/lib/types";
+
+function createConversation(): Conversation {
+  return {
+    id: "conv_shared",
+    title: "Shared UI thread",
+    titleGenerationStatus: "completed",
+    folderId: null,
+    providerProfileId: "profile_default",
+    automationId: null,
+    automationRunId: null,
+    conversationOrigin: "manual",
+    sortOrder: 0,
+    createdAt: "2026-05-06T12:00:00.000Z",
+    updatedAt: "2026-05-06T12:05:00.000Z",
+    isActive: false,
+    shareEnabled: true,
+    shareToken: "share_token_1234567890",
+    sharedAt: "2026-05-06T12:06:00.000Z"
+  };
+}
+
+function createAttachment(): MessageAttachment {
+  return {
+    id: "att_shared",
+    conversationId: "conv_shared",
+    messageId: "msg_user",
+    filename: "photo.png",
+    mimeType: "image/png",
+    byteSize: 128,
+    sha256: "hash",
+    relativePath: "conv_shared/att_shared_photo.png",
+    kind: "image",
+    extractedText: "",
+    createdAt: "2026-05-06T12:01:00.000Z"
+  };
+}
+
+function createMessages(attachment: MessageAttachment): Message[] {
+  const action: Extract<MessageTimelineItem, { timelineKind: "action" }> = {
+    id: "act_shared",
+    messageId: "msg_assistant",
+    timelineKind: "action",
+    kind: "mcp_tool_call",
+    status: "completed",
+    serverId: "browser",
+    skillId: null,
+    toolName: "screenshot",
+    label: "Web browser",
+    detail: "Captured screenshot",
+    arguments: { url: "http://localhost" },
+    resultSummary: "Screenshot captured",
+    sortOrder: 1,
+    startedAt: "2026-05-06T12:02:00.000Z",
+    completedAt: "2026-05-06T12:02:01.000Z",
+    proposalState: null,
+    proposalPayload: null,
+    proposalUpdatedAt: null
+  };
+
+  return [
+    {
+      id: "msg_user",
+      conversationId: "conv_shared",
+      role: "user",
+      content: "what do you see?",
+      thinkingContent: "",
+      status: "completed",
+      estimatedTokens: 6,
+      systemKind: null,
+      compactedAt: null,
+      createdAt: "2026-05-06T12:01:00.000Z",
+      attachments: [attachment],
+      actions: [],
+      textSegments: [],
+      timeline: []
+    },
+    {
+      id: "msg_assistant",
+      conversationId: "conv_shared",
+      role: "assistant",
+      content: "I inspected it.",
+      thinkingContent: "Need to inspect the provided screenshot.",
+      status: "completed",
+      estimatedTokens: 20,
+      systemKind: null,
+      compactedAt: null,
+      createdAt: "2026-05-06T12:02:00.000Z",
+      attachments: [],
+      actions: [action],
+      textSegments: [],
+      timeline: [
+        {
+          id: "seg_shared",
+          timelineKind: "text",
+          content: "I inspected it.",
+          sortOrder: 0,
+          createdAt: "2026-05-06T12:02:00.000Z"
+        },
+        action
+      ]
+    }
+  ];
+}
+
+describe("SharedConversationView", () => {
+  beforeEach(() => {
+    class TestImage {
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      private _src = "";
+
+      get src() {
+        return this._src;
+      }
+
+      set src(value: string) {
+        this._src = value;
+        queueMicrotask(() => this.onload?.());
+      }
+    }
+
+    vi.stubGlobal("Image", TestImage);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("renders the shared transcript with the normal chat message UI and public attachment previews", async () => {
+    const attachment = createAttachment();
+    const { container } = render(
+      <SharedConversationView
+        conversation={createConversation()}
+        messages={createMessages(attachment)}
+        shareToken="share_token_1234567890"
+      />
+    );
+
+    expect(screen.getByRole("link", { name: "Eidon" })).toHaveAttribute(
+      "href",
+      "https://github.com/Quack6765/Eidon-AI"
+    );
+    expect(screen.getByRole("link", { name: "Eidon" })).toContainHTML(
+      'font-bold leading-none tracking-[0.12em]'
+    );
+    expect(screen.getByRole("link", { name: "Eidon" })).toContainHTML(
+      "linear-gradient(to bottom, #FFFFFF 0%, #D4C8FF 40%, #8b5cf6 100%)"
+    );
+    expect(screen.getByText("Shared UI thread")).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText(/Ask, create, or start a task/i)).not.toBeInTheDocument();
+    expect(screen.queryByText("New Chat")).not.toBeInTheDocument();
+    expect(screen.queryByText("Search")).not.toBeInTheDocument();
+    expect(container.querySelector('img[src="/agent-icon.png"]')).not.toBeNull();
+    expect(screen.getByTestId("assistant-thinking-shell")).toBeInTheDocument();
+    expect(screen.getByTestId("assistant-actions-shell")).toHaveTextContent("Web browser");
+
+    fireEvent.click(screen.getByRole("button", { name: /Thought/i }));
+    expect(await screen.findByText("Need to inspect the provided screenshot.")).toBeInTheDocument();
+
+    const previewButton = screen.getByRole("button", { name: "Preview photo.png" });
+    expect(previewButton.querySelector("img")).toHaveAttribute(
+      "src",
+      "/api/share/share_token_1234567890/attachments/att_shared"
+    );
+
+    fireEvent.click(previewButton);
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog", { name: "Attachment preview" })).toBeInTheDocument();
+    });
+    expect(screen.getByRole("link", { name: "Download attachment" })).toHaveAttribute(
+      "href",
+      "/api/share/share_token_1234567890/attachments/att_shared?download=1"
+    );
+    expect(screen.queryByRole("button", { name: "Edit message" })).not.toBeInTheDocument();
+  });
+});

--- a/tests/unit/shell-share.test.tsx
+++ b/tests/unit/shell-share.test.tsx
@@ -1,0 +1,154 @@
+// @vitest-environment jsdom
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Shell } from "@/components/shell";
+import type { AuthUser, Conversation, ConversationListPage } from "@/lib/types";
+
+const push = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/chat/conv_share_header",
+  useRouter: () => ({ push })
+}));
+
+vi.mock("@/lib/ws-client", () => ({
+  addGlobalWsListener: () => () => undefined,
+  useGlobalWebSocket: () => undefined
+}));
+
+const user: AuthUser = {
+  id: "user_share_header",
+  username: "owner",
+  role: "user",
+  authSource: "local",
+  passwordManagedBy: "local",
+  createdAt: "2026-05-06T00:00:00.000Z",
+  updatedAt: "2026-05-06T00:00:00.000Z"
+};
+
+const conversation: Conversation = {
+  id: "conv_share_header",
+  title: "Header share",
+  titleGenerationStatus: "completed",
+  folderId: null,
+  providerProfileId: null,
+  automationId: null,
+  automationRunId: null,
+  conversationOrigin: "manual",
+  sortOrder: 0,
+  createdAt: "2026-05-06T00:00:00.000Z",
+  updatedAt: "2026-05-06T00:00:00.000Z",
+  isActive: false,
+  shareEnabled: false,
+  shareToken: null,
+  sharedAt: null
+};
+
+const conversationPage: ConversationListPage = {
+  conversations: [conversation],
+  hasMore: false,
+  nextCursor: null
+};
+
+describe("Shell sharing control", () => {
+  beforeEach(() => {
+    push.mockReset();
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 390
+    });
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: vi.fn().mockResolvedValue(undefined)
+      }
+    });
+  });
+
+  it("opens a share modal from the mobile header without moving the new chat button", async () => {
+    global.fetch = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          enabled: false,
+          token: null,
+          url: null
+        })
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          enabled: true,
+          token: "share_public_token",
+          url: "http://localhost/share/share_public_token"
+        })
+      } as Response);
+
+    render(
+      <Shell
+        currentUser={user}
+        passwordLoginEnabled
+        conversationPage={conversationPage}
+        folders={[]}
+      >
+        <div>Thread body</div>
+      </Shell>
+    );
+
+    const shareButton = screen
+      .getAllByRole("button", { name: "Share conversation" })
+      .find((button) => !button.className.includes("md:flex"))!;
+    const newChatButton = screen.getAllByRole("button", { name: "New chat" }).at(-1)!;
+    expect(shareButton.compareDocumentPosition(newChatButton) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+
+    fireEvent.click(shareButton);
+
+    expect(await screen.findByRole("dialog", { name: "Share conversation" })).toBeInTheDocument();
+    expect(screen.queryByText("Sharing is off for this conversation.")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Copy share link" })).not.toBeInTheDocument();
+    expect(screen.getByText("Share this conversation")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("switch", { name: "Share this conversation" }));
+
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+        `${window.location.origin}/share/share_public_token`
+      );
+    });
+  });
+
+  it("uses one sharing switch and keeps copying on the link icon button", async () => {
+    global.fetch = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          enabled: true,
+          token: "share_public_token",
+          url: "http://localhost/share/share_public_token"
+        })
+      } as Response);
+    render(
+      <Shell
+        currentUser={user}
+        passwordLoginEnabled
+        conversationPage={conversationPage}
+        folders={[]}
+      >
+        <div>Thread body</div>
+      </Shell>
+    );
+
+    const shareButton = screen
+      .getAllByRole("button", { name: "Share conversation" })
+      .find((button) => !button.className.includes("md:flex"))!;
+    fireEvent.click(shareButton);
+
+    expect(await screen.findByRole("switch", { name: "Share this conversation" })).toBeInTheDocument();
+    expect(screen.getByText("Share this conversation")).toBeInTheDocument();
+    expect(screen.queryByText("Sharing is off for this conversation.")).not.toBeInTheDocument();
+    expect(screen.queryByText("Only workspace users can read it.")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Enable sharing" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Disable sharing" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Copy share link" })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Add conversation sharing APIs and public share routes for full read-only transcript access without login
- Render shared conversations with the same chat UI, including assistant thinking, tool calls, avatars, and attachment previews
- Add shared attachment serving so public links can open and download attachments from the transcript
- Move the share control into the conversation header and keep the `+` button on the far right
- Cover the share flow with unit tests for routes, snapshot hydration, and shared-page rendering

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm test`