### PR TITLE
fix: automation sidebar back button and auto-open behavior

### DIFF
--- a/components/automations/automations-nav.tsx
+++ b/components/automations/automations-nav.tsx
@@ -30,12 +30,6 @@ export function AutomationsNav({
 
   function handleBack() {
     onCloseAction();
-
-    if (typeof window !== "undefined" && window.history.length > 1) {
-      router.back();
-      return;
-    }
-
     router.push("/");
   }
 
@@ -47,7 +41,7 @@ export function AutomationsNav({
             type="button"
             onClick={handleBack}
             className="flex h-8 w-8 items-center justify-center rounded-xl bg-white/5 transition-all duration-300 hover:bg-white/10"
-            aria-label="Open automation settings"
+            aria-label="Back to conversations"
           >
             <ArrowLeft className="h-4 w-4 text-white/60" />
           </button>

--- a/components/shell.tsx
+++ b/components/shell.tsx
@@ -55,6 +55,7 @@ export function Shell({
   const consumedHomeSubmitAutoHideConversationIdRef = useRef<string | null>(null);
   const hasAppliedDesktopDefaultRef = useRef(false);
   const prevIsSettingsPageRef = useRef(false);
+  const prevIsAutomationsPageRef = useRef(false);
 
   const pathname = usePathname();
   const router = useRouter();
@@ -237,6 +238,15 @@ export function Shell({
       return;
     }
 
+    if (isAutomationsPage) {
+      if (pathname === "/automations") {
+        hasAppliedDesktopDefaultRef.current = true;
+        sessionStorage.removeItem("eidon:sidebar:user-closed");
+        setIsSidebarOpen(true);
+      }
+      return;
+    }
+
     if (shouldAutoHideActiveConversation) {
       hasAppliedDesktopDefaultRef.current = true;
       sessionStorage.removeItem("eidon:sidebar:user-closed");
@@ -263,8 +273,13 @@ export function Shell({
       sessionStorage.removeItem("eidon:sidebar:user-closed");
       setIsSidebarOpen(true);
     }
+    if (isAutomationsPage && pathname === "/automations" && !prevIsAutomationsPageRef.current && typeof window !== "undefined" && window.innerWidth < 768) {
+      sessionStorage.removeItem("eidon:sidebar:user-closed");
+      setIsSidebarOpen(true);
+    }
     prevIsSettingsPageRef.current = isSettingsPage;
-  }, [isSettingsPage, pathname]);
+    prevIsAutomationsPageRef.current = isAutomationsPage;
+  }, [isSettingsPage, isAutomationsPage, pathname]);
 
   return (
     <div className="flex h-[100dvh] w-full bg-[var(--background)] overflow-hidden">


### PR DESCRIPTION
## Summary

- Back button in automation sidebar now always navigates to `/` (previously used `router.back()` which was unreliable)
- Sidebar auto-opens on `/automations` page for both desktop and mobile
- Sidebar no longer auto-opens on `/automations/{id}` sub-pages
- Fixed back button `aria-label` for accessibility