### PR TITLE
refactor: standardize settings UI across all pages

### DIFF
--- a/components/settings/sections/account-section.tsx
+++ b/components/settings/sections/account-section.tsx
@@ -6,7 +6,6 @@ import { Shield, Check } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import type { AuthUser } from "@/lib/types";
 
 export function AccountSection({ user }: { user: AuthUser }) {
@@ -37,17 +36,21 @@ export function AccountSection({ user }: { user: AuthUser }) {
     router.refresh();
   }
 
+  const fieldLabel = "block text-[13px] font-medium text-[var(--muted)] mb-1.5";
+  const inputLike = "w-full rounded-xl border border-white/6 bg-white/4 px-4 py-3 text-sm text-[var(--text)] outline-none transition-all duration-200 focus:border-[var(--accent)]/40 focus:bg-white/6 focus:shadow-[0_0_0_3px_var(--accent-soft)]";
+  const selectLike = `${inputLike} appearance-none bg-[url('data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2224%22%20height%3D%2224%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20stroke%3D%22%2371717a%22%20stroke-width%3D%222%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%3E%3Cpolyline%20points%3D%226%209%2012%2015%2018%209%22%3E%3C%2Fpolyline%3E%3C%2Fsvg%3E')] bg-[length:1rem_1rem] bg-[right_0.75rem_center] bg-no-repeat pr-10`;
+  const sectionTitle = "text-sm font-semibold text-[var(--text)]";
+  const sectionDivider = "border-t border-white/[0.06]";
+
   return (
     <div className="w-full max-w-none space-y-6 p-6 md:max-w-[55%] md:p-8">
-      <div className="rounded-2xl border border-white/6 bg-white/[0.02] p-6 space-y-6">
+      <div className="space-y-6">
         <div className="flex items-center gap-3">
           <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-sky-500/10 text-sky-300">
             <Shield className="h-4 w-4" />
           </div>
           <div>
-            <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-sky-300">
-              Account
-            </p>
+            <p className={sectionTitle}>Account</p>
             <h2
               className="mt-1 text-2xl leading-none text-[var(--text)]"
               style={{ fontFamily: "var(--font-display)" }}
@@ -60,7 +63,7 @@ export function AccountSection({ user }: { user: AuthUser }) {
         {isEnvManaged ? (
           <div className="space-y-4">
             <div>
-              <Label>Username</Label>
+              <label className={fieldLabel}>Username</label>
               <Input value={user.username} readOnly disabled />
             </div>
             <div className="rounded-2xl border border-amber-300/12 bg-amber-300/8 px-4 py-4 text-sm leading-6 text-amber-100/90">
@@ -72,11 +75,11 @@ export function AccountSection({ user }: { user: AuthUser }) {
           <form onSubmit={(event) => void handleAccount(event)} className="space-y-6">
             <div className="space-y-3">
               <div>
-                <Label>Username</Label>
+                <label className={fieldLabel}>Username</label>
                 <Input name="username" defaultValue={user.username} />
               </div>
               <div>
-                <Label>New password</Label>
+                <label className={fieldLabel}>New password</label>
                 <Input
                   name="password"
                   type="password"
@@ -85,17 +88,17 @@ export function AccountSection({ user }: { user: AuthUser }) {
               </div>
             </div>
 
-            <div className="space-y-3">
-              <Button type="submit" variant="secondary">
-                Update account
+            <div className="flex flex-wrap items-center gap-2">
+              <Button type="submit" className="px-3 py-1.5 text-xs">
+                Save
               </Button>
-              {accountSuccess ? (
-                <div className="flex items-center gap-1.5 text-sm text-emerald-400">
-                  <Check className="h-3.5 w-3.5" />
-                  {accountSuccess}
-                </div>
-              ) : null}
             </div>
+            {accountSuccess ? (
+              <div className="flex items-center gap-1.5 text-sm text-emerald-400">
+                <Check className="h-3.5 w-3.5" />
+                {accountSuccess}
+              </div>
+            ) : null}
           </form>
         )}
       </div>

--- a/components/settings/sections/automations-section.tsx
+++ b/components/settings/sections/automations-section.tsx
@@ -7,7 +7,6 @@ import { ProfileCard } from "@/components/settings/profile-card";
 import { SettingsSplitPane } from "@/components/settings/settings-split-pane";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import type { Automation, Persona } from "@/lib/types";
 
@@ -41,9 +40,6 @@ const WEEKDAYS = [
   { value: 6, label: "Sat" },
   { value: 0, label: "Sun" }
 ] as const;
-
-const selectClassName =
-  "w-full rounded-xl border border-white/6 bg-white/4 px-4 py-3 text-sm text-[var(--text)] outline-none transition-all duration-200 focus:border-[var(--accent)]/40 focus:bg-white/6 focus:shadow-[0_0_0_3px_var(--accent-soft)]";
 
 function createDefaultForm(providerProfileId = ""): AutomationFormState {
   return {
@@ -286,14 +282,20 @@ export function AutomationsSection() {
 
   const showDetail = isAddingNew || Boolean(selectedAutomationId);
 
+  const fieldLabel = "block text-[13px] font-medium text-[var(--muted)] mb-1.5";
+  const inputLike = "w-full rounded-xl border border-white/6 bg-white/4 px-4 py-3 text-sm text-[var(--text)] outline-none transition-all duration-200 focus:border-[var(--accent)]/40 focus:bg-white/6 focus:shadow-[0_0_0_3px_var(--accent-soft)]";
+  const selectLike = `${inputLike} appearance-none bg-[url('data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2224%22%20height%3D%2224%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20stroke%3D%22%2371717a%22%20stroke-width%3D%222%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%3E%3Cpolyline%20points%3D%226%209%2012%2015%2018%209%22%3E%3C%2Fpolyline%3E%3C%2Fsvg%3E')] bg-[length:1rem_1rem] bg-[right_0.75rem_center] bg-no-repeat pr-10`;
+  const sectionTitle = "text-sm font-semibold text-[var(--text)]";
+  const sectionDivider = "border-t border-white/[0.06]";
+
   return (
     <div className="min-h-0 p-4 md:h-full md:p-8">
       <SettingsSplitPane
         listHeader={
           <div className="flex w-full items-center justify-between">
             <div>
-              <h2 className="text-[0.9rem] font-semibold text-[#f4f4f5]">Scheduled automations</h2>
-              <p className="text-[0.68rem] text-[#52525b]">
+              <h2 className="text-sm font-semibold text-[var(--text)]">Scheduled automations</h2>
+              <p className="text-xs text-[var(--muted)]">
                 {automations.length} automation{automations.length === 1 ? "" : "s"}
               </p>
             </div>
@@ -301,23 +303,23 @@ export function AutomationsSection() {
               <button
                 type="button"
                 onClick={openNewAutomation}
-                className="flex h-7 w-7 items-center justify-center rounded-lg border border-white/6 bg-white/[0.03] text-[#71717a] transition-all duration-200 hover:bg-white/[0.06] hover:text-[#f4f4f5]"
+                className="flex h-7 w-7 items-center justify-center rounded-lg border border-white/[0.08] bg-white/[0.04] text-[var(--muted)] transition-all duration-200 hover:bg-white/[0.07] hover:text-[var(--text)]"
                 aria-label="Add automation"
               >
-                <Plus className="h-4 w-4" />
+                <Plus className="h-3.5 w-3.5" />
               </button>
             </div>
           </div>
         }
         listPanel={
           isLoading ? (
-            <div className="px-3 py-6 text-sm text-[#71717a]">Loading automations...</div>
+            <div className="px-3 py-6 text-sm text-[var(--muted)]">Loading automations...</div>
           ) : automations.length === 0 ? (
             <div className="flex flex-col items-center py-16 text-center">
               <div className="mb-4 flex h-11 w-11 items-center justify-center rounded-xl border border-white/6 bg-white/[0.03]">
-                <Clock3 className="h-4 w-4 text-[#52525b]" />
+                <Clock3 className="h-4 w-4 text-[var(--muted)]" />
               </div>
-              <p className="max-w-[180px] text-xs leading-5 text-[#71717a]">
+              <p className="max-w-[180px] text-xs leading-5 text-[var(--muted)]">
                 Create scheduled automations here. Runs will appear in the dedicated Automations workspace.
               </p>
             </div>
@@ -338,235 +340,249 @@ export function AutomationsSection() {
         isDetailVisible={mobileDetailVisible}
         onBackAction={() => setMobileDetailVisible(false)}
         detailPanel={
-          <div className="max-w-[620px] space-y-6">
+          <div className="w-full max-w-[720px]">
             {showDetail ? (
-              <>
-                <div className="flex items-start justify-between gap-3">
-                  <div className="space-y-1">
-                    <h3 className="text-[1.1rem] font-semibold text-[#f4f4f5]">
-                      {isAddingNew ? "New automation" : form.name || "Edit automation"}
-                    </h3>
-                    <p className="text-sm text-[#71717a]">
-                      Configure the prompt, execution profile, and cadence for this scheduled automation.
-                    </p>
+              <div className="space-y-0">
+                {/* Header */}
+                <div className="pb-5">
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <h3 className="text-base font-semibold text-[var(--text)]">
+                        {isAddingNew ? "New automation" : form.name || "Edit automation"}
+                      </h3>
+                      <p className="mt-1 text-xs text-[var(--muted)]">
+                        Configure the prompt, execution profile, and cadence for this scheduled automation.
+                      </p>
+                    </div>
+                    {selectedAutomationId ? (
+                      <button
+                        type="button"
+                        onClick={deleteSelectedAutomation}
+                        className="inline-flex items-center gap-1.5 px-2.5 py-1.5 text-xs text-red-400/80 transition-colors hover:text-red-300"
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                        Delete
+                      </button>
+                    ) : null}
                   </div>
-                  {selectedAutomationId ? (
-                    <Button
-                      type="button"
-                      variant="danger"
-                      onClick={deleteSelectedAutomation}
-                      className="gap-1.5 px-3 py-1.5 text-xs"
-                    >
-                      <Trash2 className="h-3 w-3" />
-                      Delete
-                    </Button>
-                  ) : null}
                 </div>
 
-                <div className="grid gap-5">
-                  <div>
-                    <Label>Name</Label>
-                    <Input
-                      aria-label="Name"
-                      value={form.name}
-                      onChange={(event) => setForm((current) => ({ ...current, name: event.target.value }))}
-                      placeholder="Morning summary"
-                    />
-                  </div>
-
-                  <div>
-                    <Label>Prompt</Label>
-                    <Textarea
-                      aria-label="Prompt"
-                      value={form.prompt}
-                      onChange={(event) => setForm((current) => ({ ...current, prompt: event.target.value }))}
-                      placeholder="Summarize priorities, blockers, and open follow-ups."
-                      rows={7}
-                    />
-                  </div>
-
-                  <div className="grid gap-5 md:grid-cols-2">
+                {/* Details */}
+                <div className={`${sectionDivider} py-5`}>
+                  <h4 className={sectionTitle}>Details</h4>
+                  <div className="mt-4 space-y-5">
                     <div>
-                      <Label>Provider profile</Label>
-                      <select
-                        aria-label="Provider profile"
-                        className={selectClassName}
-                        value={form.providerProfileId}
-                        onChange={(event) => setForm((current) => ({ ...current, providerProfileId: event.target.value }))}
-                      >
-                        <option value="">Select a profile</option>
-                        {providerProfiles.map((profile) => (
-                          <option key={profile.id} value={profile.id}>
-                            {profile.name}
-                          </option>
-                        ))}
-                      </select>
-                    </div>
-
-                    <div>
-                      <Label>Persona</Label>
-                      <select
-                        aria-label="Persona"
-                        className={selectClassName}
-                        value={form.personaId ?? ""}
-                        onChange={(event) =>
-                          setForm((current) => ({
-                            ...current,
-                            personaId: event.target.value || null
-                          }))
-                        }
-                      >
-                        <option value="">No persona</option>
-                        {personas.map((persona) => (
-                          <option key={persona.id} value={persona.id}>
-                            {persona.name}
-                          </option>
-                        ))}
-                      </select>
-                    </div>
-                  </div>
-
-                  <div className="grid gap-5 md:grid-cols-[1fr_auto] md:items-end">
-                    <div>
-                      <Label>Cadence</Label>
-                      <select
-                        aria-label="Schedule type"
-                        className={selectClassName}
-                        value={form.scheduleKind}
-                        onChange={(event) =>
-                          setForm((current) => ({
-                            ...current,
-                            scheduleKind: event.target.value as "interval" | "calendar"
-                          }))
-                        }
-                      >
-                        <option value="interval">Every X minutes</option>
-                        <option value="calendar">Specific local time</option>
-                      </select>
-                    </div>
-
-                    <label className="flex items-center gap-2 rounded-xl border border-white/6 bg-white/[0.03] px-3 py-3 text-sm text-[#d4d4d8]">
-                      <input
-                        type="checkbox"
-                        checked={form.enabled}
-                        onChange={(event) => setForm((current) => ({ ...current, enabled: event.target.checked }))}
+                      <label className={fieldLabel}>Name</label>
+                      <Input
+                        aria-label="Name"
+                        value={form.name}
+                        onChange={(event) => setForm((current) => ({ ...current, name: event.target.value }))}
+                        placeholder="Morning summary"
                       />
-                      Enabled
-                    </label>
-                  </div>
+                    </div>
 
-                  {form.scheduleKind === "interval" ? (
-                    <div className="grid gap-5 md:grid-cols-[160px_1fr] md:items-end">
+                    <div>
+                      <label className={fieldLabel}>Prompt</label>
+                      <Textarea
+                        aria-label="Prompt"
+                        value={form.prompt}
+                        onChange={(event) => setForm((current) => ({ ...current, prompt: event.target.value }))}
+                        placeholder="Summarize priorities, blockers, and open follow-ups."
+                        rows={7}
+                      />
+                    </div>
+
+                    <div className="grid gap-5 md:grid-cols-2">
                       <div>
-                        <Label>Every</Label>
-                        <Input
-                          aria-label="Every"
-                          type="number"
-                          min={5}
-                          step={5}
-                          value={String(form.intervalMinutes)}
+                        <label className={fieldLabel}>Provider profile</label>
+                        <select
+                          aria-label="Provider profile"
+                          className={selectLike}
+                          value={form.providerProfileId}
+                          onChange={(event) => setForm((current) => ({ ...current, providerProfileId: event.target.value }))}
+                        >
+                          <option value="">Select a profile</option>
+                          {providerProfiles.map((profile) => (
+                            <option key={profile.id} value={profile.id}>
+                              {profile.name}
+                            </option>
+                          ))}
+                        </select>
+                      </div>
+
+                      <div>
+                        <label className={fieldLabel}>Persona</label>
+                        <select
+                          aria-label="Persona"
+                          className={selectLike}
+                          value={form.personaId ?? ""}
                           onChange={(event) =>
                             setForm((current) => ({
                               ...current,
-                              intervalMinutes: Number(event.target.value) || 0
+                              personaId: event.target.value || null
                             }))
                           }
-                        />
+                        >
+                          <option value="">No persona</option>
+                          {personas.map((persona) => (
+                            <option key={persona.id} value={persona.id}>
+                              {persona.name}
+                            </option>
+                          ))}
+                        </select>
                       </div>
-                      <p className="pb-3 text-sm text-[#71717a]">
-                        Minimum interval is 5 minutes.
-                      </p>
                     </div>
-                  ) : (
-                    <div className="space-y-5">
-                      <div className="grid gap-5 md:grid-cols-2">
+                  </div>
+                </div>
+
+                {/* Schedule */}
+                <div className={`${sectionDivider} py-5`}>
+                  <h4 className={sectionTitle}>Schedule</h4>
+                  <div className="mt-4 space-y-5">
+                    <div className="grid gap-5 md:grid-cols-[1fr_auto] md:items-end">
+                      <div>
+                        <label className={fieldLabel}>Cadence</label>
+                        <select
+                          aria-label="Schedule type"
+                          className={selectLike}
+                          value={form.scheduleKind}
+                          onChange={(event) =>
+                            setForm((current) => ({
+                              ...current,
+                              scheduleKind: event.target.value as "interval" | "calendar"
+                            }))
+                          }
+                        >
+                          <option value="interval">Every X minutes</option>
+                          <option value="calendar">Specific local time</option>
+                        </select>
+                      </div>
+
+                      <label className="flex items-center gap-3 rounded-xl border border-white/6 bg-white/4 px-4 py-3 text-sm text-[var(--text)] cursor-pointer">
+                        <input
+                          type="checkbox"
+                          checked={form.enabled}
+                          onChange={(event) => setForm((current) => ({ ...current, enabled: event.target.checked }))}
+                        />
+                        Enabled
+                      </label>
+                    </div>
+
+                    {form.scheduleKind === "interval" ? (
+                      <div className="grid gap-5 md:grid-cols-[160px_1fr] md:items-end">
                         <div>
-                          <Label>Frequency</Label>
-                          <select
-                            aria-label="Calendar frequency"
-                            className={selectClassName}
-                            value={form.calendarFrequency}
+                          <label className={fieldLabel}>Every</label>
+                          <Input
+                            aria-label="Every"
+                            type="number"
+                            min={5}
+                            step={5}
+                            value={String(form.intervalMinutes)}
                             onChange={(event) =>
                               setForm((current) => ({
                                 ...current,
-                                calendarFrequency: event.target.value as "daily" | "weekly"
+                                intervalMinutes: Number(event.target.value) || 0
                               }))
                             }
-                          >
-                            <option value="daily">Daily</option>
-                            <option value="weekly">Weekly</option>
-                          </select>
-                        </div>
-
-                        <div>
-                          <Label>Time</Label>
-                          <Input
-                            aria-label="Time"
-                            type="time"
-                            value={form.timeOfDay}
-                            onChange={(event) => setForm((current) => ({ ...current, timeOfDay: event.target.value }))}
                           />
                         </div>
+                        <p className="pb-3 text-sm text-[var(--muted)]">
+                          Minimum interval is 5 minutes.
+                        </p>
                       </div>
+                    ) : (
+                      <div className="space-y-5">
+                        <div className="grid gap-5 md:grid-cols-2">
+                          <div>
+                            <label className={fieldLabel}>Frequency</label>
+                            <select
+                              aria-label="Calendar frequency"
+                              className={selectLike}
+                              value={form.calendarFrequency}
+                              onChange={(event) =>
+                                setForm((current) => ({
+                                  ...current,
+                                  calendarFrequency: event.target.value as "daily" | "weekly"
+                                }))
+                              }
+                            >
+                              <option value="daily">Daily</option>
+                              <option value="weekly">Weekly</option>
+                            </select>
+                          </div>
 
-                      {form.calendarFrequency === "weekly" ? (
-                        <div>
-                          <Label>Days</Label>
-                          <div className="flex flex-wrap gap-2">
-                            {WEEKDAYS.map((day) => {
-                              const active = form.daysOfWeek.includes(day.value);
-                              return (
-                                <button
-                                  key={day.value}
-                                  type="button"
-                                  aria-pressed={active}
-                                  onClick={() => toggleWeekday(day.value)}
-                                  className={`rounded-lg border px-3 py-2 text-xs font-medium transition-colors ${
-                                    active
-                                      ? "border-violet-500/30 bg-violet-500/12 text-violet-200"
-                                      : "border-white/6 bg-white/[0.03] text-[#a1a1aa] hover:bg-white/[0.06] hover:text-[#f4f4f5]"
-                                  }`}
-                                >
-                                  {day.label}
-                                </button>
-                              );
-                            })}
+                          <div>
+                            <label className={fieldLabel}>Time</label>
+                            <Input
+                              aria-label="Time"
+                              type="time"
+                              value={form.timeOfDay}
+                              onChange={(event) => setForm((current) => ({ ...current, timeOfDay: event.target.value }))}
+                            />
                           </div>
                         </div>
-                      ) : null}
-                    </div>
-                  )}
 
-                  {error ? (
-                    <div className="rounded-xl border border-red-400/20 bg-red-500/8 px-4 py-3 text-sm text-red-200">
-                      {error}
-                    </div>
-                  ) : null}
+                        {form.calendarFrequency === "weekly" ? (
+                          <div>
+                            <label className={fieldLabel}>Days</label>
+                            <div className="flex flex-wrap gap-2">
+                              {WEEKDAYS.map((day) => {
+                                const active = form.daysOfWeek.includes(day.value);
+                                return (
+                                  <button
+                                    key={day.value}
+                                    type="button"
+                                    aria-pressed={active}
+                                    onClick={() => toggleWeekday(day.value)}
+                                    className={`rounded-lg border px-3 py-2 text-xs font-medium transition-colors ${
+                                      active
+                                        ? "border-violet-500/30 bg-violet-500/12 text-violet-200"
+                                        : "border-white/6 bg-white/[0.03] text-[var(--muted)] hover:bg-white/[0.06] hover:text-[var(--text)]"
+                                    }`}
+                                  >
+                                    {day.label}
+                                  </button>
+                                );
+                              })}
+                            </div>
+                          </div>
+                        ) : null}
+                      </div>
+                    )}
+                  </div>
                 </div>
 
-                <div className="flex flex-wrap items-center gap-2 pt-2">
-                  <div className="flex items-center gap-2">
-                    <Button type="button" onClick={() => void saveAutomation()}>
-                      Save automation
+                {/* Actions */}
+                <div className={`${sectionDivider} py-5`}>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Button type="button" className="px-3 py-1.5 text-xs" onClick={() => void saveAutomation()}>
+                      Save
                     </Button>
-                    <Button type="button" variant="secondary" onClick={resetSelection}>
+                    <Button type="button" variant="ghost" className="px-2.5 py-1.5 text-xs" onClick={resetSelection}>
                       Cancel
                     </Button>
                   </div>
-                  {success ? (
-                    <div className="flex items-center gap-1.5 text-sm text-emerald-400">
-                      <Check className="h-3.5 w-3.5" />
-                      {success}
-                    </div>
-                  ) : null}
                 </div>
-              </>
+
+                {/* Messages */}
+                {success ? (
+                  <div className="flex items-center gap-1.5 pt-2 text-sm text-emerald-400">
+                    <Check className="h-3.5 w-3.5" />
+                    {success}
+                  </div>
+                ) : null}
+                {error ? (
+                  <div className="rounded-lg border border-red-400/10 bg-red-500/8 px-4 py-3 text-sm text-red-300">
+                    {error}
+                  </div>
+                ) : null}
+              </div>
             ) : (
               <div className="flex flex-col items-center justify-center py-24 text-center">
                 <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-xl border border-white/6 bg-white/[0.03]">
-                  <CalendarDays className="h-5 w-5 text-[#52525b]" />
+                  <CalendarDays className="h-5 w-5 text-[var(--muted)]" />
                 </div>
-                <p className="max-w-[260px] text-sm leading-6 text-[#71717a]">
+                <p className="max-w-[260px] text-sm leading-6 text-[var(--muted)]">
                   Select an automation to edit it, or create a new one from the list pane.
                 </p>
               </div>

--- a/components/settings/sections/general-section.tsx
+++ b/components/settings/sections/general-section.tsx
@@ -2,9 +2,8 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { Info } from "lucide-react";
 
-import { SettingsCard } from "@/components/settings/settings-card";
-import { SettingRow } from "@/components/settings/setting-row";
 import { Button } from "@/components/ui/button";
 import type { AppSettings, ConversationRetention, ImageGenerationBackend } from "@/lib/types";
 
@@ -13,11 +12,6 @@ type GeneralSectionSettings = AppSettings & {
   hasTavilyApiKey?: boolean;
   hasGoogleNanoBananaApiKey?: boolean;
 };
-
-const inputClassName =
-  "w-full rounded-lg border border-white/6 bg-white/[0.03] px-3 py-2 text-sm outline-none transition-all duration-200 focus:border-[var(--accent)]/30";
-
-const fieldLabelClassName = "mb-1 block text-xs font-medium text-[var(--muted)]";
 
 export function GeneralSection({
   settings,
@@ -200,47 +194,60 @@ export function GeneralSection({
     }
   }
 
+  const fieldLabel = "block text-[13px] font-medium text-[var(--muted)] mb-1.5";
+  const inputLike = "w-full rounded-xl border border-white/6 bg-white/4 px-4 py-3 text-sm text-[var(--text)] outline-none transition-all duration-200 focus:border-[var(--accent)]/40 focus:bg-white/6 focus:shadow-[0_0_0_3px_var(--accent-soft)]";
+  const selectLike = `${inputLike} appearance-none bg-[url('data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2224%22%20height%3D%2224%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20stroke%3D%22%2371717a%22%20stroke-width%3D%222%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%3E%3Cpolyline%20points%3D%226%209%2012%2015%2018%209%22%3E%3C%2Fpolyline%3E%3C%2Fsvg%3E')] bg-[length:1rem_1rem] bg-[right_0.75rem_center] bg-no-repeat pr-10`;
+  const sectionTitle = "text-sm font-semibold text-[var(--text)]";
+  const sectionDivider = "border-t border-white/[0.06]";
+
   return (
     <div className="w-full max-w-none space-y-6 p-4 sm:p-6 md:max-w-[55%] md:p-8">
-      <SettingsCard title="Conversation Retention">
-        <SettingRow
-          label="Keep conversations for"
-          description="Older conversations will be automatically deleted"
-        >
+      {/* Conversation Retention */}
+      <div className="space-y-4">
+        <h3 className={sectionTitle}>Conversation Retention</h3>
+        <div className="space-y-1.5">
+          <label className={fieldLabel}>Keep conversations for</label>
+          <p className="text-xs text-[var(--muted)]">Older conversations will be automatically deleted</p>
           <select
             value={conversationRetention}
             onChange={(event) => setConversationRetention(event.target.value as ConversationRetention)}
-            className={`${inputClassName} sm:w-auto`}
+            className={`${selectLike} sm:w-auto`}
           >
             <option value="forever">Forever</option>
             <option value="90d">90 days</option>
             <option value="30d">30 days</option>
             <option value="7d">7 days</option>
           </select>
-        </SettingRow>
-      </SettingsCard>
+        </div>
+      </div>
 
-      <SettingsCard title="MCP Server Timeout">
-        <SettingRow
-          label="Max tool call timeout"
-          description="Maximum time (seconds) to wait for an MCP server to respond to a tool call"
-        >
+      <div className={sectionDivider} />
+
+      {/* MCP Server Timeout */}
+      <div className="space-y-4">
+        <h3 className={sectionTitle}>MCP Server Timeout</h3>
+        <div className="space-y-1.5">
+          <label className={fieldLabel}>Max tool call timeout</label>
+          <p className="text-xs text-[var(--muted)]">Maximum time (seconds) to wait for an MCP server to respond to a tool call</p>
           <input
             type="number"
             min={10}
             max={600}
             value={Math.round(mcpTimeout / 1000)}
             onChange={(event) => setMcpTimeout(Number(event.target.value) * 1000)}
-            className={`${inputClassName} sm:w-20`}
+            className={`${inputLike} sm:w-20`}
           />
-        </SettingRow>
-      </SettingsCard>
+        </div>
+      </div>
 
-      <SettingsCard title="Speech-to-Text">
-        <SettingRow
-          label="Speech engine and language"
-          description="Choose whether dictation uses the browser speech engine or the embedded model path, then set its default language behavior."
-        >
+      <div className={sectionDivider} />
+
+      {/* Speech-to-Text */}
+      <div className="space-y-4">
+        <h3 className={sectionTitle}>Speech-to-Text</h3>
+        <div className="space-y-1.5">
+          <label className={fieldLabel}>Speech engine and language</label>
+          <p className="text-xs text-[var(--muted)]">Choose whether dictation uses the browser speech engine or the embedded model path, then set its default language behavior.</p>
           <div className="flex w-full flex-col gap-3 sm:w-auto sm:flex-row sm:items-center">
             <select
               aria-label="Speech engine"
@@ -248,7 +255,7 @@ export function GeneralSection({
               onChange={(event) =>
                 handleSpeechEngineChange(event.target.value as AppSettings["sttEngine"])
               }
-              className={`${inputClassName} sm:w-auto`}
+              className={`${selectLike} sm:w-auto`}
             >
               <option value="browser">Browser</option>
               <option value="embedded">Embedded model</option>
@@ -261,7 +268,7 @@ export function GeneralSection({
                 resetMessages();
                 setSttLanguage(event.target.value as AppSettings["sttLanguage"]);
               }}
-              className={`${inputClassName} sm:w-auto`}
+              className={`${selectLike} sm:w-auto`}
             >
               {speechLanguageOptions.map((option) => (
                 <option key={option.value} value={option.value}>
@@ -270,221 +277,219 @@ export function GeneralSection({
               ))}
             </select>
           </div>
-        </SettingRow>
-      </SettingsCard>
+        </div>
+      </div>
 
-      <SettingsCard title="Web Search">
-        <SettingRow
-          label="Search provider"
-          description="Choose which web search engine is available to the agent."
-        >
-          <div className="w-full space-y-3 sm:w-[22rem]">
-            <div>
-              <label htmlFor="web-search-engine" className={fieldLabelClassName}>
-                Web search engine
-              </label>
-              <select
-                id="web-search-engine"
-                aria-label="Web search engine"
-                value={webSearchEngine}
-                onChange={(event) => {
-                  resetMessages();
-                  setWebSearchEngine(event.target.value as AppSettings["webSearchEngine"]);
-                }}
-                className={inputClassName}
-              >
-                <option value="exa">Exa</option>
-                <option value="tavily">Tavily</option>
-                <option value="searxng">SearXNG</option>
-                <option value="disabled">Disabled</option>
-              </select>
-            </div>
+      <div className={sectionDivider} />
 
-            {webSearchEngine === "exa" ? (
-              <div className="space-y-3">
-                <div className="rounded-lg border border-white/8 bg-white/[0.03] px-3 py-2 text-sm text-[var(--muted)]">
-                  Exa API key is optional and the public endpoint works without one.
-                </div>
-                <div>
-                  <label htmlFor="exa-api-key" className={fieldLabelClassName}>
-                    Exa API key
-                  </label>
-                  <input
-                    id="exa-api-key"
-                    aria-label="Exa API key"
-                    type="password"
-                    autoComplete="off"
-                    value={exaApiKey}
-                    placeholder={
-                      hasStoredExaApiKey && !hasEditedExaApiKey ? "••••••••" : "Optional"
-                    }
-                    onChange={(event) => {
-                      resetMessages();
-                      setHasEditedExaApiKey(true);
-                      setExaApiKey(event.target.value);
-                    }}
-                    className={inputClassName}
-                  />
-                </div>
+      {/* Web Search */}
+      <div className="space-y-4">
+        <h3 className={sectionTitle}>Web Search</h3>
+        <div className="space-y-3">
+          <div>
+            <label htmlFor="web-search-engine" className={fieldLabel}>
+              Search provider
+            </label>
+            <p className="text-xs text-[var(--muted)] mb-2">Choose which web search engine is available to the agent.</p>
+            <select
+              id="web-search-engine"
+              aria-label="Web search engine"
+              value={webSearchEngine}
+              onChange={(event) => {
+                resetMessages();
+                setWebSearchEngine(event.target.value as AppSettings["webSearchEngine"]);
+              }}
+              className={`${selectLike} w-full sm:w-[22rem]`}
+            >
+              <option value="exa">Exa</option>
+              <option value="tavily">Tavily</option>
+              <option value="searxng">SearXNG</option>
+              <option value="disabled">Disabled</option>
+            </select>
+          </div>
+
+          {webSearchEngine === "exa" ? (
+            <div className="space-y-3">
+              <div className="flex items-start gap-2.5 rounded-xl border border-sky-400/15 bg-sky-400/8 px-4 py-3 text-sm text-sky-200">
+                <Info className="mt-0.5 h-4 w-4 shrink-0 text-sky-400" />
+                <span>Exa API key is optional and the public endpoint works without one.</span>
               </div>
-            ) : null}
-
-            {webSearchEngine === "tavily" ? (
               <div>
-                <label htmlFor="tavily-api-key" className={fieldLabelClassName}>
-                  Tavily API key
-                </label>
-                  <input
-                    id="tavily-api-key"
-                    aria-label="Tavily API key"
-                    type="password"
-                    autoComplete="off"
-                    value={tavilyApiKey}
-                    placeholder={
-                      hasStoredTavilyApiKey && !hasEditedTavilyApiKey ? "••••••••" : "Required"
-                    }
-                    onChange={(event) => {
-                      resetMessages();
-                      setHasEditedTavilyApiKey(true);
-                      setTavilyApiKey(event.target.value);
-                  }}
-                  className={inputClassName}
-                />
-              </div>
-            ) : null}
-
-            {webSearchEngine === "searxng" ? (
-              <div>
-                <label htmlFor="searxng-base-url" className={fieldLabelClassName}>
-                  SearXNG base URL
+                <label htmlFor="exa-api-key" className={fieldLabel}>
+                  Exa API key
                 </label>
                 <input
-                  id="searxng-base-url"
-                  aria-label="SearXNG base URL"
-                  type="url"
+                  id="exa-api-key"
+                  aria-label="Exa API key"
+                  type="password"
                   autoComplete="off"
-                  value={searxngBaseUrl}
-                  placeholder="https://search.example.com"
+                  value={exaApiKey}
+                  placeholder={
+                    hasStoredExaApiKey && !hasEditedExaApiKey ? "••••••••" : "Optional"
+                  }
                   onChange={(event) => {
                     resetMessages();
-                    setSearxngBaseUrl(event.target.value);
+                    setHasEditedExaApiKey(true);
+                    setExaApiKey(event.target.value);
                   }}
-                  className={inputClassName}
+                  className={`${inputLike} w-full sm:w-[22rem]`}
                 />
               </div>
-            ) : null}
-          </div>
-        </SettingRow>
-      </SettingsCard>
+            </div>
+          ) : null}
 
-      <SettingsCard title="Image Generation">
+          {webSearchEngine === "tavily" ? (
+            <div>
+              <label htmlFor="tavily-api-key" className={fieldLabel}>
+                Tavily API key
+              </label>
+              <input
+                id="tavily-api-key"
+                aria-label="Tavily API key"
+                type="password"
+                autoComplete="off"
+                value={tavilyApiKey}
+                placeholder={
+                  hasStoredTavilyApiKey && !hasEditedTavilyApiKey ? "••••••••" : "Required"
+                }
+                onChange={(event) => {
+                  resetMessages();
+                  setHasEditedTavilyApiKey(true);
+                  setTavilyApiKey(event.target.value);
+                }}
+                className={`${inputLike} w-full sm:w-[22rem]`}
+              />
+            </div>
+          ) : null}
+
+          {webSearchEngine === "searxng" ? (
+            <div>
+              <label htmlFor="searxng-base-url" className={fieldLabel}>
+                SearXNG base URL
+              </label>
+              <input
+                id="searxng-base-url"
+                aria-label="SearXNG base URL"
+                type="url"
+                autoComplete="off"
+                value={searxngBaseUrl}
+                placeholder="https://search.example.com"
+                onChange={(event) => {
+                  resetMessages();
+                  setSearxngBaseUrl(event.target.value);
+                }}
+                className={`${inputLike} w-full sm:w-[22rem]`}
+              />
+            </div>
+          ) : null}
+        </div>
+      </div>
+
+      <div className={sectionDivider} />
+
+      {/* Image Generation */}
+      <div className="space-y-4">
+        <h3 className={sectionTitle}>Image Generation</h3>
         {!canManageImageGeneration ? (
-          <SettingRow
-            label="Image generation backend"
-            description="Only admins can change image generation settings."
-          >
+          <div className="space-y-1.5">
+            <label className={fieldLabel}>Image generation backend</label>
+            <p className="text-xs text-[var(--muted)]">Only admins can change image generation settings.</p>
             <select
               aria-label="Image generation backend"
               value={imageGenerationBackend}
               disabled
-              className={`${inputClassName} sm:w-auto opacity-60`}
+              className={`${selectLike} sm:w-auto opacity-60`}
             >
               <option value="disabled">Disabled</option>
               <option value="google_nano_banana">Google Nano Banana</option>
             </select>
-          </SettingRow>
+          </div>
         ) : (
-          <>
-            <SettingRow
-              label="Image generation backend"
-              description="Choose the backend used for image generation."
-            >
-              <div className="w-full space-y-3 sm:w-[22rem]">
+          <div className="space-y-3">
+            <div>
+              <label htmlFor="image-generation-backend" className={fieldLabel}>
+                Image generation backend
+              </label>
+              <p className="text-xs text-[var(--muted)] mb-2">Choose the backend used for image generation.</p>
+              <select
+                id="image-generation-backend"
+                aria-label="Image generation backend"
+                value={imageGenerationBackend}
+                onChange={(event) => {
+                  resetMessages();
+                  setImageGenerationBackend(
+                    event.target.value as ImageGenerationBackend
+                  );
+                }}
+                className={`${selectLike} w-full sm:w-[22rem]`}
+              >
+                <option value="disabled">Disabled</option>
+                <option value="google_nano_banana">Google Nano Banana</option>
+              </select>
+            </div>
+
+            {imageGenerationBackend === "google_nano_banana" ? (
+              <div className="space-y-3">
                 <div>
-                  <label htmlFor="image-generation-backend" className={fieldLabelClassName}>
-                    Image generation backend
+                  <label htmlFor="google-nano-banana-model" className={fieldLabel}>
+                    Model
                   </label>
                   <select
-                    id="image-generation-backend"
-                    aria-label="Image generation backend"
-                    value={imageGenerationBackend}
+                    id="google-nano-banana-model"
+                    aria-label="Google Nano Banana model"
+                    value={googleNanoBananaModel}
                     onChange={(event) => {
                       resetMessages();
-                      setImageGenerationBackend(
-                        event.target.value as ImageGenerationBackend
+                      setGoogleNanoBananaModel(
+                        event.target.value as AppSettings["googleNanoBananaModel"]
                       );
                     }}
-                    className={inputClassName}
+                    className={`${selectLike} w-full sm:w-[22rem]`}
                   >
-                    <option value="disabled">Disabled</option>
-                    <option value="google_nano_banana">Google Nano Banana</option>
+                    <option value="gemini-2.5-flash-image">Gemini 2.5 Flash Image</option>
+                    <option value="gemini-3.1-flash-image-preview">
+                      Gemini 3.1 Flash Image Preview
+                    </option>
+                    <option value="gemini-3-pro-image-preview">
+                      Gemini 3 Pro Image Preview
+                    </option>
                   </select>
                 </div>
-
-                {imageGenerationBackend === "google_nano_banana" ? (
-                  <div className="space-y-3">
-                    <div>
-                      <label htmlFor="google-nano-banana-model" className={fieldLabelClassName}>
-                        Model
-                      </label>
-                      <select
-                        id="google-nano-banana-model"
-                        aria-label="Google Nano Banana model"
-                        value={googleNanoBananaModel}
-                        onChange={(event) => {
-                          resetMessages();
-                          setGoogleNanoBananaModel(
-                            event.target.value as AppSettings["googleNanoBananaModel"]
-                          );
-                        }}
-                        className={inputClassName}
-                      >
-                        <option value="gemini-2.5-flash-image">Gemini 2.5 Flash Image</option>
-                        <option value="gemini-3.1-flash-image-preview">
-                          Gemini 3.1 Flash Image Preview
-                        </option>
-                        <option value="gemini-3-pro-image-preview">
-                          Gemini 3 Pro Image Preview
-                        </option>
-                      </select>
-                    </div>
-                    <div>
-                      <label htmlFor="google-nano-banana-api-key" className={fieldLabelClassName}>
-                        API key
-                      </label>
-                      <input
-                        id="google-nano-banana-api-key"
-                        aria-label="Google Nano Banana API key"
-                        type="password"
-                        autoComplete="off"
-                        value={googleNanoBananaApiKey}
-                        placeholder={
-                          hasStoredGoogleNanoBananaApiKey && !hasEditedGoogleNanoBananaApiKey
-                            ? "••••••••"
-                            : ""
-                        }
-                        onChange={(event) => {
-                          resetMessages();
-                          setHasEditedGoogleNanoBananaApiKey(true);
-                          setGoogleNanoBananaApiKey(event.target.value);
-                        }}
-                        className={inputClassName}
-                      />
-                    </div>
-                  </div>
-                ) : null}
+                <div>
+                  <label htmlFor="google-nano-banana-api-key" className={fieldLabel}>
+                    API key
+                  </label>
+                  <input
+                    id="google-nano-banana-api-key"
+                    aria-label="Google Nano Banana API key"
+                    type="password"
+                    autoComplete="off"
+                    value={googleNanoBananaApiKey}
+                    placeholder={
+                      hasStoredGoogleNanoBananaApiKey && !hasEditedGoogleNanoBananaApiKey
+                        ? "••••••••"
+                        : ""
+                    }
+                    onChange={(event) => {
+                      resetMessages();
+                      setHasEditedGoogleNanoBananaApiKey(true);
+                      setGoogleNanoBananaApiKey(event.target.value);
+                    }}
+                    className={`${inputLike} w-full sm:w-[22rem]`}
+                  />
+                </div>
               </div>
-            </SettingRow>
-          </>
+            ) : null}
+          </div>
         )}
-      </SettingsCard>
-
-      <div className="flex flex-wrap items-center gap-3">
-        <Button className="w-full sm:w-auto" onClick={() => void save()} disabled={isSaving}>
-          Save settings
-        </Button>
-        {success ? <span className="text-sm text-emerald-400">{success}</span> : null}
       </div>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <Button className="px-3 py-1.5 text-xs" onClick={() => void save()} disabled={isSaving}>
+          Save
+        </Button>
+      </div>
+      {success ? <span className="text-sm text-emerald-400">{success}</span> : null}
 
       {error ? (
         <div className="rounded-xl border border-red-400/10 bg-red-500/8 px-4 py-3 text-sm text-red-300">

--- a/components/settings/sections/mcp-servers-section.tsx
+++ b/components/settings/sections/mcp-servers-section.tsx
@@ -1,11 +1,10 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Check, Plus, Server } from "lucide-react";
+import { Check, Plus, Trash2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import type { McpServer, McpTransport } from "@/lib/types";
 import { ProfileCard } from "@/components/settings/profile-card";
@@ -21,8 +20,8 @@ export function McpServersSection() {
   const [mcpArgs, setMcpArgs] = useState("");
   const [mcpEnv, setMcpEnv] = useState("");
   const [editingMcpId, setEditingMcpId] = useState<string | null>(null);
-  const [mcpDraftTestResult, setMcpDraftTestResult] = useState("");
-  const [mcpRowTestResults, setMcpRowTestResults] = useState<Record<string, string>>({});
+  const [mcpDraftTestResult, setMcpDraftTestResult] = useState<{ text: string; isSuccess: boolean } | null>(null);
+  const [mcpRowTestResults, setMcpRowTestResults] = useState<Record<string, { text: string; isSuccess: boolean }>>({});
   const [mcpTestingTarget, setMcpTestingTarget] = useState<string | null>(null);
   const [mcpEnabledDraft, setMcpEnabledDraft] = useState(true);
   const [error, setError] = useState("");
@@ -144,7 +143,7 @@ export function McpServersSection() {
       setMcpArgs(savedServer.args ? JSON.stringify(savedServer.args) : "");
       setMcpEnv(savedServer.env ? JSON.stringify(savedServer.env, null, 2) : "");
       setMcpEnabledDraft(savedServer.enabled);
-      setMcpDraftTestResult("");
+      setMcpDraftTestResult(null);
       setIsAddingNew(false);
       setMobileDetailVisible(true);
     }
@@ -203,14 +202,15 @@ export function McpServersSection() {
       const result = (await response.json()) as { text?: string; error?: string; toolCount?: number; stderr?: string };
       const message = result.text ?? result.error ?? "No result";
       const fullMessage = result.stderr ? `${message}\n${result.stderr}` : message;
+      const isSuccess = response.ok && !result.error;
 
       if (serverId) {
         setMcpRowTestResults((current) => ({
           ...current,
-          [serverId]: fullMessage
+          [serverId]: { text: fullMessage, isSuccess }
         }));
       } else {
-        setMcpDraftTestResult(fullMessage);
+        setMcpDraftTestResult({ text: fullMessage, isSuccess });
       }
 
       if (!response.ok) {
@@ -221,10 +221,10 @@ export function McpServersSection() {
       if (serverId) {
         setMcpRowTestResults((current) => ({
           ...current,
-          [serverId]: message
+          [serverId]: { text: message, isSuccess: false }
         }));
       } else {
-        setMcpDraftTestResult(message);
+        setMcpDraftTestResult({ text: message, isSuccess: false });
       }
       setError(message);
     } finally {
@@ -251,7 +251,7 @@ export function McpServersSection() {
     setMcpCommand(server.command ?? "");
     setMcpArgs(server.args ? JSON.stringify(server.args) : "");
     setMcpEnv(server.env ? JSON.stringify(server.env, null, 2) : "");
-    setMcpDraftTestResult(mcpRowTestResults[server.id] ?? "");
+    setMcpDraftTestResult(mcpRowTestResults[server.id] ?? null);
     setMcpEnabledDraft(server.enabled);
   }
 
@@ -265,7 +265,7 @@ export function McpServersSection() {
     setMcpEnv("");
     setMcpEnabledDraft(true);
     setEditingMcpId(null);
-    setMcpDraftTestResult("");
+    setMcpDraftTestResult(null);
     setSelectedServerId(null);
     setIsAddingNew(false);
   }
@@ -287,6 +287,12 @@ export function McpServersSection() {
   const selectedServer = mcpServers.find((s) => s.id === selectedServerId);
   const showDetail = selectedServerId !== null || isAddingNew;
 
+  const fieldLabel = "block text-[13px] font-medium text-[var(--muted)] mb-1.5";
+  const inputLike = "w-full rounded-xl border border-white/6 bg-white/4 px-4 py-3 text-sm text-[var(--text)] outline-none transition-all duration-200 focus:border-[var(--accent)]/40 focus:bg-white/6 focus:shadow-[0_0_0_3px_var(--accent-soft)]";
+  const selectLike = `${inputLike} appearance-none bg-[url('data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2224%22%20height%3D%2224%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20stroke%3D%22%2371717a%22%20stroke-width%3D%222%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%3E%3Cpolyline%20points%3D%226%209%2012%2015%2018%209%22%3E%3C%2Fpolyline%3E%3C%2Fsvg%3E')] bg-[length:1rem_1rem] bg-[right_0.75rem_center] bg-no-repeat pr-10`;
+  const sectionTitle = "text-sm font-semibold text-[var(--text)]";
+  const sectionDivider = "border-t border-white/[0.06]";
+
   return (
     <div className="min-h-0 p-4 md:h-full md:p-8">
       <SettingsSplitPane
@@ -296,7 +302,7 @@ export function McpServersSection() {
           <div className="flex items-center justify-between w-full">
             <div className="flex items-center gap-2">
               <h2 className="text-sm font-semibold text-[var(--text)]">MCP Servers</h2>
-              <span className="text-[0.7rem] text-[var(--muted)]">{mcpServers.length}</span>
+              <span className="text-xs text-[var(--muted)]">{mcpServers.length}</span>
             </div>
             <button
               onClick={handleAddNew}
@@ -338,19 +344,17 @@ export function McpServersSection() {
         }
         detailPanel={
           showDetail ? (
-            <div className="space-y-5">
-              <div className="flex items-center gap-3">
-                <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-sky-500/10 text-sky-400">
-                  <Server className="h-4 w-4" />
-                </div>
-                <h3 className="text-lg font-medium text-[var(--text)]">
+            <div className="space-y-0">
+              <div className="pb-5">
+                <h3 className="text-base font-semibold text-[var(--text)]">
                   {isAddingNew ? "Add MCP Server" : selectedServer?.name ?? "Server"}
                 </h3>
               </div>
 
-              <div className="space-y-3">
+              <div className={`${sectionDivider} py-5`}>
+                <div className="space-y-3">
                 <div>
-                  <Label>Name</Label>
+                  <label className={fieldLabel}>Name</label>
                   <Input
                     value={mcpName}
                     onChange={(e) => setMcpName(e.target.value)}
@@ -358,11 +362,11 @@ export function McpServersSection() {
                   />
                 </div>
                 <div>
-                  <Label>Transport</Label>
+                  <label className={fieldLabel}>Transport</label>
                   <select
                     value={mcpTransport}
                     onChange={(e) => setMcpTransport(e.target.value as McpTransport)}
-                    className="w-full rounded-xl border border-white/6 bg-white/[0.03] px-4 py-3 text-sm outline-none focus:border-[var(--accent)]/30 transition-all duration-200"
+                    className={selectLike}
                   >
                     <option value="streamable_http">Streamable HTTP</option>
                     <option value="stdio">Local stdio</option>
@@ -371,7 +375,7 @@ export function McpServersSection() {
                 {mcpTransport === "streamable_http" ? (
                   <>
                     <div>
-                      <Label>URL</Label>
+                      <label className={fieldLabel}>URL</label>
                       <Input
                         value={mcpUrl}
                         onChange={(e) => setMcpUrl(e.target.value)}
@@ -379,7 +383,7 @@ export function McpServersSection() {
                       />
                     </div>
                     <div>
-                      <Label>Headers (JSON)</Label>
+                      <label className={fieldLabel}>Headers (JSON)</label>
                       <Textarea
                         value={mcpHeaders}
                         onChange={(e) => setMcpHeaders(e.target.value)}
@@ -391,18 +395,18 @@ export function McpServersSection() {
                 ) : (
                   <>
                     <div>
-                      <Label>Command</Label>
+                      <label className={fieldLabel}>Command</label>
                       <Input
                         value={mcpCommand}
                         onChange={(e) => setMcpCommand(e.target.value)}
                         placeholder="uvx or npx"
                       />
-                      <p className="mt-1 text-xs text-white/20">
+                      <p className="mt-1 text-xs text-[var(--muted)]">
                         Use &quot;uvx&quot; for Python-based servers or &quot;npx&quot; for Node.js-based servers.
                       </p>
                     </div>
                     <div>
-                      <Label>Args (JSON array or space-separated)</Label>
+                      <label className={fieldLabel}>Args (JSON array or space-separated)</label>
                       <Input
                         value={mcpArgs}
                         onChange={(e) => setMcpArgs(e.target.value)}
@@ -414,7 +418,7 @@ export function McpServersSection() {
                       />
                     </div>
                     <div>
-                      <Label>Environment variables (JSON, optional)</Label>
+                      <label className={fieldLabel}>Environment variables (JSON, optional)</label>
                       <Textarea
                         value={mcpEnv}
                         onChange={(e) => setMcpEnv(e.target.value)}
@@ -428,53 +432,62 @@ export function McpServersSection() {
 
               {editingMcpId ? (
                 <div className="flex items-center gap-2">
-                  <label className="flex cursor-pointer items-center gap-2 rounded-lg border border-white/8 bg-white/[0.04] px-2.5 py-1.5 text-xs text-white/65 transition-colors hover:border-white/15">
+                  <label className="flex cursor-pointer items-center gap-3 rounded-xl border border-white/6 bg-white/4 px-4 py-3 text-sm text-[var(--text)]">
                     <input
                       type="checkbox"
                       checked={mcpEnabledDraft}
                       onChange={(e) => setMcpEnabledDraft(e.target.checked)}
-                      className="rounded"
                     />
                     Enabled
                   </label>
                 </div>
               ) : null}
-
-              <div className="flex items-center gap-2">
-                <Button
-                  type="button"
-                  variant="secondary"
-                  onClick={() => void testMcpServer()}
-                  disabled={mcpTestingTarget === "draft"}
-                >
-                  {mcpTestingTarget === "draft" ? "Testing" : "Test"}
-                </Button>
-                <Button type="button" onClick={() => void saveMcpServer()}>
-                  {editingMcpId ? "Update" : "Add server"}
-                </Button>
-                {editingMcpId && (
-                  <Button
-                    type="button"
-                    variant="danger"
-                    onClick={() => deleteMcpServer(editingMcpId)}
-                  >
-                    Delete
-                  </Button>
-                )}
-                {success ? (
-                  <div className="flex items-center gap-1.5 text-sm text-emerald-400">
-                    <Check className="h-3.5 w-3.5" />
-                    {success}
-                  </div>
-                ) : null}
               </div>
 
+              <div className={`${sectionDivider} py-5`}>
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div className="flex flex-wrap items-center gap-2">
+                  <Button type="button" className="px-3 py-1.5 text-xs" onClick={() => void saveMcpServer()}>
+                    Save
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    className="px-2.5 py-1.5 text-xs"
+                    onClick={() => void testMcpServer()}
+                    disabled={mcpTestingTarget === "draft"}
+                  >
+                    {mcpTestingTarget === "draft" ? "Testing" : "Test"}
+                  </Button>
+                </div>
+                {editingMcpId && (
+                  <button
+                    type="button"
+                    onClick={() => deleteMcpServer(editingMcpId)}
+                    className="inline-flex items-center gap-1.5 px-2.5 py-1.5 text-xs text-red-400/80 transition-colors hover:text-red-300"
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                    Delete
+                  </button>
+                )}
+              </div>
+              </div>
+
+              {success ? (
+                <div className="flex items-center gap-1.5 pt-2 text-sm text-emerald-400">
+                  <Check className="h-3.5 w-3.5" />
+                  {success}
+                </div>
+              ) : null}
+
               {mcpDraftTestResult && (
-                <p className="text-xs text-white/35">{mcpDraftTestResult}</p>
+                <p className={`pt-2 text-sm ${mcpDraftTestResult.isSuccess ? "text-emerald-400" : "text-red-300"}`}>
+                  {mcpDraftTestResult.text}
+                </p>
               )}
 
               {error && (
-                <div className="rounded-xl bg-red-500/8 border border-red-400/10 px-4 py-3 text-sm text-red-300">
+                <div className="rounded-lg border border-red-400/10 bg-red-500/8 px-4 py-3 text-sm text-red-300">
                   {error}
                 </div>
               )}

--- a/components/settings/sections/memories-section.tsx
+++ b/components/settings/sections/memories-section.tsx
@@ -10,8 +10,6 @@ import type { AppSettings, MemoryCategory, UserMemory } from "@/lib/types";
 
 import { SettingsSplitPane } from "../settings-split-pane";
 import { ProfileCard } from "../profile-card";
-import { SettingsCard } from "../settings-card";
-import { SettingRow } from "../setting-row";
 
 const CATEGORIES: Array<{ value: MemoryCategory | "all"; label: string }> = [
   { value: "all", label: "All" },
@@ -120,48 +118,71 @@ export function MemoriesSection() {
   }
 
   const selectedMemory = memories.find((m) => m.id === selectedMemoryId);
-  const labelClass = "text-[0.68rem] font-semibold uppercase tracking-[0.12em] text-[#71717a]";
+
+  const fieldLabel = "block text-[13px] font-medium text-[var(--muted)] mb-1.5";
+  const inputLike = "w-full rounded-xl border border-white/6 bg-white/4 px-4 py-3 text-sm text-[var(--text)] outline-none transition-all duration-200 focus:border-[var(--accent)]/40 focus:bg-white/6 focus:shadow-[0_0_0_3px_var(--accent-soft)]";
+  const selectLike = `${inputLike} appearance-none bg-[url('data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2224%22%20height%3D%2224%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20stroke%3D%22%2371717a%22%20stroke-width%3D%222%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%3E%3Cpolyline%20points%3D%226%209%2012%2015%2018%209%22%3E%3C%2Fpolyline%3E%3C%2Fsvg%3E')] bg-[length:1rem_1rem] bg-[right_0.75rem_center] bg-no-repeat pr-10`;
+  const sectionTitle = "text-sm font-semibold text-[var(--text)]";
+  const sectionDivider = "border-t border-white/[0.06]";
 
   return (
     <div className="min-h-0 p-4 md:h-full md:p-8 space-y-6">
-      <SettingsCard
-        title="Memory Settings"
-        description="The assistant automatically saves important facts about you across conversations."
-      >
-        <div className="space-y-4">
-          <SettingRow label="Enable memories" description="Allow the assistant to save and recall facts about you">
-            <label className="relative inline-flex cursor-pointer items-center">
-              <input
-                type="checkbox"
-                checked={settings?.memoriesEnabled ?? true}
-                onChange={(e) => saveSettings({ memoriesEnabled: e.target.checked })}
-                className="peer sr-only"
-              />
-              <div className="h-5 w-9 rounded-full bg-white/10 peer-checked:bg-violet-500/60 transition-colors after:absolute after:left-[2px] after:top-[2px] after:h-4 after:w-4 after:rounded-full after:bg-white after:transition-all peer-checked:after:translate-x-full" />
-            </label>
-          </SettingRow>
-          <SettingRow label="Max memories" description={`Maximum number of memories (current: ${memories.length})`}>
-            <Input
-              type="number"
-              min={1}
-              max={500}
-              value={settings?.memoriesMaxCount ?? 100}
-              onChange={(e) => {
-                const val = parseInt(e.target.value, 10);
-                if (val >= 1 && val <= 500) saveSettings({ memoriesMaxCount: val });
-              }}
-              className="w-20 text-center text-sm"
-            />
-          </SettingRow>
+      <div className="space-y-0">
+        <div className="pb-5">
+          <h3 className="text-base font-semibold text-[var(--text)]">Memory Settings</h3>
+          <p className="mt-1 text-xs text-[var(--muted)]">
+            The assistant automatically saves important facts about you across conversations.
+          </p>
         </div>
-      </SettingsCard>
+
+        <div className={`${sectionDivider} py-5`}>
+          <div className="space-y-4">
+            <div className="flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+              <div className="min-w-0">
+                <div className="text-[13px] text-[var(--text)]">Enable memories</div>
+                <div className="mt-0.5 text-xs text-[var(--muted)]">Allow the assistant to save and recall facts about you</div>
+              </div>
+              <div className="w-full sm:w-auto sm:flex-shrink-0">
+                <label className="relative inline-flex cursor-pointer items-center">
+                  <input
+                    type="checkbox"
+                    checked={settings?.memoriesEnabled ?? true}
+                    onChange={(e) => saveSettings({ memoriesEnabled: e.target.checked })}
+                    className="peer sr-only"
+                  />
+                  <div className="h-5 w-9 rounded-full bg-white/10 peer-checked:bg-violet-500/60 transition-colors after:absolute after:left-[2px] after:top-[2px] after:h-4 after:w-4 after:rounded-full after:bg-white after:transition-all peer-checked:after:translate-x-full" />
+                </label>
+              </div>
+            </div>
+            <div className="flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+              <div className="min-w-0">
+                <div className="text-[13px] text-[var(--text)]">Max memories</div>
+                <div className="mt-0.5 text-xs text-[var(--muted)]">Maximum number of memories (current: {memories.length})</div>
+              </div>
+              <div className="w-full sm:w-auto sm:flex-shrink-0">
+                <Input
+                  type="number"
+                  min={1}
+                  max={500}
+                  value={settings?.memoriesMaxCount ?? 100}
+                  onChange={(e) => {
+                    const val = parseInt(e.target.value, 10);
+                    if (val >= 1 && val <= 500) saveSettings({ memoriesMaxCount: val });
+                  }}
+                  className="w-20 text-center text-sm"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
 
       <SettingsSplitPane
         listHeader={
           <div className="flex items-center justify-between w-full">
             <div>
-              <h2 className="text-[0.9rem] font-semibold text-[#f4f4f5]">Memories</h2>
-              <p className="text-[0.68rem] text-[#52525b]">
+              <h2 className="text-sm font-semibold text-[var(--text)]">Memories</h2>
+              <p className="text-xs text-[var(--muted)]">
                 {memories.length} memor{memories.length !== 1 ? "ies" : "y"}
               </p>
             </div>
@@ -171,13 +192,13 @@ export function MemoriesSection() {
           <div className="space-y-3">
             <div className="flex gap-2">
               <div className="relative flex-1">
-                <Search className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-[#52525b]" />
+                <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--muted)]" />
                 <input
                   type="text"
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
                   placeholder="Search memories..."
-                  className="w-full rounded-lg border border-white/6 bg-white/[0.03] py-2 pl-8 pr-3 text-xs text-[#f4f4f5] placeholder:text-[#52525b] outline-none focus:border-violet-500/30 transition-colors"
+                  className={`${inputLike} pl-10`}
                 />
               </div>
             </div>
@@ -190,7 +211,7 @@ export function MemoriesSection() {
                   className={`rounded-md px-2.5 py-1 text-[10px] font-medium transition-all duration-200 ${
                     filterCategory === cat.value
                       ? "bg-violet-500/15 text-violet-300 border border-violet-500/25"
-                      : "bg-white/[0.03] text-[#71717a] border border-white/4 hover:bg-white/[0.06] hover:text-[#a1a1aa]"
+                      : "bg-white/[0.03] text-[var(--muted)] border border-white/4 hover:bg-white/[0.06] hover:text-[var(--text)]"
                   }`}
                 >
                   {cat.label}
@@ -201,9 +222,9 @@ export function MemoriesSection() {
               {memories.length === 0 ? (
                 <div className="flex flex-col items-center py-12 text-center">
                   <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-white/[0.03] border border-white/6 mb-3">
-                    <Brain className="h-4 w-4 text-[#52525b]" />
+                    <Brain className="h-4 w-4 text-[var(--muted)]" />
                   </div>
-                  <p className="text-xs text-[#52525b]">
+                  <p className="text-xs text-[var(--muted)]">
                     No memories yet. The assistant will automatically save important facts about you as you chat.
                   </p>
                 </div>
@@ -223,7 +244,7 @@ export function MemoriesSection() {
                             e.stopPropagation();
                             deleteMemory(memory.id);
                           }}
-                          className="opacity-0 group-hover:opacity-100 flex h-6 w-6 items-center justify-center rounded-md text-[#52525b] hover:text-red-400 hover:bg-red-500/10 transition-all"
+                          className="opacity-0 group-hover:opacity-100 flex h-6 w-6 items-center justify-center rounded-md text-[var(--muted)] hover:text-red-400 hover:bg-red-500/10 transition-all"
                         >
                           <Trash2 className="h-3 w-3" />
                         </button>
@@ -238,23 +259,22 @@ export function MemoriesSection() {
         isDetailVisible={mobileDetailVisible}
         onBackAction={() => setMobileDetailVisible(false)}
         detailPanel={
-          <div className="max-w-[560px] space-y-6">
+          <div             className="w-full max-w-[720px] space-y-8">
             {selectedMemory ? (
               <>
                 <div className="space-y-4">
                   <div className="flex items-center justify-between">
-                    <h3 className="text-[1.1rem] font-semibold text-[#f4f4f5]">Edit Memory</h3>
-                    <Button
+                    <h3 className="text-base font-semibold text-[var(--text)]">Edit Memory</h3>
+                    <button
                       type="button"
-                      variant="danger"
                       onClick={() => deleteMemory(selectedMemory.id)}
-                      className="gap-1.5 px-3 py-1.5 text-xs"
+                      className="inline-flex items-center gap-1.5 px-2.5 py-1.5 text-xs text-red-400/80 transition-colors hover:text-red-300"
                     >
                       <Trash2 className="h-3 w-3" />
                       Delete
-                    </Button>
+                    </button>
                   </div>
-                  <div className="flex gap-4 text-xs text-[#52525b]">
+                  <div className="flex gap-4 text-xs text-[var(--muted)]">
                     <span>Created {formatRelativeTime(selectedMemory.createdAt)}</span>
                     <span>Updated {formatRelativeTime(selectedMemory.updatedAt)}</span>
                   </div>
@@ -262,7 +282,7 @@ export function MemoriesSection() {
 
                 <div className="space-y-5">
                   <div>
-                    <label className={labelClass}>Content</label>
+                    <label className={fieldLabel}>Content</label>
                     <Textarea
                       value={editContent}
                       onChange={(e) => setEditContent(e.target.value)}
@@ -271,11 +291,11 @@ export function MemoriesSection() {
                     />
                   </div>
                   <div>
-                    <label className={labelClass}>Category</label>
+                    <label className={fieldLabel}>Category</label>
                     <select
                       value={editCategory}
                       onChange={(e) => setEditCategory(e.target.value as MemoryCategory)}
-                      className="w-full rounded-xl border border-white/6 bg-white/4 px-4 py-3 text-sm text-[var(--text)] outline-none transition-all duration-200 focus:border-violet-500/30"
+                      className={selectLike}
                     >
                       <option value="personal">Personal</option>
                       <option value="preference">Preference</option>
@@ -286,13 +306,14 @@ export function MemoriesSection() {
                   </div>
                 </div>
 
-                <div className="flex gap-2 pt-2">
-                  <Button type="button" onClick={saveMemory}>
+                <div className="flex flex-wrap items-center gap-2">
+                  <Button type="button" className="px-3 py-1.5 text-xs" onClick={saveMemory}>
                     Save
                   </Button>
                   <Button
                     type="button"
-                    variant="secondary"
+                    variant="ghost"
+                    className="px-2.5 py-1.5 text-xs"
                     onClick={() => {
                       setSelectedMemoryId(null);
                       setMobileDetailVisible(false);
@@ -305,9 +326,9 @@ export function MemoriesSection() {
             ) : (
               <div className="flex flex-col items-center justify-center py-24 text-center">
                 <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-white/[0.03] border border-white/6 mb-4">
-                  <Brain className="h-5 w-5 text-[#52525b]" />
+                  <Brain className="h-5 w-5 text-[var(--muted)]" />
                 </div>
-                <p className="text-[0.85rem] text-[#71717a]">
+                <p className="text-sm text-[var(--muted)]">
                   Select a memory to view and edit
                 </p>
               </div>

--- a/components/settings/sections/personas-section.tsx
+++ b/components/settings/sections/personas-section.tsx
@@ -19,6 +19,8 @@ export function PersonasSection() {
   const [selectedPersonaId, setSelectedPersonaId] = useState<string | null>(null);
   const [mobileDetailVisible, setMobileDetailVisible] = useState(false);
   const [isAddingNew, setIsAddingNew] = useState(false);
+  const [isPersonaContentOpen, setIsPersonaContentOpen] = useState(false);
+  const [personaContentDraft, setPersonaContentDraft] = useState("");
 
   useEffect(() => {
     fetch("/api/personas")
@@ -92,12 +94,33 @@ export function PersonasSection() {
     setSelectedPersonaId(null);
     setIsAddingNew(false);
     setMobileDetailVisible(false);
+    setIsPersonaContentOpen(false);
+    setPersonaContentDraft("");
+  }
+
+  function openPersonaContent() {
+    setPersonaContentDraft(personaContent);
+    setIsPersonaContentOpen(true);
+  }
+
+  function savePersonaContent() {
+    setPersonaContent(personaContentDraft);
+    setIsPersonaContentOpen(false);
+  }
+
+  function closePersonaContent() {
+    setIsPersonaContentOpen(false);
+    setPersonaContentDraft("");
   }
 
   const selectedPersona = personas.find((p) => p.id === selectedPersonaId);
   const showDetail = selectedPersona || isAddingNew;
 
-  const labelClass = "text-[0.68rem] font-semibold uppercase tracking-[0.12em] text-[#71717a]";
+  const fieldLabel = "block text-[13px] font-medium text-[var(--muted)] mb-1.5";
+  const inputLike = "w-full rounded-xl border border-white/6 bg-white/4 px-4 py-3 text-sm text-[var(--text)] outline-none transition-all duration-200 focus:border-[var(--accent)]/40 focus:bg-white/6 focus:shadow-[0_0_0_3px_var(--accent-soft)]";
+  const selectLike = `${inputLike} appearance-none bg-[url('data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2224%22%20height%3D%2224%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20stroke%3D%22%2371717a%22%20stroke-width%3D%222%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%3E%3Cpolyline%20points%3D%226%209%2012%2015%2018%209%22%3E%3C%2Fpolyline%3E%3C%2Fsvg%3E')] bg-[length:1rem_1rem] bg-[right_0.75rem_center] bg-no-repeat pr-10`;
+  const sectionTitle = "text-sm font-semibold text-[var(--text)]";
+  const sectionDivider = "border-t border-white/[0.06]";
 
   return (
     <div className="min-h-0 p-4 md:h-full md:p-8">
@@ -105,17 +128,18 @@ export function PersonasSection() {
         listHeader={
           <div className="flex items-center justify-between w-full">
             <div>
-              <h2 className="text-[0.9rem] font-semibold text-[#f4f4f5]">Personas</h2>
-              <p className="text-[0.68rem] text-[#52525b]">
+              <h2 className="text-sm font-semibold text-[var(--text)]">Personas</h2>
+              <p className="text-xs text-[var(--muted)]">
                 {personas.length} persona{personas.length !== 1 ? "s" : ""}
               </p>
             </div>
             <button
               type="button"
               onClick={handleAddNew}
-              className="flex h-7 w-7 items-center justify-center rounded-lg border border-white/6 bg-white/[0.03] text-[#71717a] hover:text-[#f4f4f5] hover:bg-white/[0.06] transition-all duration-200"
+              className="flex h-7 w-7 items-center justify-center rounded-lg border border-white/[0.08] bg-white/[0.04] text-[var(--muted)] hover:text-[var(--text)] hover:bg-white/[0.07] transition-all duration-200"
+              aria-label="Add persona"
             >
-              <Plus className="h-4 w-4" />
+              <Plus className="h-3.5 w-3.5" />
             </button>
           </div>
         }
@@ -134,63 +158,135 @@ export function PersonasSection() {
         isDetailVisible={mobileDetailVisible}
         onBackAction={() => setMobileDetailVisible(false)}
         detailPanel={
-          <div className="max-w-[560px] space-y-6">
+          <div className="w-full max-w-[720px]">
             {showDetail ? (
-              <>
-                <div className="space-y-4">
-                  <div>
-                    <h3 className="text-[1.1rem] font-semibold text-[#f4f4f5]">
-                      {isAddingNew ? "New Persona" : selectedPersona?.name}
-                    </h3>
+              <div className="space-y-0">
+                {/* Header */}
+                <div className="pb-5">
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <h3 className="text-base font-semibold text-[var(--text)]">
+                        {isAddingNew ? "New persona" : selectedPersona?.name}
+                      </h3>
+                      <p className="mt-1 text-xs text-[var(--muted)]">
+                        {isAddingNew
+                          ? "Create a new persona with custom system instructions."
+                          : "Edit the name and system instructions for this persona."}
+                      </p>
+                    </div>
+                    {!isAddingNew && selectedPersona ? (
+                      <button
+                        type="button"
+                        onClick={() => deletePersona(selectedPersona.id)}
+                        className="inline-flex items-center gap-1.5 px-2.5 py-1.5 text-xs text-red-400/80 transition-colors hover:text-red-300"
+                      >
+                        Delete
+                      </button>
+                    ) : null}
                   </div>
+                </div>
 
-                  {!isAddingNew && selectedPersona ? (
-                    <Button
-                      type="button"
-                      variant="danger"
-                      onClick={() => deletePersona(selectedPersona.id)}
-                      className="gap-1.5 px-3 py-1.5 text-xs"
-                    >
-                      Delete
+                {/* Identity */}
+                <div className={`${sectionDivider} py-5`}>
+                  <h4 className={sectionTitle}>Identity</h4>
+                  <div className="mt-4 space-y-5">
+                    <div>
+                      <label className={fieldLabel}>Name</label>
+                      <Input
+                        value={personaName}
+                        onChange={(e) => setPersonaName(e.target.value)}
+                        placeholder="Persona name"
+                      />
+                    </div>
+                    <div>
+                      <div className="flex items-center justify-between mb-1.5">
+                        <label className={fieldLabel}>System Instructions (Markdown)</label>
+                        <button
+                          type="button"
+                          onClick={openPersonaContent}
+                          className="text-xs text-[var(--accent)] hover:underline"
+                        >
+                          Edit
+                        </button>
+                      </div>
+                      <div
+                        onClick={openPersonaContent}
+                        className="cursor-pointer rounded-xl border border-white/6 bg-white/4 px-4 py-3 text-sm text-[var(--muted)] line-clamp-3 hover:bg-white/[0.06] transition-colors"
+                      >
+                        {personaContent || "No system instructions set"}
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                {/* Actions */}
+                <div className={`${sectionDivider} py-5`}>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Button type="button" className="px-3 py-1.5 text-xs" onClick={savePersona}>
+                      Save
                     </Button>
-                  ) : null}
-                </div>
-
-                <div className="space-y-5">
-                  <div>
-                    <label className={labelClass}>Name</label>
-                    <Input
-                      value={personaName}
-                      onChange={(e) => setPersonaName(e.target.value)}
-                      placeholder="Persona name"
-                    />
-                  </div>
-                  <div>
-                    <label className={labelClass}>System Instructions (Markdown)</label>
-                    <Textarea
-                      value={personaContent}
-                      onChange={(e) => setPersonaContent(e.target.value)}
-                      placeholder="Enter the persona instructions in markdown..."
-                      rows={12}
-                    />
+                    <Button type="button" variant="ghost" className="px-2.5 py-1.5 text-xs" onClick={resetPersonaForm}>
+                      Cancel
+                    </Button>
                   </div>
                 </div>
 
-                <div className="flex gap-2 pt-2">
-                  <Button type="button" onClick={savePersona}>
-                    {editingPersonaId ? "Update" : "Add persona"}
-                  </Button>
-                  <Button type="button" variant="secondary" onClick={resetPersonaForm}>
-                    Cancel
-                  </Button>
-                </div>
-              </>
+                {/* Persona Content Modal */}
+                {isPersonaContentOpen && (
+                  <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+                    <div
+                      className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+                      onClick={closePersonaContent}
+                    />
+                    <div className="relative w-full max-w-[720px] max-h-[80vh] flex flex-col rounded-2xl border border-white/[0.08] bg-[#121214] p-6 shadow-2xl">
+                      <div className="flex items-center justify-between mb-4">
+                        <h3 className="text-sm font-semibold text-[var(--text)]">Edit system instructions</h3>
+                        <button
+                          type="button"
+                          onClick={closePersonaContent}
+                          className="text-[var(--muted)] hover:text-[var(--text)] transition-colors"
+                        >
+                          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
+                        </button>
+                      </div>
+                      <p className="mb-3 text-xs text-[var(--muted)]">
+                        Markdown is supported
+                      </p>
+                      <Textarea
+                        autoComplete="off"
+                        spellCheck={false}
+                        value={personaContentDraft}
+                        onChange={(event) => setPersonaContentDraft(event.target.value)}
+                        rows={16}
+                        className="flex-1 resize-none min-h-[300px]"
+                      />
+                      <div className="flex flex-wrap items-center justify-end gap-2 mt-5 pt-4 border-t border-white/[0.06]">
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          className="px-3 py-1.5 text-xs"
+                          onClick={closePersonaContent}
+                        >
+                          Cancel
+                        </Button>
+                        <Button
+                          type="button"
+                          className="px-3 py-1.5 text-xs"
+                          onClick={savePersonaContent}
+                        >
+                          Save
+                        </Button>
+                      </div>
+                    </div>
+                  </div>
+                )}
+              </div>
             ) : (
               <div className="flex flex-col items-center justify-center py-24 text-center">
                 <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-white/[0.03] border border-white/6 mb-4">
-                  <FileText className="h-5 w-5 text-[#52525b]" />
+                  <FileText className="h-5 w-5 text-[var(--muted)]" />
                 </div>
-                <p className="text-[0.85rem] text-[#71717a]">
+                <p className="text-sm text-[var(--muted)]">
                   Select a persona or add a new one
                 </p>
               </div>

--- a/components/settings/sections/providers-section.tsx
+++ b/components/settings/sections/providers-section.tsx
@@ -1,17 +1,13 @@
 "use client";
 
 import { type FormEvent, useEffect, useMemo, useState } from "react";
-import { useRouter } from "next/navigation";
 import {
-  Sparkles,
   Plus,
   Trash2,
   Check,
   Eye,
   EyeOff,
-  Zap,
-  Shield,
-  FlaskConical
+  Zap
 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -28,7 +24,6 @@ import type { AppSettings, ApiMode, McpServer, ProviderPresetId, ReasoningEffort
 
 import { SettingsSplitPane } from "../settings-split-pane";
 import { ProfileCard } from "../profile-card";
-import { CollapsibleSection } from "../collapsible-section";
 
 type SettingsPayload = AppSettings & {
   providerProfiles: Array<{
@@ -75,10 +70,9 @@ type ProviderProfileDraft = SettingsPayload["providerProfiles"][number] & {
 };
 
 export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
-  const router = useRouter();
   const [error, setError] = useState("");
   const [success, setSuccess] = useState("");
-  const [testResult, setTestResult] = useState("");
+  const [testResult, setTestResult] = useState<{ text: string; isSuccess: boolean } | null>(null);
   const [defaultProviderProfileId, setDefaultProviderProfileId] = useState(
     settings.defaultProviderProfileId ?? settings.providerProfiles[0]?.id ?? ""
   );
@@ -96,6 +90,8 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
   const [showApiKey, setShowApiKey] = useState(false);
   const [mcpServers, setMcpServers] = useState<McpServer[]>([]);
   const [copilotModels, setCopilotModels] = useState<Array<{ id: string; name: string; maxContextWindowTokens: number | null }>>([]);
+  const [isSystemPromptOpen, setIsSystemPromptOpen] = useState(false);
+  const [systemPromptDraft, setSystemPromptDraft] = useState("");
   const maskedApiKeyValue = "••••••••";
 
   useEffect(() => {
@@ -327,19 +323,51 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
   }
 
   async function runConnectionTest() {
-    setTestResult("");
+    setTestResult(null);
     const response = await fetch("/api/settings/test", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ providerProfileId: selectedProviderProfileId })
     });
     const result = (await response.json()) as { text?: string; error?: string };
-    setTestResult(result.text ?? result.error ?? "No result");
+    const text = result.text ?? result.error ?? "No result";
+    setTestResult({ text, isSuccess: response.ok && !result.error });
   }
 
-  const selectClass =
-    "w-full rounded-xl border border-white/6 bg-white/[0.03] px-4 py-3 text-sm outline-none focus:border-[rgba(139,92,246,0.3)] transition-all duration-200 text-[#f4f4f5]";
-  const labelClass = "text-[0.68rem] font-semibold uppercase tracking-[0.12em] text-[#71717a]";
+  async function handleToggleDefault() {
+    if (!activeProviderProfile || activeProviderProfile.id === defaultProviderProfileId) {
+      return;
+    }
+    setError("");
+    setSuccess("");
+    if (await saveSettingsWithDefault(activeProviderProfile.id)) {
+      setDefaultProviderProfileId(activeProviderProfile.id);
+      setSuccess("Default provider updated.");
+    }
+  }
+
+  function openSystemPrompt() {
+    if (!activeProviderProfile) return;
+    setSystemPromptDraft(activeProviderProfile.systemPrompt);
+    setIsSystemPromptOpen(true);
+  }
+
+  function saveSystemPrompt() {
+    updateActiveProviderProfile({ systemPrompt: systemPromptDraft });
+    setIsSystemPromptOpen(false);
+  }
+
+  function closeSystemPrompt() {
+    setIsSystemPromptOpen(false);
+    setSystemPromptDraft("");
+  }
+
+  const fieldLabel = "block text-[13px] font-medium text-[var(--muted)] mb-1.5";
+  const inputLike =
+    "w-full rounded-xl border border-white/6 bg-white/4 px-4 py-3 text-sm text-[var(--text)] outline-none transition-all duration-200 focus:border-[var(--accent)]/40 focus:bg-white/6 focus:shadow-[0_0_0_3px_var(--accent-soft)]";
+  const selectLike = `${inputLike} appearance-none bg-[url('data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2224%22%20height%3D%2224%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20stroke%3D%22%2371717a%22%20stroke-width%3D%222%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%3E%3Cpolyline%20points%3D%226%209%2012%2015%2018%209%22%3E%3C%2Fpolyline%3E%3C%2Fsvg%3E')] bg-[length:1rem_1rem] bg-[right_0.75rem_center] bg-no-repeat pr-10`;
+  const sectionTitle = "text-sm font-semibold text-[var(--text)]";
+  const sectionDivider = "border-t border-white/[0.06]";
 
   return (
     <div className="min-h-0 p-4 md:h-full md:p-8">
@@ -347,17 +375,17 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
         listHeader={
           <div className="flex items-center justify-between w-full">
             <div>
-              <h2 className="text-[0.9rem] font-semibold text-[#f4f4f5]">Providers</h2>
-              <p className="text-[0.68rem] text-[#52525b]">
+              <h2 className="text-sm font-semibold text-[var(--text)]">Providers</h2>
+              <p className="text-xs text-[var(--muted)]">
                 {providerProfiles.length} profile{providerProfiles.length !== 1 ? "s" : ""}
               </p>
             </div>
             <button
               type="button"
               onClick={addProviderProfile}
-              className="flex h-7 w-7 items-center justify-center rounded-lg border border-white/6 bg-white/[0.03] text-[#71717a] hover:text-[#f4f4f5] hover:bg-white/[0.06] transition-all duration-200"
+              className="flex h-7 w-7 items-center justify-center rounded-lg border border-white/[0.08] bg-white/[0.04] text-[var(--muted)] hover:text-[var(--text)] hover:bg-white/[0.07] transition-all duration-200"
             >
-              <Plus className="h-4 w-4" />
+              <Plus className="h-3.5 w-3.5" />
             </button>
           </div>
         }
@@ -397,151 +425,138 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
         detailPanel={
           <form
             onSubmit={(event) => void handleSettings(event)}
-            className="max-w-[560px] space-y-6"
+            className="w-full max-w-[840px]"
           >
             {activeProviderProfile ? (
-              <>
-                <div className="space-y-4">
-                  <div>
-                    <h3 className="text-[1.1rem] font-semibold text-[#f4f4f5]">
+              <div className="space-y-0">
+                {/* Header */}
+                <div className="pb-5">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <h3 className="text-base font-semibold text-[var(--text)]">
                       {activeProviderProfile.name}
                     </h3>
-                    <p className="mt-0.5 text-[0.75rem] text-[#52525b]">
-                      {isCopilot
-                        ? `GitHub Copilot${activeProviderProfile.model ? ` · ${activeProviderProfile.model}` : ""}`
-                        : `${activeProviderProfile.apiBaseUrl} · ${activeProviderProfile.model} · ${activeProviderProfile.apiMode}`}
-                    </p>
+                    {activeProviderProfile.id === defaultProviderProfileId && (
+                      <span className="inline-flex items-center rounded-md bg-[var(--accent)]/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-[var(--accent)]">
+                        Default
+                      </span>
+                    )}
+                    {!activeProviderProfile.hasApiKey && !activeProviderProfile.apiKey && activeProviderProfile.providerKind !== "github_copilot" && (
+                      <span className="inline-flex items-center rounded-md bg-amber-500/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-amber-400">
+                        No key
+                      </span>
+                    )}
+                    {activeProviderProfile.providerKind === "github_copilot" && activeProviderProfile.githubConnectionStatus === "disconnected" && (
+                      <span className="inline-flex items-center rounded-md bg-amber-500/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-amber-400">
+                        Not connected
+                      </span>
+                    )}
                   </div>
+                  <p className="mt-1 text-xs text-[var(--muted)]">
+                    {isCopilot
+                      ? `GitHub Copilot${activeProviderProfile.model ? ` · ${activeProviderProfile.model}` : ""}`
+                      : `${activeProviderProfile.apiBaseUrl} · ${activeProviderProfile.model} · ${activeProviderProfile.apiMode}`}
+                  </p>
+                </div>
 
-                  <div className="flex flex-wrap items-center gap-2">
-                    <Button
-                      type="button"
-                      variant="secondary"
-                      onClick={runConnectionTest}
-                      className="gap-1.5 px-3 py-1.5 text-xs"
-                    >
-                      <Zap className="h-3.5 w-3.5" />
-                      Test
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="secondary"
-                      onClick={async () => {
-                        setError("");
-                        setSuccess("");
-                        const nextDefaultProfileId = activeProviderProfile.id;
-
-                        if (await saveSettingsWithDefault(nextDefaultProfileId)) {
-                          setDefaultProviderProfileId(nextDefaultProfileId);
+                {/* Identity */}
+                <div className={`${sectionDivider} py-5`}>
+                  <h4 className={sectionTitle}>Identity</h4>
+                  <div className="mt-4 grid grid-cols-1 gap-5 sm:grid-cols-2">
+                    <div className="sm:col-span-2">
+                      <label className={fieldLabel}>Profile name</label>
+                      <Input
+                        name="provider-profile-name"
+                        autoComplete="off"
+                        value={activeProviderProfile.name}
+                        onChange={(event) =>
+                          updateActiveProviderProfile({ name: event.target.value })
                         }
-                      }}
-                      disabled={activeProviderProfile.id === defaultProviderProfileId}
-                      className="gap-1.5 px-3 py-1.5 text-xs"
-                    >
-                      <Shield className="h-3.5 w-3.5" />
-                      {activeProviderProfile.id === defaultProviderProfileId
-                        ? "Is Default"
-                        : "Set Default"}
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="secondary"
-                      onClick={() => removeProviderProfile(activeProviderProfile.id)}
-                      disabled={providerProfiles.length === 1}
-                      className="gap-1.5 px-3 py-1.5 text-xs text-red-400 hover:text-red-300"
-                    >
-                      <Trash2 className="h-3.5 w-3.5" />
-                      Delete
-                    </Button>
+                        required
+                      />
+                    </div>
+                    <label className="flex items-center gap-3 rounded-xl border border-white/6 bg-white/4 px-4 py-3 text-sm text-[var(--text)] cursor-pointer sm:col-span-2">
+                      <input
+                        type="checkbox"
+                        checked={activeProviderProfile.id === defaultProviderProfileId}
+                        onChange={() => {
+                          if (activeProviderProfile.id !== defaultProviderProfileId) {
+                            void handleToggleDefault();
+                          }
+                        }}
+                        disabled={activeProviderProfile.id === defaultProviderProfileId}
+                      />
+                      Default provider
+                    </label>
+                    <div>
+                      <label className={fieldLabel}>Provider type</label>
+                      <select
+                        className={selectLike}
+                        value={activeProviderProfile.providerKind ?? "openai_compatible"}
+                        onChange={(event) => {
+                          const value = event.target.value as "openai_compatible" | "github_copilot";
+                          if (value === "github_copilot") {
+                            updateActiveProviderProfile({
+                              providerKind: "github_copilot",
+                              apiBaseUrl: "",
+                              apiKey: "",
+                              model: "",
+                              apiMode: "responses",
+                              systemPrompt: "",
+                              tokenizerModel: "off",
+                              providerPresetId: null
+                            });
+                          } else {
+                            updateActiveProviderProfile({
+                              providerKind: "openai_compatible",
+                              apiBaseUrl: activeProviderProfile.apiBaseUrl || "https://api.openai.com/v1",
+                              apiKey: "",
+                              providerPresetId: null
+                            });
+                          }
+                        }}
+                      >
+                        <option value="openai_compatible">OpenAI compatible</option>
+                        <option value="github_copilot">GitHub Copilot</option>
+                      </select>
+                    </div>
+                    {!isCopilot && (
+                      <div>
+                        <label className={fieldLabel}>Provider preset</label>
+                        <select
+                          value={activeProviderPresetId ?? ""}
+                          onChange={(event) => {
+                            const nextPresetId = event.target.value as ProviderPresetId;
+                            if (!nextPresetId) return;
+                            applyPresetToActiveProviderProfile(nextPresetId);
+                          }}
+                          className={selectLike}
+                        >
+                          <option value="">Manual configuration</option>
+                          {PROVIDER_PRESETS.map((preset) => (
+                            <option key={preset.id} value={preset.id}>
+                              {preset.label}
+                            </option>
+                          ))}
+                        </select>
+                      </div>
+                    )}
                   </div>
                 </div>
 
-                <div className="space-y-5">
-                  <div>
-                    <label className={labelClass}>Provider type</label>
-                    <select
-                      className={selectClass}
-                      value={activeProviderProfile.providerKind ?? "openai_compatible"}
-                      onChange={(event) => {
-                        const value = event.target.value as "openai_compatible" | "github_copilot";
-
-                        if (value === "github_copilot") {
-                          updateActiveProviderProfile({
-                            providerKind: "github_copilot",
-                            apiBaseUrl: "",
-                            apiKey: "",
-                            model: "",
-                            apiMode: "responses",
-                            systemPrompt: "",
-                            tokenizerModel: "off",
-                            providerPresetId: null
-                          });
-                        } else {
-                          updateActiveProviderProfile({
-                            providerKind: "openai_compatible",
-                            apiBaseUrl: activeProviderProfile.apiBaseUrl || "https://api.openai.com/v1",
-                            apiKey: "",
-                            providerPresetId: null
-                          });
-                        }
-                      }
-                    }
-                    >
-                      <option value="openai_compatible">OpenAI compatible</option>
-                      <option value="github_copilot">GitHub Copilot</option>
-                    </select>
-                  </div>
-
-                  {!isCopilot && (
-                    <div>
-                      <label className={labelClass}>Provider preset</label>
-                      <select
-                        value={activeProviderPresetId ?? ""}
-                        onChange={(event) => {
-                          const nextPresetId = event.target.value as ProviderPresetId;
-
-                          if (!nextPresetId) {
-                            return;
-                          }
-
-                          applyPresetToActiveProviderProfile(nextPresetId);
-                        }}
-                        className={selectClass}
-                      >
-                        <option value="">Manual configuration</option>
-                        {PROVIDER_PRESETS.map((preset) => (
-                          <option key={preset.id} value={preset.id}>
-                            {preset.label}
-                          </option>
-                        ))}
-                      </select>
-                    </div>
-                  )}
-
-                  <div>
-                    <label className={labelClass}>Profile name</label>
-                    <Input
-                      name="provider-profile-name"
-                      autoComplete="off"
-                      value={activeProviderProfile.name}
-                      onChange={(event) =>
-                        updateActiveProviderProfile({ name: event.target.value })
-                      }
-                      required
-                    />
-                  </div>
-
+                {/* Connection */}
+                <div className={`${sectionDivider} py-5`}>
+                  <h4 className={sectionTitle}>Connection</h4>
                   {isCopilot ? (
-                    <div className="space-y-3">
-                      <p className={labelClass}>GitHub connection</p>
-                      <div className="rounded-xl border border-white/6 bg-white/[0.03] px-4 py-3 text-sm text-[#f4f4f5]">
+                    <div className="mt-4 space-y-4">
+                      <div className="rounded-lg border border-white/[0.06] bg-white/[0.03] px-4 py-3 text-sm text-[var(--text)]">
                         {activeProviderProfile.githubConnectionStatus === "connected"
                           ? `Connected as ${activeProviderProfile.githubAccountLogin ?? "GitHub user"}`
                           : "No GitHub account connected"}
                       </div>
-                      <div className="flex gap-2">
+                      <div className="flex flex-wrap items-center gap-2">
                         <Button
                           type="button"
+                          className="px-3 py-1.5 text-xs"
                           onClick={async () => {
                             if (await saveSettings()) {
                               window.location.href = `/api/providers/github/connect?providerProfileId=${activeProviderProfile.id}`;
@@ -555,6 +570,7 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
                         <Button
                           type="button"
                           variant="ghost"
+                          className="px-2.5 py-1.5 text-xs"
                           onClick={async () => {
                             await fetch("/api/providers/github/disconnect", {
                               method: "POST",
@@ -572,12 +588,42 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
                           Disconnect
                         </Button>
                       </div>
+                      {isCopilot && copilotModels.length > 0 && (
+                        <div>
+                          <label className={fieldLabel}>Model</label>
+                          <select
+                            value={activeProviderProfile.model}
+                            onChange={(event) => {
+                              const selected = copilotModels.find((m) => m.id === event.target.value);
+                              updateActiveProviderProfile({
+                                model: event.target.value,
+                                ...(selected?.maxContextWindowTokens
+                                  ? { modelContextLimit: selected.maxContextWindowTokens }
+                                  : {})
+                              });
+                            }}
+                            className={selectLike}
+                          >
+                            {copilotModels.map((model) => (
+                              <option key={model.id} value={model.id}>{model.name}</option>
+                            ))}
+                          </select>
+                        </div>
+                      )}
+                      {isCopilot && copilotModels.length === 0 && activeProviderProfile.githubConnectionStatus !== "connected" && (
+                        <div>
+                          <label className={fieldLabel}>Model</label>
+                          <div className="rounded-lg border border-white/[0.06] bg-white/[0.03] px-4 py-3 text-sm text-[var(--muted)]">
+                            Connect GitHub to browse models
+                          </div>
+                        </div>
+                      )}
                     </div>
                   ) : (
-                    <>
-                      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                    <div className="mt-4 space-y-4">
+                      <div className="grid grid-cols-1 gap-5 sm:grid-cols-2">
                         <div>
-                          <label className={labelClass}>API base URL</label>
+                          <label className={fieldLabel}>API base URL</label>
                           <Input
                             name="provider-api-base-url"
                             autoComplete="url"
@@ -589,7 +635,7 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
                           />
                         </div>
                         <div>
-                          <label className={labelClass}>Model</label>
+                          <label className={fieldLabel}>Model</label>
                           <Input
                             name="provider-model"
                             autoComplete="off"
@@ -601,9 +647,8 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
                           />
                         </div>
                       </div>
-
                       <div>
-                        <label className={labelClass}>API key</label>
+                        <label className={fieldLabel}>API key</label>
                         <div className="relative">
                           <Input
                             name="provider-api-key"
@@ -614,122 +659,74 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
                             onChange={(event) =>
                               updateActiveProviderProfile({
                                 apiKey: event.target.value,
-                                hasApiKey:
-                                  activeProviderProfile.hasApiKey || Boolean(event.target.value)
+                                hasApiKey: activeProviderProfile.hasApiKey || Boolean(event.target.value)
                               })
                             }
-                            placeholder={
-                              activeProviderProfile.hasApiKey
-                                ? maskedApiKeyValue
-                                : "sk-..."
-                            }
+                            placeholder={activeProviderProfile.hasApiKey ? maskedApiKeyValue : "sk-..."}
                             className="pr-10"
                           />
                           <button
                             type="button"
                             onClick={() => setShowApiKey((v) => !v)}
-                            className="absolute right-3 top-1/2 -translate-y-1/2 text-[#52525b] hover:text-[#a1a1aa] transition-colors"
+                            className="absolute right-3 top-1/2 -translate-y-1/2 text-[var(--muted)] hover:text-[var(--text)] transition-colors"
                           >
-                            {showApiKey ? (
-                              <EyeOff className="h-4 w-4" />
-                            ) : (
-                              <Eye className="h-4 w-4" />
-                            )}
+                            {showApiKey ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
                           </button>
                         </div>
-                      </div>
-                    </>
-                  )}
-
-                  {isCopilot && copilotModels.length > 0 && (
-                    <div>
-                      <label className={labelClass}>Model</label>
-                      <select
-                        value={activeProviderProfile.model}
-                        onChange={(event) => {
-                          const selected = copilotModels.find((m) => m.id === event.target.value);
-                          updateActiveProviderProfile({
-                            model: event.target.value,
-                            ...(selected?.maxContextWindowTokens
-                              ? { modelContextLimit: selected.maxContextWindowTokens }
-                              : {})
-                          });
-                        }}
-                        className={selectClass}
-                      >
-                        {copilotModels.map((model) => (
-                          <option key={model.id} value={model.id}>{model.name}</option>
-                        ))}
-                      </select>
-                    </div>
-                  )}
-
-                  {isCopilot && copilotModels.length === 0 && activeProviderProfile.githubConnectionStatus !== "connected" && (
-                    <div>
-                      <label className={labelClass}>Model</label>
-                      <div className="rounded-xl border border-white/6 bg-white/[0.03] px-4 py-3 text-sm text-[#52525b]">
-                        Connect GitHub to browse models
                       </div>
                     </div>
                   )}
                 </div>
 
-                <CollapsibleSection
-                  title="Advanced Settings"
-                  icon={<FlaskConical className="h-4 w-4" />}
-                >
-                  <div className="mb-3 flex justify-end">
+                {/* Configuration */}
+                <div className={`${sectionDivider} py-5`}>
+                  <div className="flex items-center justify-between">
+                    <h4 className={sectionTitle}>Configuration</h4>
                     <Button
                       type="button"
-                      variant="secondary"
+                      variant="ghost"
                       onClick={resetActiveProviderAdvancedSettings}
-                      className="gap-1.5 px-3 py-1.5 text-xs"
+                      className="px-2.5 py-1 text-[11px]"
                     >
-                      Reset advanced defaults
+                      Reset defaults
                     </Button>
                   </div>
-                  <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                  <div className="mt-4 grid grid-cols-1 gap-x-8 gap-y-4 sm:grid-cols-2">
                     {!isCopilot && (
                       <>
                         <div>
-                          <label className={labelClass}>Temperature</label>
+                          <label className={fieldLabel}>Temperature</label>
                           <Input
                             name="provider-temperature"
                             type="number"
                             step="0.1"
                             value={activeProviderProfile.temperature}
                             onChange={(event) =>
-                              updateActiveProviderProfile({
-                                temperature: Number(event.target.value || 0)
-                              })
+                              updateActiveProviderProfile({ temperature: Number(event.target.value || 0) })
                             }
                           />
                         </div>
                         <div>
-                          <label className={labelClass}>Max output tokens</label>
+                          <label className={fieldLabel}>Max output tokens</label>
                           <Input
                             name="provider-max-output-tokens"
                             type="number"
                             value={activeProviderProfile.maxOutputTokens}
                             onChange={(event) =>
-                              updateActiveProviderProfile({
-                                maxOutputTokens: Number(event.target.value || 0)
-                              })
+                              updateActiveProviderProfile({ maxOutputTokens: Number(event.target.value || 0) })
                             }
                           />
                         </div>
                       </>
                     )}
                     <div>
-                      <label className={labelClass}>Reasoning effort</label>
+                      <label className={fieldLabel}>Reasoning effort</label>
                       <select
                         value={activeProviderProfile.reasoningEffort}
                         onChange={(event) =>
-                          updateActiveProviderProfile({
-                            reasoningEffort: event.target.value as ReasoningEffort
-                          })
+                          updateActiveProviderProfile({ reasoningEffort: event.target.value as ReasoningEffort })
                         }
-                        className={selectClass}
+                        className={selectLike}
                       >
                         <option value="low">low</option>
                         <option value="medium">medium</option>
@@ -740,50 +737,46 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
                     {!isCopilot && (
                       <>
                         <div>
-                          <label className={labelClass}>Reasoning summary</label>
-                          <label className="flex h-[46px] items-center gap-3 rounded-xl border border-white/6 bg-white/[0.03] px-4 text-[0.82rem] text-[#a1a1aa] cursor-pointer">
-                            <input
-                              type="checkbox"
-                              checked={activeProviderProfile.reasoningSummaryEnabled}
-                              onChange={(event) =>
-                                updateActiveProviderProfile({
-                                  reasoningSummaryEnabled: event.target.checked
-                                })
-                              }
-                            />
-                            Show reasoning when supported
-                          </label>
-                        </div>
-                        <div>
-                          <label className={labelClass}>API mode</label>
+                          <label className={fieldLabel}>API mode</label>
                           <select
                             value={activeProviderProfile.apiMode}
                             onChange={(event) =>
                               updateActiveProviderProfile({ apiMode: event.target.value as ApiMode })
                             }
-                            className={selectClass}
+                            className={selectLike}
                           >
                             <option value="responses">responses</option>
                             <option value="chat_completions">chat_completions</option>
                           </select>
                         </div>
+                        <div>
+                          <label className={fieldLabel}>Reasoning summary</label>
+                          <label className="flex h-[42px] items-center gap-3 rounded-lg border border-white/[0.06] bg-white/[0.03] px-3 text-sm text-[var(--muted)] cursor-pointer">
+                            <input
+                              type="checkbox"
+                              checked={activeProviderProfile.reasoningSummaryEnabled}
+                              onChange={(event) =>
+                                updateActiveProviderProfile({ reasoningSummaryEnabled: event.target.checked })
+                              }
+                            />
+                            Show reasoning when supported
+                          </label>
+                        </div>
                       </>
                     )}
                     <div>
-                      <label className={labelClass}>Model context limit</label>
+                      <label className={fieldLabel}>Model context limit</label>
                       <Input
                         name="provider-model-context-limit"
                         type="number"
                         value={activeProviderProfile.modelContextLimit}
                         onChange={(event) =>
-                          updateActiveProviderProfile({
-                            modelContextLimit: Number(event.target.value || 0)
-                          })
+                          updateActiveProviderProfile({ modelContextLimit: Number(event.target.value || 0) })
                         }
                       />
                     </div>
                     <div>
-                      <label className={labelClass}>Compaction threshold %</label>
+                      <label className={fieldLabel}>Compaction threshold %</label>
                       <Input
                         name="provider-compaction-threshold"
                         type="number"
@@ -793,42 +786,39 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
                         value={Math.round(activeProviderProfile.compactionThreshold * 100)}
                         onChange={(event) =>
                           updateActiveProviderProfile({
-                            compactionThreshold:
-                              Math.round(Number(event.target.value || 0)) / 100
+                            compactionThreshold: Math.round(Number(event.target.value || 0)) / 100
                           })
                         }
                       />
                     </div>
                     <div>
-                      <label className={labelClass}>Fresh tail turns</label>
+                      <label className={fieldLabel}>Fresh tail turns</label>
                       <Input
                         name="provider-fresh-tail-count"
                         type="number"
                         value={activeProviderProfile.freshTailCount}
                         onChange={(event) =>
-                          updateActiveProviderProfile({
-                            freshTailCount: Number(event.target.value || 0)
-                          })
+                          updateActiveProviderProfile({ freshTailCount: Number(event.target.value || 0) })
                         }
                       />
                     </div>
                     {!isCopilot && (
                       <>
                         <div>
-                          <label className={labelClass}>Tokenizer model</label>
+                          <label className={fieldLabel}>Tokenizer model</label>
                           <select
                             value={activeProviderProfile.tokenizerModel}
                             onChange={(event) =>
                               updateActiveProviderProfile({ tokenizerModel: event.target.value as "gpt-tokenizer" | "off" })
                             }
-                            className={selectClass}
+                            className={selectLike}
                           >
                             <option value="gpt-tokenizer">gpt-tokenizer</option>
                             <option value="off">Off (char / 4)</option>
                           </select>
                         </div>
                         <div>
-                          <label className={labelClass}>Safety margin tokens</label>
+                          <label className={fieldLabel}>Safety margin tokens</label>
                           <Input
                             name="provider-safety-margin-tokens"
                             type="number"
@@ -839,7 +829,7 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
                           />
                         </div>
                         <div>
-                          <label className={labelClass}>Leaf source token limit</label>
+                          <label className={fieldLabel}>Leaf source token limit</label>
                           <Input
                             name="provider-leaf-source-token-limit"
                             type="number"
@@ -850,7 +840,7 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
                           />
                         </div>
                         <div>
-                          <label className={labelClass}>Leaf min message count</label>
+                          <label className={fieldLabel}>Leaf min message count</label>
                           <Input
                             name="provider-leaf-min-message-count"
                             type="number"
@@ -861,7 +851,7 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
                           />
                         </div>
                         <div>
-                          <label className={labelClass}>Merged min node count</label>
+                          <label className={fieldLabel}>Merged min node count</label>
                           <Input
                             name="provider-merged-min-node-count"
                             type="number"
@@ -872,7 +862,7 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
                           />
                         </div>
                         <div>
-                          <label className={labelClass}>Merged target tokens</label>
+                          <label className={fieldLabel}>Merged target tokens</label>
                           <Input
                             name="provider-merged-target-tokens"
                             type="number"
@@ -885,13 +875,13 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
                       </>
                     )}
                     <div>
-                      <label className={labelClass}>Vision mode</label>
+                      <label className={fieldLabel}>Vision mode</label>
                       <select
                         value={activeProviderProfile.visionMode ?? "native"}
                         onChange={(event) =>
                           updateActiveProviderProfile({ visionMode: event.target.value as VisionMode })
                         }
-                        className={selectClass}
+                        className={selectLike}
                       >
                         <option value="native">native</option>
                         <option value="none">none</option>
@@ -900,13 +890,13 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
                     </div>
                     {activeProviderProfile.visionMode === "mcp" && (
                       <div>
-                        <label className={labelClass}>Vision MCP server</label>
+                        <label className={fieldLabel}>Vision MCP server</label>
                         <select
                           value={activeProviderProfile.visionMcpServerId ?? ""}
                           onChange={(event) =>
                             updateActiveProviderProfile({ visionMcpServerId: event.target.value || null })
                           }
-                          className={selectClass}
+                          className={selectLike}
                         >
                           <option value="">Select a server...</option>
                           {mcpServers
@@ -918,71 +908,149 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
                             ))}
                         </select>
                         {activeProviderProfile.visionMcpServerId === null && (
-                          <p className="mt-1 text-xs text-amber-400">
+                          <p className="mt-1.5 text-xs text-amber-400">
                             Select an MCP server for image analysis
                           </p>
                         )}
                       </div>
                     )}
                   </div>
-                </CollapsibleSection>
-
-                <CollapsibleSection
-                  title="System Prompt & Skills"
-                  icon={<Sparkles className="h-4 w-4" />}
-                  defaultOpen={false}
-                >
-                  <div className="space-y-4">
-                    <div>
-                      <label className={labelClass}>
-                        System prompt (applied to new conversations only)
-                      </label>
-                      <Textarea
-                        name="provider-system-prompt"
-                        autoComplete="off"
-                        spellCheck={false}
-                        value={activeProviderProfile.systemPrompt}
-                        onChange={(event) =>
-                          updateActiveProviderProfile({ systemPrompt: event.target.value })
-                        }
-                        rows={5}
-                        required
-                      />
-                    </div>
-                    <div>
-                      <label className={labelClass}>Workspace skills</label>
-                      <label className="flex h-[46px] items-center gap-3 rounded-xl border border-white/6 bg-white/[0.03] px-4 text-[0.82rem] text-[#a1a1aa] cursor-pointer">
-                        <input
-                          type="checkbox"
-                          checked={skillsEnabled}
-                          onChange={(event) => setSkillsEnabled(event.target.checked)}
-                        />
-                        Make enabled skills available to every chat in this workspace
-                      </label>
-                    </div>
-                  </div>
-                </CollapsibleSection>
-
-                <div className="flex flex-wrap items-center gap-3 pt-2">
-                  <Button type="submit">Save Changes</Button>
-                  {success ? (
-                    <div className="flex items-center gap-1.5 text-sm text-emerald-400">
-                      <Check className="h-3.5 w-3.5" />
-                      {success}
-                    </div>
-                  ) : null}
                 </div>
 
-                {testResult ? (
-                  <p className="text-[0.82rem] text-[#71717a]">{testResult}</p>
-                ) : null}
+                {/* System */}
+                <div className={`${sectionDivider} py-5`}>
+                  <h4 className={sectionTitle}>System</h4>
+                  <div className="mt-4 space-y-4">
+                    <div>
+                      <div className="flex items-center justify-between mb-1.5">
+                        <label className={fieldLabel}>System prompt</label>
+                        <button
+                          type="button"
+                          onClick={openSystemPrompt}
+                          className="text-xs text-[var(--accent)] hover:underline"
+                        >
+                          Edit
+                        </button>
+                      </div>
+                      <p className="mb-1.5 text-xs text-[var(--muted)]">
+                        Applied to new conversations only
+                      </p>
+                      <div
+                        onClick={openSystemPrompt}
+                        className="cursor-pointer rounded-xl border border-white/6 bg-white/4 px-4 py-3 text-sm text-[var(--muted)] line-clamp-3 hover:bg-white/[0.06] transition-colors"
+                      >
+                        {activeProviderProfile.systemPrompt || "No system prompt set"}
+                      </div>
+                    </div>
+                    <label className="flex items-center gap-3 rounded-lg border border-white/[0.06] bg-white/[0.03] px-3 py-2.5 text-sm text-[var(--muted)] cursor-pointer">
+                      <input
+                        type="checkbox"
+                        checked={skillsEnabled}
+                        onChange={(event) => setSkillsEnabled(event.target.checked)}
+                      />
+                      Make enabled skills available to every chat in this workspace
+                    </label>
+                  </div>
+                </div>
 
+                {/* Actions */}
+                <div className={`${sectionDivider} py-5`}>
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Button type="submit" className="px-3 py-1.5 text-xs">
+                        Save
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        onClick={runConnectionTest}
+                        className="gap-1.5 px-2.5 py-1.5 text-xs"
+                      >
+                        <Zap className="h-3.5 w-3.5" />
+                        Test
+                      </Button>
+
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => removeProviderProfile(activeProviderProfile.id)}
+                      disabled={providerProfiles.length === 1}
+                      className="inline-flex items-center gap-1.5 px-2.5 py-1.5 text-xs text-red-400/80 transition-colors hover:text-red-300 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                      Delete
+                    </button>
+                  </div>
+                </div>
+
+                {/* Messages */}
+                {success ? (
+                  <div className="flex items-center gap-1.5 pt-2 text-sm text-emerald-400">
+                    <Check className="h-3.5 w-3.5" />
+                    {success}
+                  </div>
+                ) : null}
+                {testResult ? (
+                  <p className={`pt-2 text-sm ${testResult.isSuccess ? "text-emerald-400" : "text-red-300"}`}>
+                    {testResult.text}
+                  </p>
+                ) : null}
                 {error ? (
-                  <div className="rounded-xl bg-red-500/8 border border-red-400/10 px-4 py-3 text-sm text-red-300">
+                  <div className="rounded-lg border border-red-400/10 bg-red-500/8 px-4 py-3 text-sm text-red-300">
                     {error}
                   </div>
                 ) : null}
-              </>
+
+                {/* System Prompt Modal */}
+                {isSystemPromptOpen && (
+                  <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+                    <div
+                      className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+                      onClick={closeSystemPrompt}
+                    />
+                    <div className="relative w-full max-w-[720px] max-h-[80vh] flex flex-col rounded-2xl border border-white/[0.08] bg-[#121214] p-6 shadow-2xl">
+                      <div className="flex items-center justify-between mb-4">
+                        <h3 className="text-sm font-semibold text-[var(--text)]">Edit system prompt</h3>
+                        <button
+                          type="button"
+                          onClick={closeSystemPrompt}
+                          className="text-[var(--muted)] hover:text-[var(--text)] transition-colors"
+                        >
+                          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
+                        </button>
+                      </div>
+                      <p className="mb-3 text-xs text-[var(--muted)]">
+                        Applied to new conversations only
+                      </p>
+                      <Textarea
+                        autoComplete="off"
+                        spellCheck={false}
+                        value={systemPromptDraft}
+                        onChange={(event) => setSystemPromptDraft(event.target.value)}
+                        rows={16}
+                        className="flex-1 resize-none min-h-[300px]"
+                      />
+                      <div className="flex flex-wrap items-center justify-end gap-2 mt-5 pt-4 border-t border-white/[0.06]">
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          className="px-3 py-1.5 text-xs"
+                          onClick={closeSystemPrompt}
+                        >
+                          Cancel
+                        </Button>
+                        <Button
+                          type="button"
+                          className="px-3 py-1.5 text-xs"
+                          onClick={saveSystemPrompt}
+                        >
+                          Save
+                        </Button>
+                      </div>
+                    </div>
+                  </div>
+                )}
+              </div>
             ) : null}
           </form>
         }

--- a/components/settings/sections/skills-section.tsx
+++ b/components/settings/sections/skills-section.tsx
@@ -183,7 +183,10 @@ export function SkillsSection() {
   const isBuiltin = selectedSkill?.id.startsWith("builtin-") ?? false;
   const showDetail = selectedSkill || isAddingNew;
 
-  const labelClass = "text-[0.68rem] font-semibold uppercase tracking-[0.12em] text-[#71717a]";
+  const fieldLabel = "block text-[13px] font-medium text-[var(--muted)] mb-1.5";
+  const inputLike = "w-full rounded-xl border border-white/6 bg-white/4 px-4 py-3 text-sm text-[var(--text)] outline-none transition-all duration-200 focus:border-[var(--accent)]/40 focus:bg-white/6 focus:shadow-[0_0_0_3px_var(--accent-soft)]";
+  const sectionTitle = "text-sm font-semibold text-[var(--text)]";
+  const sectionDivider = "border-t border-white/[0.06]";
 
   return (
     <div className="min-h-0 p-4 md:h-full md:p-8">
@@ -191,8 +194,8 @@ export function SkillsSection() {
         listHeader={
           <div className="flex items-center justify-between w-full">
             <div>
-              <h2 className="text-[0.9rem] font-semibold text-[#f4f4f5]">Skills</h2>
-              <p className="text-[0.68rem] text-[#52525b]">
+              <h2 className="text-sm font-semibold text-[var(--text)]">Skills</h2>
+              <p className="text-xs text-[var(--muted)]">
                 {skills.length} skill{skills.length !== 1 ? "s" : ""}
               </p>
             </div>
@@ -207,7 +210,7 @@ export function SkillsSection() {
               <button
                 type="button"
                 onClick={() => fileInputRef.current?.click()}
-                className="flex h-7 w-7 items-center justify-center rounded-lg border border-white/6 bg-white/[0.03] text-[#71717a] hover:text-[#f4f4f5] hover:bg-white/[0.06] transition-all duration-200"
+                className="flex h-7 w-7 items-center justify-center rounded-lg border border-white/6 bg-white/[0.03] text-[var(--muted)] hover:text-[var(--text)] hover:bg-white/[0.06] transition-all duration-200"
                 title="Import skill from .md file"
               >
                 <Upload className="h-4 w-4" />
@@ -217,7 +220,7 @@ export function SkillsSection() {
                 onClick={handleAddNew}
                 aria-label="Add skill"
                 title="Add skill"
-                className="flex h-7 w-7 items-center justify-center rounded-lg border border-white/6 bg-white/[0.03] text-[#71717a] hover:text-[#f4f4f5] hover:bg-white/[0.06] transition-all duration-200"
+                className="flex h-7 w-7 items-center justify-center rounded-lg border border-white/6 bg-white/[0.03] text-[var(--muted)] hover:text-[var(--text)] hover:bg-white/[0.06] transition-all duration-200"
               >
                 <Plus className="h-4 w-4" />
               </button>
@@ -246,32 +249,33 @@ export function SkillsSection() {
         isDetailVisible={mobileDetailVisible}
         onBackAction={() => setMobileDetailVisible(false)}
         detailPanel={
-          <div className="max-w-[560px] space-y-6">
+          <div className="max-w-[720px] space-y-6">
             {showDetail ? (
               <>
                 <div className="space-y-4">
                   <div>
-                    <h3 className="text-[1.1rem] font-semibold text-[#f4f4f5]">
+                    <h3 className={sectionTitle}>
                       {isAddingNew ? "New Skill" : selectedSkill?.name}
                     </h3>
                     {!isAddingNew && selectedSkill ? (
-                      <p className="mt-0.5 text-[0.75rem] text-[#52525b]">
+                      <p className="mt-0.5 text-xs text-[var(--muted)]">
                         {selectedSkill.description}
                       </p>
                     ) : null}
                   </div>
 
                   {!isAddingNew && !isBuiltin && selectedSkill ? (
-                    <Button
+                    <button
                       type="button"
-                      variant="danger"
                       onClick={() => deleteSkill(selectedSkill.id)}
-                      className="gap-1.5 px-3 py-1.5 text-xs"
+                      className="inline-flex items-center gap-1.5 px-2.5 py-1.5 text-xs text-red-400/80 transition-colors hover:text-red-300"
                     >
                       Delete
-                    </Button>
+                    </button>
                   ) : null}
                 </div>
+
+                <div className={sectionDivider} />
 
                 <div className="space-y-5">
                   {selectedSkill && isBuiltin ? (
@@ -286,39 +290,41 @@ export function SkillsSection() {
                   ) : null}
 
                   <div>
-                    <label className={labelClass}>Name</label>
+                    <label className={fieldLabel}>Name</label>
                     <Input
                       value={skillName}
                       onChange={(e) => setSkillName(e.target.value)}
                       placeholder="Skill name"
                       disabled={isBuiltin}
+                      className={inputLike}
                     />
                   </div>
                   <div>
-                    <label className={labelClass}>Description</label>
+                    <label className={fieldLabel}>Description</label>
                     <Input
                       value={skillDescription}
                       onChange={(e) => setSkillDescription(e.target.value)}
                       placeholder="Explain when this skill should and should not trigger"
                       disabled={isBuiltin}
+                      className={inputLike}
                     />
                   </div>
                   <div>
-                    <label className={labelClass}>INSTRUCTIONS</label>
+                    <label className={fieldLabel}>Instructions</label>
                     <Textarea
                       value={skillContent}
                       onChange={(e) => setSkillContent(e.target.value)}
                       placeholder="Enter the full skill instructions..."
                       rows={8}
                       readOnly={isBuiltin}
-                      className={isBuiltin ? "opacity-60 cursor-default" : ""}
+                      className={isBuiltin ? `opacity-60 cursor-default ${inputLike}` : inputLike}
                     />
                   </div>
                 </div>
 
                 {selectedSkill ? (
                   <div className="flex gap-2 pt-2">
-                    <label className="flex cursor-pointer items-center gap-2 rounded-lg border border-white/8 bg-white/[0.04] px-2.5 py-1.5 text-xs text-[#52525b] transition-colors hover:border-white/15">
+                    <label className="flex cursor-pointer items-center gap-2 rounded-xl border border-white/6 bg-white/4 px-4 py-3 text-sm text-[var(--muted)] transition-colors hover:border-white/15">
                       <input
                         type="checkbox"
                         checked={skillEnabledDraft}
@@ -330,27 +336,27 @@ export function SkillsSection() {
                   </div>
                 ) : null}
 
-                <div className="flex gap-2 pt-2">
-                  <Button type="button" onClick={saveSkill}>
-                    {editingSkillId ? "Update" : "Add skill"}
+                <div className="flex flex-wrap items-center gap-2">
+                  <Button type="button" className="px-3 py-1.5 text-xs" onClick={saveSkill}>
+                    Save
                   </Button>
-                  <Button type="button" variant="secondary" onClick={resetSkillForm}>
+                  <Button type="button" variant="ghost" className="px-2.5 py-1.5 text-xs" onClick={resetSkillForm}>
                     {isBuiltin ? "Close" : "Cancel"}
                   </Button>
-                  {skillSuccess ? (
-                    <div className="flex items-center gap-1.5 text-sm text-emerald-400">
-                      <Check className="h-3.5 w-3.5" />
-                      {skillSuccess}
-                    </div>
-                  ) : null}
                 </div>
+                {skillSuccess ? (
+                  <div className="flex items-center gap-1.5 text-sm text-emerald-400">
+                    <Check className="h-3.5 w-3.5" />
+                    {skillSuccess}
+                  </div>
+                ) : null}
               </>
             ) : (
               <div className="flex flex-col items-center justify-center py-24 text-center">
                 <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-white/[0.03] border border-white/6 mb-4">
-                  <FileText className="h-5 w-5 text-[#52525b]" />
+                  <FileText className="h-5 w-5 text-[var(--muted)]" />
                 </div>
-                <p className="text-[0.85rem] text-[#71717a]">
+                <p className="text-[0.85rem] text-[var(--muted)]">
                   Select a skill or add a new one
                 </p>
               </div>

--- a/components/settings/sections/users-section.tsx
+++ b/components/settings/sections/users-section.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { AlertTriangle, Plus, Shield, Trash2, UserRound } from "lucide-react";
+import { AlertTriangle, Plus, Trash2, UserRound } from "lucide-react";
 
 import { ProfileCard } from "@/components/settings/profile-card";
 import { SettingsSplitPane } from "@/components/settings/settings-split-pane";
@@ -183,18 +183,23 @@ export function UsersSection({ users }: { users: PersistedUser[] }) {
 
   const showDetail = isAddingNew || Boolean(selectedUser);
   const isProtectedUser = selectedUser?.authSource === "env_super_admin";
+
+  const fieldLabel = "block text-[13px] font-medium text-[var(--muted)] mb-1.5";
+  const inputLike = "w-full rounded-xl border border-white/6 bg-white/4 px-4 py-3 text-sm text-[var(--text)] outline-none transition-all duration-200 focus:border-[var(--accent)]/40 focus:bg-white/6 focus:shadow-[0_0_0_3px_var(--accent-soft)]";
+  const selectLike = `${inputLike} appearance-none bg-[url('data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2224%22%20height%3D%2224%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20stroke%3D%22%2371717a%22%20stroke-width%3D%222%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%3E%3Cpolyline%20points%3D%226%209%2012%2015%2018%209%22%3E%3C%2Fpolyline%3E%3C%2Fsvg%3E')] bg-[length:1rem_1rem] bg-[right_0.75rem_center] bg-no-repeat pr-10`;
+  const sectionTitle = "text-sm font-semibold text-[var(--text)]";
+  const sectionDivider = "border-t border-white/[0.06]";
+
   const emptyState = (
     <div className="flex flex-col items-center justify-center py-24 text-center">
       <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-white/6 bg-white/[0.03]">
-        <UserRound className="h-5 w-5 text-[#52525b]" />
+        <UserRound className="h-5 w-5 text-[var(--muted)]" />
       </div>
-      <p className="mt-4 text-[0.85rem] text-[#71717a]">
+      <p className="mt-4 text-[0.85rem] text-[var(--muted)]">
         Select a user from the roster or create a new login.
       </p>
     </div>
   );
-  const selectClass =
-    "w-full rounded-xl border border-white/6 bg-white/[0.03] px-4 py-3 text-sm outline-none transition-all duration-200 text-[#f4f4f5] focus:border-[rgba(139,92,246,0.3)]";
 
   return (
     <div className="min-h-0 p-4 md:h-full md:p-8">
@@ -204,15 +209,15 @@ export function UsersSection({ users }: { users: PersistedUser[] }) {
         listHeader={
           <div className="flex w-full items-center justify-between">
             <div>
-              <h2 className="text-[0.9rem] font-semibold text-[#f4f4f5]">Users</h2>
-              <p className="text-[0.68rem] text-[#52525b]">
+              <h2 className="text-sm font-semibold text-[var(--text)]">Users</h2>
+              <p className="text-xs text-[var(--muted)]">
                 {userRows.length} account{userRows.length === 1 ? "" : "s"}
               </p>
             </div>
             <button
               type="button"
               onClick={handleAddUser}
-              className="flex h-7 w-7 items-center justify-center rounded-lg border border-white/6 bg-white/[0.03] text-[#71717a] transition-all duration-200 hover:bg-white/[0.06] hover:text-[#f4f4f5]"
+              className="flex h-7 w-7 items-center justify-center rounded-lg border border-white/6 bg-white/[0.03] text-[var(--muted)] transition-all duration-200 hover:bg-white/[0.06] hover:text-[var(--text)]"
               aria-label="Add user"
             >
               <Plus className="h-4 w-4" />
@@ -235,26 +240,13 @@ export function UsersSection({ users }: { users: PersistedUser[] }) {
         }
         detailPanel={
           showDetail ? (
-            <div className="max-w-[620px] space-y-6">
+            <div className="max-w-[720px] space-y-6">
               <div className="flex items-start justify-between gap-4">
-                <div className="space-y-2">
-                  <div className="flex items-center gap-3">
-                    <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-sky-500/10 text-sky-300">
-                      <Shield className="h-4 w-4" />
-                    </div>
-                    <div>
-                      <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-sky-300">
-                        Access
-                      </p>
-                      <h3
-                        className="text-[1.2rem] font-semibold text-[#f4f4f5]"
-                        style={{ fontFamily: "var(--font-display)" }}
-                      >
-                        {isAddingNew ? "Create user" : selectedUser?.username}
-                      </h3>
-                    </div>
-                  </div>
-                  <div className="flex flex-wrap items-center gap-2 pl-12">
+                <div>
+                  <h3 className={sectionTitle}>
+                    {isAddingNew ? "Create user" : selectedUser?.username}
+                  </h3>
+                  <div className="mt-2 flex flex-wrap items-center gap-2">
                     {selectedUser ? (
                       <>
                         <Badge variant={buildRoleBadge(selectedUser).variant}>
@@ -271,18 +263,19 @@ export function UsersSection({ users }: { users: PersistedUser[] }) {
                 </div>
 
                 {!isAddingNew && !isProtectedUser ? (
-                  <Button
+                  <button
                     type="button"
-                    variant="danger"
                     onClick={() => void deleteUser()}
                     disabled={isSaving}
-                    className="gap-2"
+                    className="inline-flex items-center gap-1.5 px-2.5 py-1.5 text-xs text-red-400/80 transition-colors hover:text-red-300 disabled:cursor-not-allowed disabled:opacity-50"
                   >
-                    <Trash2 className="h-4 w-4" />
-                    Delete user
-                  </Button>
+                    <Trash2 className="h-3.5 w-3.5" />
+                    Delete
+                  </button>
                 ) : null}
               </div>
+
+              <div className={sectionDivider} />
 
               {isProtectedUser ? (
                 <div className="space-y-4">
@@ -290,34 +283,35 @@ export function UsersSection({ users }: { users: PersistedUser[] }) {
                     This account is env-managed and protected from UI edits. Change the bootstrap
                     admin credentials through environment variables instead.
                   </div>
-                  <div className="grid gap-4 rounded-2xl border border-white/6 bg-white/[0.02] p-5 md:grid-cols-2">
+                  <div className="grid gap-4 md:grid-cols-2">
                     <div>
-                      <Label>Username</Label>
-                      <Input value={selectedUser?.username ?? ""} readOnly disabled />
+                      <label className={fieldLabel}>Username</label>
+                      <Input value={selectedUser?.username ?? ""} readOnly disabled className={inputLike} />
                     </div>
                     <div>
-                      <Label>Role</Label>
-                      <Input value={selectedUser?.role ?? ""} readOnly disabled />
+                      <label className={fieldLabel}>Role</label>
+                      <Input value={selectedUser?.role ?? ""} readOnly disabled className={inputLike} />
                     </div>
                   </div>
                 </div>
               ) : (
-                <div className="space-y-5 rounded-2xl border border-white/6 bg-white/[0.02] p-5">
+                <div className="space-y-5">
                   <div className="grid gap-4 md:grid-cols-2">
                     <div>
-                      <Label>Username</Label>
+                      <label className={fieldLabel}>Username</label>
                       <Input
                         value={draftUsername}
                         onChange={(event) => setDraftUsername(event.target.value)}
                         placeholder="Username"
+                        className={inputLike}
                       />
                     </div>
                     <div>
-                      <Label>Role</Label>
+                      <label className={fieldLabel}>Role</label>
                       <select
                         value={draftRole}
                         onChange={(event) => setDraftRole(event.target.value as UserRole)}
-                        className={selectClass}
+                        className={selectLike}
                       >
                         <option value="user">User</option>
                         <option value="admin">Admin</option>
@@ -326,16 +320,17 @@ export function UsersSection({ users }: { users: PersistedUser[] }) {
                   </div>
 
                   <div>
-                    <Label>{isAddingNew ? "Password" : "New password"}</Label>
+                    <label className={fieldLabel}>{isAddingNew ? "Password" : "New password"}</label>
                     <Input
                       type="password"
                       value={draftPassword}
                       onChange={(event) => setDraftPassword(event.target.value)}
                       placeholder={isAddingNew ? "Set a password" : "Leave blank to keep the current password"}
+                      className={inputLike}
                     />
                   </div>
 
-                  <div className="rounded-2xl border border-white/6 bg-black/20 px-4 py-4 text-sm leading-6 text-[#a1a1aa]">
+                  <div className="rounded-2xl border border-white/6 bg-black/20 px-4 py-4 text-sm leading-6 text-[var(--muted)]">
                     {isAddingNew ? (
                       <>
                         New users start with their own empty conversations, personas, memories,
@@ -349,20 +344,14 @@ export function UsersSection({ users }: { users: PersistedUser[] }) {
                     )}
                   </div>
 
-                  <div className="flex flex-wrap gap-2">
-                    <Button type="button" onClick={() => void saveUser()} disabled={isSaving}>
-                      {isAddingNew ? (
-                        <>
-                          <Plus className="mr-2 h-4 w-4" />
-                          Create user
-                        </>
-                      ) : (
-                        "Save changes"
-                      )}
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Button type="button" className="px-3 py-1.5 text-xs" onClick={() => void saveUser()} disabled={isSaving}>
+                      Save
                     </Button>
                     <Button
                       type="button"
-                      variant="secondary"
+                      variant="ghost"
+                      className="px-2.5 py-1.5 text-xs"
                       onClick={() => {
                         if (selectedUser) {
                           handleSelectUser(selectedUser);
@@ -379,18 +368,18 @@ export function UsersSection({ users }: { users: PersistedUser[] }) {
                 </div>
               )}
 
+              <div className={sectionDivider} />
+
               {success ? (
-                <div className="rounded-2xl border border-emerald-400/12 bg-emerald-500/8 px-4 py-3 text-sm text-emerald-200">
+                <div className="flex items-center gap-1.5 text-sm text-emerald-400">
                   {success}
                 </div>
               ) : null}
 
               {error ? (
-                <div className="rounded-2xl border border-red-400/12 bg-red-500/8 px-4 py-3 text-sm text-red-200">
-                  <div className="flex items-center gap-2">
-                    <AlertTriangle className="h-4 w-4" />
-                    <span>{error}</span>
-                  </div>
+                <div className="flex items-center gap-2 text-sm text-red-200">
+                  <AlertTriangle className="h-4 w-4" />
+                  <span>{error}</span>
                 </div>
               ) : null}
             </div>

--- a/components/settings/settings-nav.tsx
+++ b/components/settings/settings-nav.tsx
@@ -175,26 +175,21 @@ export function SettingsNav({
           ) : null}
         </div>
 
-        <div className="mt-8 rounded-2xl border border-white/6 bg-white/[0.02] px-4 py-4">
-          <p className="text-[10px] font-semibold uppercase tracking-[0.24em] text-white/30">
-            Signed in
-          </p>
-          <p className="mt-2 text-sm font-medium text-white/85">
-            {currentUser.username}
-          </p>
-          <p className="mt-1 text-xs text-white/45">
-            {currentUser.role === "admin" ? "Administrator access" : "Private workspace"}
-          </p>
-          <Button
-            type="button"
-            variant="danger"
-            onClick={() => void handleLogout()}
-            disabled={isSigningOut}
-            className="mt-4 w-full gap-2 rounded-2xl border-red-400/15 bg-red-500/[0.07] px-3 py-2.5 text-sm text-red-100 hover:bg-red-500/[0.12]"
-          >
-            <LogOut className="h-3.5 w-3.5" />
-            Sign out
-          </Button>
+        <div className="mt-auto pt-6">
+          <div className="border-t border-white/[0.06] pt-4">
+            <p className="text-sm font-medium text-[var(--text)]">
+              {currentUser.username}
+            </p>
+            <button
+              type="button"
+              onClick={() => void handleLogout()}
+              disabled={isSigningOut}
+              className="mt-1.5 inline-flex items-center gap-1.5 text-xs text-red-400/80 transition-colors hover:text-red-300 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              <LogOut className="h-3 w-3" />
+              Sign out
+            </button>
+          </div>
         </div>
       </div>
     </aside>

--- a/tests/e2e/features.spec.ts
+++ b/tests/e2e/features.spec.ts
@@ -1046,7 +1046,7 @@ test.describe("Feature: MCP Servers in settings", () => {
     await page.getByPlaceholder("https://...").fill("https://mcp.example.com/api");
     await page.getByRole("button", { name: "Test", exact: true }).click();
     await expect(page.locator("text=2 tools discovered").first()).toBeVisible({ timeout: 5000 });
-    await page.getByRole("button", { name: "Add server" }).click();
+    await page.getByRole("button", { name: "Save" }).click();
 
     await expect(page.locator("span").filter({ hasText: serverName }).first()).toBeVisible({
       timeout: 5000
@@ -1120,7 +1120,7 @@ test.describe("Feature: Skills in settings", () => {
     await page.getByPlaceholder("Skill name").fill("Test Skill");
     await page.getByPlaceholder("Explain when this skill should and should not trigger").fill("Use when the user asks for French output.");
     await page.getByPlaceholder("Enter the full skill instructions...").fill("Always respond in French.");
-    await page.getByRole("button", { name: "Add skill" }).last().click();
+    await page.getByRole("button", { name: "Save" }).last().click();
 
     await expect(page.getByRole("heading", { name: "Test Skill", exact: true })).toBeVisible({
       timeout: 5000
@@ -1147,7 +1147,7 @@ test.describe("Feature: Automations workspace", () => {
     await page.getByLabel("Name").fill("Morning summary");
     await page.getByLabel("Prompt").fill("Summarize priorities");
     await expect(page.getByLabel("Provider profile")).toHaveValue(/profile_/);
-    await page.getByRole("button", { name: "Save automation" }).click();
+    await page.getByRole("button", { name: "Save" }).click();
     await expect(page.getByRole("heading", { name: "Morning summary" })).toBeVisible({
       timeout: 5000
     });

--- a/tests/unit/account-section.test.tsx
+++ b/tests/unit/account-section.test.tsx
@@ -31,7 +31,7 @@ describe("account section", () => {
 
     expect(screen.getByText(/managed by environment variables/i)).toBeInTheDocument();
     expect(screen.queryByText("New password")).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Update account" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Save" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Sign out" })).not.toBeInTheDocument();
   });
 
@@ -49,7 +49,7 @@ describe("account section", () => {
     );
 
     expect(screen.getByText("New password")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Update account" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Sign out" })).not.toBeInTheDocument();
   });
 });

--- a/tests/unit/automations-section.test.tsx
+++ b/tests/unit/automations-section.test.tsx
@@ -118,7 +118,7 @@ describe("automations section", () => {
     fireEvent.change(screen.getByLabelText("Name"), { target: { value: "Morning summary" } });
     fireEvent.change(screen.getByLabelText("Prompt"), { target: { value: "Summarize priorities" } });
     fireEvent.change(screen.getByLabelText("Every"), { target: { value: "4" } });
-    fireEvent.click(screen.getByRole("button", { name: "Save automation" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     expect(screen.getByText("Interval must be at least 5 minutes")).toBeInTheDocument();
     expect(global.fetch).not.toHaveBeenCalledWith(
@@ -139,7 +139,7 @@ describe("automations section", () => {
     fireEvent.click(screen.getByRole("button", { name: "Add automation" }));
     fireEvent.change(screen.getByLabelText("Name"), { target: { value: "Morning summary" } });
     fireEvent.change(screen.getByLabelText("Prompt"), { target: { value: "Summarize priorities" } });
-    fireEvent.click(screen.getByRole("button", { name: "Save automation" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => {
       expect(screen.getByText("Automation saved.")).toBeInTheDocument();

--- a/tests/unit/general-section.test.tsx
+++ b/tests/unit/general-section.test.tsx
@@ -64,7 +64,7 @@ describe("general section", () => {
 
     fireEvent.change(screen.getByDisplayValue("Forever"), { target: { value: "30d" } });
     fireEvent.change(screen.getByRole("spinbutton"), { target: { value: "45" } });
-    fireEvent.click(screen.getByRole("button", { name: "Save settings" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => {
       expect(global.fetch).toHaveBeenCalledTimes(1);
@@ -101,7 +101,7 @@ describe("general section", () => {
 
     fireEvent.change(screen.getByDisplayValue("Browser"), { target: { value: "embedded" } });
     fireEvent.change(screen.getByDisplayValue("English"), { target: { value: "es" } });
-    fireEvent.click(screen.getByRole("button", { name: "Save settings" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
 
@@ -195,7 +195,7 @@ describe("general section", () => {
       })
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Save settings" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     expect(global.fetch).not.toHaveBeenCalled();
     expect(await screen.findByText("Tavily API key is required.")).toBeInTheDocument();
@@ -210,7 +210,7 @@ describe("general section", () => {
       })
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Save settings" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     expect(global.fetch).not.toHaveBeenCalled();
     expect(await screen.findByText("SearXNG base URL is required.")).toBeInTheDocument();
@@ -228,7 +228,7 @@ describe("general section", () => {
     fireEvent.change(screen.getByLabelText("SearXNG base URL"), {
       target: { value: "not-a-url" }
     });
-    fireEvent.click(screen.getByRole("button", { name: "Save settings" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     expect(global.fetch).not.toHaveBeenCalled();
     expect(await screen.findByText("SearXNG base URL must be valid.")).toBeInTheDocument();
@@ -247,7 +247,7 @@ describe("general section", () => {
     render(React.createElement(GeneralSection, { settings }));
 
     fireEvent.change(screen.getByDisplayValue("Forever"), { target: { value: "30d" } });
-    fireEvent.click(screen.getByRole("button", { name: "Save settings" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
 
@@ -300,7 +300,7 @@ describe("general section", () => {
     const exaInput = screen.getByLabelText("Exa API key");
     fireEvent.change(exaInput, { target: { value: "temporary-value" } });
     fireEvent.change(exaInput, { target: { value: "" } });
-    fireEvent.click(screen.getByRole("button", { name: "Save settings" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
 
@@ -329,7 +329,7 @@ describe("general section", () => {
     fireEvent.change(tavilyInput, { target: { value: "" } });
     fireEvent.change(screen.getByLabelText("Web search engine"), { target: { value: "exa" } });
     fireEvent.change(screen.getByDisplayValue("Forever"), { target: { value: "30d" } });
-    fireEvent.click(screen.getByRole("button", { name: "Save settings" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
 
@@ -371,7 +371,7 @@ describe("general section", () => {
     expect(screen.queryByRole("option", { name: "ComfyUI" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Test ComfyUI workflow" })).toBeNull();
 
-    fireEvent.click(screen.getByRole("button", { name: "Save settings" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => {
       expect(global.fetch).toHaveBeenCalledWith(

--- a/tests/unit/providers-section.test.tsx
+++ b/tests/unit/providers-section.test.tsx
@@ -376,19 +376,17 @@ describe("providers section", () => {
       } as Response);
     });
 
-    const { container } = render(React.createElement(ProvidersSection, { settings }));
+    render(React.createElement(ProvidersSection, { settings }));
 
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith("/api/mcp-servers");
     });
 
-    fireEvent.click(container.querySelectorAll("summary")[0]);
-
     expect(screen.getByText("Fresh tail turns")).toBeInTheDocument();
     expect(screen.getByDisplayValue("80")).toBeInTheDocument();
 
     fireEvent.change(screen.getByDisplayValue("80"), { target: { value: "75" } });
-    fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(
@@ -447,15 +445,14 @@ describe("providers section", () => {
       } as Response);
     });
 
-    const { container } = render(React.createElement(ProvidersSection, { settings }));
+    render(React.createElement(ProvidersSection, { settings }));
 
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith("/api/mcp-servers");
     });
 
-    fireEvent.click(container.querySelectorAll("summary")[0]);
     fireEvent.change(screen.getByDisplayValue("80"), { target: { value: "75.5" } });
-    fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(
@@ -576,7 +573,10 @@ describe("providers section", () => {
     });
 
     fireEvent.click(screen.getByText("Backup"));
-    fireEvent.click(screen.getByRole("button", { name: "Set Default" }));
+
+    const defaultCheckbox = screen.getByLabelText("Default provider");
+    expect(defaultCheckbox).not.toBeChecked();
+    fireEvent.click(defaultCheckbox);
 
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(
@@ -591,6 +591,8 @@ describe("providers section", () => {
     const body = JSON.parse(String(putCall?.[1]?.body));
 
     expect(body.defaultProviderProfileId).toBe("profile_backup");
-    expect(screen.getByRole("button", { name: "Is Default" })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByLabelText("Default provider")).toBeChecked();
+    });
   });
 });


### PR DESCRIPTION
## Summary

Comprehensive redesign of all settings pages for visual consistency and improved UX.

### Button Standardization
- All save/submit buttons now use the consistent **"Save"** label
- Removed variants: "Save Changes", "Update", "Create User", "Add skill/server/persona", "Save settings", "Save automation"
- Action bars at the bottom with compact button sizing (`px-3 py-1.5 text-xs`)
- Destructive actions (Delete) use minimal text links with red hover

### Provider Settings Redesign
- Section-based layout (Identity, Connection, Configuration, System, Actions) with hairline dividers
- Styled select dropdowns matching input styling with custom chevron
- "Is Default" button replaced with checkbox toggle in Identity section
- System prompt gets modal editor with large textarea for long content
- Test results show green (success) / red (failure) color feedback

### All Settings Pages Updated
- `account`, `general`, `users`, `skills`, `automations`, `personas`, `memories`, `mcp-servers`
- Flat section-based layouts replacing card wrappers
- Sentence-case labels replacing uppercase/tracked labels
- CSS variable colors replacing hardcoded hex values
- Wider detail panels for less cramped feel

### Sidebar User Info
- Simplified from bulky card to minimal footer
- Username + compact "Sign out" text link in red

### Test Results
- Provider and MCP test results now color-coded:
  - Green (`text-emerald-400`) on success
  - Red (`text-red-300`) on failure

### Tests
- All 101 test files pass (993 tests)