### PR TITLE
feat: use caret streaming for thinking mode in message bubble

### DIFF
--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -1229,7 +1229,11 @@ export function MessageBubble({
 
                 {thinkingOpen && thinkingContent ? (
                   <div className="markdown-body thinking-markdown-body mt-1.5">
-                    <Streamdown mode="static" remend={STREAMDOWN_REMEND_OPTIONS}>{thinkingContent}</Streamdown>
+                    <Streamdown
+                      remend={STREAMDOWN_REMEND_OPTIONS}
+                      caret={thinkingInProgress ? "block" : undefined}
+                      isAnimating={thinkingInProgress}
+                    >{thinkingContent}</Streamdown>
                   </div>
                 ) : null}
               </div>


### PR DESCRIPTION
## Summary

- Switch thinking mode rendering from static Streamdown to caret streaming mode
- Shows an animated block caret while thinking is in progress, and static mode once complete
- Uses the same `caret` and `isAnimating` pattern already used elsewhere in Streamdown