### PR TITLE
Auto-open settings sidebar on mobile

### DIFF
--- a/components/shell.tsx
+++ b/components/shell.tsx
@@ -54,6 +54,7 @@ export function Shell({
   const shareCopyFadeHandle = useRef<number | null>(null);
   const consumedHomeSubmitAutoHideConversationIdRef = useRef<string | null>(null);
   const hasAppliedDesktopDefaultRef = useRef(false);
+  const prevIsSettingsPageRef = useRef(false);
 
   const pathname = usePathname();
   const router = useRouter();
@@ -256,6 +257,14 @@ export function Shell({
       setIsSidebarOpen(false);
     }
   }, [activeConversationId, isSettingsPage, pathname]);
+
+  useEffect(() => {
+    if (isSettingsPage && !prevIsSettingsPageRef.current && typeof window !== "undefined" && window.innerWidth < 768) {
+      sessionStorage.removeItem("eidon:sidebar:user-closed");
+      setIsSidebarOpen(true);
+    }
+    prevIsSettingsPageRef.current = isSettingsPage;
+  }, [isSettingsPage, pathname]);
 
   return (
     <div className="flex h-[100dvh] w-full bg-[var(--background)] overflow-hidden">


### PR DESCRIPTION
## Summary
- When navigating to Settings from the chat sidebar on mobile, the sidebar now auto-opens to show the SettingsNav with all sub-menus (Providers, MCP Servers, Skills, etc.)
- Adds a `useEffect` in `shell.tsx` that detects the transition from a non-settings page to a settings page on mobile viewports and opens the sidebar automatically