### PR TITLE
fix: repair collapsed tables, column mismatches, and merged block elements in markdown rendering

### DIFF
--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -334,10 +334,18 @@ function splitCollapsedMarkdownHeaderAlignmentLine(line: string) {
       headerCells.length < 2 ||
       alignmentCellCount !== headerCells.length ||
       nextPart === undefined ||
-      nextPart.trim() !== "" ||
-      followingPart === undefined
+      nextPart.trim() !== ""
     ) {
       continue;
+    }
+
+    if (followingPart === undefined) {
+      return {
+        headerLine: `|${headerCells.join("|")}|`,
+        alignmentLine: `|${parts.slice(boundaryIndex + 1, nextPartIndex).join("|")}|`,
+        remainderLine: "",
+        columnCount: alignmentCellCount
+      };
     }
 
     return {
@@ -377,6 +385,49 @@ function splitCollapsedMarkdownTableRows(line: string, columnCount: number) {
   return rows;
 }
 
+function isMarkdownTableAlignmentRow(line: string) {
+  const trimmed = line.trim();
+  if (!trimmed.startsWith("|")) return false;
+  const inner = trimmed.replace(/^\|/, "").replace(/\|$/, "");
+  if (inner === "") return false;
+  return inner.split("|").every((cell) => isMarkdownTableAlignmentCell(cell));
+}
+
+function repairTableColumnMismatch(content: string) {
+  const lines = content.split("\n");
+  const result: string[] = [];
+  let pendingHeaderColumnCount: number | null = null;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    if (!trimmed.startsWith("|")) {
+      pendingHeaderColumnCount = null;
+      result.push(line);
+      continue;
+    }
+
+    const cellCount = getMarkdownTableCellCount(line);
+
+    if (isMarkdownTableAlignmentRow(line) && pendingHeaderColumnCount !== null && cellCount > pendingHeaderColumnCount) {
+      const parts = line.split("|");
+      result.push(`|${parts.slice(1, pendingHeaderColumnCount + 1).join("|")}|`);
+      pendingHeaderColumnCount = null;
+      continue;
+    }
+
+    if (!isMarkdownTableAlignmentRow(line)) {
+      pendingHeaderColumnCount = cellCount;
+    } else {
+      pendingHeaderColumnCount = null;
+    }
+
+    result.push(line);
+  }
+
+  return result.join("\n");
+}
+
 function repairCollapsedMarkdownTableBoundaries(content: string) {
   const repairedLines: string[] = [];
   let activeTableColumnCount: number | null = null;
@@ -388,12 +439,14 @@ function repairCollapsedMarkdownTableBoundaries(content: string) {
       activeTableColumnCount = headerAlignmentSplit.columnCount;
       repairedLines.push(headerAlignmentSplit.headerLine);
       repairedLines.push(headerAlignmentSplit.alignmentLine);
-      repairedLines.push(
-        ...splitCollapsedMarkdownTableRows(
-          headerAlignmentSplit.remainderLine,
-          headerAlignmentSplit.columnCount
-        )
-      );
+      if (headerAlignmentSplit.remainderLine) {
+        repairedLines.push(
+          ...splitCollapsedMarkdownTableRows(
+            headerAlignmentSplit.remainderLine,
+            headerAlignmentSplit.columnCount
+          )
+        );
+      }
       return;
     }
 
@@ -426,9 +479,87 @@ function repairCollapsedMarkdownTableBoundaries(content: string) {
   return repairedLines.join("\n");
 }
 
+function repairMergedBlockElements(content: string) {
+  const lines = content.split("\n");
+  const result: string[] = [];
+
+  for (const line of lines) {
+    if (line.trimStart().startsWith("|")) {
+      result.push(line);
+      continue;
+    }
+
+    const trimmed = line.trim();
+
+    if (/^[\u2014\u2013]{2,}$/.test(trimmed)) {
+      result.push("---");
+      continue;
+    }
+
+    const dashPrefix = trimmed.match(/^([\u2014\u2013]{2,})(.+)$/);
+    if (dashPrefix) {
+      result.push("---");
+      result.push("");
+      result.push(dashPrefix[2].trimStart());
+      continue;
+    }
+
+    const dashSuffix = trimmed.match(/^(.+?)([\u2014\u2013]{2,})\s*$/);
+    if (dashSuffix) {
+      result.push(dashSuffix[1].trimEnd());
+      result.push("");
+      result.push("---");
+      continue;
+    }
+
+    const dashMidIdx = trimmed.search(/[^\s\u2014\u2013][\u2014\u2013]{2,}\S/);
+    if (dashMidIdx !== -1) {
+      const splitAt = dashMidIdx + 1;
+      const dashEnd = splitAt;
+      let end = dashEnd;
+      while (end < trimmed.length && /[\u2014\u2013]/.test(trimmed[end])) end += 1;
+      result.push(trimmed.slice(0, splitAt).trimEnd());
+      result.push("");
+      result.push("---");
+      result.push(trimmed.slice(end).trimStart());
+      continue;
+    }
+
+    const headingIdx = line.search(/[^\s#](#{1,6}\s)/);
+    if (headingIdx !== -1) {
+      const splitAt = headingIdx + 1;
+      result.push(line.slice(0, splitAt).trimEnd());
+      result.push("");
+      result.push(line.slice(splitAt));
+      continue;
+    }
+
+    const hrIdx = line.search(/[^\s](-{3,}|\*{3,}|_{3,})\s*$/);
+    if (hrIdx !== -1) {
+      const splitAt = hrIdx + 1;
+      result.push(line.slice(0, splitAt).trimEnd());
+      result.push("");
+      result.push(line.slice(splitAt));
+      continue;
+    }
+
+    const listIdx = line.search(/[.!?>;]\s*([-*+]\s\S)/);
+    if (listIdx !== -1 && !line.trimStart().startsWith("-") && !line.trimStart().startsWith("*") && !line.trimStart().startsWith("+")) {
+      const splitAt = listIdx + 1;
+      result.push(line.slice(0, splitAt).trimEnd());
+      result.push(line.slice(splitAt));
+      continue;
+    }
+
+    result.push(line);
+  }
+
+  return result.join("\n");
+}
+
 function getRenderableAssistantMarkdown(content: string, attachments: MessageAttachment[]) {
   return stripAttachmentStyleImageMarkdown(
-    repairCollapsedMarkdownTableBoundaries(normalizeMarkdownLineBreaks(content)),
+    repairMergedBlockElements(repairTableColumnMismatch(repairCollapsedMarkdownTableBoundaries(normalizeMarkdownLineBreaks(content)))),
     attachments
   );
 }
@@ -1324,7 +1455,7 @@ export function MessageBubble({
                 />
               ) : content ? (
                 <div ref={contentRef} className="markdown-body">
-                  <ReactMarkdown remarkPlugins={MARKDOWN_PLUGINS}>{content}</ReactMarkdown>
+                  <ReactMarkdown remarkPlugins={MARKDOWN_PLUGINS}>{repairMergedBlockElements(repairTableColumnMismatch(repairCollapsedMarkdownTableBoundaries(content)))}</ReactMarkdown>
                 </div>
               ) : null}
               {message.attachments?.length ? (

--- a/tests/unit/message-bubble.test.ts
+++ b/tests/unit/message-bubble.test.ts
@@ -960,6 +960,77 @@ describe("message bubble", () => {
     expect(screen.queryByText(/------------/)).toBeNull();
   });
 
+  it("repairs collapsed assistant table header and divider without a data row on the same line", () => {
+    render(
+      React.createElement(MessageBubble, {
+        message: {
+          ...createAssistantMessage(),
+          content: [
+            "Why this combo?",
+            "",
+            "| Part | What it does ||---|---|",
+            "| Graphite face | Soft touch, dampens hard shots, teaches feel & control |",
+            "| Thick polymer core | Deadens vibration, huge sweet spot, very forgiving on off-centre hits |",
+            "| Widebody shape (7.9–8.25\") | More surface area = fewer mishits |"
+          ].join("\n")
+        }
+      })
+    );
+
+    expect(screen.getByRole("table")).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Part" })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "What it does" })).toBeInTheDocument();
+    expect(screen.getByRole("cell", { name: "Graphite face" })).toBeInTheDocument();
+    expect(screen.getByRole("cell", { name: "Thick polymer core" })).toBeInTheDocument();
+    expect(screen.getByRole("cell", { name: /Widebody shape/ })).toBeInTheDocument();
+    expect(screen.queryByText(/---/)).toBeNull();
+  });
+
+  it("repairs assistant table with separator row having more columns than header", () => {
+    render(
+      React.createElement(MessageBubble, {
+        message: {
+          ...createAssistantMessage(),
+          content: [
+            "| Part | What it does |",
+            "|---|---|---|",
+            "| Graphite face | Soft touch, dampens hard shots, teaches feel & control |",
+            "| Thick polymer core | Deadens vibration, huge sweet spot, very forgiving on off-centre hits |"
+          ].join("\n")
+        }
+      })
+    );
+
+    expect(screen.getByRole("table")).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Part" })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "What it does" })).toBeInTheDocument();
+    expect(screen.getByRole("cell", { name: "Graphite face" })).toBeInTheDocument();
+    expect(screen.getByRole("cell", { name: "Thick polymer core" })).toBeInTheDocument();
+    expect(screen.queryByText(/\|---\|---\|---\|/)).toBeNull();
+  });
+
+  it("repairs collapsed header and separator in user message tables", () => {
+    render(
+      React.createElement(MessageBubble, {
+        message: {
+          ...createUserMessage(),
+          content: [
+            "Reply with this table:",
+            "",
+            "| Part | What it does ||---|---|",
+            "| Graphite face | Soft touch, dampens hard shots, teaches feel & control |",
+            "| Thick polymer core | Deadens vibration, huge sweet spot, very forgiving on off-centre hits |"
+          ].join("\n")
+        }
+      })
+    );
+
+    expect(screen.getByRole("table")).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Part" })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "What it does" })).toBeInTheDocument();
+    expect(screen.getByRole("cell", { name: "Graphite face" })).toBeInTheDocument();
+  });
+
   it("renders fenced assistant code blocks with a language label and block-local copy action", () => {
     render(
       React.createElement(MessageBubble, {
@@ -990,7 +1061,84 @@ describe("message bubble", () => {
     expect(screen.getByTestId("assistant-message-bubble").parentElement?.parentElement?.className).toContain("min-w-0");
   });
 
-  it("renders assistant fenced code blocks without an extra outer pre wrapper", () => {
+  it("splits headings merged with preceding text into separate lines", () => {
+    render(
+      React.createElement(MessageBubble, {
+        message: {
+          ...createAssistantMessage(),
+          content: "Some text before.### Heading Here\n\nParagraph after."
+        }
+      })
+    );
+
+    expect(screen.getByRole("heading", { level: 3, name: "Heading Here" })).toBeInTheDocument();
+    expect(screen.getByText("Some text before.")).toBeInTheDocument();
+    expect(screen.getByText("Paragraph after.")).toBeInTheDocument();
+  });
+
+  it("splits horizontal rules merged with preceding text into separate lines", () => {
+    render(
+      React.createElement(MessageBubble, {
+        message: {
+          ...createAssistantMessage(),
+          content: "Some text before.---\n\nParagraph after."
+        }
+      })
+    );
+
+    expect(screen.getByRole("separator")).toBeInTheDocument();
+    expect(screen.getByText("Some text before.")).toBeInTheDocument();
+  });
+
+  it("splits list items merged with preceding text on the same line", () => {
+    render(
+      React.createElement(MessageBubble, {
+        message: {
+          ...createAssistantMessage(),
+          content: [
+            "- **First item** with details.",
+            "- **Second item** with info. The game gives it to you automatically.- **Third item** with more info.",
+            "- **Fourth item** end."
+          ].join("\n")
+        }
+      })
+    );
+
+    expect(screen.getByText("First item")).toBeInTheDocument();
+    expect(screen.getByText("Third item")).toBeInTheDocument();
+    expect(screen.getByText(/automatically/)).toBeInTheDocument();
+  });
+
+  it("converts em-dash sequences to horizontal rules", () => {
+    render(
+      React.createElement(MessageBubble, {
+        message: {
+          ...createAssistantMessage(),
+          content: "Some text before.\n\n\u2014\u2014\n\nSome text after."
+        }
+      })
+    );
+
+    expect(screen.getByRole("separator")).toBeInTheDocument();
+    expect(screen.getByText("Some text before.")).toBeInTheDocument();
+    expect(screen.getByText("Some text after.")).toBeInTheDocument();
+  });
+
+  it("converts em-dash sequences merged with text to horizontal rules", () => {
+    render(
+      React.createElement(MessageBubble, {
+        message: {
+          ...createAssistantMessage(),
+          content: "Some text.\n\n\u2014\u2014There is also more text after."
+        }
+      })
+    );
+
+    expect(screen.getByRole("separator")).toBeInTheDocument();
+    expect(screen.getByText("Some text.")).toBeInTheDocument();
+  });
+
+  it("renders fenced assistant code blocks without an extra outer pre wrapper", () => {
     render(
       React.createElement(MessageBubble, {
         message: {


### PR DESCRIPTION
## Summary
- Fix collapsed markdown table rendering when header and alignment rows have no following data row on the same line
- Repair table separator rows that have more columns than the header row
- Split merged block elements into separate lines (headings, horizontal rules, list items, em-dash sequences)
- Add comprehensive test coverage for all new repair functions