### PR TITLE
feat: change user message bubble expansion to fit content width

### DIFF
--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -965,7 +965,7 @@ export function MessageBubble({
       <>
         <div data-message-id={message.id} className="flex w-full justify-end">
           <div className="group flex w-full flex-col items-end md:max-w-[95%]">
-            <div className="w-full rounded-2xl border border-[var(--accent)]/10 bg-[var(--accent-soft)] px-4 py-3 text-[var(--text)]">
+            <div className={`${!readOnly && isEditing ? "w-full" : "w-fit max-w-full"} rounded-2xl border border-[var(--accent)]/10 bg-[var(--accent-soft)] px-4 py-3 text-[var(--text)]`}>
               {!readOnly && isEditing ? (
                 <Textarea
                   ref={editRef}


### PR DESCRIPTION
## Summary
- Change user message bubbles to use `w-fit max-w-full` instead of always expanding to full width
- Bubbles now shrink to fit their text content while respecting a maximum width
- Full-width is still applied when actively editing a message