### PR TITLE
feat: add retry on error for assistant messages

### DIFF
--- a/app/api/messages/[messageId]/retry/route.ts
+++ b/app/api/messages/[messageId]/retry/route.ts
@@ -1,0 +1,107 @@
+import { z } from "zod";
+
+import { requireUser } from "@/lib/auth";
+import {
+  getAssistantTurnStartPreflight,
+  startAssistantTurnFromExistingUserMessage
+} from "@/lib/chat-turn";
+import {
+  deleteAssistantMessageAndChildren,
+  getConversationSnapshot,
+  getMessage,
+  listMessages
+} from "@/lib/conversations";
+import { claimChatTurnStart, releaseChatTurnStart } from "@/lib/chat-turn-control";
+import { badRequest, ok } from "@/lib/http";
+import { getConversationManager } from "@/lib/ws-singleton";
+
+const paramsSchema = z.object({
+  messageId: z.string().min(1)
+});
+
+export async function POST(
+  request: Request,
+  context: { params: Promise<{ messageId: string }> }
+) {
+  const user = await requireUser();
+  const params = paramsSchema.safeParse(await context.params);
+  if (!params.success) {
+    return badRequest("Invalid message id");
+  }
+
+  const message = getMessage(params.data.messageId, user.id);
+  if (!message) {
+    return badRequest("Message not found", 404);
+  }
+  if (message.role !== "assistant") {
+    return badRequest("Only assistant messages can be retried", 400);
+  }
+  if (message.status !== "error") {
+    return badRequest("Only error messages can be retried", 400);
+  }
+
+  const snapshot = getConversationSnapshot(message.conversationId, user.id);
+  if (!snapshot) {
+    return badRequest("Conversation not found", 404);
+  }
+  if (snapshot.conversation.isActive) {
+    return badRequest(
+      "Wait for the current assistant response to finish before retrying",
+      409
+    );
+  }
+
+  const allMessages = listMessages(message.conversationId);
+  const targetIndex = allMessages.findIndex((m) => m.id === message.id);
+
+  let userMessageId: string | null = null;
+  for (let i = targetIndex - 1; i >= 0; i--) {
+    if (allMessages[i].role === "user") {
+      userMessageId = allMessages[i].id;
+      break;
+    }
+  }
+
+  if (!userMessageId) {
+    return badRequest("No user message found before this assistant message", 400);
+  }
+
+  const preflight = getAssistantTurnStartPreflight(message.conversationId);
+  if (!preflight.ok) {
+    return badRequest(preflight.errorMessage, preflight.statusCode);
+  }
+
+  const claimed = claimChatTurnStart(message.conversationId);
+  if (!claimed.ok) {
+    return badRequest(
+      "Wait for the current assistant response to finish before retrying",
+      409
+    );
+  }
+
+  try {
+    const rewritten = deleteAssistantMessageAndChildren(
+      message.id,
+      user.id
+    );
+
+    void startAssistantTurnFromExistingUserMessage(
+      getConversationManager(),
+      rewritten.conversation.id,
+      userMessageId,
+      undefined,
+      {
+        control: claimed.control,
+        preflight
+      }
+    ).catch((error) => {
+      releaseChatTurnStart(message.conversationId, claimed.control);
+      console.error("[message-retry-route] continuation failed:", error);
+    });
+
+    return ok(rewritten);
+  } catch (error) {
+    releaseChatTurnStart(message.conversationId, claimed.control);
+    throw error;
+  }
+}

--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -571,6 +571,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
   const streamTimelineRef = useRef<MessageTimelineItem[]>([]);
   const [updatingMessageId, setUpdatingMessageId] = useState<string | null>(null);
   const [forkingMessageId, setForkingMessageId] = useState<string | null>(null);
+  const [retryingMessageId, setRetryingMessageId] = useState<string | null>(null);
   const titlePollTimeoutRef = useRef<number | null>(null);
   const titlePollAttemptsRef = useRef(0);
   const messageSyncTimeoutRef = useRef<number | null>(null);
@@ -1930,6 +1931,60 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
     }
   }
 
+  async function retryAssistantMessage(messageId: string) {
+    if (retryingMessageId) {
+      return;
+    }
+
+    setError("");
+    setRetryingMessageId(messageId);
+
+    try {
+      const response = await fetch(`/api/messages/${messageId}/retry`, {
+        method: "POST"
+      });
+
+      if (!response.ok) {
+        let message = "Unable to retry message";
+
+        try {
+          const failure = (await response.json()) as { error?: string };
+          message = failure.error ?? message;
+        } catch {}
+
+        throw new Error(message);
+      }
+
+      const result = (await response.json()) as {
+        conversation?: Conversation;
+        messages?: Message[];
+      };
+
+      resetStreamingState();
+
+      if (result.messages) {
+        setMessages(sanitizeMessages(result.messages));
+      }
+
+      if (result.conversation) {
+        setConversationTitle(result.conversation.title);
+        setTitleGenerationStatus(result.conversation.titleGenerationStatus);
+        dispatchConversationActivityUpdated({
+          conversationId: result.conversation.id,
+          isActive: true
+        });
+      }
+
+      setIsSending(true);
+    } catch (caughtError) {
+      setError(
+        caughtError instanceof Error ? caughtError.message : "Unable to retry message"
+      );
+    } finally {
+      setRetryingMessageId((current) => (current === messageId ? null : current));
+    }
+  }
+
   async function approveMemoryProposal(
     actionId: string,
     overrides?: { content?: string; category?: MemoryCategory }
@@ -2420,6 +2475,8 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
                     isUpdating={updatingMessageId === message.id}
                     onForkAssistantMessage={forkAssistantMessage}
                     isForking={forkingMessageId === message.id}
+                    onRetryAssistantMessage={retryAssistantMessage}
+                    isRetrying={retryingMessageId === message.id}
                   />
                   {isStreamingMessage && isAgentIdle && hasReceivedFirstToken && (
                     <div className="animate-fade-in mt-[6px] inline-flex items-center overflow-hidden rounded-lg border border-white/5 bg-white/[0.015] px-2 py-1 md:ml-[42px]">
@@ -2432,7 +2489,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
           ))}
 
           {error ? (
-            <div className="mt-3 rounded-xl bg-red-500/8 border border-red-400/10 px-4 py-3 text-sm text-red-300 text-center animate-slide-up">
+            <div className="mx-auto mt-3 max-w-md rounded-xl bg-red-500/8 border border-red-400/10 px-4 py-3 text-sm text-red-300 text-center animate-slide-up">
               {error}
             </div>
           ) : null}

--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -1945,7 +1945,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
       });
 
       if (!response.ok) {
-        let message = "Unable to retry message";
+        let message = "Message retry failed";
 
         try {
           const failure = (await response.json()) as { error?: string };
@@ -1978,7 +1978,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
       setIsSending(true);
     } catch (caughtError) {
       setError(
-        caughtError instanceof Error ? caughtError.message : "Unable to retry message"
+        caughtError instanceof Error ? caughtError.message : "Message retry failed"
       );
     } finally {
       setRetryingMessageId((current) => (current === messageId ? null : current));

--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -683,7 +683,15 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
   }, [updateStreamTimeline]);
 
   useEffect(() => {
-    setMessages(sanitizeMessages(payload.messages));
+    setMessages((current) => {
+      const incoming = sanitizeMessages(payload.messages);
+      if (!current.length) return incoming;
+      return incoming.map((msg) => {
+        if (msg.status !== "error" || msg.content) return msg;
+        const local = current.find((m) => m.id === msg.id);
+        return local?.content ? { ...msg, content: local.content } : msg;
+      });
+    });
   }, [payload.messages]);
 
   useEffect(() => {

--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -1036,6 +1036,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
       wasStreamingRef.current = true;
       setIsConversationActive(true);
       setStreamMessageId(event.messageId);
+      streamMessageIdRef.current = event.messageId;
       setHasReceivedFirstToken(false);
       resetIdleTimer();
       setStreamAnswerTarget("");

--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -1257,10 +1257,10 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
       });
       setMessages((current) =>
         current.map((m) =>
-          m.id === activeStreamMessageId ? { ...m, status: "error" as const } : m
+          m.id === activeStreamMessageId ? { ...m, status: "error" as const, content: event.message } : m
         )
       );
-      setError(event.message);
+      setError("");
       setStreamMessageId(null);
       updateStreamTimeline([]);
       setIsSending(false);
@@ -1393,12 +1393,12 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
             const activeStreamMessageId = streamMessageIdRef.current;
             if (activeStreamMessageId) {
               return current.map((m) =>
-                m.id === activeStreamMessageId ? { ...m, status: "error" as const } : m
+                m.id === activeStreamMessageId ? { ...m, status: "error" as const, content: msg.message } : m
               );
             }
             return current;
           });
-          setError(msg.message);
+          setError("");
           setStreamMessageId(null);
           updateStreamTimeline([]);
           setIsSending(false);

--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -1254,14 +1254,14 @@ export function MessageBubble({
                   <TypingIndicator compact />
                 </div>
               )
-            ) : message.status === "error" && content ? (
+            ) : message.status === "error" ? (
               <div className="group flex w-full min-w-0 flex-col items-start">
                 <div className={`flex w-full ${ASSISTANT_MAX_WIDTH} flex-col gap-3`}>
                   <div
                     className="w-fit max-w-full rounded-2xl border border-red-400/10 bg-red-500/5 px-2.5 py-2 text-red-300/85 shadow-[0_8px_24px_rgba(0,0,0,0.28)] md:px-4 md:py-3"
                     data-testid="assistant-error-bubble"
                   >
-                    {content}
+                    {content || "Something went wrong"}
                   </div>
                 </div>
                 {onRetryAssistantMessage ? (
@@ -1381,19 +1381,6 @@ export function MessageBubble({
                           <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
                         ) : (
                           <GitFork className="h-3.5 w-3.5" />
-                        )}
-                      </ActionButton>
-                    ) : null}
-                    {onRetryAssistantMessage && message.status === "error" ? (
-                      <ActionButton
-                        label="Retry message"
-                        onClick={() => onRetryAssistantMessage(message.id)}
-                        disabled={isRetrying}
-                      >
-                        {isRetrying ? (
-                          <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
-                        ) : (
-                          <RefreshCw className="h-3.5 w-3.5" />
                         )}
                       </ActionButton>
                     ) : null}

--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -1254,6 +1254,32 @@ export function MessageBubble({
                   <TypingIndicator compact />
                 </div>
               )
+            ) : message.status === "error" && content ? (
+              <div className="group flex w-full min-w-0 flex-col items-start">
+                <div className="flex w-full max-w-[calc(100%-32px)] flex-col gap-3">
+                  <div
+                    className="rounded-xl border border-red-400/15 bg-red-500/8 px-3.5 py-2.5 text-[14px] text-red-300/90"
+                    data-testid="assistant-error-bubble"
+                  >
+                    {content}
+                  </div>
+                </div>
+                {onRetryAssistantMessage ? (
+                  <div className="mt-2 flex items-center gap-1">
+                    <ActionButton
+                      label="Retry message"
+                      onClick={() => onRetryAssistantMessage(message.id)}
+                      disabled={isRetrying}
+                    >
+                      {isRetrying ? (
+                        <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
+                      ) : (
+                        <RefreshCw className="h-3.5 w-3.5" />
+                      )}
+                    </ActionButton>
+                  </div>
+                ) : null}
+              </div>
             ) : assistantBlocks.length || content || assistantImageAttachments.length || assistantFileAttachments.length ? (
               <div className="group flex w-full min-w-0 flex-col items-start">
                 <div ref={contentRef} className={`flex w-full ${ASSISTANT_MAX_WIDTH} flex-col gap-3`}>

--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useEffect, useRef, useState } from "react";
-import { Brain, Check, ChevronDown, ChevronRight, Copy, FileText, GitFork, LoaderCircle, Pencil, Square, X } from "lucide-react";
+import { Brain, Check, ChevronDown, ChevronRight, Copy, FileText, GitFork, LoaderCircle, Pencil, RefreshCw, Square, X } from "lucide-react";
 import type { RemendHandler } from "remend";
 import { Streamdown } from "streamdown";
 import { code } from "@streamdown/code";
@@ -815,6 +815,8 @@ export function MessageBubble({
   isUpdating = false,
   onForkAssistantMessage,
   isForking = false,
+  onRetryAssistantMessage,
+  isRetrying = false,
   onApproveMemoryProposal,
   onDismissMemoryProposal,
   onPreviewAttachment,
@@ -838,6 +840,8 @@ export function MessageBubble({
   isUpdating?: boolean;
   onForkAssistantMessage?: (messageId: string) => void;
   isForking?: boolean;
+  onRetryAssistantMessage?: (messageId: string) => void;
+  isRetrying?: boolean;
   onPreviewAttachment?: (attachment: MessageAttachment) => void;
   readOnly?: boolean;
 }) {
@@ -1351,6 +1355,19 @@ export function MessageBubble({
                           <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
                         ) : (
                           <GitFork className="h-3.5 w-3.5" />
+                        )}
+                      </ActionButton>
+                    ) : null}
+                    {onRetryAssistantMessage && message.status === "error" ? (
+                      <ActionButton
+                        label="Retry message"
+                        onClick={() => onRetryAssistantMessage(message.id)}
+                        disabled={isRetrying}
+                      >
+                        {isRetrying ? (
+                          <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
+                        ) : (
+                          <RefreshCw className="h-3.5 w-3.5" />
                         )}
                       </ActionButton>
                     ) : null}

--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -1256,9 +1256,9 @@ export function MessageBubble({
               )
             ) : message.status === "error" && content ? (
               <div className="group flex w-full min-w-0 flex-col items-start">
-                <div className="flex w-full max-w-[calc(100%-32px)] flex-col gap-3">
+                <div className={`flex w-full ${ASSISTANT_MAX_WIDTH} flex-col gap-3`}>
                   <div
-                    className="rounded-xl border border-red-400/15 bg-red-500/8 px-3.5 py-2.5 text-[14px] text-red-300/90"
+                    className="w-fit max-w-full rounded-2xl border border-red-400/10 bg-red-500/5 px-2.5 py-2 text-red-300/85 shadow-[0_8px_24px_rgba(0,0,0,0.28)] md:px-4 md:py-3"
                     data-testid="assistant-error-bubble"
                   >
                     {content}

--- a/lib/chat-turn.ts
+++ b/lib/chat-turn.ts
@@ -698,8 +698,9 @@ async function startAssistantTurn(
       }
 
       if (assistantMessageId) {
+        const errorMessage = error instanceof Error ? error.message : "Chat stream failed";
         updateMessage(assistantMessageId, {
-          content: "",
+          content: errorMessage,
           thinkingContent: "",
           status: "error"
         });

--- a/lib/conversations.ts
+++ b/lib/conversations.ts
@@ -2130,6 +2130,54 @@ export function rewriteConversationFromEditedUserMessage(
   return snapshot;
 }
 
+export function deleteAssistantMessageAndChildren(
+  messageId: string,
+  userId?: string
+) {
+  const db = getDb();
+  const deletedAttachmentPaths = new Set<string>();
+  const transaction = db.transaction(() => {
+    const message = getMessage(messageId, userId);
+
+    if (!message) {
+      throw new Error("Message not found");
+    }
+
+    if (message.role !== "assistant") {
+      throw new Error("Only assistant messages can be retried");
+    }
+
+    const conversation = getConversation(message.conversationId, userId);
+
+    if (!conversation) {
+      throw new Error("Conversation not found");
+    }
+
+    listAttachmentsForMessageIds([message.id]).forEach((attachment) => {
+      deletedAttachmentPaths.add(attachment.relativePath);
+    });
+
+    db.prepare("DELETE FROM message_actions WHERE message_id = ?").run(message.id);
+    db.prepare("DELETE FROM message_text_segments WHERE message_id = ?").run(message.id);
+    db.prepare("DELETE FROM message_timeline WHERE message_id = ?").run(message.id);
+    db.prepare("DELETE FROM message_attachments WHERE message_id = ?").run(message.id);
+    db.prepare("DELETE FROM messages WHERE id = ?").run(message.id);
+
+    setConversationActive(conversation.id, false);
+
+    return getConversationSnapshot(conversation.id, userId);
+  });
+
+  const snapshot = transaction();
+  deleteAttachmentFiles([...deletedAttachmentPaths]);
+
+  if (!snapshot) {
+    throw new Error("Conversation not found");
+  }
+
+  return snapshot;
+}
+
 export function createMessageAction(input: {
   messageId: string;
   kind: MessageActionKind;


### PR DESCRIPTION
## Summary
- Add `POST /api/messages/[messageId]/retry` endpoint that deletes a failed assistant message and re-generates the response from the preceding user message
- Add `deleteAssistantMessageAndChildren` DB function to clean up failed messages and their attachments
- Persist error messages to assistant message content in the database instead of only displaying them client-side
- Render error-status assistant messages as red bubbles with a retry (RefreshCw) button
- Wire `retryAssistantMessage` handler in ChatView with loading state and streaming re-entry
- Fix streamMessageIdRef sync on `message_start` and preserve local error content across payload refreshes