### PR TITLE
fix: persist desktop sidebar toggle state across navigation

### DIFF
--- a/components/shell.tsx
+++ b/components/shell.tsx
@@ -227,6 +227,7 @@ export function Shell({
 
     if (pathname === "/") {
       hasAppliedDesktopDefaultRef.current = true;
+      sessionStorage.removeItem("eidon:sidebar:user-closed");
       setIsSidebarOpen(true);
       return;
     }
@@ -237,13 +238,22 @@ export function Shell({
 
     if (shouldAutoHideActiveConversation) {
       hasAppliedDesktopDefaultRef.current = true;
+      sessionStorage.removeItem("eidon:sidebar:user-closed");
       setIsSidebarOpen(false);
       return;
     }
 
+    const userClosed = sessionStorage.getItem("eidon:sidebar:user-closed") === "true";
+
     if (!hasAppliedDesktopDefaultRef.current) {
       hasAppliedDesktopDefaultRef.current = true;
-      setIsSidebarOpen(true);
+      if (userClosed) {
+        setIsSidebarOpen(false);
+      } else {
+        setIsSidebarOpen(true);
+      }
+    } else if (userClosed) {
+      setIsSidebarOpen(false);
     }
   }, [activeConversationId, isSettingsPage, pathname]);
 
@@ -257,14 +267,14 @@ export function Shell({
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
             transition={{ duration: 0.2 }}
-            className="fixed inset-0 z-[60] bg-black/70 backdrop-blur-sm md:hidden"
-            onClick={() => setIsSidebarOpen(false)}
+            className="fixed inset-0 z-[60] bg-black/70 backdrop-blur-sm"
+            onClick={() => { sessionStorage.setItem("eidon:sidebar:user-closed", "true"); setIsSidebarOpen(false); }}
           />
         )}
       </AnimatePresence>
 
       <div
-        className={`fixed inset-y-0 left-0 z-[70] w-[280px] transform transition-transform duration-300 ease-out border-r border-white/5 md:z-50 ${
+        className={`fixed inset-y-0 left-0 z-[70] w-[280px] transform transition-transform duration-300 ease-out border-r border-white/5 md:z-[70] ${
           isSidebarOpen ? "translate-x-0" : "-translate-x-full"
         } ${
           isDesktopSidebarOpen ? "md:translate-x-0" : "md:-translate-x-full"
@@ -274,20 +284,20 @@ export function Shell({
           <SettingsNav
             currentUser={currentUser}
             passwordLoginEnabled={passwordLoginEnabled}
-            onCloseAction={() => setIsSidebarOpen(false)}
+            onCloseAction={() => { sessionStorage.setItem("eidon:sidebar:user-closed", "true"); setIsSidebarOpen(false); }}
           />
         ) : isAutomationsPage ? (
-          <AutomationsNav automations={automations ?? []} onCloseAction={() => setIsSidebarOpen(false)} />
+          <AutomationsNav automations={automations ?? []} onCloseAction={() => { sessionStorage.setItem("eidon:sidebar:user-closed", "true"); setIsSidebarOpen(false); }} />
         ) : (
-          <Sidebar conversationPage={conversationPage} folders={folders} onClose={() => setIsSidebarOpen(false)} />
+          <Sidebar conversationPage={conversationPage} folders={folders} onClose={() => { sessionStorage.setItem("eidon:sidebar:user-closed", "true"); setIsSidebarOpen(false); }} />
         )}
       </div>
 
       {!isSettingsPage ? (
         <button
           type="button"
-          onClick={() => setIsSidebarOpen((prev) => !prev)}
-          className={`group/sidebar-toggle hidden md:flex fixed top-[72px] z-50 h-9 w-9 items-center justify-center rounded-lg border border-white/10 bg-[var(--background)]/95 text-white/45 shadow-[0_2px_8px_rgba(0,0,0,0.18)] backdrop-blur-sm transition-[left,background-color,border-color,color] duration-200 ease-out hover:border-white/18 hover:bg-[#171717] hover:text-white/75 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/20 ${
+          onClick={() => setIsSidebarOpen((prev) => { if (prev) sessionStorage.setItem("eidon:sidebar:user-closed", "true"); else sessionStorage.removeItem("eidon:sidebar:user-closed"); return !prev; })}
+          className={`group/sidebar-toggle hidden md:flex fixed top-[72px] z-[80] h-9 w-9 items-center justify-center rounded-lg border border-white/10 bg-[var(--background)]/95 text-white/45 shadow-[0_2px_8px_rgba(0,0,0,0.18)] backdrop-blur-sm transition-[left,background-color,border-color,color] duration-200 ease-out hover:border-white/18 hover:bg-[#171717] hover:text-white/75 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/20 ${
             isSidebarOpen ? "left-[262px]" : "left-3"
           }`}
           aria-label={sidebarToggleLabel}
@@ -317,7 +327,7 @@ export function Shell({
           <button
             type="button"
             className="p-2 -ml-2 text-[var(--text)] hover:bg-white/5 rounded-lg transition-colors duration-200"
-            onClick={() => setIsSidebarOpen(true)}
+            onClick={() => { sessionStorage.removeItem("eidon:sidebar:user-closed"); setIsSidebarOpen(true); }}
             aria-label={mobileMenuLabel}
           >
             <Menu className="h-5 w-5" />

--- a/tests/unit/shell-desktop-toggle.test.tsx
+++ b/tests/unit/shell-desktop-toggle.test.tsx
@@ -215,7 +215,7 @@ describe("Desktop Sidebar Toggle", () => {
     fireEvent.click(screen.getByRole("button", { name: "Open menu" }));
 
     const overlay = Array.from(document.querySelectorAll("div")).find((element) => {
-      return element.className.includes("bg-black/70") && element.className.includes("md:hidden");
+      return element.className.includes("bg-black/70") && element.className.includes("z-[60]");
     });
 
     expect(overlay).toHaveClass("z-[60]");


### PR DESCRIPTION
## Summary
- Remember whether the user closed the sidebar on desktop using `sessionStorage`, so it stays closed across page navigations within the same session
- Clear the "user closed" flag when navigating to home or opening the sidebar via the hamburger menu
- Remove `md:hidden` from the overlay so it also works on desktop viewports
- Bump sidebar toggle button z-index to `z-[80]` and desktop sidebar to `z-[70]` for correct layering