### PR TITLE
feat: add declarative model capabilities registry

### DIFF
--- a/lib/model-capabilities.ts
+++ b/lib/model-capabilities.ts
@@ -1,81 +1,70 @@
 import type { ApiMode, VisionMode } from "@/lib/types";
+import { MODEL_REGISTRY, type ModelCapabilityOverride } from "@/lib/model-registry";
 
-function normalizeModel(model: string) {
-  return model.trim().toLowerCase();
+type CapabilityFlag = boolean | { apiModes: ApiMode[] };
+
+type ResolvedCapabilities = {
+  reasoning: boolean;
+  vision: boolean;
+  thinkingReplay: boolean;
+  extraBody: "none" | "thinking" | "reasoning_effort";
+  strictExtraRejection: boolean;
+};
+
+const DEFAULT_CAPABILITIES: ResolvedCapabilities = {
+  reasoning: false,
+  vision: false,
+  thinkingReplay: false,
+  extraBody: "none",
+  strictExtraRejection: false,
+};
+
+function resolveCapabilityFlag(flag: CapabilityFlag, apiMode: ApiMode): boolean {
+  if (typeof flag === "boolean") return flag;
+  return flag.apiModes.includes(apiMode);
 }
 
-export function supportsVisibleReasoning(model: string, apiMode: ApiMode) {
-  const normalized = normalizeModel(model);
+export function resolveCapabilities(
+  model: string,
+  apiMode: ApiMode,
+  userOverrides?: Partial<ResolvedCapabilities>
+): ResolvedCapabilities {
+  const normalized = model.trim().toLowerCase();
 
-  if (!normalized) {
-    return false;
+  const resolved = { ...DEFAULT_CAPABILITIES };
+
+  const entry: Partial<ModelCapabilityOverride> | undefined =
+    MODEL_REGISTRY.find((e) => normalized.startsWith(e.prefix));
+
+  if (entry) {
+    const { prefix: _, ...overrides } = entry;
+    for (const [key, value] of Object.entries(overrides)) {
+      if (value !== undefined) {
+        if (key === "reasoning" || key === "vision") {
+          (resolved as Record<string, unknown>)[key] = resolveCapabilityFlag(
+            value as CapabilityFlag,
+            apiMode
+          );
+        } else {
+          (resolved as Record<string, unknown>)[key] = value;
+        }
+      }
+    }
   }
 
-  if (normalized.startsWith("glm-5") || normalized.startsWith("glm-4.7")) {
-    return true;
+  if (userOverrides) {
+    Object.assign(resolved, userOverrides);
   }
 
-  if (normalized.startsWith("kimi-k2")) {
-    return true;
-  }
-
-  if (apiMode === "chat_completions" && normalized.startsWith("deepseek-")) {
-    return true;
-  }
-
-  if (apiMode !== "responses") {
-    return false;
-  }
-
-  if (
-    normalized.startsWith("gpt-5") ||
-    normalized.startsWith("o1") ||
-    normalized.startsWith("o3") ||
-    normalized.startsWith("o4") ||
-    normalized.startsWith("gpt-oss")
-  ) {
-    return true;
-  }
-
-  if (
-    normalized.startsWith("gpt-4.1") ||
-    normalized.startsWith("gpt-4o") ||
-    normalized.startsWith("gpt-3.5")
-  ) {
-    return false;
-  }
-
-  return false;
+  return resolved;
 }
 
-export function supportsImageInput(model: string, apiMode: ApiMode) {
-  const normalized = normalizeModel(model);
+export function supportsVisibleReasoning(model: string, apiMode: ApiMode): boolean {
+  return resolveCapabilities(model, apiMode).reasoning;
+}
 
-  if (!normalized) {
-    return false;
-  }
-
-  if (
-    normalized.startsWith("gpt-5") ||
-    normalized.startsWith("gpt-4o") ||
-    normalized.startsWith("gpt-4.1") ||
-    normalized.startsWith("o1") ||
-    normalized.startsWith("o3") ||
-    normalized.startsWith("o4") ||
-    normalized.startsWith("claude-3") ||
-    normalized.startsWith("claude-4") ||
-    normalized.startsWith("gemini") ||
-    normalized.startsWith("glm-4") ||
-    normalized.startsWith("glm-5")
-  ) {
-    return true;
-  }
-
-  if (apiMode === "responses" && normalized.startsWith("gpt-oss")) {
-    return true;
-  }
-
-  return false;
+export function supportsImageInput(model: string, apiMode: ApiMode): boolean {
+  return resolveCapabilities(model, apiMode).vision;
 }
 
 export function getDefaultVisionMode(model: string, apiMode: ApiMode): VisionMode {

--- a/lib/model-registry.ts
+++ b/lib/model-registry.ts
@@ -1,0 +1,26 @@
+export type ModelCapabilityOverride = {
+  prefix: string;
+  reasoning?: boolean | { apiModes: Array<"responses" | "chat_completions"> };
+  vision?: boolean | { apiModes: Array<"responses" | "chat_completions"> };
+  thinkingReplay?: boolean;
+  extraBody?: "none" | "thinking" | "reasoning_effort";
+  strictExtraRejection?: boolean;
+};
+
+export const MODEL_REGISTRY: ModelCapabilityOverride[] = [
+  { prefix: "gpt-5", reasoning: { apiModes: ["responses"] }, vision: true, extraBody: "thinking" },
+  { prefix: "o1", reasoning: { apiModes: ["responses"] }, vision: true, extraBody: "thinking" },
+  { prefix: "o3", reasoning: { apiModes: ["responses"] }, vision: true, extraBody: "thinking" },
+  { prefix: "o4", reasoning: { apiModes: ["responses"] }, vision: true, extraBody: "thinking" },
+  { prefix: "gpt-oss", reasoning: { apiModes: ["responses"] }, vision: { apiModes: ["responses"] }, extraBody: "thinking" },
+  { prefix: "gpt-4.1", vision: true },
+  { prefix: "gpt-4o", vision: true },
+  { prefix: "glm-5v", reasoning: true, vision: true },
+  { prefix: "glm-5", reasoning: true, extraBody: "thinking" },
+  { prefix: "glm-4.7", reasoning: true, extraBody: "thinking" },
+  { prefix: "kimi-", reasoning: true, vision: true, strictExtraRejection: true },
+  { prefix: "deepseek-", reasoning: { apiModes: ["chat_completions"] }, thinkingReplay: true, extraBody: "thinking" },
+  { prefix: "claude-3", vision: true },
+  { prefix: "claude-4", vision: true },
+  { prefix: "gemini", vision: true },
+];

--- a/lib/provider.ts
+++ b/lib/provider.ts
@@ -3,7 +3,7 @@ import OpenAI from "openai";
 import { getAttachmentDataUrl } from "@/lib/attachments";
 import { ensureFreshGithubAccessToken, runGithubCopilotChat, streamGithubCopilotChat } from "@/lib/github-copilot";
 import { buildCopilotTools, type CopilotToolContext } from "@/lib/copilot-tools";
-import { supportsVisibleReasoning } from "@/lib/model-capabilities";
+import { resolveCapabilities, supportsVisibleReasoning } from "@/lib/model-capabilities";
 import { estimatePromptTokens, setActiveTokenizer } from "@/lib/tokenization";
 import { normalizeLineBreaks } from "@/lib/text-utils";
 import type {
@@ -150,19 +150,17 @@ function buildResponsesInput(messages: PromptMessage[]): any[] {
   return input;
 }
 
-function usesDeepSeekThinkingReplay(settings: ProviderProfile) {
+function usesThinkingReplay(settings: ProviderProfile) {
   if (settings.apiMode !== "chat_completions") {
     return false;
   }
 
-  const model = settings.model.trim().toLowerCase();
-  const baseUrl = settings.apiBaseUrl.trim().toLowerCase();
-
-  return model.startsWith("deepseek-") || baseUrl.includes("deepseek.com");
+  const caps = resolveCapabilities(settings.model, settings.apiMode);
+  return caps.thinkingReplay;
 }
 
 function buildChatCompletionMessages(messages: PromptMessage[], settings?: ProviderProfile): any[] {
-  const replayReasoningContent = settings ? usesDeepSeekThinkingReplay(settings) : false;
+  const replayReasoningContent = settings ? usesThinkingReplay(settings) : false;
 
   return messages.map((message) => {
     if (message.role === "tool") {
@@ -243,6 +241,7 @@ function buildChatCompletionsOptions(settings: ProviderProfile) {
     return {};
   }
 
+  const caps = resolveCapabilities(settings.model, settings.apiMode);
   const effort = normalizeReasoningEffort(settings.reasoningEffort);
 
   if (settings.apiBaseUrl.includes("ollama.com")) {
@@ -258,13 +257,21 @@ function buildChatCompletionsOptions(settings: ProviderProfile) {
     } as const;
   }
 
-  return {
-    extra_body: {
-      thinking: {
-        type: settings.reasoningSummaryEnabled ? "enabled" : "disabled"
+  if (caps.strictExtraRejection) {
+    return {};
+  }
+
+  if (caps.extraBody === "thinking") {
+    return {
+      extra_body: {
+        thinking: {
+          type: settings.reasoningSummaryEnabled ? "enabled" : "disabled"
+        }
       }
-    }
-  } as const;
+    } as const;
+  }
+
+  return {};
 }
 
 function getResponseText(output: unknown) {

--- a/tests/unit/conversations-extended.test.ts
+++ b/tests/unit/conversations-extended.test.ts
@@ -355,4 +355,17 @@ describe("conversations extended", () => {
     expect(page.conversations[0]?.updatedAt).toBe("2026-04-01T00:00:00.000Z");
     expect(page.conversations[1]?.updatedAt).toBe("2026-03-31T12:00:00.000Z");
   });
+
+  it("deduplicates conversations when search matches multiple messages", async () => {
+    const user = await createLocalUser({ username: "dedup@test.com", password: "Password123!", role: "user" });
+    const conv = createConversation("Unique Dedup Title", null, undefined, user.id);
+
+    createMessage({ conversationId: conv.id, role: "user", content: "alpha bravo charlie", userId: user.id });
+    createMessage({ conversationId: conv.id, role: "assistant", content: "alpha bravo delta", userId: user.id });
+
+    const results = searchConversations("alpha bravo", user.id);
+
+    const matching = results.filter((r) => r.id === conv.id);
+    expect(matching).toHaveLength(1);
+  });
 });

--- a/tests/unit/conversations.test.ts
+++ b/tests/unit/conversations.test.ts
@@ -403,6 +403,44 @@ describe("conversation helpers", () => {
     expect(after?.updatedAt).toBe(before?.updatedAt);
   });
 
+  it("fails title generation when provider profile has no API key", async () => {
+    updateSettings({
+      defaultProviderProfileId: "profile_no_key",
+      providerProfiles: [
+        {
+          id: "profile_no_key",
+          name: "No Key",
+          apiBaseUrl: "https://api.example.com/v1",
+          apiKey: "",
+          apiKeyEncrypted: "",
+          model: "gpt-5-mini",
+          apiMode: "responses",
+          systemPrompt: "Be exact.",
+          temperature: 0.2,
+          maxOutputTokens: 512,
+          reasoningEffort: "medium",
+          reasoningSummaryEnabled: true,
+          modelContextLimit: 16000,
+          compactionThreshold: 0.8,
+          freshTailCount: 12
+        }
+      ]
+    });
+
+    const conversation = createConversation();
+    const message = createMessage({
+      conversationId: conversation.id,
+      role: "user",
+      content: "Hello"
+    });
+
+    await generateConversationTitleFromFirstUserMessage(conversation.id, message.id);
+
+    const after = getConversation(conversation.id);
+    expect(after?.titleGenerationStatus).toBe("failed");
+    expect(generateConversationTitle).not.toHaveBeenCalled();
+  });
+
   it("can complete or fail title generation without bumping the conversation timestamp", () => {
     const conversation = createConversation();
     const before = getConversation(conversation.id);

--- a/tests/unit/model-capabilities.test.ts
+++ b/tests/unit/model-capabilities.test.ts
@@ -1,6 +1,66 @@
-import { getDefaultVisionMode, supportsImageInput, supportsVisibleReasoning } from "@/lib/model-capabilities";
+import { getDefaultVisionMode, resolveCapabilities, supportsImageInput, supportsVisibleReasoning } from "@/lib/model-capabilities";
 
-describe("model capabilities", () => {
+describe("resolveCapabilities", () => {
+  it("returns defaults for unknown models", () => {
+    const caps = resolveCapabilities("unknown-model", "chat_completions");
+    expect(caps.reasoning).toBe(false);
+    expect(caps.vision).toBe(false);
+    expect(caps.thinkingReplay).toBe(false);
+    expect(caps.extraBody).toBe("none");
+    expect(caps.strictExtraRejection).toBe(false);
+  });
+
+  it("returns defaults for empty model string", () => {
+    const caps = resolveCapabilities("", "responses");
+    expect(caps.reasoning).toBe(false);
+    expect(caps.vision).toBe(false);
+  });
+
+  it("applies registry overrides for kimi", () => {
+    const caps = resolveCapabilities("kimi-k2.6", "chat_completions");
+    expect(caps.reasoning).toBe(true);
+    expect(caps.vision).toBe(true);
+    expect(caps.strictExtraRejection).toBe(true);
+    expect(caps.thinkingReplay).toBe(false);
+    expect(caps.extraBody).toBe("none");
+  });
+
+  it("applies registry overrides for glm-5", () => {
+    const caps = resolveCapabilities("glm-5-turbo", "chat_completions");
+    expect(caps.reasoning).toBe(true);
+    expect(caps.vision).toBe(false);
+    expect(caps.extraBody).toBe("thinking");
+  });
+
+  it("matches glm-5v before glm-5 for vision", () => {
+    const caps = resolveCapabilities("glm-5v-turbo", "chat_completions");
+    expect(caps.reasoning).toBe(true);
+    expect(caps.vision).toBe(true);
+  });
+
+  it("applies user overrides on top of registry", () => {
+    const caps = resolveCapabilities("kimi-k2.6", "chat_completions", { vision: false });
+    expect(caps.vision).toBe(false);
+    expect(caps.reasoning).toBe(true);
+  });
+
+  it("resolves apiMode-constrained reasoning for deepseek", () => {
+    expect(resolveCapabilities("deepseek-r1", "chat_completions").reasoning).toBe(true);
+    expect(resolveCapabilities("deepseek-r1", "responses").reasoning).toBe(false);
+  });
+
+  it("resolves apiMode-constrained vision for gpt-oss", () => {
+    expect(resolveCapabilities("gpt-oss-mini", "responses").vision).toBe(true);
+    expect(resolveCapabilities("gpt-oss-mini", "chat_completions").vision).toBe(false);
+  });
+
+  it("applies thinkingReplay for deepseek", () => {
+    expect(resolveCapabilities("deepseek-r1", "chat_completions").thinkingReplay).toBe(true);
+    expect(resolveCapabilities("kimi-k2.6", "chat_completions").thinkingReplay).toBe(false);
+  });
+});
+
+describe("supportsVisibleReasoning", () => {
   it("treats GPT-5 and o-series models as reasoning-capable on responses", () => {
     expect(supportsVisibleReasoning("gpt-5-mini", "responses")).toBe(true);
     expect(supportsVisibleReasoning("gpt-5.4", "responses")).toBe(true);
@@ -16,17 +76,40 @@ describe("model capabilities", () => {
     expect(supportsVisibleReasoning("", "responses")).toBe(false);
   });
 
-  it("detects likely image-capable models", () => {
+  it("treats kimi as reasoning-capable", () => {
+    expect(supportsVisibleReasoning("kimi-k2.6", "chat_completions")).toBe(true);
+  });
+});
+
+describe("supportsImageInput", () => {
+  it("detects image-capable models", () => {
     expect(supportsImageInput("gpt-4o-mini", "chat_completions")).toBe(true);
     expect(supportsImageInput("gpt-5-mini", "responses")).toBe(true);
     expect(supportsImageInput("claude-3-7-sonnet", "chat_completions")).toBe(true);
     expect(supportsImageInput("gemini-3-flash-preview", "chat_completions")).toBe(true);
     expect(supportsImageInput("gpt-oss-mini", "responses")).toBe(true);
+  });
+
+  it("detects non-image-capable models", () => {
     expect(supportsImageInput("gpt-oss-mini", "chat_completions")).toBe(false);
     expect(supportsImageInput("", "chat_completions")).toBe(false);
     expect(supportsImageInput("gpt-3.5-turbo", "chat_completions")).toBe(false);
   });
 
+  it("kimi has native vision", () => {
+    expect(supportsImageInput("kimi-k2.6", "chat_completions")).toBe(true);
+  });
+
+  it("glm-5 does not have native vision", () => {
+    expect(supportsImageInput("glm-5-turbo", "chat_completions")).toBe(false);
+  });
+
+  it("glm-5v-turbo has native vision", () => {
+    expect(supportsImageInput("glm-5v-turbo", "chat_completions")).toBe(true);
+  });
+});
+
+describe("getDefaultVisionMode", () => {
   it("returns native vision for image-capable models and none otherwise", () => {
     expect(getDefaultVisionMode("gpt-4o-mini", "chat_completions")).toBe("native");
     expect(getDefaultVisionMode("gpt-3.5-turbo", "chat_completions")).toBe("none");

--- a/tests/unit/model-registry.test.ts
+++ b/tests/unit/model-registry.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { MODEL_REGISTRY } from "@/lib/model-registry";
+
+describe("model registry", () => {
+  it("has at least one entry", () => {
+    expect(MODEL_REGISTRY.length).toBeGreaterThan(0);
+  });
+
+  it("every entry has a prefix", () => {
+    for (const entry of MODEL_REGISTRY) {
+      expect(entry.prefix).toBeTruthy();
+      expect(typeof entry.prefix).toBe("string");
+    }
+  });
+
+  it("has no duplicate prefixes", () => {
+    const prefixes = MODEL_REGISTRY.map((e) => e.prefix);
+    expect(new Set(prefixes).size).toBe(prefixes.length);
+  });
+
+  it("longer prefixes come before shorter ones that share a root", () => {
+    for (let i = 0; i < MODEL_REGISTRY.length; i++) {
+      for (let j = i + 1; j < MODEL_REGISTRY.length; j++) {
+        const a = MODEL_REGISTRY[i].prefix;
+        const b = MODEL_REGISTRY[j].prefix;
+        if (b.startsWith(a)) {
+          throw new Error(
+            `Prefix "${b}" (index ${j}) extends "${a}" (index ${i}) but appears after it — longer prefixes must come before shorter ones`
+          );
+        }
+      }
+    }
+  });
+
+  it("every entry has at least one override (not just a prefix)", () => {
+    for (const entry of MODEL_REGISTRY) {
+      const { prefix, ...overrides } = entry;
+      expect(Object.keys(overrides).length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/tests/unit/provider.test.ts
+++ b/tests/unit/provider.test.ts
@@ -331,6 +331,63 @@ describe("provider integration", () => {
     ]);
   });
 
+  it("streams responses without tools and recovers text from output_item.done message", async () => {
+    responsesCreate.mockResolvedValue(
+      createAsyncStream([
+        { type: "response.function_call_arguments.delta" },
+        {
+          type: "response.output_item.done",
+          item: {
+            type: "function_call",
+            name: "get_weather",
+            arguments: "{\"city\":\"SF\"}",
+            call_id: "fc_1"
+          }
+        },
+        {
+          type: "response.output_item.done",
+          item: {
+            type: "message",
+            content: [{ text: "It is sunny in SF" }]
+          }
+        },
+        {
+          type: "response.completed",
+          response: {
+            usage: { input_tokens: 5, output_tokens: 3 }
+          }
+        }
+      ])
+    );
+
+    const { streamProviderResponse } = await import("@/lib/provider");
+    const stream = streamProviderResponse({
+      settings: createSettings({
+        model: "gpt-5-mini",
+        apiMode: "responses"
+      }),
+      promptMessages: [{ role: "user", content: "Weather?" }]
+    });
+
+    const events: ChatStreamEvent[] = [];
+
+    while (true) {
+      const next = await stream.next();
+
+      if (next.done) {
+        expect(next.value.answer).toBe("It is sunny in SF");
+        expect(next.value.toolCalls).toEqual([
+          { id: "fc_1", name: "get_weather", arguments: "{\"city\":\"SF\"}" }
+        ]);
+        break;
+      }
+
+      events.push(next.value);
+    }
+
+    expect(events).toContainEqual({ type: "answer_delta", text: "It is sunny in SF" });
+  });
+
   it("uses output_item reasoning summaries when no direct reasoning delta arrives", async () => {
     responsesCreate.mockResolvedValue(
       createAsyncStream([


### PR DESCRIPTION
## Summary

- Introduces a declarative `MODEL_REGISTRY` in `lib/model-registry.ts` that maps model prefixes to capability overrides (reasoning, vision, thinkingReplay, extraBody, strictExtraRejection)
- Replaces the scattered `if/else` chains in `model-capabilities.ts` with a single `resolveCapabilities()` function driven by the registry, using 3-tier precedence: defaults → registry match → user overrides
- Refactors `provider.ts` to use the registry for `thinkingReplay` detection and `extraBody`/`strictExtraRejection` handling, fixing the Kimi model error where unsupported `extra_body` was being sent
- Adds comprehensive test coverage for the registry, resolution logic, and prefix ordering validation