### PR TITLE
Preserve DeepSeek reasoning content in OpenCode Go replay

### DIFF
--- a/lib/assistant-runtime.ts
+++ b/lib/assistant-runtime.ts
@@ -831,15 +831,9 @@ async function executeMcpToolCall(
 
   const resultMsg = buildToolResultMessage(toolCallId, resultText);
 
-  const assistantMsg: PromptMessage = {
-    role: "assistant",
-    content: "",
-    toolCalls: [{ id: toolCallId, name: functionName, arguments: JSON.stringify(correctedArgs) }]
-  };
-
   return {
     nextSortOrder: sortOrder,
-    promptMessages: [...context.promptMessages, assistantMsg, resultMsg]
+    promptMessages: [...context.promptMessages, resultMsg]
   };
 }
 
@@ -1411,6 +1405,16 @@ export async function resolveAssistantTurn(input: {
     if (answer) {
       await commitAnswerSegment(answer);
     }
+
+    promptMessages = [
+      ...promptMessages,
+      {
+        role: "assistant",
+        content: answer,
+        reasoningContent: thinking || undefined,
+        toolCalls
+      }
+    ];
 
     if (step === MAX_ASSISTANT_CONTROL_STEPS - 1) {
       const forcedResult = await forceDirectAnswerAfterToolLoop({

--- a/lib/model-capabilities.ts
+++ b/lib/model-capabilities.ts
@@ -19,6 +19,10 @@ export function supportsVisibleReasoning(model: string, apiMode: ApiMode) {
     return true;
   }
 
+  if (apiMode === "chat_completions" && normalized.startsWith("deepseek-")) {
+    return true;
+  }
+
   if (apiMode !== "responses") {
     return false;
   }

--- a/lib/provider.ts
+++ b/lib/provider.ts
@@ -150,7 +150,20 @@ function buildResponsesInput(messages: PromptMessage[]): any[] {
   return input;
 }
 
-function buildChatCompletionMessages(messages: PromptMessage[]): any[] {
+function usesDeepSeekThinkingReplay(settings: ProviderProfile) {
+  if (settings.apiMode !== "chat_completions") {
+    return false;
+  }
+
+  const model = settings.model.trim().toLowerCase();
+  const baseUrl = settings.apiBaseUrl.trim().toLowerCase();
+
+  return model.startsWith("deepseek-") || baseUrl.includes("deepseek.com");
+}
+
+function buildChatCompletionMessages(messages: PromptMessage[], settings?: ProviderProfile): any[] {
+  const replayReasoningContent = settings ? usesDeepSeekThinkingReplay(settings) : false;
+
   return messages.map((message) => {
     if (message.role === "tool") {
       return {
@@ -161,7 +174,7 @@ function buildChatCompletionMessages(messages: PromptMessage[]): any[] {
     }
 
     if (message.role === "assistant" && message.toolCalls?.length) {
-      return {
+      const assistantMessage: Record<string, unknown> = {
         role: "assistant" as const,
         content: typeof message.content === "string" && message.content.trim() ? message.content : null,
         tool_calls: message.toolCalls.map((tc) => ({
@@ -169,6 +182,23 @@ function buildChatCompletionMessages(messages: PromptMessage[]): any[] {
           type: "function" as const,
           function: { name: tc.name, arguments: tc.arguments }
         }))
+      };
+
+      if (replayReasoningContent && message.reasoningContent?.trim()) {
+        assistantMessage.reasoning_content = message.reasoningContent;
+        if (assistantMessage.content === null) {
+          assistantMessage.content = "";
+        }
+      }
+
+      return assistantMessage;
+    }
+
+    if (message.role === "assistant" && replayReasoningContent && message.reasoningContent?.trim()) {
+      return {
+        role: "assistant" as const,
+        content: toChatCompletionContentParts(message.content),
+        reasoning_content: message.reasoningContent
       };
     }
 
@@ -385,7 +415,7 @@ export async function callProviderText(input: {
 
   const response = await client.chat.completions.create({
     model: settings.model,
-    messages: buildChatCompletionMessages(contextualPrompt),
+    messages: buildChatCompletionMessages(contextualPrompt, settings),
     temperature: settings.temperature,
     max_completion_tokens: Math.min(settings.maxOutputTokens, 4000),
     ...buildChatCompletionsOptions(settings)
@@ -853,7 +883,7 @@ export async function* streamProviderResponse(input: {
 
   const chatCreateParams: Record<string, unknown> = {
     model: settings.model,
-    messages: buildChatCompletionMessages(contextualPromptMessages),
+    messages: buildChatCompletionMessages(contextualPromptMessages, settings),
     stream: true,
     temperature: settings.temperature,
     max_completion_tokens: settings.maxOutputTokens,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -491,6 +491,7 @@ export type PromptMessage = {
   content: string | PromptContentPart[];
   toolCallId?: string;
   toolCalls?: ProviderToolCall[];
+  reasoningContent?: string;
 };
 
 export type ToolDefinition = {

--- a/tests/unit/assistant-runtime.test.ts
+++ b/tests/unit/assistant-runtime.test.ts
@@ -1,4 +1,4 @@
-import type { ChatStreamEvent, ProviderProfileWithApiKey, Skill } from "@/lib/types";
+import type { ChatStreamEvent, PromptMessage, ProviderProfileWithApiKey, Skill } from "@/lib/types";
 
 const streamProviderResponse = vi.fn();
 const callProviderText = vi.fn();
@@ -242,6 +242,53 @@ ${JSON.stringify({
     expect(started).toEqual([expect.objectContaining({ kind: "skill_load", label: "Load skill", detail: "Release Notes" })]);
     expect(completed).toEqual([{ handle: "act_skill", resultSummary: "Skill instructions loaded." }]);
     expect(result.answer).toBe("Done");
+  });
+
+  it("keeps assistant reasoning on the replayed tool-call message", async () => {
+    streamProviderResponse
+      .mockReturnValueOnce(
+        createProviderStream([], {
+          answer: "",
+          thinking: "Need to load the release-notes skill.",
+          toolCalls: [{ id: "call_1", name: "load_skill", arguments: JSON.stringify({ skill_name: "Release Notes" }) }],
+          usage: { inputTokens: 10 }
+        })
+      )
+      .mockReturnValueOnce(
+        createProviderStream([{ type: "answer_delta", text: "Done" }], {
+          answer: "Done",
+          thinking: "",
+          usage: { inputTokens: 20, outputTokens: 1 }
+        })
+      );
+
+    const { resolveAssistantTurn } = await import("@/lib/assistant-runtime");
+
+    await resolveAssistantTurn({
+      settings: createSettings(),
+      promptMessages: [{ role: "user", content: "Write release notes" }],
+      skills: [createSkill()],
+      mcpToolSets: [],
+      onEvent: () => {},
+      onActionStart: () => "act_skill",
+      onActionComplete: () => {}
+    });
+
+    const replayMessages = (streamProviderResponse.mock.calls[1]?.[0]?.promptMessages ?? []) as PromptMessage[];
+    const assistantReplay = replayMessages.find((message) => message.role === "assistant");
+
+    expect(assistantReplay).toEqual(
+      expect.objectContaining({
+        role: "assistant",
+        reasoningContent: "Need to load the release-notes skill.",
+        toolCalls: [{ id: "call_1", name: "load_skill", arguments: JSON.stringify({ skill_name: "Release Notes" }) }]
+      })
+    );
+    expect(replayMessages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ role: "tool", toolCallId: "call_1" })
+      ])
+    );
   });
 
   it("injects enum values into MCP tool descriptions", async () => {

--- a/tests/unit/provider.test.ts
+++ b/tests/unit/provider.test.ts
@@ -889,6 +889,58 @@ describe("provider integration", () => {
     ]);
   });
 
+  it("replays assistant reasoning_content for DeepSeek chat-completions tool turns", async () => {
+    chatCreate.mockResolvedValue(
+      createAsyncStream([
+        { choices: [{ delta: { content: "Done" } }] }
+      ])
+    );
+
+    const { streamProviderResponse } = await import("@/lib/provider");
+    const stream = streamProviderResponse({
+      settings: createSettings({
+        apiBaseUrl: "https://opencode.ai/zen/go/v1",
+        model: "deepseek-v4-flash",
+        apiMode: "chat_completions"
+      }),
+      promptMessages: [
+        { role: "user", content: "What is the weather?" },
+        {
+          role: "assistant",
+          content: "",
+          reasoningContent: "I need the date before calling the weather tool.",
+          toolCalls: [{ id: "call_date", name: "get_date", arguments: "{}" }]
+        },
+        { role: "tool", toolCallId: "call_date", content: "2026-05-08" }
+      ]
+    });
+
+    while (!(await stream.next()).done) {
+      // drain
+    }
+
+    expect(chatCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messages: expect.arrayContaining([
+          expect.objectContaining({
+            role: "assistant",
+            reasoning_content: "I need the date before calling the weather tool.",
+            tool_calls: [
+              {
+                id: "call_date",
+                type: "function",
+                function: { name: "get_date", arguments: "{}" }
+              }
+            ]
+          })
+        ])
+      }),
+      expect.objectContaining({
+        signal: expect.any(AbortSignal)
+      })
+    );
+  });
+
   it("serializes assistant tool calls and accumulates streamed chat tool call chunks", async () => {
     chatCreate.mockResolvedValue(
       createAsyncStream([


### PR DESCRIPTION
## Summary
- Preserve assistant reasoning text on tool-call turns so follow-up requests can replay DeepSeek thinking mode correctly
- Serialize `reasoning_content` for DeepSeek chat-completions requests in the provider layer
- Extend model capability detection so DeepSeek chat-completions models are treated as reasoning-capable
- Add regression coverage for the runtime replay path and the DeepSeek request payload

## Testing
- `npm test` passed with global coverage above the repo threshold
- `npm run lint` passed
- `npm run typecheck` passed