### PR TITLE
feat: add temporary chat mode

### DIFF
--- a/app/api/conversations/[conversationId]/route.ts
+++ b/app/api/conversations/[conversationId]/route.ts
@@ -9,6 +9,7 @@ import {
   listVisibleMessages,
   moveConversationToFolder,
   setConversationActive,
+  setConversationTemporary,
   updateConversationProviderProfile
 } from "@/lib/conversations";
 import { getConversationDebugStats } from "@/lib/compaction";
@@ -85,13 +86,15 @@ const updateSchema = z
   .object({
     folderId: z.string().nullable().optional(),
     providerProfileId: z.string().min(1).optional(),
-    isActive: z.boolean().optional()
+    isActive: z.boolean().optional(),
+    isTemporary: z.boolean().optional()
   })
   .refine(
     (value) =>
       value.folderId !== undefined ||
       value.providerProfileId !== undefined ||
-      value.isActive !== undefined,
+      value.isActive !== undefined ||
+      value.isTemporary !== undefined,
     "Invalid conversation update"
   );
 
@@ -138,6 +141,10 @@ export async function PATCH(
 
   if (body.data.isActive !== undefined) {
     setConversationActive(conversation.id, body.data.isActive);
+  }
+
+  if (body.data.isTemporary !== undefined) {
+    setConversationTemporary(conversation.id, body.data.isTemporary);
   }
 
   const updated = getConversation(conversation.id, user.id);

--- a/app/api/conversations/route.ts
+++ b/app/api/conversations/route.ts
@@ -36,7 +36,8 @@ export async function GET(request: Request) {
 const createSchema = z.object({
   title: z.string().optional(),
   folderId: z.string().nullable().optional(),
-  providerProfileId: z.string().min(1).optional()
+  providerProfileId: z.string().min(1).optional(),
+  isTemporary: z.boolean().optional()
 });
 
 export async function POST(request: Request) {
@@ -64,7 +65,8 @@ export async function POST(request: Request) {
   }
 
   const conversation = createConversation(title, folderId, {
-    providerProfileId
+    providerProfileId,
+    isTemporary: body.success ? body.data.isTemporary : undefined
   }, user.id);
 
   try {
@@ -76,7 +78,8 @@ export async function POST(request: Request) {
         folderId: conversation.folderId,
         createdAt: conversation.createdAt,
         updatedAt: conversation.updatedAt,
-        isActive: conversation.isActive
+        isActive: conversation.isActive,
+        isTemporary: conversation.isTemporary
       }
     }, user.id);
   } catch { /* WS server may not be running */ }

--- a/components/chat-composer.tsx
+++ b/components/chat-composer.tsx
@@ -256,29 +256,31 @@ export function ChatComposer({
   }));
 
   return (
-    <div className={cn("relative", isTemporary && !showTemporaryToggle && "pt-2.5")}>
+    <div className="relative">
       {isTemporary && !showTemporaryToggle && (
-        <div className="absolute -top-2.5 right-4 z-10 rounded-md bg-violet-500 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-white">
-          Temporary
+        <div className="absolute -top-[19px] right-4 z-10 flex items-center h-[19px]">
+          <div className="relative flex h-full items-center rounded-t-md border border-b-0 border-violet-500/50 border-dashed bg-zinc-900/70 backdrop-blur-2xl px-2.5 text-[10px] font-bold uppercase tracking-wider text-violet-300">
+            Temporary
+          </div>
         </div>
       )}
       {showTemporaryToggle && (
-        <div className="flex items-center justify-between px-3 pt-2">
-          <span />
+        <div className="absolute -top-[19px] right-4 z-10 flex items-center h-[19px]">
           <button
             type="button"
             onClick={() => onTemporaryChange?.(!isTemporary)}
+            style={{ fontSize: '10px' }}
             className={cn(
-              "flex items-center gap-2 rounded-lg px-2.5 py-1 text-[11px] font-medium transition-all duration-200",
+              "relative flex h-full items-center gap-1 rounded-t-md border border-b-0 px-2 font-bold uppercase tracking-wider transition-all duration-200",
               isTemporary
-                ? "bg-violet-500/15 text-violet-300"
-                : "text-white/40 hover:text-white/60 hover:bg-white/5"
+                ? "border-violet-500/50 border-dashed bg-zinc-900/70 backdrop-blur-2xl text-violet-300"
+                : "border-white/10 border-solid bg-zinc-900/70 backdrop-blur-2xl text-white/40 hover:text-white/60"
             )}
           >
             {isTemporary ? (
-              <ToggleRight className="h-4 w-4 text-violet-400" />
+              <ToggleRight className="h-3 w-3 text-violet-400" />
             ) : (
-              <ToggleLeft className="h-4 w-4" />
+              <ToggleLeft className="h-3 w-3" />
             )}
             Temporary
           </button>

--- a/components/chat-composer.tsx
+++ b/components/chat-composer.tsx
@@ -11,6 +11,8 @@ import {
   Mic,
   Paperclip,
   Square,
+  ToggleLeft,
+  ToggleRight,
   Users,
   X
 } from "lucide-react";
@@ -56,6 +58,9 @@ type ChatComposerProps = {
   onStartSpeech: () => void | Promise<void>;
   onStopSpeech: () => void | Promise<void>;
   queueingEnabled?: boolean;
+  isTemporary?: boolean;
+  showTemporaryToggle?: boolean;
+  onTemporaryChange?: (value: boolean) => void;
 };
 
 function CustomDropdown<T extends { id: string; name: string }>({
@@ -213,6 +218,9 @@ export function ChatComposer({
   onStartSpeech,
   onStopSpeech,
   queueingEnabled = false,
+  isTemporary = false,
+  showTemporaryToggle = false,
+  onTemporaryChange,
 }: ChatComposerProps) {
   const fileInputRef = React.useRef<HTMLInputElement | null>(null);
   const [mounted, setMounted] = useState(false);
@@ -248,9 +256,38 @@ export function ChatComposer({
   }));
 
   return (
+    <div className={cn("relative", isTemporary && !showTemporaryToggle && "pt-2.5")}>
+      {isTemporary && !showTemporaryToggle && (
+        <div className="absolute -top-2.5 right-4 z-10 rounded-md bg-violet-500 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-white">
+          Temporary
+        </div>
+      )}
+      {showTemporaryToggle && (
+        <div className="flex items-center justify-between px-3 pt-2">
+          <span />
+          <button
+            type="button"
+            onClick={() => onTemporaryChange?.(!isTemporary)}
+            className={cn(
+              "flex items-center gap-2 rounded-lg px-2.5 py-1 text-[11px] font-medium transition-all duration-200",
+              isTemporary
+                ? "bg-violet-500/15 text-violet-300"
+                : "text-white/40 hover:text-white/60 hover:bg-white/5"
+            )}
+          >
+            {isTemporary ? (
+              <ToggleRight className="h-4 w-4 text-violet-400" />
+            ) : (
+              <ToggleLeft className="h-4 w-4" />
+            )}
+            Temporary
+          </button>
+        </div>
+      )}
     <div
       className={cn(
-        "relative rounded-[22px] sm:rounded-[26px] border border-white/10 bg-zinc-900/70 backdrop-blur-2xl p-1.5 sm:p-2 shadow-[0_0_40px_rgba(0,0,0,0.5)] transition-all duration-500 focus-within:border-[var(--accent)]/30 focus-within:shadow-[0_0_50px_rgba(0,0,0,0.6),0_0_20px_var(--accent-soft)]",
+        "relative rounded-[22px] sm:rounded-[26px] border bg-zinc-900/70 backdrop-blur-2xl p-1.5 sm:p-2 shadow-[0_0_40px_rgba(0,0,0,0.5)] transition-all duration-500 focus-within:border-[var(--accent)]/30 focus-within:shadow-[0_0_50px_rgba(0,0,0,0.6),0_0_20px_var(--accent-soft)]",
+        isTemporary ? "border-violet-500/50 border-dashed" : "border-white/10",
         className
       )}
     >
@@ -516,6 +553,7 @@ export function ChatComposer({
           )}
         </div>
       </div>
+    </div>
     </div>
   );
 }

--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -1561,6 +1561,34 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
   }, [payload.conversation.id]);
 
   useEffect(() => {
+    if (!payload.conversation.isTemporary) {
+      return;
+    }
+
+    const conversationId = payload.conversation.id;
+
+    const handleBeforeUnload = () => {
+      fetch(`/api/conversations/${conversationId}`, { method: "DELETE", keepalive: true }).catch(() => {});
+    };
+
+    window.addEventListener("beforeunload", handleBeforeUnload);
+
+    return () => {
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+
+      if (typeof window === "undefined") {
+        return;
+      }
+
+      if (window.location.pathname === `/chat/${conversationId}`) {
+        return;
+      }
+
+      fetch(`/api/conversations/${conversationId}`, { method: "DELETE" }).catch(() => {});
+    };
+  }, [payload.conversation.id, payload.conversation.isTemporary]);
+
+  useEffect(() => {
     if (titleGenerationStatus === "completed" || titleGenerationStatus === "failed") {
       stopTitlePolling();
     }
@@ -2469,6 +2497,8 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
             speechLevel={speechSnapshot.level}
             speechError={speechSnapshot.error}
             queueingEnabled={isConversationActive}
+            isTemporary={payload.conversation.isTemporary}
+            showTemporaryToggle={false}
             onStartSpeech={() => {
               setError("");
               void startSpeech();

--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -492,6 +492,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
   const [error, setError] = useState("");
   const [isSending, setIsSending] = useState(false);
   const [isStopPending, setIsStopPending] = useState(false);
+  const [isTemporaryToggled, setIsTemporaryToggled] = useState(payload.conversation.isTemporary);
   const [streamThinkingTarget, setStreamThinkingTarget] = useState("");
   const [streamThinkingDisplay, setStreamThinkingDisplay] = useState("");
   const [streamAnswerTarget, setStreamAnswerTarget] = useState("");
@@ -1561,7 +1562,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
   }, [payload.conversation.id]);
 
   useEffect(() => {
-    if (!payload.conversation.isTemporary) {
+    if (!isTemporaryToggled) {
       return;
     }
 
@@ -1586,7 +1587,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
 
       fetch(`/api/conversations/${conversationId}`, { method: "DELETE" }).catch(() => {});
     };
-  }, [payload.conversation.id, payload.conversation.isTemporary]);
+  }, [payload.conversation.id, isTemporaryToggled]);
 
   useEffect(() => {
     if (titleGenerationStatus === "completed" || titleGenerationStatus === "failed") {
@@ -2497,8 +2498,16 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
             speechLevel={speechSnapshot.level}
             speechError={speechSnapshot.error}
             queueingEnabled={isConversationActive}
-            isTemporary={payload.conversation.isTemporary}
-            showTemporaryToggle={false}
+            isTemporary={isTemporaryToggled}
+            showTemporaryToggle={messages.length === 0}
+            onTemporaryChange={(value: boolean) => {
+              setIsTemporaryToggled(value);
+              fetch(`/api/conversations/${payload.conversation.id}`, {
+                method: "PATCH",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ isTemporary: value })
+              }).catch(() => {});
+            }}
             onStartSpeech={() => {
               setError("");
               void startSpeech();

--- a/components/home-view.tsx
+++ b/components/home-view.tsx
@@ -39,6 +39,7 @@ export function HomeView({
   const [personas, setPersonas] = useState<Array<{ id: string; name: string }>>([]);
   const [personaId, setPersonaId] = useState<string | null>(null);
   const [draftConversationId, setDraftConversationId] = useState<string | null>(null);
+  const [isTemporary, setIsTemporary] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const dragDepthRef = useRef(0);
   const {
@@ -97,7 +98,8 @@ export function HomeView({
         "Content-Type": "application/json"
       },
       body: JSON.stringify({
-        providerProfileId
+        providerProfileId,
+        isTemporary
       })
     });
 
@@ -371,6 +373,9 @@ export function HomeView({
               setInput((current) => appendTranscriptToDraft(current, transcript));
             });
           }}
+          isTemporary={isTemporary}
+          showTemporaryToggle={true}
+          onTemporaryChange={setIsTemporary}
         />
 
         {error ? (

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -898,8 +898,12 @@ export function Sidebar({
     return addGlobalWsListener((msg: ServerMessage) => {
       switch (msg.type) {
         case "conversation_created": {
+          const newConv = msg.conversation as Conversation;
+          if (newConv.isTemporary) {
+            break;
+          }
           setLocalConversations((current) =>
-            mergeConversations([msg.conversation as Conversation], current)
+            mergeConversations([newConv], current)
           );
           break;
         }

--- a/lib/conversations.ts
+++ b/lib/conversations.ts
@@ -630,6 +630,12 @@ export function setConversationActive(conversationId: string, active: boolean) {
     .run(active ? 1 : 0, timestamp, conversationId);
 }
 
+export function setConversationTemporary(conversationId: string, temporary: boolean) {
+  getDb()
+    .prepare("UPDATE conversations SET is_temporary = ? WHERE id = ?")
+    .run(temporary ? 1 : 0, conversationId);
+}
+
 export function createMessage(input: {
   conversationId: string;
   role: MessageRole;

--- a/lib/conversations.ts
+++ b/lib/conversations.ts
@@ -66,6 +66,7 @@ type ConversationRow = {
   share_token: string | null;
   share_enabled: number;
   shared_at: string | null;
+  is_temporary: number;
 };
 
 type ConversationCursor = {
@@ -102,7 +103,8 @@ function rowToConversation(row: ConversationRow): Conversation {
     isActive: row.is_active === 1,
     shareEnabled: row.share_enabled === 1,
     shareToken: row.share_token,
-    sharedAt: row.shared_at
+    sharedAt: row.shared_at,
+    isTemporary: row.is_temporary === 1
   };
 }
 
@@ -120,8 +122,9 @@ function selectConversationColumns(activityTimestamp: string) {
             ${activityTimestamp} AS updated_at,
             c.is_active,
             c.share_token,
-            c.share_enabled,
-            c.shared_at`;
+             c.share_enabled,
+             c.shared_at,
+             c.is_temporary`;
 }
 
 function generateShareToken() {
@@ -320,6 +323,7 @@ export function listConversations(userId?: string) {
            FROM conversations c
            WHERE c.user_id = ?
              AND c.conversation_origin = ?
+             AND c.is_temporary = 0
            ORDER BY ${activityTimestamp} DESC, c.id DESC`
         )
         .all(userId, MANUAL_CONVERSATION_ORIGIN)
@@ -329,6 +333,7 @@ export function listConversations(userId?: string) {
             ${selectConversationColumns(activityTimestamp)}
            FROM conversations c
            WHERE c.conversation_origin = ?
+             AND c.is_temporary = 0
            ORDER BY ${activityTimestamp} DESC, c.id DESC`
         )
         .all(MANUAL_CONVERSATION_ORIGIN)) as ConversationRow[];
@@ -353,6 +358,7 @@ export function listConversationsPage(input: {
             ${selectConversationColumns(activityTimestamp)}
            FROM conversations c
            WHERE ${userCondition}c.conversation_origin = ?
+             AND c.is_temporary = 0
              AND (
                ${activityTimestamp} < ?
                OR (${activityTimestamp} = ? AND c.id < ?)
@@ -374,6 +380,7 @@ export function listConversationsPage(input: {
             ${selectConversationColumns(activityTimestamp)}
            FROM conversations c
            WHERE ${userCondition}c.conversation_origin = ?
+             AND c.is_temporary = 0
            ORDER BY ${activityTimestamp} DESC, c.id DESC
            LIMIT ?`
         )
@@ -434,6 +441,7 @@ export function createConversation(
     origin?: ConversationOrigin;
     automationId?: string | null;
     automationRunId?: string | null;
+    isTemporary?: boolean;
   },
   userId?: string
 ) {
@@ -464,7 +472,8 @@ export function createConversation(
     isActive: false,
     shareEnabled: false,
     shareToken: null,
-    sharedAt: null
+    sharedAt: null,
+    isTemporary: options?.isTemporary ?? false
   };
 
   getDb()
@@ -485,8 +494,9 @@ export function createConversation(
         sort_order,
         created_at,
         updated_at,
-        is_active
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        is_active,
+        is_temporary
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     )
     .run(
       conversation.id,
@@ -504,7 +514,8 @@ export function createConversation(
       conversation.sortOrder,
       conversation.createdAt,
       conversation.updatedAt,
-      0
+      0,
+      conversation.isTemporary ? 1 : 0
     );
 
   return conversation;
@@ -2560,7 +2571,8 @@ export function searchConversations(query: string, userId?: string): Conversatio
         AND m.content LIKE ?
         AND (m.role != 'system' OR m.system_kind IS NOT NULL)
        WHERE ${userCondition}c.conversation_origin = ?
-         AND (
+          AND c.is_temporary = 0
+          AND (
            c.title LIKE ?
            OR m.id IS NOT NULL
          )

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -449,8 +449,8 @@ function migrate(db: Database.Database) {
   }
   if (!automationConversationCols.some((col) => col.name === "is_temporary")) {
     db.exec("ALTER TABLE conversations ADD COLUMN is_temporary INTEGER NOT NULL DEFAULT 0");
+    db.exec("DELETE FROM conversations WHERE is_temporary = 1");
   }
-  db.exec("DELETE FROM conversations WHERE is_temporary = 1");
 
   const messageActionCols = db.prepare("PRAGMA table_info(message_actions)").all() as Array<{ name: string }>;
   if (!messageActionCols.some((col) => col.name === "proposal_state")) {

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -447,6 +447,10 @@ function migrate(db: Database.Database) {
       "ALTER TABLE conversations ADD COLUMN conversation_origin TEXT NOT NULL DEFAULT 'manual'"
     );
   }
+  if (!automationConversationCols.some((col) => col.name === "is_temporary")) {
+    db.exec("ALTER TABLE conversations ADD COLUMN is_temporary INTEGER NOT NULL DEFAULT 0");
+  }
+  db.exec("DELETE FROM conversations WHERE is_temporary = 1");
 
   const messageActionCols = db.prepare("PRAGMA table_info(message_actions)").all() as Array<{ name: string }>;
   if (!messageActionCols.some((col) => col.name === "proposal_state")) {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -151,6 +151,7 @@ export type Conversation = {
   shareEnabled: boolean;
   shareToken: string | null;
   sharedAt: string | null;
+  isTemporary: boolean;
 };
 
 export type ConversationSearchResult = Conversation & {

--- a/lib/ws-protocol.ts
+++ b/lib/ws-protocol.ts
@@ -17,7 +17,7 @@ export type ServerMessage =
   | { type: "queue_updated"; conversationId: string; queuedMessages: QueuedMessage[] }
   | { type: "delta"; conversationId: string; event: ChatStreamEvent }
   | { type: "error"; message: string }
-  | { type: "conversation_created"; conversation: { id: string; title: string; folderId: string | null; createdAt: string; updatedAt: string; isActive: boolean } }
+  | { type: "conversation_created"; conversation: { id: string; title: string; folderId: string | null; createdAt: string; updatedAt: string; isActive: boolean; isTemporary: boolean } }
   | { type: "conversation_deleted"; conversationId: string }
   | { type: "conversation_updated"; conversation: { id: string; title: string; folderId: string | null; updatedAt: string; isActive: boolean } }
   | { type: "conversation_activity"; conversationId: string; isActive: boolean }

--- a/tests/unit/chat-view.test.ts
+++ b/tests/unit/chat-view.test.ts
@@ -193,7 +193,8 @@ function createPayload(overrides: Partial<ChatViewPayload> = {}): ChatViewPayloa
       isActive: false,
       shareEnabled: false,
       shareToken: null,
-      sharedAt: null
+      sharedAt: null,
+      isTemporary: false
     },
     messages: [] as Message[],
     queuedMessages: [],

--- a/tests/unit/shared-conversation-view.test.tsx
+++ b/tests/unit/shared-conversation-view.test.tsx
@@ -23,7 +23,8 @@ function createConversation(): Conversation {
     isActive: false,
     shareEnabled: true,
     shareToken: "share_token_1234567890",
-    sharedAt: "2026-05-06T12:06:00.000Z"
+    sharedAt: "2026-05-06T12:06:00.000Z",
+    isTemporary: false
   };
 }
 

--- a/tests/unit/shell-share.test.tsx
+++ b/tests/unit/shell-share.test.tsx
@@ -43,7 +43,8 @@ const conversation: Conversation = {
   isActive: false,
   shareEnabled: false,
   shareToken: null,
-  sharedAt: null
+  sharedAt: null,
+  isTemporary: false
 };
 
 const conversationPage: ConversationListPage = {

--- a/tests/unit/sidebar.test.tsx
+++ b/tests/unit/sidebar.test.tsx
@@ -31,7 +31,8 @@ const conversationPage: ConversationListPage = {
       isActive: false,
       shareEnabled: false,
       shareToken: null,
-      sharedAt: null
+      sharedAt: null,
+      isTemporary: false
     }
   ],
   hasMore: false,

--- a/tests/unit/temporary-chat.test.ts
+++ b/tests/unit/temporary-chat.test.ts
@@ -1,0 +1,100 @@
+import fs from "node:fs";
+import path from "node:path";
+import {
+  createConversation,
+  deleteConversation,
+  getConversation,
+  listConversations,
+  listConversationsPage,
+  searchConversations,
+  createMessage,
+  getConversationSnapshot
+} from "@/lib/conversations";
+import { resetDbForTests } from "@/lib/db";
+import { updateSettings } from "@/lib/settings";
+
+describe("temporary chat", () => {
+  beforeEach(() => {
+    resetDbForTests();
+    updateSettings({
+      defaultProviderProfileId: "profile_default",
+      skillsEnabled: true,
+      providerProfiles: [
+        {
+          id: "profile_default",
+          name: "Default",
+          apiBaseUrl: "https://api.example.com/v1",
+          apiKey: "sk-test",
+          model: "gpt-5-mini",
+          apiMode: "responses",
+          systemPrompt: "Be exact.",
+          temperature: 0.2,
+          maxOutputTokens: 512,
+          reasoningEffort: "medium",
+          reasoningSummaryEnabled: true,
+          modelContextLimit: 16000,
+          compactionThreshold: 0.8,
+          freshTailCount: 12
+        }
+      ]
+    });
+  });
+
+  it("creates a temporary conversation with isTemporary flag", () => {
+    const conv = createConversation(null, null, { isTemporary: true });
+    expect(conv.isTemporary).toBe(true);
+
+    const loaded = getConversation(conv.id);
+    expect(loaded?.isTemporary).toBe(true);
+  });
+
+  it("creates a regular conversation without isTemporary by default", () => {
+    const conv = createConversation();
+    expect(conv.isTemporary).toBe(false);
+  });
+
+  it("excludes temporary conversations from listConversations", () => {
+    createConversation("Regular", null, undefined);
+    createConversation("Temp", null, { isTemporary: true });
+
+    const all = listConversations();
+    expect(all).toHaveLength(1);
+    expect(all[0].title).toBe("Regular");
+  });
+
+  it("excludes temporary conversations from listConversationsPage", () => {
+    createConversation("Regular", null, undefined);
+    createConversation("Temp", null, { isTemporary: true });
+
+    const page = listConversationsPage({ limit: 10 });
+    expect(page.conversations).toHaveLength(1);
+    expect(page.conversations[0].title).toBe("Regular");
+  });
+
+  it("excludes temporary conversations from searchConversations", () => {
+    const regular = createConversation("Important Topic", null, undefined);
+    createConversation("Important Secret", null, { isTemporary: true });
+    createMessage({ conversationId: regular.id, role: "user", content: "Important details here" });
+
+    const results = searchConversations("Important");
+    expect(results.length).toBe(1);
+    expect(results[0].title).toBe("Important Topic");
+  });
+
+  it("can delete a temporary conversation", () => {
+    const conv = createConversation(null, null, { isTemporary: true });
+    expect(deleteConversation(conv.id)).toBe(true);
+    expect(getConversation(conv.id)).toBeNull();
+  });
+
+  it("temporary conversation supports full snapshot with messages", () => {
+    const conv = createConversation(null, null, { isTemporary: true });
+    createMessage({ conversationId: conv.id, role: "user", content: "Hello temp" });
+    createMessage({ conversationId: conv.id, role: "assistant", content: "Hi there" });
+
+    const snapshot = getConversationSnapshot(conv.id);
+    expect(snapshot).not.toBeNull();
+    expect(snapshot!.conversation.isTemporary).toBe(true);
+    expect(snapshot!.messages.length).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `is_temporary` column to conversations schema and types
- Server-side temporary conversation CRUD with listing/search filtering
- Accept `isTemporary` in conversation creation API and WS broadcast
- Filter temporary conversations from sidebar WS events
- Add temporary chat toggle UI with purple dashed border to composer
- Wire temporary toggle in home view to conversation creation
- Wire temporary chat cleanup in chat view with beforeunload
- Allow toggling temporary mode before first message
- Add unit tests for temporary chat behavior