### PR TITLE
Fix mobile sidebar layering and footer scroll behavior

### DIFF
--- a/components/shell.tsx
+++ b/components/shell.tsx
@@ -223,14 +223,14 @@ export function Shell({
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
             transition={{ duration: 0.2 }}
-            className="fixed inset-0 z-40 bg-black/70 backdrop-blur-sm md:hidden"
+            className="fixed inset-0 z-[60] bg-black/70 backdrop-blur-sm md:hidden"
             onClick={() => setIsSidebarOpen(false)}
           />
         )}
       </AnimatePresence>
 
       <div
-        className={`fixed inset-y-0 left-0 z-50 w-[280px] transform transition-transform duration-300 ease-out border-r border-white/5 ${
+        className={`fixed inset-y-0 left-0 z-[70] w-[280px] transform transition-transform duration-300 ease-out border-r border-white/5 md:z-50 ${
           isSidebarOpen ? "translate-x-0" : "-translate-x-full"
         } ${
           isDesktopSidebarOpen ? "md:translate-x-0" : "md:-translate-x-full"

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -1175,7 +1175,7 @@ export function Sidebar({
 
   return (
     <aside className="no-scrollbar flex h-full w-full flex-col bg-transparent text-gray-300">
-      <div className="flex h-full flex-col px-4 py-6">
+      <div className="flex h-full min-h-0 flex-col px-4 py-6">
         <div className="mb-8 px-2">
           <Link
             href="/"
@@ -1285,7 +1285,7 @@ export function Sidebar({
 
         <div
           ref={scrollContainerRef}
-          className="scrollbar-thin flex-1 overflow-y-auto overflow-x-hidden pr-1 -mr-1 space-y-8"
+          className="scrollbar-thin min-h-0 flex-1 overflow-y-auto overflow-x-hidden pr-1 -mr-1 space-y-8"
         >
           <div>
             <div className="flex items-center justify-between px-2 mb-3">
@@ -1344,7 +1344,9 @@ export function Sidebar({
           )}
         </div>
 
-        <SidebarFooterNav onNavigateAction={navigateToHref} />
+        <div className="shrink-0">
+          <SidebarFooterNav onNavigateAction={navigateToHref} />
+        </div>
       </div>
     </aside>
   );

--- a/tests/unit/shell-desktop-toggle.test.tsx
+++ b/tests/unit/shell-desktop-toggle.test.tsx
@@ -206,4 +206,19 @@ describe("Desktop Sidebar Toggle", () => {
     expect(screen.getByRole("button", { name: "Collapse sidebar" })).toBeInTheDocument();
     expect(screen.getByTestId("sidebar").parentElement).toHaveClass("md:translate-x-0");
   });
+
+  it("layers the open mobile sidebar above fixed chat composer content", () => {
+    mockPathname = "/chat/conv_existing";
+    setViewportWidth(390);
+
+    render(<Shell {...mockProps} />);
+    fireEvent.click(screen.getByRole("button", { name: "Open menu" }));
+
+    const overlay = Array.from(document.querySelectorAll("div")).find((element) => {
+      return element.className.includes("bg-black/70") && element.className.includes("md:hidden");
+    });
+
+    expect(overlay).toHaveClass("z-[60]");
+    expect(screen.getByTestId("sidebar").parentElement).toHaveClass("z-[70]");
+  });
 });

--- a/tests/unit/sidebar.test.tsx
+++ b/tests/unit/sidebar.test.tsx
@@ -1,8 +1,42 @@
 // @vitest-environment jsdom
 
-import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
 
-import { highlightMatch } from "@/components/sidebar";
+import { highlightMatch, Sidebar } from "@/components/sidebar";
+import type { ConversationListPage } from "@/lib/types";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/chat/conversation-1",
+  useRouter: () => ({
+    push: vi.fn(),
+    refresh: vi.fn()
+  })
+}));
+
+const conversationPage: ConversationListPage = {
+  conversations: [
+    {
+      id: "conversation-1",
+      title: "Mobile drawer layout",
+      titleGenerationStatus: "completed",
+      folderId: null,
+      providerProfileId: null,
+      automationId: null,
+      automationRunId: null,
+      conversationOrigin: "manual",
+      sortOrder: 0,
+      createdAt: "2026-05-07T12:00:00.000Z",
+      updatedAt: "2026-05-07T12:00:00.000Z",
+      isActive: false,
+      shareEnabled: false,
+      shareToken: null,
+      sharedAt: null
+    }
+  ],
+  hasMore: false,
+  nextCursor: null
+};
 
 describe("highlightMatch", () => {
   it("escapes raw html while preserving highlighted search text", () => {
@@ -12,5 +46,28 @@ describe("highlightMatch", () => {
     expect(result).toContain('<mark class="bg-[var(--accent)]/30 text-white rounded px-0.5">silver moon</mark>');
     expect(result).not.toContain("<img");
     expect(result).not.toContain('onerror="alert(1)"');
+  });
+});
+
+describe("Sidebar", () => {
+  it("keeps the footer outside a min-height scroll region in the mobile drawer", () => {
+    const { container } = render(<Sidebar conversationPage={conversationPage} folders={[]} />);
+
+    const sidebar = container.querySelector("aside");
+    const innerColumn = sidebar?.firstElementChild;
+    const scrollRegion = screen.getByText("Mobile drawer layout").closest(".overflow-y-auto");
+    const automationsLink = screen.getByRole("link", { name: /automations/i });
+    const settingsLink = screen.getByRole("link", { name: /settings/i });
+    const footerWrapper = automationsLink.parentElement?.parentElement;
+
+    expect(sidebar).toHaveClass("h-full");
+    expect(innerColumn).toHaveClass("min-h-0");
+    expect(scrollRegion).toHaveClass("flex-1");
+    expect(scrollRegion).toHaveClass("min-h-0");
+    expect(scrollRegion).toHaveClass("overflow-y-auto");
+    expect(scrollRegion).toContainElement(screen.getByText("Mobile drawer layout"));
+    expect(scrollRegion).not.toContainElement(automationsLink);
+    expect(scrollRegion).not.toContainElement(settingsLink);
+    expect(footerWrapper).toHaveClass("shrink-0");
   });
 });


### PR DESCRIPTION
## Summary
- Raise the mobile sidebar overlay and drawer above fixed composer content so the drawer stays interactive on small screens.
- Add `min-h-0` to the sidebar layout so the scroll region can shrink correctly.
- Keep the footer nav outside the scrollable area to prevent it from being pushed off-screen.
- Add unit coverage for the mobile layering and sidebar layout behavior.

## Testing
- Added/updated unit tests for mobile sidebar layering and sidebar scroll/footer structure.
- Not run (not requested).