### PR TITLE
fix: eliminate scroll rubber banding at conversation bottom

### DIFF
--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -774,7 +774,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
     if (!el) return;
 
     const updateScrollPadding = () => {
-      setScrollPadding(Math.max(SCROLL_BOTTOM_PADDING, el.clientHeight));
+      setScrollPadding(SCROLL_BOTTOM_PADDING);
     };
 
     updateScrollPadding();
@@ -849,13 +849,13 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
     suppressNextScrollEventRef.current = false;
   }
 
-  const preventPaddingOnlyScroll = useCallback((event: { preventDefault: () => void }) => {
+  const preventOverscroll = useCallback((event: { preventDefault: () => void }) => {
     if (!queueRef.current) {
       return false;
     }
 
     const bottomTarget = getComposerAwareBottomTarget(queueRef.current, scrollPadding);
-    if (bottomTarget > 0) {
+    if (queueRef.current.scrollTop < bottomTarget) {
       return false;
     }
 
@@ -880,22 +880,32 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
 
     const handleWheel = (event: WheelEvent) => {
       if (event.deltaY > 0) {
-        preventPaddingOnlyScroll(event);
+        preventOverscroll(event);
       }
     };
 
+    let lastTouchY = 0;
+    const handleTouchStart = (event: TouchEvent) => {
+      lastTouchY = event.touches[0]?.clientY ?? 0;
+    };
     const handleTouchMove = (event: TouchEvent) => {
-      preventPaddingOnlyScroll(event);
+      const touchY = event.touches[0]?.clientY ?? 0;
+      if (touchY < lastTouchY) {
+        preventOverscroll(event);
+      }
+      lastTouchY = touchY;
     };
 
     el.addEventListener("wheel", handleWheel, { passive: false });
+    el.addEventListener("touchstart", handleTouchStart, { passive: true });
     el.addEventListener("touchmove", handleTouchMove, { passive: false });
 
     return () => {
       el.removeEventListener("wheel", handleWheel);
+      el.removeEventListener("touchstart", handleTouchStart);
       el.removeEventListener("touchmove", handleTouchMove);
     };
-  }, [preventPaddingOnlyScroll]);
+  }, [preventOverscroll]);
 
   const followAnchoredOverflowIfNeeded = useCallback(() => {
     const canFollowAnchor =
@@ -2278,7 +2288,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
 
       <div
         ref={queueRef}
-        className="no-scrollbar min-h-0 flex-1 overflow-y-auto px-2 md:px-8 relative z-0 isolate"
+        className="no-scrollbar min-h-0 flex-1 overflow-y-auto overscroll-y-contain px-2 md:px-8 relative z-0 isolate"
         onScroll={() => {
           if (!queueRef.current) {
             return;
@@ -2296,12 +2306,11 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
             !streamMessageIdRef.current &&
             queueRef.current.scrollTop > bottomTarget + ANCHOR_SCROLL_TOLERANCE_PX
           ) {
-            const isPaddingOnlyScroll = bottomTarget <= 0;
             suppressNextScrollEventRef.current = true;
             queueRef.current.scrollTo?.({ top: bottomTarget, behavior: "auto" });
             queueRef.current.scrollTop = bottomTarget;
             setIsConversationAtBottom(true);
-            shouldAutoScrollRef.current = isPaddingOnlyScroll;
+            shouldAutoScrollRef.current = true;
             userScrollIntentRef.current = false;
             requestAnimationFrame(() => {
               suppressNextScrollEventRef.current = false;
@@ -2347,13 +2356,13 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
           userScrollIntentRef.current = false;
         }}
         onWheel={(event) => {
-          if (event.deltaY > 0 && preventPaddingOnlyScroll(event)) {
+          if (event.deltaY > 0 && preventOverscroll(event)) {
             return;
           }
           cancelAutoScrollForUserIntent();
         }}
         onTouchMove={(event) => {
-          if (preventPaddingOnlyScroll(event)) {
+          if (preventOverscroll(event)) {
             return;
           }
           cancelAutoScrollForUserIntent();

--- a/tests/unit/chat-view.test.ts
+++ b/tests/unit/chat-view.test.ts
@@ -2808,22 +2808,16 @@ describe("chat view", () => {
     expect(pill.className).not.toContain("md:bottom-full");
   });
 
-  it("sets dynamic bottom padding from the queue height with a 260px minimum", async () => {
+  it("uses fixed bottom padding of 260px", async () => {
     const { container } = renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
     const queue = container.querySelector(".no-scrollbar.overflow-y-auto") as HTMLDivElement;
     const messageList = queue.firstElementChild as HTMLDivElement;
 
-    let clientHeight = 420;
     Object.defineProperty(queue, "clientHeight", {
       configurable: true,
-      get: () => clientHeight
+      get: () => 420
     });
 
-    await flushResizeObservers();
-
-    expect(messageList).toHaveStyle({ paddingBottom: "420px" });
-
-    clientHeight = 180;
     await flushResizeObservers();
 
     expect(messageList).toHaveStyle({ paddingBottom: "260px" });
@@ -2885,7 +2879,7 @@ describe("chat view", () => {
     await flushAnimationFrame();
 
     await waitFor(() => {
-      expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ top: 620 }));
+      expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ top: 720 }));
     });
     expect(scrollTo).not.toHaveBeenCalledWith(expect.objectContaining({ top: 1080 }));
   });
@@ -2951,7 +2945,7 @@ describe("chat view", () => {
     await flushAnimationFrame();
 
     await waitFor(() => {
-      expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ top: 620 }));
+      expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ top: 720 }));
     });
     expect(scrollTo).not.toHaveBeenCalledWith(expect.objectContaining({ top: 1080 }));
   });
@@ -3010,7 +3004,7 @@ describe("chat view", () => {
     });
 
     await waitFor(() => {
-      expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ top: 620 }));
+      expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ top: 720 }));
     });
 
     scrollTo.mockClear();
@@ -3027,9 +3021,9 @@ describe("chat view", () => {
     await flushAnimationFrame();
     await flushAnimationFrame();
 
-    expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ top: 620 }));
-    expect(scrollTop).toBe(620);
-    expect(messageList).toHaveStyle({ paddingBottom: "360px" });
+    expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ top: 720 }));
+    expect(scrollTop).toBe(720);
+    expect(messageList).toHaveStyle({ paddingBottom: "260px" });
   });
 
   it("anchors to the reconciled server user message when the optimistic local message is removed first", async () => {
@@ -3402,7 +3396,7 @@ describe("chat view", () => {
     });
 
     await waitFor(() => {
-      expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ top: 620 }));
+      expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ top: 720 }));
     });
 
     scrollTo.mockClear();
@@ -3420,10 +3414,10 @@ describe("chat view", () => {
     await flushAnimationFrame();
     await flushAnimationFrame();
 
-    expect(scrollTo).not.toHaveBeenCalledWith(expect.objectContaining({ top: 620 }));
+    expect(scrollTo).not.toHaveBeenCalledWith(expect.objectContaining({ top: 720 }));
   });
 
-  it("clamps idle scrolling before the padding-only blank area after streaming ends", async () => {
+  it("does not clamp when scroll position matches the bottom target after streaming ends", async () => {
     const { container } = renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
     const queue = container.querySelector(".no-scrollbar.overflow-y-auto") as HTMLDivElement;
     const textarea = screen.getByPlaceholderText(
@@ -3481,10 +3475,8 @@ describe("chat view", () => {
     scrollTop = 720;
     fireEvent.scroll(queue);
 
-    expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({
-      behavior: "auto",
-      top: 620
-    }));
+    expect(scrollTo).not.toHaveBeenCalled();
+    expect(scrollTop).toBe(720);
   });
 
   it("prevents downward wheel scrolling into padding-only space for short chats", async () => {


### PR DESCRIPTION
## Summary

- **Root cause:** The scroll container used `scrollPadding = max(260, clientHeight)`, which created a large scrollable padding zone below the last message (540px on an 800px viewport). Browser smooth scroll animations could overshoot into this zone, and the JS snap-back in the `onScroll` handler caused visible rubber banding when scrolling down repeatedly at the bottom of conversations.

- **Fix:** Changed `scrollPadding` to use fixed `SCROLL_BOTTOM_PADDING` (260px), so `bottomTarget` equals `maxScrollTop`. This eliminates the padding zone entirely — the browser naturally stops at the correct position and cannot overshoot.

- **Additional improvements:**
  - Renamed `preventPaddingOnlyScroll` → `preventOverscroll` with corrected guard condition (`scrollTop < bottomTarget` instead of `bottomTarget > 0`)
  - Added `overscroll-behavior-y: contain` CSS to prevent elastic overscroll
  - Added touch direction tracking to only prevent downward touch overscroll
  - Fixed `shouldAutoScrollRef` in the `onScroll` clamp (was incorrectly set to `false` for normal content)
  - Updated all scroll-related unit tests to match new scroll positions