### PR TITLE
feat: auto-expanding textarea in chat composer

### DIFF
--- a/components/chat-composer.tsx
+++ b/components/chat-composer.tsx
@@ -22,6 +22,7 @@ import { ContextGauge } from "@/components/context-gauge";
 import { Textarea } from "@/components/ui/textarea";
 import type { SpeechPhase } from "@/lib/speech/types";
 import { cn } from "@/lib/utils";
+import { useAutoResize } from "@/lib/use-auto-resize";
 import type {
   MessageAttachment,
   ProviderProfileSummary
@@ -224,6 +225,11 @@ export function ChatComposer({
 }: ChatComposerProps) {
   const fileInputRef = React.useRef<HTMLInputElement | null>(null);
   const [mounted, setMounted] = useState(false);
+  const { height: textareaHeight } = useAutoResize({
+    ref: textareaRef as React.RefObject<HTMLTextAreaElement | null>,
+    value: input
+  });
+  const isExpanded = textareaHeight > 60;
 
   useEffect(() => {
     setMounted(true);
@@ -361,15 +367,15 @@ export function ChatComposer({
         ) : null}
       </AnimatePresence>
 
-      <div className="flex w-full items-center gap-2 pb-1 pr-1.5">
+      <div className={cn("flex w-full gap-2 pb-1 pr-1.5", isExpanded ? "items-end" : "items-center")}>
         <div className="flex-1 min-w-0">
           <Textarea
             ref={textareaRef}
             value={input}
             onChange={(event) => onInputChange(event.target.value)}
             placeholder="Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
-            className="max-h-[300px] min-h-[52px] w-full resize-none border-0 bg-transparent px-4 py-3.5 text-[15px] text-[var(--text)] focus-visible:ring-0 focus:outline-none scrollbar-thin placeholder:text-white/20 caret-[var(--accent)]"
-            style={{ height: "auto" }}
+            className="max-h-[60vh] min-h-[52px] w-full resize-none border-0 bg-transparent px-4 py-3.5 text-[15px] text-[var(--text)] focus-visible:ring-0 focus:outline-none scrollbar-thin placeholder:text-white/20 caret-[var(--accent)] overflow-y-auto"
+            style={{ height: `${textareaHeight}px`, transition: "height 150ms ease" }}
             onKeyDown={(event) => {
               if (event.key === "Enter" && !event.shiftKey) {
                 event.preventDefault();

--- a/lib/use-auto-resize.ts
+++ b/lib/use-auto-resize.ts
@@ -1,0 +1,30 @@
+"use client";
+
+import { useCallback, useLayoutEffect, useState } from "react";
+
+type UseAutoResizeOptions = {
+  ref: React.RefObject<HTMLTextAreaElement | null>;
+  value: string;
+  minHeight?: number;
+};
+
+export function useAutoResize({ ref, value, minHeight = 52 }: UseAutoResizeOptions) {
+  const [height, setHeight] = useState<number>(minHeight);
+
+  const adjustHeight = useCallback(() => {
+    const textarea = ref.current;
+    if (!textarea) return;
+
+    textarea.style.height = "auto";
+    const scrollHeight = textarea.scrollHeight;
+    const newHeight = Math.max(minHeight, scrollHeight);
+    textarea.style.height = `${newHeight}px`;
+    setHeight(newHeight);
+  }, [ref, minHeight]);
+
+  useLayoutEffect(() => {
+    adjustHeight();
+  }, [value, adjustHeight]);
+
+  return { height };
+}

--- a/tests/unit/use-auto-resize.test.ts
+++ b/tests/unit/use-auto-resize.test.ts
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+
+import { useAutoResize } from "@/lib/use-auto-resize";
+
+function createTextarea(scrollHeight: number) {
+  const textarea = document.createElement("textarea");
+  Object.defineProperty(textarea, "scrollHeight", {
+    get: () => scrollHeight,
+    configurable: true
+  });
+  vi.spyOn(textarea.style, "height", "set");
+  return textarea;
+}
+
+describe("useAutoResize", () => {
+  it("sets height to scrollHeight when content grows", () => {
+    const textarea = createTextarea(120);
+    const ref = { current: textarea };
+
+    const { result } = renderHook(() =>
+      useAutoResize({ ref, value: "hello\nworld" })
+    );
+
+    expect(result.current.height).toBe(120);
+    expect(textarea.style.height).toBe("120px");
+  });
+
+  it("respects minHeight when scrollHeight is smaller", () => {
+    const textarea = createTextarea(30);
+    const ref = { current: textarea };
+
+    const { result } = renderHook(() =>
+      useAutoResize({ ref, value: "hi", minHeight: 52 })
+    );
+
+    expect(result.current.height).toBe(52);
+    expect(textarea.style.height).toBe("52px");
+  });
+
+  it("adjusts height when value changes", () => {
+    const textarea = createTextarea(80);
+    const ref = { current: textarea };
+
+    const { result, rerender } = renderHook(
+      ({ value }) => useAutoResize({ ref, value }),
+      { initialProps: { value: "short" } }
+    );
+
+    expect(result.current.height).toBe(80);
+
+    Object.defineProperty(textarea, "scrollHeight", { get: () => 200, configurable: true });
+    rerender({ value: "short\nmuch\nlonger\ntext\nhere" });
+
+    expect(result.current.height).toBe(200);
+    expect(textarea.style.height).toBe("200px");
+  });
+
+  it("shrinks back when text is deleted", () => {
+    const textarea = createTextarea(200);
+    const ref = { current: textarea };
+
+    const { result, rerender } = renderHook(
+      ({ value }) => useAutoResize({ ref, value }),
+      { initialProps: { value: "long text" } }
+    );
+
+    expect(result.current.height).toBe(200);
+
+    Object.defineProperty(textarea, "scrollHeight", { get: () => 80, configurable: true });
+    rerender({ value: "short" });
+
+    expect(result.current.height).toBe(80);
+  });
+
+  it("uses default minHeight of 52", () => {
+    const textarea = createTextarea(30);
+    const ref = { current: textarea };
+
+    const { result } = renderHook(() =>
+      useAutoResize({ ref, value: "" })
+    );
+
+    expect(result.current.height).toBe(52);
+  });
+
+  it("does nothing when ref.current is null", () => {
+    const ref = { current: null };
+
+    const { result } = renderHook(() =>
+      useAutoResize({ ref, value: "hello" })
+    );
+
+    expect(result.current.height).toBe(52);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `useAutoResize` hook that dynamically adjusts textarea height based on content (`lib/use-auto-resize.ts`)
- Integrate the hook into `ChatComposer`, replacing the static `height: auto` with smooth animated expansion
- Switch bottom toolbar alignment from `items-center` to `items-end` when the textarea expands past its minimum height
- Change max height from fixed `300px` to `60vh` for better viewport responsiveness
- Add comprehensive unit tests for the hook (grows, shrinks, respects minHeight, handles null ref)