### PR TITLE
feat: add mermaid diagram support via @streamdown/mermaid

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Use it as a private assistant, a day-to-day work companion, or a shared workspac
 - Previous message editing with restart-from-edit flow for fast iteration
 - Browser speech-to-text in the chat composer
 - Image generation support
+- Mermaid diagram generation
 - Multiple clients live sync
 - Support native or dedicated MCP server for vision capabilites
 - Temporary chat

--- a/app/globals.css
+++ b/app/globals.css
@@ -363,6 +363,10 @@ select {
   border-color: rgba(255, 255, 255, 0.06) !important;
 }
 
+.markdown-body [data-streamdown="mermaid"] [class*="border-border"] {
+  border-color: rgba(255, 255, 255, 0.06) !important;
+}
+
 .markdown-body [data-streamdown="mermaid-block"] .bg-red-50 {
   background: rgba(255, 255, 255, 0.04) !important;
   border: 1px solid rgba(255, 255, 255, 0.06);

--- a/app/globals.css
+++ b/app/globals.css
@@ -349,6 +349,9 @@ select {
 
 .markdown-body [data-streamdown="mermaid-block"] > div:last-child {
   background-color: transparent !important;
+  border: none !important;
+  border-radius: 0 !important;
+  padding: 0 0.5rem 0.5rem 0.5rem !important;
 }
 
 .markdown-body [data-streamdown="mermaid-block"] details pre {

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,6 +1,7 @@
 @import "tailwindcss";
 @source "../node_modules/streamdown/dist/*.js";
 @source "../node_modules/@streamdown/code/dist/*.js";
+@source "../node_modules/@streamdown/mermaid/dist/*.js";
 
 @theme {
   --color-background: var(--background);

--- a/app/globals.css
+++ b/app/globals.css
@@ -341,6 +341,47 @@ select {
   background: rgba(255, 255, 255, 0.03) !important;
 }
 
+.markdown-body [data-streamdown="mermaid-block"] {
+  border-color: rgba(255, 255, 255, 0.06) !important;
+  padding: 0.25rem !important;
+  gap: 0.25rem !important;
+}
+
+.markdown-body [data-streamdown="mermaid-block"] > div:last-child {
+  background-color: transparent !important;
+}
+
+.markdown-body [data-streamdown="mermaid-block"] details pre {
+  background: rgba(255, 255, 255, 0.06) !important;
+  color: rgba(255, 255, 255, 0.75) !important;
+}
+
+.markdown-body [data-streamdown="mermaid-block"] [data-streamdown="mermaid-block-actions"] {
+  border-color: rgba(255, 255, 255, 0.06) !important;
+}
+
+.markdown-body [data-streamdown="mermaid-block"] .bg-red-50 {
+  background: rgba(255, 255, 255, 0.04) !important;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 0.5rem;
+}
+
+.markdown-body [data-streamdown="mermaid-block"] .text-red-700 {
+  color: rgba(248, 113, 113, 0.9) !important;
+}
+
+.markdown-body [data-streamdown="mermaid-block"] .text-red-600 {
+  color: rgba(248, 113, 113, 0.7) !important;
+}
+
+.markdown-body [data-streamdown="mermaid-block"] .bg-red-100 {
+  background: rgba(255, 255, 255, 0.06) !important;
+}
+
+.markdown-body [data-streamdown="mermaid-block"] .text-red-800 {
+  color: rgba(255, 255, 255, 0.65) !important;
+}
+
 
 .thinking-markdown-body {
   color: rgba(255, 255, 255, 0.48);

--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -2,7 +2,6 @@
 
 import React, { useEffect, useRef, useState } from "react";
 import { Brain, Check, ChevronDown, ChevronRight, Copy, FileText, GitFork, LoaderCircle, Pencil, Square, X } from "lucide-react";
-import type { RemendHandler } from "remend";
 import { Streamdown } from "streamdown";
 import { code } from "@streamdown/code";
 import { mermaid } from "@streamdown/mermaid";
@@ -23,161 +22,9 @@ import type {
   MessageAttachment,
   MessageTimelineItem
 } from "@/lib/types";
-import { normalizeMarkdownLineBreaks } from "@/lib/text-utils";
+import { normalizeLineBreaks } from "@/lib/text-utils";
 
 const STREAMDOWN_PLUGINS = { code, mermaid };
-
-const KNOWN_LANG_PREFIXES = [
-  "yaml", "yml", "json", "json5", "jsonc", "python", "py", "javascript", "js",
-  "typescript", "ts", "bash", "sh", "shell", "zsh", "fish", "html", "css", "scss",
-  "sql", "mysql", "postgres", "go", "rust", "java", "csharp", "cs", "cpp", "c",
-  "ruby", "rb", "php", "swift", "kotlin", "dockerfile", "docker", "makefile",
-  "xml", "svg",   "markdown", "mermaid", "md", "text", "diff", "graphql", "toml", "ini",
-  "jsx", "tsx", "objective-c", "objc", "r", "lua", "perl", "groovy", "scala",
-  "haskell", "elm", "erlang", "clojure", "vim", "powershell", "bat", "ps1",
-  "nix", "terraform", "tf", "hcl", "docker-compose", "nginx", "apache", "conf",
-];
-
-function splitMergedCodeFenceLang(text: string): [string, string] | null {
-  if (!text || /^\w+$/.test(text)) return null;
-  if (!/[:\s=]/.test(text)) return null;
-
-  let bestMatch = "";
-  for (const lang of KNOWN_LANG_PREFIXES) {
-    if (text.startsWith(lang) && lang.length > bestMatch.length) {
-      bestMatch = lang;
-    }
-  }
-
-  if (bestMatch && text.length > bestMatch.length) {
-    return [bestMatch, text.slice(bestMatch.length)];
-  }
-
-  return null;
-}
-
-const splitMergedBlockElements: RemendHandler = {
-  name: "split-merged-block-elements",
-  priority: 90,
-  handle: (text: string): string => {
-    const lines = text.split("\n");
-    const result: string[] = [];
-    let insideCodeBlock = false;
-
-    for (const line of lines) {
-      const trimmed = line.trim();
-
-      if (insideCodeBlock) {
-        const closingFence = trimmed.match(/^`{3,}\s*$/);
-        if (closingFence) {
-          insideCodeBlock = false;
-        }
-        result.push(line);
-        continue;
-      }
-
-      const openingFence = trimmed.match(/^(`{3,})(\S*)/);
-      if (openingFence) {
-        insideCodeBlock = true;
-        result.push(line);
-        continue;
-      }
-
-      const fenceCount = (line.match(/`{3,}/g) || []).length;
-
-      if (/^\|.*\|$/.test(trimmed) && /\|\|/.test(trimmed)) {
-        const cells = trimmed.split(/\|\|/);
-        for (const cell of cells) {
-          result.push(("|" + cell + (cell.endsWith("|") ? "" : "|")).trim());
-        }
-        continue;
-      }
-
-      if (line.trimStart().startsWith("|")) {
-        result.push(line);
-        continue;
-      }
-
-      const headingTableMatch = trimmed.match(/^(#{1,6}\s+\S.*?)\|(\s*\S)/);
-      if (headingTableMatch) {
-        result.push(headingTableMatch[1].trimEnd());
-        result.push("");
-        result.push("|" + headingTableMatch[2] + trimmed.slice(headingTableMatch[0].length));
-        continue;
-      }
-
-      const codeblockBeforeIdx = line.search(/[^\s](`{3,})/);
-      if (codeblockBeforeIdx !== -1 && fenceCount < 2) {
-        const splitAt = codeblockBeforeIdx + 1;
-        const beforeText = line.slice(0, splitAt).trimEnd();
-        const delimiterAndAfter = line.slice(splitAt);
-        const afterMatch = delimiterAndAfter.match(/^(`{3,})(\s*\S+.*)$/);
-        if (afterMatch && afterMatch[2] && afterMatch[2].trim() && /\s/.test(afterMatch[2].trim())) {
-          result.push(beforeText);
-          result.push("");
-          result.push(afterMatch[1]);
-          result.push(afterMatch[2].trimStart());
-        } else {
-          result.push(beforeText);
-          result.push("");
-          result.push(delimiterAndAfter);
-        }
-        continue;
-      }
-
-      if (fenceCount < 2) {
-        const codeblockAfterMatch = trimmed.match(/^(`{3,})\s+(\S+(?:\s+\S+)+)$/);
-        if (codeblockAfterMatch) {
-          const indent = line.slice(0, line.length - trimmed.length);
-          result.push(indent + codeblockAfterMatch[1]);
-          result.push(codeblockAfterMatch[2]);
-          continue;
-        }
-      }
-
-      if (fenceCount < 2) {
-        const fenceLangMatch = trimmed.match(/^(`{3,})(\S+)(?:\s+(.*))?$/);
-        if (fenceLangMatch) {
-          const langPart = fenceLangMatch[2];
-          const restOfLine = fenceLangMatch[3] || "";
-          const split = splitMergedCodeFenceLang(langPart);
-          if (split) {
-            const indent = line.slice(0, line.length - trimmed.length);
-            result.push(indent + fenceLangMatch[1] + split[0]);
-            result.push(split[1] + (restOfLine ? " " + restOfLine : ""));
-            continue;
-          }
-        }
-      }
-
-      const headingIdx = line.search(/[^\s#](#{1,6}\s)/);
-      if (headingIdx !== -1) {
-        const splitAt = headingIdx + 1;
-        result.push(line.slice(0, splitAt).trimEnd());
-        result.push("");
-        result.push(line.slice(splitAt));
-        continue;
-      }
-
-      const hrIdx = line.search(/[^\s](-{3,}|\*{3,}|_{3,})\s*$/);
-      if (hrIdx !== -1) {
-        const splitAt = hrIdx + 1;
-        result.push(line.slice(0, splitAt).trimEnd());
-        result.push("");
-        result.push(line.slice(splitAt));
-        continue;
-      }
-
-      result.push(line);
-    }
-
-    return result.join("\n");
-  },
-};
-
-const STREAMDOWN_REMEND_OPTIONS = {
-  handlers: [splitMergedBlockElements],
-};
 const COPY_RESET_DELAY_MS = 1600;
 
 function getAnsiForegroundClassName(foregroundColor: ReturnType<typeof parseAnsiText>[number]["foregroundColor"]) {
@@ -236,7 +83,6 @@ function renderAssistantMarkdown(content: string, isStreaming: boolean) {
   return (
     <Streamdown
       plugins={STREAMDOWN_PLUGINS}
-      remend={STREAMDOWN_REMEND_OPTIONS}
       caret={isStreaming ? "block" : undefined}
       isAnimating={isStreaming}
     >
@@ -864,8 +710,8 @@ export function MessageBubble({
   const rawThinking = streamingThinking ?? message.thinkingContent;
   const actions = message.actions ?? [];
   const liveTimeline = streamingTimeline ?? message.timeline;
-  const content = normalizeMarkdownLineBreaks(rawContent);
-  const thinkingContent = normalizeMarkdownLineBreaks(rawThinking);
+  const content = normalizeLineBreaks(rawContent);
+  const thinkingContent = normalizeLineBreaks(rawThinking);
   const timeline = liveTimeline ?? actions.map((action) => ({
     ...action,
     timelineKind: "action" as const
@@ -935,7 +781,7 @@ export function MessageBubble({
     )
     .map((item) => item.content)
     .join("");
-  const normalizedConsumedText = normalizeMarkdownLineBreaks(consumedText);
+  const normalizedConsumedText = normalizeLineBreaks(consumedText);
 
   if (content && content.length > normalizedConsumedText.length) {
     assistantBlocks.push({
@@ -1135,7 +981,7 @@ export function MessageBubble({
                 />
               ) : content ? (
                 <div ref={contentRef} className="markdown-body">
-                  <Streamdown mode="static" plugins={STREAMDOWN_PLUGINS} remend={STREAMDOWN_REMEND_OPTIONS}>{content}</Streamdown>
+                  <Streamdown mode="static" plugins={STREAMDOWN_PLUGINS}>{content}</Streamdown>
                 </div>
               ) : null}
               {message.attachments?.length ? (
@@ -1248,7 +1094,7 @@ export function MessageBubble({
 
                 {thinkingOpen && thinkingContent ? (
                   <div className="markdown-body thinking-markdown-body mt-1.5">
-                    <Streamdown mode="static" remend={STREAMDOWN_REMEND_OPTIONS}>{thinkingContent}</Streamdown>
+                    <Streamdown mode="static">{thinkingContent}</Streamdown>
                   </div>
                 ) : null}
               </div>

--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -5,6 +5,7 @@ import { Brain, Check, ChevronDown, ChevronRight, Copy, FileText, GitFork, Loade
 import type { RemendHandler } from "remend";
 import { Streamdown } from "streamdown";
 import { code } from "@streamdown/code";
+import { mermaid } from "@streamdown/mermaid";
 import {
   AttachmentPreviewModal,
   useAttachmentUrlBuilder,
@@ -24,14 +25,14 @@ import type {
 } from "@/lib/types";
 import { normalizeMarkdownLineBreaks } from "@/lib/text-utils";
 
-const STREAMDOWN_PLUGINS = { code };
+const STREAMDOWN_PLUGINS = { code, mermaid };
 
 const KNOWN_LANG_PREFIXES = [
   "yaml", "yml", "json", "json5", "jsonc", "python", "py", "javascript", "js",
   "typescript", "ts", "bash", "sh", "shell", "zsh", "fish", "html", "css", "scss",
   "sql", "mysql", "postgres", "go", "rust", "java", "csharp", "cs", "cpp", "c",
   "ruby", "rb", "php", "swift", "kotlin", "dockerfile", "docker", "makefile",
-  "xml", "svg", "markdown", "md", "text", "diff", "graphql", "toml", "ini",
+  "xml", "svg",   "markdown", "mermaid", "md", "text", "diff", "graphql", "toml", "ini",
   "jsx", "tsx", "objective-c", "objc", "r", "lua", "perl", "groovy", "scala",
   "haskell", "elm", "erlang", "clojure", "vim", "powershell", "bat", "ps1",
   "nix", "terraform", "tf", "hcl", "docker-compose", "nginx", "apache", "conf",

--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -62,9 +62,27 @@ const splitMergedBlockElements: RemendHandler = {
   handle: (text: string): string => {
     const lines = text.split("\n");
     const result: string[] = [];
+    let insideCodeBlock = false;
 
     for (const line of lines) {
       const trimmed = line.trim();
+
+      if (insideCodeBlock) {
+        const closingFence = trimmed.match(/^`{3,}\s*$/);
+        if (closingFence) {
+          insideCodeBlock = false;
+        }
+        result.push(line);
+        continue;
+      }
+
+      const openingFence = trimmed.match(/^(`{3,})(\S*)/);
+      if (openingFence) {
+        insideCodeBlock = true;
+        result.push(line);
+        continue;
+      }
+
       const fenceCount = (line.match(/`{3,}/g) || []).length;
 
       if (/^\|.*\|$/.test(trimmed) && /\|\|/.test(trimmed)) {

--- a/lib/assistant-local-attachments.ts
+++ b/lib/assistant-local-attachments.ts
@@ -6,7 +6,7 @@ import {
   decodeMarkdownTarget,
   findMarkdownTargets,
   isExternalMarkdownTarget,
-  normalizeProtectedMarkdownContent,
+  normalizeProtectedMarkdownContentOutsideCodeBlocks,
   parseAssistantDataImageTarget
 } from "@/lib/assistant-markdown-parsing";
 import { env } from "@/lib/env";
@@ -49,7 +49,7 @@ function isPathInsideRoot(candidatePath: string, rootPath: string) {
 }
 
 function collapseWhitespace(content: string) {
-  return normalizeProtectedMarkdownContent(content);
+  return normalizeProtectedMarkdownContentOutsideCodeBlocks(content);
 }
 
 function buildFailureNote(deniedNames: Set<string>, failedNames: Set<string>) {

--- a/lib/assistant-markdown-parsing.ts
+++ b/lib/assistant-markdown-parsing.ts
@@ -200,6 +200,48 @@ export function normalizeProtectedMarkdownContent(content: string) {
     .replace(/[ \t]+$/, "");
 }
 
+export function normalizeProtectedMarkdownContentOutsideCodeBlocks(content: string) {
+  const parts = splitAroundCodeBlocks(content);
+  return parts.map((part) =>
+    part.insideCode ? part.text : normalizeProtectedMarkdownContent(part.text)
+  ).join("");
+}
+
+function splitAroundCodeBlocks(content: string): Array<{ text: string; insideCode: boolean }> {
+  const parts: Array<{ text: string; insideCode: boolean }> = [];
+  const fenceRegex = /^(`{3,})/gm;
+  let lastEnd = 0;
+
+  while (true) {
+    const match = fenceRegex.exec(content);
+    if (!match) break;
+
+    const fenceLen = match[1].length;
+    const fenceStart = match.index;
+    const afterFence = fenceStart + fenceLen;
+    const rest = content.slice(afterFence);
+    const closeFence = rest.match(new RegExp(`\n((?:[ \t]*\n)?)\`{${fenceLen},}[ \t]*$`, "m"));
+
+    if (closeFence) {
+      const codeEnd = afterFence + (closeFence.index ?? 0) + closeFence[0].length;
+      if (fenceStart > lastEnd) {
+        parts.push({ text: content.slice(lastEnd, fenceStart), insideCode: false });
+      }
+      parts.push({ text: content.slice(fenceStart, codeEnd), insideCode: true });
+      lastEnd = codeEnd;
+      fenceRegex.lastIndex = codeEnd;
+    } else {
+      break;
+    }
+  }
+
+  if (lastEnd < content.length) {
+    parts.push({ text: content.slice(lastEnd), insideCode: false });
+  }
+
+  return parts.length > 0 ? parts : [{ text: content, insideCode: false }];
+}
+
 export function decodeMarkdownTarget(target: string) {
   try {
     return decodeURIComponent(target);

--- a/lib/assistant-runtime.ts
+++ b/lib/assistant-runtime.ts
@@ -84,7 +84,7 @@ const INLINE_ATTACHMENT_DIRECTIVE =
 const NON_NATIVE_VISION_DIRECTIVE =
   "The current model configuration cannot inspect attached images directly in this turn. Attached images were provided only as text placeholders. Do not claim to have viewed image contents directly. If image analysis is required, explain the limitation or use the configured vision MCP server when available.";
 const MERMAID_DIAGRAM_DIRECTIVE =
-  "When you need to present diagrams (flowcharts, sequence diagrams, class diagrams, state diagrams, ER diagrams, Gantt charts, pie charts, mind maps, or any other diagram type), use mermaid.js syntax inside a fenced code block with the `mermaid` language identifier. For example:\n\n```mermaid\ngraph TD\n    A[Start] --> B{Decision}\n    B -->|Yes| C[Success]\n    B -->|No| D[Try Again]\n```\n\nAlways prefer mermaid diagrams over ASCII art or text-based diagrams.";
+  "When you need to present diagrams (flowcharts, sequence diagrams, class diagrams, state diagrams, ER diagrams, Gantt charts, pie charts, mind maps, or any other diagram type), use mermaid.js syntax inside a fenced code block with the `mermaid` language identifier. Each diagram statement must be on its own line with actual line breaks. For example:\n\n```mermaid\ngraph TD\n    A[Start] --> B{Decision}\n    B -->|Yes| C[Success]\n    B -->|No| D[Try Again]\n```\n\nDo not put multiple statements on a single line. Do not collapse lines together. Always prefer mermaid diagrams over ASCII art or text-based diagrams.";
 
 function mcpToolFunctionName(serverSlug: string, toolName: string) {
   return `mcp_${serverSlug}_${toolName}`;

--- a/lib/assistant-runtime.ts
+++ b/lib/assistant-runtime.ts
@@ -84,7 +84,7 @@ const INLINE_ATTACHMENT_DIRECTIVE =
 const NON_NATIVE_VISION_DIRECTIVE =
   "The current model configuration cannot inspect attached images directly in this turn. Attached images were provided only as text placeholders. Do not claim to have viewed image contents directly. If image analysis is required, explain the limitation or use the configured vision MCP server when available.";
 const MERMAID_DIAGRAM_DIRECTIVE =
-  "When you need to present diagrams (flowcharts, sequence diagrams, class diagrams, state diagrams, ER diagrams, Gantt charts, pie charts, mind maps, or any other diagram type), use mermaid.js syntax inside a fenced code block with the `mermaid` language identifier. Each diagram statement must be on its own line with actual line breaks. For example:\n\n```mermaid\ngraph TD\n    A[Start] --> B{Decision}\n    B -->|Yes| C[Success]\n    B -->|No| D[Try Again]\n```\n\nDo not put multiple statements on a single line. Do not collapse lines together. Always prefer mermaid diagrams over ASCII art or text-based diagrams.";
+  "When you need to present diagrams (flowcharts, sequence diagrams, class diagrams, state diagrams, ER diagrams, Gantt charts, pie charts, mind maps, or any other diagram type), use mermaid.js syntax inside a fenced code block with the `mermaid` language identifier. For example:\n\n```mermaid\ngraph TD\n    A[Start] --> B{Decision}\n    B -->|Yes| C[Success]\n    B -->|No| D[Try Again]\n```\n\nAlways prefer mermaid diagrams over ASCII art or text-based diagrams.";
 
 function mcpToolFunctionName(serverSlug: string, toolName: string) {
   return `mcp_${serverSlug}_${toolName}`;

--- a/lib/assistant-runtime.ts
+++ b/lib/assistant-runtime.ts
@@ -83,6 +83,8 @@ const INLINE_ATTACHMENT_DIRECTIVE =
   "When you create or capture an image file, rely on the runtime attachment flow. Do not run base64 on screenshot/image files. Do not embed data: image URLs in your visible response.";
 const NON_NATIVE_VISION_DIRECTIVE =
   "The current model configuration cannot inspect attached images directly in this turn. Attached images were provided only as text placeholders. Do not claim to have viewed image contents directly. If image analysis is required, explain the limitation or use the configured vision MCP server when available.";
+const MERMAID_DIAGRAM_DIRECTIVE =
+  "When you need to present diagrams (flowcharts, sequence diagrams, class diagrams, state diagrams, ER diagrams, Gantt charts, pie charts, mind maps, or any other diagram type), use mermaid.js syntax inside a fenced code block with the `mermaid` language identifier. For example:\n\n```mermaid\ngraph TD\n    A[Start] --> B{Decision}\n    B -->|Yes| C[Success]\n    B -->|No| D[Try Again]\n```\n\nAlways prefer mermaid diagrams over ASCII art or text-based diagrams.";
 
 function mcpToolFunctionName(serverSlug: string, toolName: string) {
   return `mcp_${serverSlug}_${toolName}`;
@@ -1302,6 +1304,8 @@ export async function resolveAssistantTurn(input: {
   if (input.appSettings?.imageGenerationBackend && input.appSettings.imageGenerationBackend !== "disabled") {
     promptMessages = mergeSystemMessage(promptMessages, IMAGE_TOOL_LATEST_REQUEST_DIRECTIVE);
   }
+
+  promptMessages = mergeSystemMessage(promptMessages, MERMAID_DIAGRAM_DIRECTIVE);
 
   let timelineSortOrder = 0;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@radix-ui/react-scroll-area": "^1.2.2",
         "@radix-ui/react-slot": "^1.1.1",
         "@streamdown/code": "^1.1.1",
+        "@streamdown/mermaid": "^1.0.2",
         "argon2": "^0.41.1",
         "better-sqlite3": "^11.7.0",
         "clsx": "^2.1.1",
@@ -2812,6 +2813,18 @@
       "license": "Apache-2.0",
       "dependencies": {
         "shiki": "^3.19.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@streamdown/mermaid": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@streamdown/mermaid/-/mermaid-1.0.2.tgz",
+      "integrity": "sha512-Fr/4sBWnAeSnxM3PcrV/+DiZe5oPMq9gOkUIAH7ZauJeuwrZ/DVzD4g0zlav6AH0axh2m/sOfrfLtY5aLT7niw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mermaid": "^11.12.2"
       },
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@radix-ui/react-scroll-area": "^1.2.2",
     "@radix-ui/react-slot": "^1.1.1",
     "@streamdown/code": "^1.1.1",
+    "@streamdown/mermaid": "^1.0.2",
     "argon2": "^0.41.1",
     "better-sqlite3": "^11.7.0",
     "clsx": "^2.1.1",

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -33,7 +33,7 @@ if (typeof window !== "undefined") {
       ) {}
       observe() {
         this.callback(
-          [{ isIntersecting: true, target: document.createElement("div") } as IntersectionObserverEntry],
+          [{ isIntersecting: true, target: document.createElement("div") } as unknown as IntersectionObserverEntry],
           this as unknown as IntersectionObserver
         );
       }

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -21,6 +21,34 @@ if (typeof window !== "undefined") {
     configurable: true,
     value: () => undefined
   });
+
+  if (!window.IntersectionObserver) {
+    class IntersectionObserver {
+      readonly root: Element | null = null;
+      readonly rootMargin: string = "";
+      readonly thresholds: ReadonlyArray<number> = [];
+      constructor(
+        private callback: IntersectionObserverCallback,
+        _options?: IntersectionObserverInit
+      ) {}
+      observe() {
+        this.callback(
+          [{ isIntersecting: true, target: document.createElement("div") } as IntersectionObserverEntry],
+          this as unknown as IntersectionObserver
+        );
+      }
+      unobserve() {}
+      disconnect() {}
+      takeRecords(): IntersectionObserverEntry[] {
+        return [];
+      }
+    }
+    Object.defineProperty(window, "IntersectionObserver", {
+      configurable: true,
+      writable: true,
+      value: IntersectionObserver
+    });
+  }
 }
 
 beforeEach(async () => {

--- a/tests/unit/assistant-runtime.test.ts
+++ b/tests/unit/assistant-runtime.test.ts
@@ -690,6 +690,34 @@ ${JSON.stringify({
     expect(assignAttachmentsToMessage).toHaveBeenCalledWith("conv_image", "msg_assistant_image", ["att_1"]);
   });
 
+  it("injects the mermaid diagram directive into the system prompt", async () => {
+    streamProviderResponse.mockImplementation(({ promptMessages }: { promptMessages?: Array<{ content: string }> }) => {
+      const systemPrompt = String(promptMessages?.[0]?.content ?? "");
+      expect(systemPrompt).toContain("mermaid");
+      expect(systemPrompt).toContain("graph TD");
+      expect(systemPrompt).toContain("Always prefer mermaid diagrams over ASCII art");
+      return createProviderStream([{ type: "answer_delta", text: "Done." }], {
+        answer: "Done.",
+        thinking: "",
+        usage: { outputTokens: 2 }
+      });
+    });
+
+    const { resolveAssistantTurn } = await import("@/lib/assistant-runtime");
+
+    const result = await resolveAssistantTurn({
+      settings: createSettings(),
+      promptMessages: [{ role: "user", content: "Draw a flowchart" }],
+      skills: [],
+      mcpToolSets: [],
+      appSettings: createAppSettings(),
+      conversationId: "conv_mermaid",
+      assistantMessageId: "msg_mermaid"
+    });
+
+    expect(result.answer).toBe("Done.");
+  });
+
   it("binds every generated assistant attachment to the provided assistant message id", async () => {
     let providerCallCount = 0;
     streamProviderResponse.mockImplementation(() => {

--- a/tests/unit/chat-turn.test.ts
+++ b/tests/unit/chat-turn.test.ts
@@ -876,7 +876,8 @@ describe("chat-turn", () => {
       (message: { role: string; content: unknown }) => message.role === "system"
     )?.content;
 
-    expect(systemPrompt).toBeUndefined();
+    expect(systemPrompt).not.toContain("Do not run base64 on screenshot/image files");
+    expect(systemPrompt).not.toContain("Do not embed data: image URLs");
   });
 
   it("keeps the inline attachment directive when the user explicitly says not to send base64 or a data URL", async () => {
@@ -957,7 +958,8 @@ describe("chat-turn", () => {
       (message: { role: string; content: unknown }) => message.role === "system"
     )?.content;
 
-    expect(systemPrompt).toBeUndefined();
+    expect(systemPrompt).not.toContain("Do not run base64 on screenshot/image files");
+    expect(systemPrompt).not.toContain("Do not embed data: image URLs");
   });
 
   it("persists pending memory proposal metadata on assistant actions", async () => {

--- a/tests/unit/message-bubble.test.ts
+++ b/tests/unit/message-bubble.test.ts
@@ -1087,6 +1087,19 @@ describe("message bubble", () => {
     expect(codeElements.length).toBeGreaterThanOrEqual(2);
   });
 
+  it("renders mermaid code blocks via streamdown", async () => {
+    const message = createAssistantMessage();
+    message.content = "Here is a diagram:\n\n```mermaid\ngraph TD\n    A --> B\n```";
+
+    const { container } = render(
+      React.createElement(MessageBubble, { message })
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-streamdown="mermaid-block"]')).not.toBeNull();
+    });
+  });
+
   it("renders single-line untagged fenced assistant code blocks through the code block renderer", () => {
     const { container } = render(
       React.createElement(MessageBubble, {
@@ -1116,7 +1129,7 @@ describe("message bubble", () => {
     fireEvent.click(screen.getByRole("button", { name: /Thought/i }));
 
     await waitFor(() => {
-      expect(container.querySelector('[data-streamdown="code-block"]')).not.toBeNull();
+    expect(container.querySelector('[data-streamdown="code-block"]')).not.toBeNull();
     });
 
     expect(container.querySelector(".thinking-markdown-body pre code")).not.toBeNull();


### PR DESCRIPTION
## Summary

- Add `@streamdown/mermaid` dependency and register the mermaid plugin in Streamdown components
- Add a mermaid diagram directive to the AI system prompt so models know to emit mermaid code blocks
- Add dark-mode CSS overrides for mermaid containers matching existing code/table block styling
- Preserve code block content during whitespace normalization (splits around fenced blocks before collapsing)
- Remove custom markdown preprocessing from `message-bubble`, delegating rendering to Streamdown
- Add unit tests for mermaid directive injection and code block rendering