### PR TITLE
fix: allow multiple providers with same preset, prevent duplicate names

### DIFF
--- a/app/api/settings/providers/route.ts
+++ b/app/api/settings/providers/route.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+
 import { requireAdminUser } from "@/lib/auth";
 import { badRequest, forbidden, ok } from "@/lib/http";
 import { updateProviderCatalog } from "@/lib/settings";
@@ -16,6 +18,10 @@ export async function PUT(request: Request) {
     const payload = await request.json();
     return ok({ settings: updateProviderCatalog(payload) });
   } catch (error) {
+    if (error instanceof z.ZodError) {
+      const message = error.issues.map((issue) => issue.message).join("; ");
+      return badRequest(message);
+    }
     return badRequest(error instanceof Error ? error.message : "Unable to update provider settings");
   }
 }

--- a/components/settings/sections/providers-section.tsx
+++ b/components/settings/sections/providers-section.tsx
@@ -18,6 +18,7 @@ import { DEFAULT_PROVIDER_SETTINGS } from "@/lib/constants";
 import {
   applyProviderPreset,
   getMatchingProviderPresetId,
+  getProviderPreset,
   PROVIDER_PRESETS
 } from "@/lib/provider-presets";
 import type { AppSettings, ApiMode, McpServer, ProviderPresetId, ReasoningEffort, VisionMode } from "@/lib/types";
@@ -111,6 +112,13 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
     ? activeProviderProfile.providerPresetId ?? getMatchingProviderPresetId(activeProviderProfile)
     : null;
   const isCopilot = activeProviderProfile?.providerKind === "github_copilot";
+  const isDuplicateName = activeProviderProfile
+    ? providerProfiles.some(
+        (p) =>
+          p.id !== activeProviderProfile.id &&
+          p.name.trim().toLowerCase() === activeProviderProfile.name.trim().toLowerCase()
+      )
+    : false;
 
   useEffect(() => {
     if (
@@ -195,10 +203,17 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
       return;
     }
 
-    updateActiveProviderProfile({
+    const isAutoName = /^Profile \d+$/.test(activeProviderProfile.name);
+    const patch: Partial<ProviderProfileDraft> = {
       ...applyProviderPreset(activeProviderProfile, presetId),
       providerPresetId: presetId
-    });
+    };
+
+    if (isAutoName) {
+      patch.name = getProviderPreset(presetId).values.name;
+    }
+
+    updateActiveProviderProfile(patch);
   }
 
   function resetActiveProviderAdvancedSettings() {
@@ -473,6 +488,9 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
                         }
                         required
                       />
+                      {isDuplicateName && (
+                        <p className="mt-1 text-xs text-red-400">A profile with this name already exists</p>
+                      )}
                     </div>
                     <label className="flex items-center gap-3 rounded-xl border border-white/6 bg-white/4 px-4 py-3 text-sm text-[var(--text)] cursor-pointer sm:col-span-2">
                       <input
@@ -957,7 +975,7 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
                 <div className={`${sectionDivider} py-5`}>
                   <div className="flex flex-wrap items-center justify-between gap-3">
                     <div className="flex flex-wrap items-center gap-2">
-                      <Button type="submit" className="px-3 py-1.5 text-xs">
+                      <Button type="submit" className="px-3 py-1.5 text-xs" disabled={isDuplicateName}>
                         Save
                       </Button>
                       <Button

--- a/lib/provider-presets.ts
+++ b/lib/provider-presets.ts
@@ -116,9 +116,11 @@ export function applyProviderPreset<T extends PresetCompatibleProfile>(
     return profile;
   }
 
+  const { name: _presetName, ...presetValues } = getProviderPreset(presetId).values;
+
   return {
     ...profile,
-    ...getProviderPreset(presetId).values
+    ...presetValues
   };
 }
 
@@ -133,7 +135,6 @@ export function getMatchingProviderPresetId(
     const { values } = entry;
 
     return (
-      values.name === profile.name &&
       values.apiBaseUrl === profile.apiBaseUrl &&
       values.model === profile.model &&
       values.apiMode === profile.apiMode &&

--- a/lib/settings.ts
+++ b/lib/settings.ts
@@ -89,6 +89,7 @@ const settingsSchema = z
   })
   .superRefine((value, context) => {
     const ids = new Set<string>();
+    const names = new Set<string>();
 
     value.providerProfiles.forEach((profile, index) => {
       if (ids.has(profile.id)) {
@@ -100,6 +101,17 @@ const settingsSchema = z
       }
 
       ids.add(profile.id);
+
+      const normalizedName = profile.name.trim().toLowerCase();
+      if (names.has(normalizedName)) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "Provider profile names must be unique",
+          path: ["providerProfiles", index, "name"]
+        });
+      }
+
+      names.add(normalizedName);
     });
 
     if (!ids.has(value.defaultProviderProfileId)) {

--- a/tests/unit/provider-presets.test.ts
+++ b/tests/unit/provider-presets.test.ts
@@ -26,10 +26,10 @@ function createProfile() {
 }
 
 describe("provider presets", () => {
-  it("applies the Ollama Cloud preset values", () => {
+  it("applies the Ollama Cloud preset values without overwriting the name", () => {
     const profile = applyProviderPreset(createProfile(), "ollama_cloud");
 
-    expect(profile.name).toBe("Ollama Cloud");
+    expect(profile.name).toBe("Original profile");
     expect(profile.apiBaseUrl).toBe("https://ollama.com/v1");
     expect(profile.model).toBe("glm-4.7:cloud");
     expect(profile.apiMode).toBe("chat_completions");
@@ -38,10 +38,10 @@ describe("provider presets", () => {
     expect(profile.modelContextLimit).toBe(64000);
   });
 
-  it("applies the GLM Coding Plan preset values", () => {
+  it("applies the GLM Coding Plan preset values without overwriting the name", () => {
     const profile = applyProviderPreset(createProfile(), "glm_coding_plan");
 
-    expect(profile.name).toBe("GLM Coding Plan");
+    expect(profile.name).toBe("Original profile");
     expect(profile.apiBaseUrl).toBe("https://api.z.ai/api/coding/paas/v4");
     expect(profile.model).toBe("glm-5.1");
     expect(profile.apiMode).toBe("chat_completions");
@@ -50,10 +50,10 @@ describe("provider presets", () => {
     expect(profile.modelContextLimit).toBe(200000);
   });
 
-  it("applies the custom OpenAI compatible preset values", () => {
+  it("applies the custom OpenAI compatible preset values without overwriting the name", () => {
     const profile = applyProviderPreset(createProfile(), "custom_openai_compatible");
 
-    expect(profile.name).toBe("Custom OpenAI compatible");
+    expect(profile.name).toBe("Original profile");
     expect(profile.apiBaseUrl).toBe("https://api.openai.com/v1");
     expect(profile.model).toBe("gpt-5-mini");
     expect(profile.apiMode).toBe("responses");
@@ -62,10 +62,10 @@ describe("provider presets", () => {
     expect(profile.modelContextLimit).toBe(200000);
   });
 
-  it("applies the OpenRouter preset values", () => {
+  it("applies the OpenRouter preset values without overwriting the name", () => {
     const profile = applyProviderPreset(createProfile(), "openrouter");
 
-    expect(profile.name).toBe("OpenRouter");
+    expect(profile.name).toBe("Original profile");
     expect(profile.apiBaseUrl).toBe("https://openrouter.ai/api/v1");
     expect(profile.model).toBe("");
     expect(profile.apiMode).toBe(DEFAULT_PROVIDER_SETTINGS.apiMode);
@@ -76,10 +76,10 @@ describe("provider presets", () => {
     expect(profile.modelContextLimit).toBe(200000);
   });
 
-  it("applies the OpenCode Go preset values", () => {
+  it("applies the OpenCode Go preset values without overwriting the name", () => {
     const profile = applyProviderPreset(createProfile(), "opencode_go");
 
-    expect(profile.name).toBe("OpenCode Go");
+    expect(profile.name).toBe("Original profile");
     expect(profile.apiBaseUrl).toBe("https://opencode.ai/zen/go/v1");
     expect(profile.model).toBe("kimi-k2.6");
     expect(profile.apiMode).toBe("chat_completions");
@@ -95,6 +95,17 @@ describe("provider presets", () => {
     };
 
     expect(getMatchingProviderPresetId(profile)).toBe("opencode_go");
+  });
+
+  it("matches a profile back to its preset even with a different name", () => {
+    const { name: _presetName, ...presetValues } = getProviderPreset("ollama_cloud").values;
+    const profile = {
+      ...createProfile(),
+      ...presetValues,
+      name: "My Custom Ollama"
+    };
+
+    expect(getMatchingProviderPresetId(profile)).toBe("ollama_cloud");
   });
 
   it("preserves non-provider tuning and secrets when applying a preset", () => {

--- a/tests/unit/providers-section.test.tsx
+++ b/tests/unit/providers-section.test.tsx
@@ -305,7 +305,7 @@ describe("providers section", () => {
       target: { value: "openrouter" }
     });
 
-    expect(profileNameInput).toHaveValue("OpenRouter");
+    expect(profileNameInput).toHaveValue("Default");
     expect(apiBaseUrlInput).toHaveValue("https://openrouter.ai/api/v1");
     expect(modelInput).toHaveValue("");
   });

--- a/tests/unit/settings.test.ts
+++ b/tests/unit/settings.test.ts
@@ -836,6 +836,74 @@ describe("settings storage", () => {
     ).toThrow();
   });
 
+  it("rejects duplicate profile names (case-insensitive)", () => {
+    const alpha = buildProfile({
+      id: "profile_alpha",
+      name: "My Provider"
+    });
+    const beta = buildProfile({
+      id: "profile_beta",
+      name: "my provider"
+    });
+
+    expect(() =>
+      updateSettings({
+        defaultProviderProfileId: alpha.id,
+        skillsEnabled: true,
+        providerProfiles: [alpha, beta]
+      })
+    ).toThrow("Provider profile names must be unique");
+  });
+
+  it("rejects duplicate profile names with different whitespace", () => {
+    const alpha = buildProfile({
+      id: "profile_alpha",
+      name: "My Provider"
+    });
+    const beta = buildProfile({
+      id: "profile_beta",
+      name: " My Provider "
+    });
+
+    expect(() =>
+      updateSettings({
+        defaultProviderProfileId: alpha.id,
+        skillsEnabled: true,
+        providerProfiles: [alpha, beta]
+      })
+    ).toThrow("Provider profile names must be unique");
+  });
+
+  it("allows multiple profiles with the same preset but different names", () => {
+    const alpha = buildProfile({
+      id: "profile_alpha",
+      name: "Ollama Primary",
+      apiBaseUrl: "https://ollama.com/v1",
+      model: "glm-4.7:cloud",
+      apiMode: "chat_completions",
+      providerPresetId: "ollama_cloud"
+    });
+    const beta = buildProfile({
+      id: "profile_beta",
+      name: "Ollama Secondary",
+      apiBaseUrl: "https://ollama.com/v1",
+      model: "glm-4.7:cloud",
+      apiMode: "chat_completions",
+      providerPresetId: "ollama_cloud"
+    });
+
+    updateSettings({
+      defaultProviderProfileId: alpha.id,
+      skillsEnabled: true,
+      providerProfiles: [alpha, beta]
+    });
+
+    const stored = listProviderProfiles();
+    expect(stored).toHaveLength(2);
+    expect(stored.map((p) => p.name)).toEqual(["Ollama Primary", "Ollama Secondary"]);
+    expect(stored.every((p) => p.providerPresetId === "ollama_cloud")).toBe(true);
+  });
+
   it("stores github copilot profiles without requiring an api key", () => {
     const copilot = {
       ...buildProfile({


### PR DESCRIPTION
## Summary

- **Fix preset name overwrite**: `applyProviderPreset()` no longer overwrites the profile `name`, allowing multiple providers to share the same preset with different names
- **Fix preset matching**: `getMatchingProviderPresetId()` no longer compares `name` when matching, so custom-named profiles still show their preset correctly
- **Prevent duplicate names**: Added case-insensitive, trim-aware duplicate name validation in the Zod schema — rejects saves with a clear error message
- **UI improvements**: Inline "A profile with this name already exists" error under the name field; Save button disabled when duplicates exist; auto-generated names (`Profile N`) are replaced with the preset's name on first apply
- **API error handling**: Proper `ZodError` formatting in the providers route for readable error messages