### PR TITLE
fix: remove skill description char limit and add save error handling

### DIFF
--- a/app/api/skills/route.ts
+++ b/app/api/skills/route.ts
@@ -18,7 +18,7 @@ export async function GET() {
 
 const createSchema = z.object({
   name: z.string().trim().min(1).max(100).optional().default("Untitled Skill"),
-  description: z.string().trim().min(1).max(240).optional(),
+  description: z.string().trim().min(1).optional(),
   content: z.string().min(1)
 });
 

--- a/components/settings/sections/skills-section.tsx
+++ b/components/settings/sections/skills-section.tsx
@@ -21,6 +21,7 @@ export function SkillsSection() {
   const [selectedSkillId, setSelectedSkillId] = useState<string | null>(null);
   const [mobileDetailVisible, setMobileDetailVisible] = useState(false);
   const [isAddingNew, setIsAddingNew] = useState(false);
+  const [skillError, setSkillError] = useState("");
   const [skillSuccess, setSkillSuccess] = useState("");
   const [skillEnabledDraft, setSkillEnabledDraft] = useState(true);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -36,6 +37,7 @@ export function SkillsSection() {
 
   async function saveSkill() {
     if (!skillName.trim() || !skillDescription.trim() || !skillContent.trim()) return;
+    setSkillError("");
     setSkillSuccess("");
 
     let savedId = editingSkillId;
@@ -56,11 +58,15 @@ export function SkillsSection() {
     }
 
     if (editingSkillId) {
-      await fetch(`/api/skills/${editingSkillId}`, {
+      const updateRes = await fetch(`/api/skills/${editingSkillId}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(payload)
       });
+      if (!updateRes.ok) {
+        setSkillError("Failed to save skill.");
+        return;
+      }
     } else {
       const createRes = await fetch("/api/skills", {
         method: "POST",
@@ -71,6 +77,10 @@ export function SkillsSection() {
           content: skillContent
         })
       });
+      if (!createRes.ok) {
+        setSkillError("Failed to save skill.");
+        return;
+      }
       const createdData = (await createRes.json().catch(() => null)) as { skill?: Skill } | null;
       savedId = createdData?.skill?.id ?? savedId;
       if (savedId && skillEnabledDraft === false) {
@@ -348,6 +358,11 @@ export function SkillsSection() {
                   <div className="flex items-center gap-1.5 text-sm text-emerald-400">
                     <Check className="h-3.5 w-3.5" />
                     {skillSuccess}
+                  </div>
+                ) : null}
+                {skillError ? (
+                  <div className="text-sm text-red-400">
+                    {skillError}
                   </div>
                 ) : null}
               </>

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -70,7 +70,7 @@ function deriveSkillDescription(content: string) {
   const metadata = parseSkillContentMetadata(content);
 
   if (metadata.description?.trim()) {
-    return metadata.description.trim().slice(0, 240);
+    return metadata.description.trim();
   }
 
   const lines = content
@@ -83,7 +83,7 @@ function deriveSkillDescription(content: string) {
       continue;
     }
 
-    return line.slice(0, 240);
+    return line;
   }
 
   return "Reusable skill instructions.";

--- a/lib/skills.ts
+++ b/lib/skills.ts
@@ -33,7 +33,7 @@ function deriveDescription(content: string) {
   const metadata = parseSkillContentMetadata(content);
 
   if (metadata.description?.trim()) {
-    return metadata.description.trim().slice(0, 240);
+    return metadata.description.trim();
   }
 
   const lines = content
@@ -46,7 +46,7 @@ function deriveDescription(content: string) {
       continue;
     }
 
-    return line.slice(0, 240);
+    return line;
   }
 
   return "Reusable skill instructions.";


### PR DESCRIPTION
## Summary
- Remove the 240-character truncation limit on skill descriptions in both the API schema and derivation logic
- Add error state handling and display in the skills section UI for failed save operations