### PR TITLE
Prevent short-chat padding-only scroll flicker in ChatView

### DIFF
--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -848,6 +848,54 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
     suppressNextScrollEventRef.current = false;
   }
 
+  const preventPaddingOnlyScroll = useCallback((event: { preventDefault: () => void }) => {
+    if (!queueRef.current) {
+      return false;
+    }
+
+    const bottomTarget = getComposerAwareBottomTarget(queueRef.current, scrollPadding);
+    if (bottomTarget > 0) {
+      return false;
+    }
+
+    event.preventDefault();
+    if (queueRef.current.scrollTop > bottomTarget) {
+      suppressNextScrollEventRef.current = true;
+      queueRef.current.scrollTo?.({ top: bottomTarget, behavior: "auto" });
+      queueRef.current.scrollTop = bottomTarget;
+      requestAnimationFrame(() => {
+        suppressNextScrollEventRef.current = false;
+      });
+    }
+    setIsConversationAtBottom(true);
+    shouldAutoScrollRef.current = true;
+    userScrollIntentRef.current = false;
+    return true;
+  }, [scrollPadding]);
+
+  useEffect(() => {
+    const el = queueRef.current;
+    if (!el) return;
+
+    const handleWheel = (event: WheelEvent) => {
+      if (event.deltaY > 0) {
+        preventPaddingOnlyScroll(event);
+      }
+    };
+
+    const handleTouchMove = (event: TouchEvent) => {
+      preventPaddingOnlyScroll(event);
+    };
+
+    el.addEventListener("wheel", handleWheel, { passive: false });
+    el.addEventListener("touchmove", handleTouchMove, { passive: false });
+
+    return () => {
+      el.removeEventListener("wheel", handleWheel);
+      el.removeEventListener("touchmove", handleTouchMove);
+    };
+  }, [preventPaddingOnlyScroll]);
+
   const followAnchoredOverflowIfNeeded = useCallback(() => {
     const canFollowAnchor =
       scrollModeRef.current === "anchored" ||
@@ -2219,11 +2267,12 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
             !streamMessageIdRef.current &&
             queueRef.current.scrollTop > bottomTarget + ANCHOR_SCROLL_TOLERANCE_PX
           ) {
+            const isPaddingOnlyScroll = bottomTarget <= 0;
             suppressNextScrollEventRef.current = true;
             queueRef.current.scrollTo?.({ top: bottomTarget, behavior: "auto" });
             queueRef.current.scrollTop = bottomTarget;
             setIsConversationAtBottom(true);
-            shouldAutoScrollRef.current = false;
+            shouldAutoScrollRef.current = isPaddingOnlyScroll;
             userScrollIntentRef.current = false;
             requestAnimationFrame(() => {
               suppressNextScrollEventRef.current = false;
@@ -2268,10 +2317,16 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
           shouldAutoScrollRef.current = nextIsAtBottom;
           userScrollIntentRef.current = false;
         }}
-        onWheel={() => {
+        onWheel={(event) => {
+          if (event.deltaY > 0 && preventPaddingOnlyScroll(event)) {
+            return;
+          }
           cancelAutoScrollForUserIntent();
         }}
-        onTouchMove={() => {
+        onTouchMove={(event) => {
+          if (preventPaddingOnlyScroll(event)) {
+            return;
+          }
           cancelAutoScrollForUserIntent();
         }}
         onPointerDown={() => {

--- a/tests/unit/chat-view.test.ts
+++ b/tests/unit/chat-view.test.ts
@@ -3486,6 +3486,63 @@ describe("chat view", () => {
     }));
   });
 
+  it("prevents downward wheel scrolling into padding-only space for short chats", async () => {
+    const { container } = renderWithProvider(
+      React.createElement(ChatView, {
+        payload: createPayload({
+          messages: [
+            createMessage({
+              id: "msg_short_user",
+              role: "user",
+              content: "Short prompt"
+            }),
+            createMessage({
+              id: "msg_short_assistant",
+              role: "assistant",
+              content: "Short answer"
+            })
+          ]
+        })
+      })
+    );
+    const queue = container.querySelector(".no-scrollbar.overflow-y-auto") as HTMLDivElement;
+
+    let scrollTop = 0;
+    Object.defineProperty(queue, "clientHeight", { configurable: true, get: () => 200 });
+    Object.defineProperty(queue, "scrollHeight", { configurable: true, get: () => 240 });
+    Object.defineProperty(queue, "scrollTop", {
+      configurable: true,
+      get: () => scrollTop,
+      set: (value: number) => { scrollTop = value; }
+    });
+    Object.defineProperty(queue, "scrollTo", {
+      configurable: true,
+      value: vi.fn(({ top }: { top?: number }) => {
+        if (typeof top === "number") {
+          scrollTop = top;
+        }
+      })
+    });
+
+    await flushResizeObservers();
+    await flushAnimationFrame();
+
+    const wheelEvent = new WheelEvent("wheel", {
+      bubbles: true,
+      cancelable: true,
+      deltaY: 120
+    });
+
+    const defaultAllowed = fireEvent(queue, wheelEvent);
+    if (defaultAllowed && !wheelEvent.defaultPrevented) {
+      scrollTop = 60;
+    }
+
+    expect(wheelEvent.defaultPrevented).toBe(true);
+    expect(scrollTop).toBe(0);
+    expect(screen.queryByRole("button", { name: "Scroll to newest messages" })).toBeNull();
+  });
+
   it("transitions to following mode when streaming content fills the viewport", async () => {
     const { container } = renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
     const queue = container.querySelector(".no-scrollbar.overflow-y-auto") as HTMLDivElement;


### PR DESCRIPTION
## Summary
- Block native downward wheel and touch scrolling when the chat is already at the composer-aware bottom and only padding remains.
- Keep the queue anchored at `0` in that short-chat state so bubbles do not flicker during rapid scroll attempts.
- Add a regression test covering the padding-only scroll case and assert the newest-messages affordance stays hidden.

## Testing
- `npx vitest run tests/unit/chat-view.test.ts -t "prevents downward wheel scrolling into padding-only space for short chats"`
- `npx vitest run tests/unit/chat-view.test.ts`
- `npm test`
- Local browser validation against the dev server on a short conversation, confirming repeated downward scroll does not move the transcript and the latest-messages button stays absent.