### PR TITLE
fix(ui): reposition latest messages button to right of composer

### DIFF
--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -2369,18 +2369,18 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
               "pointer-events-none absolute z-50 flex items-center",
               "left-3 sm:left-5",
               queueBannerHeight > 0
-                ? "-top-10 md:left-[-12px] md:-translate-x-full md:-translate-y-1/2 md:bottom-4 md:top-auto"
-                : "bottom-full mb-2 translate-y-0 md:left-[-12px] md:-translate-x-full md:-translate-y-1/2 md:top-1/2 md:bottom-auto md:mb-0"
+                ? "-top-10 md:left-full md:ml-3 md:top-auto md:bottom-4 md:translate-x-0"
+                : "bottom-full mb-2 translate-y-0 md:left-full md:ml-3 md:top-1/2 md:-translate-y-1/2 md:bottom-auto md:mb-0 md:translate-x-0"
             )}>
               <button
                 type="button"
                 onClick={jumpToBottom}
-                className="pointer-events-auto relative inline-flex h-8 w-8 items-center justify-center gap-2 rounded-full border border-[var(--accent)]/45 bg-[var(--panel)] px-2 text-[var(--accent)] shadow-[0_2px_12px_rgba(0,0,0,0.45)] transition-colors duration-150 before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:bg-[var(--accent)] before:opacity-0 before:transition-opacity before:duration-150 hover:before:opacity-[0.16] active:scale-95 md:w-auto md:min-w-[8rem] md:justify-start"
+                className="pointer-events-auto relative inline-flex h-8 w-8 items-center justify-center gap-2 rounded-full bg-[var(--accent)] px-2 text-white shadow-[0_0_20px_var(--accent-glow)] transition-all duration-150 hover:opacity-90 active:scale-[0.96] whitespace-nowrap md:w-auto md:justify-start md:px-4 md:py-2"
                 aria-label="Scroll to newest messages"
                 title="Scroll to bottom"
               >
                 ↓
-                <span className="hidden md:inline text-[11px] font-medium text-[var(--text)]/85">Latest messages</span>
+                <span className="hidden md:inline text-xs font-semibold">Latest messages</span>
               </button>
             </div>
           ) : null}

--- a/tests/unit/chat-view.test.ts
+++ b/tests/unit/chat-view.test.ts
@@ -2758,6 +2758,55 @@ describe("chat view", () => {
     expect(screen.queryByRole("button", { name: "Scroll to newest messages" })).toBeNull();
   });
 
+  it("positions the Latest Messages pill to the right of the composer on desktop", async () => {
+    const { container } = renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
+    const queue = container.querySelector(".no-scrollbar.overflow-y-auto") as HTMLDivElement;
+
+    let scrollTop = 700;
+    const scrollTo = vi.fn(({ top }: { top?: number }) => {
+      if (typeof top === "number") {
+        scrollTop = top;
+      }
+    });
+
+    Object.defineProperty(queue, "clientHeight", {
+      configurable: true,
+      get: () => 300
+    });
+    Object.defineProperty(queue, "scrollHeight", {
+      configurable: true,
+      get: () => 1000
+    });
+    Object.defineProperty(queue, "scrollTop", {
+      configurable: true,
+      get: () => scrollTop,
+      set: (value: number) => {
+        scrollTop = value;
+      }
+    });
+    Object.defineProperty(queue, "scrollTo", {
+      configurable: true,
+      value: scrollTo
+    });
+
+    await flushAnimationFrame();
+
+    scrollTop = 120;
+    fireEvent.scroll(queue);
+    scrollTo.mockClear();
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Scroll to newest messages" })).toBeInTheDocument();
+    });
+
+    const pill = screen.getByRole("button", { name: "Scroll to newest messages" }).parentElement!;
+    expect(pill.className).toContain("md:left-full");
+    expect(pill.className).toContain("md:ml-3");
+    expect(pill.className).toContain("md:-translate-y-1/2");
+    expect(pill.className).not.toContain("md:left-4");
+    expect(pill.className).not.toContain("md:bottom-full");
+  });
+
   it("sets dynamic bottom padding from the queue height with a 260px minimum", async () => {
     const { container } = renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
     const queue = container.querySelector(".no-scrollbar.overflow-y-auto") as HTMLDivElement;


### PR DESCRIPTION
## Summary
- Move "Latest messages" jump-to-bottom button from left of composer to right of composer on desktop
- Restyle button from bordered outline to solid accent-colored pill with glow effect
- Update unit test to verify new positioning classes (`md:left-full`, `md:ml-3`)
- Minor formatting cleanup in shell.tsx