### PR TITLE
Render persisted markdown tables correctly in chat bubbles

### DIFF
--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -250,6 +250,189 @@ function renderAssistantMarkdown(content: string, isStreaming: boolean) {
   );
 }
 
+function getMarkdownTableCellCount(line: string) {
+  const trimmed = line.trim();
+
+  if (!trimmed.startsWith("|")) {
+    return 0;
+  }
+
+  const inner = trimmed
+    .replace(/^\|/, "")
+    .replace(/\|$/, "");
+
+  return inner.split("|").length;
+}
+
+function isMarkdownTableAlignmentCell(cell: string) {
+  return /^:?-{3,}:?$/.test(cell.trim());
+}
+
+function splitCollapsedMarkdownAlignmentLine(line: string) {
+  if (!line.trimStart().startsWith("|")) {
+    return null;
+  }
+
+  const parts = line.split("|");
+  let alignmentCellCount = 0;
+
+  for (let index = 1; index < parts.length; index += 1) {
+    if (!isMarkdownTableAlignmentCell(parts[index])) {
+      break;
+    }
+
+    alignmentCellCount += 1;
+  }
+
+  if (alignmentCellCount < 2) {
+    return null;
+  }
+
+  const nextPartIndex = alignmentCellCount + 1;
+  const nextPart = parts[nextPartIndex];
+  const followingPart = parts[nextPartIndex + 1];
+
+  if (nextPart === undefined || (nextPart.trim() !== "" || followingPart === undefined)) {
+    return null;
+  }
+
+  return {
+    alignmentLine: `|${parts.slice(1, nextPartIndex).join("|")}|`,
+    remainderLine: `|${parts.slice(nextPartIndex + 1).join("|")}`,
+    columnCount: alignmentCellCount
+  };
+}
+
+function splitCollapsedMarkdownHeaderAlignmentLine(line: string) {
+  if (!line.trimStart().startsWith("|")) {
+    return null;
+  }
+
+  const parts = line.split("|");
+
+  for (let boundaryIndex = 2; boundaryIndex < parts.length - 2; boundaryIndex += 1) {
+    if (parts[boundaryIndex].trim() !== "") {
+      continue;
+    }
+
+    const headerCells = parts.slice(1, boundaryIndex);
+    let alignmentCellCount = 0;
+
+    for (let index = boundaryIndex + 1; index < parts.length; index += 1) {
+      if (!isMarkdownTableAlignmentCell(parts[index])) {
+        break;
+      }
+
+      alignmentCellCount += 1;
+    }
+
+    const nextPartIndex = boundaryIndex + alignmentCellCount + 1;
+    const nextPart = parts[nextPartIndex];
+    const followingPart = parts[nextPartIndex + 1];
+
+    if (
+      headerCells.length < 2 ||
+      alignmentCellCount !== headerCells.length ||
+      nextPart === undefined ||
+      nextPart.trim() !== "" ||
+      followingPart === undefined
+    ) {
+      continue;
+    }
+
+    return {
+      headerLine: `|${headerCells.join("|")}|`,
+      alignmentLine: `|${parts.slice(boundaryIndex + 1, nextPartIndex).join("|")}|`,
+      remainderLine: `|${parts.slice(nextPartIndex + 1).join("|")}`,
+      columnCount: alignmentCellCount
+    };
+  }
+
+  return null;
+}
+
+function splitCollapsedMarkdownTableRows(line: string, columnCount: number) {
+  const rows: string[] = [];
+  let current = line;
+
+  while (current.includes("||") && getMarkdownTableCellCount(current) > columnCount) {
+    const splitIndex = current.indexOf("||");
+    rows.push(`${current.slice(0, splitIndex)}|`);
+    current = `|${current.slice(splitIndex + 2).trimStart()}`;
+  }
+
+  const headingIndex = current.indexOf("|**");
+
+  if (
+    headingIndex !== -1 &&
+    getMarkdownTableCellCount(current.slice(0, headingIndex + 1)) >= columnCount
+  ) {
+    rows.push(current.slice(0, headingIndex + 1));
+    rows.push("");
+    rows.push(current.slice(headingIndex + 1));
+    return rows;
+  }
+
+  rows.push(current);
+  return rows;
+}
+
+function repairCollapsedMarkdownTableBoundaries(content: string) {
+  const repairedLines: string[] = [];
+  let activeTableColumnCount: number | null = null;
+
+  content.split("\n").forEach((line) => {
+    const headerAlignmentSplit = splitCollapsedMarkdownHeaderAlignmentLine(line);
+
+    if (headerAlignmentSplit) {
+      activeTableColumnCount = headerAlignmentSplit.columnCount;
+      repairedLines.push(headerAlignmentSplit.headerLine);
+      repairedLines.push(headerAlignmentSplit.alignmentLine);
+      repairedLines.push(
+        ...splitCollapsedMarkdownTableRows(
+          headerAlignmentSplit.remainderLine,
+          headerAlignmentSplit.columnCount
+        )
+      );
+      return;
+    }
+
+    const alignmentSplit = splitCollapsedMarkdownAlignmentLine(line);
+
+    if (alignmentSplit) {
+      activeTableColumnCount = alignmentSplit.columnCount;
+      repairedLines.push(alignmentSplit.alignmentLine);
+      repairedLines.push(
+        ...splitCollapsedMarkdownTableRows(
+          alignmentSplit.remainderLine,
+          alignmentSplit.columnCount
+        )
+      );
+      return;
+    }
+
+    if (activeTableColumnCount && line.trimStart().startsWith("|")) {
+      repairedLines.push(...splitCollapsedMarkdownTableRows(line, activeTableColumnCount));
+      return;
+    }
+
+    if (line.trim() === "" || !line.trimStart().startsWith("|")) {
+      activeTableColumnCount = null;
+    }
+
+    repairedLines.push(line);
+  });
+
+  return repairedLines.join("\n");
+}
+
+function getRenderableAssistantMarkdown(content: string, attachments: MessageAttachment[]) {
+  return stripAttachmentStyleImageMarkdown(
+    repairCollapsedMarkdownTableBoundaries(normalizeMarkdownLineBreaks(content)),
+    attachments
+  );
+}
+
 export function TypingIndicator({ compact = false }: { compact?: boolean }) {
   return (
     <div className={compact ? "flex items-center gap-1" : "flex items-center gap-1.5 px-1 py-2"}>
@@ -901,10 +1084,6 @@ export function MessageBubble({
       return next;
     }
 
-    if (current.endsWith(next)) {
-      return current;
-    }
-
     return `${current}${next}`;
   }
 
@@ -942,14 +1121,15 @@ export function MessageBubble({
     )
     .map((item) => item.content)
     .join("");
+  const normalizedConsumedText = normalizeMarkdownLineBreaks(consumedText);
 
-  if (rawContent && rawContent.length > consumedText.length) {
+  if (content && content.length > normalizedConsumedText.length) {
     assistantBlocks.push({
       id: `content_${message.id}_remaining`,
       timelineKind: "text",
       sortOrder: assistantBlocks.length,
       createdAt: message.createdAt,
-      content: rawContent.slice(consumedText.length)
+      content: content.slice(normalizedConsumedText.length)
     });
   }
 
@@ -971,7 +1151,7 @@ export function MessageBubble({
     .join("");
   const renderedAssistantText =
     message.role === "assistant"
-      ? stripAttachmentStyleImageMarkdown(assistantText, message.attachments ?? [])
+      ? getRenderableAssistantMarkdown(assistantText, message.attachments ?? [])
       : assistantText;
   const [thinkingOpen, setThinkingOpen] = useState(false);
   const [toolOpenItems, setToolOpenItems] = useState<Record<string, boolean>>({});
@@ -999,10 +1179,7 @@ export function MessageBubble({
         return;
       }
 
-      const renderedContent = stripAttachmentStyleImageMarkdown(
-        item.content,
-        message.attachments ?? []
-      );
+      const renderedContent = getRenderableAssistantMarkdown(item.content, message.attachments ?? []);
 
       renderedAssistantBlockContentById.set(item.id, renderedContent);
 
@@ -1144,8 +1321,8 @@ export function MessageBubble({
                   }}
                 />
               ) : content ? (
-                <div ref={contentRef}>
-                  <p className="whitespace-pre-wrap text-[14.5px] leading-7">{content}</p>
+                <div ref={contentRef} className="markdown-body">
+                  <ReactMarkdown remarkPlugins={MARKDOWN_PLUGINS}>{content}</ReactMarkdown>
                 </div>
               ) : null}
               {message.attachments?.length ? (

--- a/tests/unit/message-bubble.test.ts
+++ b/tests/unit/message-bubble.test.ts
@@ -41,6 +41,10 @@ function createUserMessage(): Message {
   };
 }
 
+function normalizeEscapedLineBreaksForTest(content: string) {
+  return content.replace(/\\n/g, "\n");
+}
+
 function createMemoryProposalAction(
   overrides: Partial<Extract<MessageTimelineItem, { timelineKind: "action" }>> = {}
 ) {
@@ -542,6 +546,41 @@ describe("message bubble", () => {
     expect(bubbles[0]?.textContent).toContain("Hello there");
   });
 
+  it("does not append a second assistant bubble when normalized timeline text already covers escaped message content", () => {
+    const escapedContent = [
+      "Here is the table:",
+      "",
+      "| Name | Department |",
+      "| --- | --- |",
+      "| Elena Varga | Engineering |"
+    ].join("\\n");
+
+    const { container } = render(
+      React.createElement(MessageBubble, {
+        message: {
+          ...createAssistantMessage(),
+          content: escapedContent,
+          timeline: [
+            {
+              id: "txt_table",
+              timelineKind: "text",
+              sortOrder: 0,
+              createdAt: new Date().toISOString(),
+              content: normalizeEscapedLineBreaksForTest(escapedContent)
+            }
+          ]
+        }
+      })
+    );
+
+    const bubbles = container.querySelectorAll('[data-testid="assistant-message-bubble"]');
+
+    expect(bubbles).toHaveLength(1);
+    expect(screen.getByRole("table")).toBeInTheDocument();
+    expect(bubbles[0]?.textContent).toContain("Elena Varga");
+    expect(bubbles[0]?.textContent).not.toContain("\\n");
+  });
+
   it("renders memory proposal cards after the full assistant answer", () => {
     const { container } = render(
       React.createElement(MessageBubble, {
@@ -843,6 +882,82 @@ describe("message bubble", () => {
     );
     expect(container.querySelector('input[type="checkbox"]')).not.toBeNull();
     expect(container.querySelector("hr")).not.toBeNull();
+  });
+
+  it("renders GFM tables from completed assistant timeline text with escaped line breaks", () => {
+    render(
+      React.createElement(MessageBubble, {
+        message: {
+          ...createAssistantMessage(),
+          content: "",
+          timeline: [
+            {
+              id: "txt_table",
+              timelineKind: "text",
+              sortOrder: 0,
+              createdAt: new Date().toISOString(),
+              content: [
+                "Here is the table:",
+                "",
+                "| Name | Department |",
+                "| :--- | :--- |",
+                "| Elena Varga | Engineering |"
+              ].join("\\n")
+            }
+          ]
+        }
+      })
+    );
+
+    expect(screen.getByRole("table")).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Name" })).toBeInTheDocument();
+    expect(screen.getByRole("cell", { name: "Engineering" })).toBeInTheDocument();
+  });
+
+  it("repairs collapsed assistant table row boundaries from persisted completion text", () => {
+    render(
+      React.createElement(MessageBubble, {
+        message: {
+          ...createAssistantMessage(),
+          content: [
+            "Dataset:",
+            "",
+            "| Name | Department | Role |",
+            "| :--- | :--- | :--- || Elena Varga | Engineering | Backend Dev |",
+            "| Tom Bradley | Engineering | Manager || Fatima Al-Rashid | Data | Data Analyst |**Key notes about the data:**",
+            "- **Performance Scores** are on a 0-100 scale.- **Remote Status** categories: On-site, Hybrid, Full-time."
+          ].join("\n")
+        }
+      })
+    );
+
+    expect(screen.getByRole("table")).toBeInTheDocument();
+    expect(screen.getByRole("cell", { name: "Elena Varga" })).toBeInTheDocument();
+    expect(screen.getByRole("cell", { name: "Fatima Al-Rashid" })).toBeInTheDocument();
+    expect(within(screen.getByRole("table")).queryByText("Key notes about the data:")).toBeNull();
+    expect(screen.getByText("Key notes about the data:")).toBeInTheDocument();
+  });
+
+  it("repairs collapsed assistant table header, divider, and first row from persisted completion text", () => {
+    render(
+      React.createElement(MessageBubble, {
+        message: {
+          ...createAssistantMessage(),
+          content: [
+            "Mission log:",
+            "",
+            "| Mission ID | Planet | Commander | Crew | Status ||------------|--------|-----------|------|--------|| TH-001 | Xerion-IV | Capt. Elena Voss | 4 | Completed |",
+            "| TH-002 | Krell Moons | Lt. Jace Okonkwo | 6 | Completed |"
+          ].join("\n")
+        }
+      })
+    );
+
+    expect(screen.getByRole("table")).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Mission ID" })).toBeInTheDocument();
+    expect(screen.getByRole("cell", { name: "TH-001" })).toBeInTheDocument();
+    expect(screen.getByRole("cell", { name: "Xerion-IV" })).toBeInTheDocument();
+    expect(screen.queryByText(/------------/)).toBeNull();
   });
 
   it("renders fenced assistant code blocks with a language label and block-local copy action", () => {
@@ -1367,6 +1482,21 @@ describe("message bubble", () => {
     expect(
       screen.queryByRole("button", { name: "Fork conversation from message" })
     ).toBeNull();
+  });
+
+  it("renders GFM tables inside user message bubbles", () => {
+    render(
+      React.createElement(MessageBubble, {
+        message: {
+          ...createUserMessage(),
+          content: ["| Symbol | Price |", "| --- | ---: |", "| AAPL | $198 |"].join("\n")
+        }
+      })
+    );
+
+    expect(screen.getByRole("table")).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Symbol" })).toBeInTheDocument();
+    expect(screen.getByRole("cell", { name: "$198" })).toBeInTheDocument();
   });
 
   it("allows editing user messages through the inline controls", async () => {


### PR DESCRIPTION
## Summary
- Render user messages through the markdown pipeline so tables display inside chat bubbles.
- Repair persisted assistant markdown before rendering, including collapsed table rows, escaped line breaks, and collapsed header/divider rows that were flattening into plain text.
- Prevent duplicate assistant bubbles by comparing normalized consumed timeline text against the saved message content.
- Add regressions for user tables, completed assistant tables, split-bubble fallback, and collapsed persisted table shapes.

## Testing
- `npx vitest run tests/unit/message-bubble.test.ts --coverage.enabled false`
- `npm test`
- Live browser validation on the affected conversation page confirmed the table renders as a single assistant bubble with a real `<table>` element.