### PR TITLE
feat: add TextEditModal component and skill instructions edit modal

### DIFF
--- a/components/settings/sections/personas-section.tsx
+++ b/components/settings/sections/personas-section.tsx
@@ -5,7 +5,7 @@ import { Plus, FileText } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
+import { TextEditModal } from "@/components/ui/text-edit-modal";
 import type { Persona } from "@/lib/types";
 
 import { SettingsSplitPane } from "../settings-split-pane";
@@ -20,7 +20,6 @@ export function PersonasSection() {
   const [mobileDetailVisible, setMobileDetailVisible] = useState(false);
   const [isAddingNew, setIsAddingNew] = useState(false);
   const [isPersonaContentOpen, setIsPersonaContentOpen] = useState(false);
-  const [personaContentDraft, setPersonaContentDraft] = useState("");
 
   useEffect(() => {
     fetch("/api/personas")
@@ -94,23 +93,15 @@ export function PersonasSection() {
     setSelectedPersonaId(null);
     setIsAddingNew(false);
     setMobileDetailVisible(false);
-    setIsPersonaContentOpen(false);
-    setPersonaContentDraft("");
   }
 
   function openPersonaContent() {
-    setPersonaContentDraft(personaContent);
     setIsPersonaContentOpen(true);
   }
 
-  function savePersonaContent() {
-    setPersonaContent(personaContentDraft);
+  function savePersonaContent(value: string) {
+    setPersonaContent(value);
     setIsPersonaContentOpen(false);
-  }
-
-  function closePersonaContent() {
-    setIsPersonaContentOpen(false);
-    setPersonaContentDraft("");
   }
 
   const selectedPersona = personas.find((p) => p.id === selectedPersonaId);
@@ -231,55 +222,14 @@ export function PersonasSection() {
                   </div>
                 </div>
 
-                {/* Persona Content Modal */}
-                {isPersonaContentOpen && (
-                  <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-                    <div
-                      className="absolute inset-0 bg-black/60 backdrop-blur-sm"
-                      onClick={closePersonaContent}
-                    />
-                    <div className="relative w-full max-w-[720px] max-h-[80vh] flex flex-col rounded-2xl border border-white/[0.08] bg-[#121214] p-6 shadow-2xl">
-                      <div className="flex items-center justify-between mb-4">
-                        <h3 className="text-sm font-semibold text-[var(--text)]">Edit system instructions</h3>
-                        <button
-                          type="button"
-                          onClick={closePersonaContent}
-                          className="text-[var(--muted)] hover:text-[var(--text)] transition-colors"
-                        >
-                          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
-                        </button>
-                      </div>
-                      <p className="mb-3 text-xs text-[var(--muted)]">
-                        Markdown is supported
-                      </p>
-                      <Textarea
-                        autoComplete="off"
-                        spellCheck={false}
-                        value={personaContentDraft}
-                        onChange={(event) => setPersonaContentDraft(event.target.value)}
-                        rows={16}
-                        className="flex-1 resize-none min-h-[300px]"
-                      />
-                      <div className="flex flex-wrap items-center justify-end gap-2 mt-5 pt-4 border-t border-white/[0.06]">
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          className="px-3 py-1.5 text-xs"
-                          onClick={closePersonaContent}
-                        >
-                          Cancel
-                        </Button>
-                        <Button
-                          type="button"
-                          className="px-3 py-1.5 text-xs"
-                          onClick={savePersonaContent}
-                        >
-                          Save
-                        </Button>
-                      </div>
-                    </div>
-                  </div>
-                )}
+                <TextEditModal
+                  open={isPersonaContentOpen}
+                  onOpenChange={setIsPersonaContentOpen}
+                  value={personaContent}
+                  onChange={savePersonaContent}
+                  title="Edit system instructions"
+                  subtitle="Markdown is supported"
+                />
               </div>
             ) : (
               <div className="flex flex-col items-center justify-center py-24 text-center">

--- a/components/settings/sections/providers-section.tsx
+++ b/components/settings/sections/providers-section.tsx
@@ -13,6 +13,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import { TextEditModal } from "@/components/ui/text-edit-modal";
 import { createId } from "@/lib/ids";
 import { DEFAULT_PROVIDER_SETTINGS } from "@/lib/constants";
 import {
@@ -92,7 +93,6 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
   const [mcpServers, setMcpServers] = useState<McpServer[]>([]);
   const [copilotModels, setCopilotModels] = useState<Array<{ id: string; name: string; maxContextWindowTokens: number | null }>>([]);
   const [isSystemPromptOpen, setIsSystemPromptOpen] = useState(false);
-  const [systemPromptDraft, setSystemPromptDraft] = useState("");
   const maskedApiKeyValue = "••••••••";
 
   useEffect(() => {
@@ -363,18 +363,12 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
 
   function openSystemPrompt() {
     if (!activeProviderProfile) return;
-    setSystemPromptDraft(activeProviderProfile.systemPrompt);
     setIsSystemPromptOpen(true);
   }
 
-  function saveSystemPrompt() {
-    updateActiveProviderProfile({ systemPrompt: systemPromptDraft });
+  function saveSystemPrompt(value: string) {
+    updateActiveProviderProfile({ systemPrompt: value });
     setIsSystemPromptOpen(false);
-  }
-
-  function closeSystemPrompt() {
-    setIsSystemPromptOpen(false);
-    setSystemPromptDraft("");
   }
 
   const fieldLabel = "block text-[13px] font-medium text-[var(--muted)] mb-1.5";
@@ -1019,55 +1013,14 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
                   </div>
                 ) : null}
 
-                {/* System Prompt Modal */}
-                {isSystemPromptOpen && (
-                  <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-                    <div
-                      className="absolute inset-0 bg-black/60 backdrop-blur-sm"
-                      onClick={closeSystemPrompt}
-                    />
-                    <div className="relative w-full max-w-[720px] max-h-[80vh] flex flex-col rounded-2xl border border-white/[0.08] bg-[#121214] p-6 shadow-2xl">
-                      <div className="flex items-center justify-between mb-4">
-                        <h3 className="text-sm font-semibold text-[var(--text)]">Edit system prompt</h3>
-                        <button
-                          type="button"
-                          onClick={closeSystemPrompt}
-                          className="text-[var(--muted)] hover:text-[var(--text)] transition-colors"
-                        >
-                          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
-                        </button>
-                      </div>
-                      <p className="mb-3 text-xs text-[var(--muted)]">
-                        Applied to new conversations only
-                      </p>
-                      <Textarea
-                        autoComplete="off"
-                        spellCheck={false}
-                        value={systemPromptDraft}
-                        onChange={(event) => setSystemPromptDraft(event.target.value)}
-                        rows={16}
-                        className="flex-1 resize-none min-h-[300px]"
-                      />
-                      <div className="flex flex-wrap items-center justify-end gap-2 mt-5 pt-4 border-t border-white/[0.06]">
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          className="px-3 py-1.5 text-xs"
-                          onClick={closeSystemPrompt}
-                        >
-                          Cancel
-                        </Button>
-                        <Button
-                          type="button"
-                          className="px-3 py-1.5 text-xs"
-                          onClick={saveSystemPrompt}
-                        >
-                          Save
-                        </Button>
-                      </div>
-                    </div>
-                  </div>
-                )}
+                <TextEditModal
+                  open={isSystemPromptOpen}
+                  onOpenChange={setIsSystemPromptOpen}
+                  value={activeProviderProfile?.systemPrompt ?? ""}
+                  onChange={saveSystemPrompt}
+                  title="Edit system prompt"
+                  subtitle="Applied to new conversations only"
+                />
               </div>
             ) : null}
           </form>

--- a/components/settings/sections/skills-section.tsx
+++ b/components/settings/sections/skills-section.tsx
@@ -5,7 +5,7 @@ import { Check, Plus, FileText, Upload } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
+import { TextEditModal } from "@/components/ui/text-edit-modal";
 import { parseSkillContentMetadata } from "@/lib/skill-metadata";
 import type { Skill } from "@/lib/types";
 
@@ -24,6 +24,7 @@ export function SkillsSection() {
   const [skillError, setSkillError] = useState("");
   const [skillSuccess, setSkillSuccess] = useState("");
   const [skillEnabledDraft, setSkillEnabledDraft] = useState(true);
+  const [isInstructionsOpen, setIsInstructionsOpen] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -121,6 +122,11 @@ export function SkillsSection() {
     setSkillSuccess("Skill saved.");
     setIsAddingNew(false);
     setMobileDetailVisible(true);
+  }
+
+  function saveInstructions(value: string) {
+    setSkillContent(value);
+    setIsInstructionsOpen(false);
   }
 
   async function deleteSkill(id: string) {
@@ -320,15 +326,25 @@ export function SkillsSection() {
                     />
                   </div>
                   <div>
-                    <label className={fieldLabel}>Instructions</label>
-                    <Textarea
-                      value={skillContent}
-                      onChange={(e) => setSkillContent(e.target.value)}
-                      placeholder="Enter the full skill instructions..."
-                      rows={8}
-                      readOnly={isBuiltin}
-                      className={isBuiltin ? `opacity-60 cursor-default ${inputLike}` : inputLike}
-                    />
+                    <div className="flex items-center justify-between mb-1.5">
+                      <label className={fieldLabel}>Instructions</label>
+                      <button
+                        type="button"
+                        onClick={() => setIsInstructionsOpen(true)}
+                        disabled={isBuiltin}
+                        className="text-xs text-[var(--accent)] hover:underline disabled:opacity-40 disabled:cursor-not-allowed disabled:no-underline"
+                      >
+                        Edit
+                      </button>
+                    </div>
+                    <div
+                      onClick={() => { if (!isBuiltin) setIsInstructionsOpen(true); }}
+                      className={`rounded-xl border border-white/6 bg-white/4 px-4 py-3 text-sm text-[var(--muted)] line-clamp-3 transition-colors ${
+                        isBuiltin ? "opacity-60 cursor-default" : "cursor-pointer hover:bg-white/[0.06]"
+                      }`}
+                    >
+                      {skillContent || "No instructions set"}
+                    </div>
                   </div>
                 </div>
 
@@ -354,6 +370,16 @@ export function SkillsSection() {
                     {isBuiltin ? "Close" : "Cancel"}
                   </Button>
                 </div>
+                <TextEditModal
+                  open={isInstructionsOpen}
+                  onOpenChange={setIsInstructionsOpen}
+                  value={skillContent}
+                  onChange={saveInstructions}
+                  title="Edit instructions"
+                  subtitle="Skill instructions are applied when the skill is activated"
+                  placeholder="Enter the full skill instructions..."
+                  readOnly={isBuiltin}
+                />
                 {skillSuccess ? (
                   <div className="flex items-center gap-1.5 text-sm text-emerald-400">
                     <Check className="h-3.5 w-3.5" />

--- a/components/ui/text-edit-modal.tsx
+++ b/components/ui/text-edit-modal.tsx
@@ -118,7 +118,7 @@ export function TextEditModal({
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0 }}
             transition={{ duration: 1.2, ease: [0.22, 1, 0.36, 1] }}
-            className="fixed bottom-4 right-4 sm:bottom-6 sm:right-6 left-4 sm:left-auto z-50 flex items-center gap-2 rounded-lg border border-emerald-400/15 bg-emerald-500/12 px-4 py-2.5 text-sm text-emerald-300 shadow-[0_4px_24px_rgba(0,0,0,0.4)]"
+            className="fixed bottom-4 right-4 sm:bottom-6 sm:right-6 left-4 sm:left-auto z-50 flex items-center gap-2 rounded-lg border border-emerald-400/20 bg-emerald-900/90 px-4 py-2.5 text-sm text-emerald-200 shadow-[0_4px_24px_rgba(0,0,0,0.5)]"
           >
             <Check className="h-3.5 w-3.5" />
             Saved successfully !

--- a/components/ui/text-edit-modal.tsx
+++ b/components/ui/text-edit-modal.tsx
@@ -114,7 +114,7 @@ export function TextEditModal({
             key="save-toast"
             initial={{ opacity: 0, y: 12 }}
             animate={{ opacity: 1, y: 0, transition: { duration: 0.25, ease: [0.22, 1, 0.36, 1] } }}
-            exit={{ opacity: 0, transition: { duration: 3, ease: "easeOut" } }}
+            exit={{ opacity: 0, transition: { duration: 1.5, ease: "easeOut" } }}
             className="fixed bottom-4 right-4 sm:bottom-6 sm:right-6 left-4 sm:left-auto z-50 flex items-center gap-2 rounded-lg border border-emerald-400/20 bg-emerald-900 px-4 py-2.5 text-sm text-emerald-200 shadow-[0_4px_24px_rgba(0,0,0,0.5)]"
           >
             <Check className="h-3.5 w-3.5" />

--- a/components/ui/text-edit-modal.tsx
+++ b/components/ui/text-edit-modal.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+
+type TextEditModalProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  value: string;
+  onChange: (value: string) => void;
+  title: string;
+  subtitle?: string;
+  placeholder?: string;
+  readOnly?: boolean;
+};
+
+export function TextEditModal({
+  open,
+  onOpenChange,
+  value,
+  onChange,
+  title,
+  subtitle,
+  placeholder,
+  readOnly,
+}: TextEditModalProps) {
+  const [draft, setDraft] = useState(value);
+
+  useEffect(() => {
+    if (open) {
+      setDraft(value);
+    }
+  }, [open, value]);
+
+  if (!open) return null;
+
+  function handleClose() {
+    onOpenChange(false);
+  }
+
+  function handleSave() {
+    onChange(draft);
+    onOpenChange(false);
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div
+        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+        onClick={handleClose}
+      />
+      <div className="relative w-full max-w-[720px] max-h-[80vh] flex flex-col rounded-2xl border border-white/[0.08] bg-[#121214] p-6 shadow-2xl">
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="text-sm font-semibold text-[var(--text)]">{title}</h3>
+          <button
+            type="button"
+            onClick={handleClose}
+            className="text-[var(--muted)] hover:text-[var(--text)] transition-colors"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
+          </button>
+        </div>
+        {subtitle ? (
+          <p className="mb-3 text-xs text-[var(--muted)]">{subtitle}</p>
+        ) : null}
+        <Textarea
+          autoComplete="off"
+          spellCheck={false}
+          value={draft}
+          onChange={(event) => setDraft(event.target.value)}
+          rows={16}
+          placeholder={placeholder}
+          readOnly={readOnly}
+          className={`flex-1 resize-none min-h-[300px]${readOnly ? " opacity-60 cursor-default" : ""}`}
+        />
+        <div className="flex flex-wrap items-center justify-end gap-2 mt-5 pt-4 border-t border-white/[0.06]">
+          <Button
+            type="button"
+            variant="ghost"
+            className="px-3 py-1.5 text-xs"
+            onClick={handleClose}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            className="px-3 py-1.5 text-xs"
+            onClick={handleSave}
+            disabled={readOnly}
+          >
+            Save
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/ui/text-edit-modal.tsx
+++ b/components/ui/text-edit-modal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useId, useState } from "react";
+import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 
@@ -25,13 +26,15 @@ export function TextEditModal({
   placeholder,
   readOnly,
 }: TextEditModalProps) {
+  const titleId = useId();
   const [draft, setDraft] = useState(value);
 
   useEffect(() => {
     if (open) {
       setDraft(value);
     }
-  }, [open, value]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
 
   if (!open) return null;
 
@@ -45,14 +48,14 @@ export function TextEditModal({
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4" role="dialog" aria-modal="true" aria-labelledby={titleId}>
       <div
         className="absolute inset-0 bg-black/60 backdrop-blur-sm"
         onClick={handleClose}
       />
       <div className="relative w-full max-w-[720px] max-h-[80vh] flex flex-col rounded-2xl border border-white/[0.08] bg-[#121214] p-6 shadow-2xl">
         <div className="flex items-center justify-between mb-4">
-          <h3 className="text-sm font-semibold text-[var(--text)]">{title}</h3>
+          <h3 id={titleId} className="text-sm font-semibold text-[var(--text)]">{title}</h3>
           <button
             type="button"
             onClick={handleClose}
@@ -72,7 +75,7 @@ export function TextEditModal({
           rows={16}
           placeholder={placeholder}
           readOnly={readOnly}
-          className={`flex-1 resize-none min-h-[300px]${readOnly ? " opacity-60 cursor-default" : ""}`}
+          className={cn("flex-1 resize-none min-h-[300px]", readOnly && "opacity-60 cursor-default")}
         />
         <div className="flex flex-wrap items-center justify-end gap-2 mt-5 pt-4 border-t border-white/[0.06]">
           <Button

--- a/components/ui/text-edit-modal.tsx
+++ b/components/ui/text-edit-modal.tsx
@@ -45,8 +45,6 @@ export function TextEditModal({
     return () => clearTimeout(timer);
   }, [toastVisible]);
 
-  if (!open && !toastVisible) return null;
-
   function handleClose() {
     onOpenChange(false);
   }
@@ -116,7 +114,7 @@ export function TextEditModal({
             key="save-toast"
             initial={{ opacity: 0, y: 12 }}
             animate={{ opacity: 1, y: 0, transition: { duration: 0.25, ease: [0.22, 1, 0.36, 1] } }}
-            exit={{ opacity: 0, transition: { duration: 1.5, ease: "easeOut" } }}
+            exit={{ opacity: 0, transition: { duration: 3, ease: "easeOut" } }}
             className="fixed bottom-4 right-4 sm:bottom-6 sm:right-6 left-4 sm:left-auto z-50 flex items-center gap-2 rounded-lg border border-emerald-400/20 bg-emerald-900 px-4 py-2.5 text-sm text-emerald-200 shadow-[0_4px_24px_rgba(0,0,0,0.5)]"
           >
             <Check className="h-3.5 w-3.5" />

--- a/components/ui/text-edit-modal.tsx
+++ b/components/ui/text-edit-modal.tsx
@@ -116,12 +116,12 @@ export function TextEditModal({
             key="save-toast"
             initial={{ opacity: 0, y: 12 }}
             animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0, y: 6 }}
-            transition={{ duration: 0.2, ease: [0.22, 1, 0.36, 1] }}
-            className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 flex items-center gap-2 rounded-lg border border-emerald-400/15 bg-emerald-500/12 px-4 py-2.5 text-sm text-emerald-300 shadow-[0_4px_24px_rgba(0,0,0,0.4)]"
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.6, ease: [0.22, 1, 0.36, 1] }}
+            className="fixed bottom-6 right-6 z-50 flex items-center gap-2 rounded-lg border border-emerald-400/15 bg-emerald-500/12 px-4 py-2.5 text-sm text-emerald-300 shadow-[0_4px_24px_rgba(0,0,0,0.4)]"
           >
             <Check className="h-3.5 w-3.5" />
-            Saved
+            Saved successfully !
           </motion.div>
         )}
       </AnimatePresence>

--- a/components/ui/text-edit-modal.tsx
+++ b/components/ui/text-edit-modal.tsx
@@ -117,8 +117,8 @@ export function TextEditModal({
             initial={{ opacity: 0, y: 12 }}
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0 }}
-            transition={{ duration: 0.6, ease: [0.22, 1, 0.36, 1] }}
-            className="fixed bottom-6 right-6 z-50 flex items-center gap-2 rounded-lg border border-emerald-400/15 bg-emerald-500/12 px-4 py-2.5 text-sm text-emerald-300 shadow-[0_4px_24px_rgba(0,0,0,0.4)]"
+            transition={{ duration: 1.2, ease: [0.22, 1, 0.36, 1] }}
+            className="fixed bottom-4 right-4 sm:bottom-6 sm:right-6 left-4 sm:left-auto z-50 flex items-center gap-2 rounded-lg border border-emerald-400/15 bg-emerald-500/12 px-4 py-2.5 text-sm text-emerald-300 shadow-[0_4px_24px_rgba(0,0,0,0.4)]"
           >
             <Check className="h-3.5 w-3.5" />
             Saved successfully !

--- a/components/ui/text-edit-modal.tsx
+++ b/components/ui/text-edit-modal.tsx
@@ -114,7 +114,7 @@ export function TextEditModal({
             key="save-toast"
             initial={{ opacity: 0, y: 12 }}
             animate={{ opacity: 1, y: 0, transition: { duration: 0.25, ease: [0.22, 1, 0.36, 1] } }}
-            exit={{ opacity: 0, transition: { duration: 1.5, ease: "easeOut" } }}
+            exit={{ opacity: 0, transition: { duration: 0.8, ease: "easeOut" } }}
             className="fixed bottom-4 right-4 sm:bottom-6 sm:right-6 left-4 sm:left-auto z-50 flex items-center gap-2 rounded-lg border border-emerald-400/20 bg-emerald-900 px-4 py-2.5 text-sm text-emerald-200 shadow-[0_4px_24px_rgba(0,0,0,0.5)]"
           >
             <Check className="h-3.5 w-3.5" />

--- a/components/ui/text-edit-modal.tsx
+++ b/components/ui/text-edit-modal.tsx
@@ -115,10 +115,9 @@ export function TextEditModal({
           <motion.div
             key="save-toast"
             initial={{ opacity: 0, y: 12 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: 1.2, ease: [0.22, 1, 0.36, 1] }}
-            className="fixed bottom-4 right-4 sm:bottom-6 sm:right-6 left-4 sm:left-auto z-50 flex items-center gap-2 rounded-lg border border-emerald-400/20 bg-emerald-900/90 px-4 py-2.5 text-sm text-emerald-200 shadow-[0_4px_24px_rgba(0,0,0,0.5)]"
+            animate={{ opacity: 1, y: 0, transition: { duration: 0.25, ease: [0.22, 1, 0.36, 1] } }}
+            exit={{ opacity: 0, transition: { duration: 1.5, ease: "easeOut" } }}
+            className="fixed bottom-4 right-4 sm:bottom-6 sm:right-6 left-4 sm:left-auto z-50 flex items-center gap-2 rounded-lg border border-emerald-400/20 bg-emerald-900 px-4 py-2.5 text-sm text-emerald-200 shadow-[0_4px_24px_rgba(0,0,0,0.5)]"
           >
             <Check className="h-3.5 w-3.5" />
             Saved successfully !

--- a/components/ui/text-edit-modal.tsx
+++ b/components/ui/text-edit-modal.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useEffect, useId, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { Check } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
@@ -28,6 +30,7 @@ export function TextEditModal({
 }: TextEditModalProps) {
   const titleId = useId();
   const [draft, setDraft] = useState(value);
+  const [toastVisible, setToastVisible] = useState(false);
 
   useEffect(() => {
     if (open) {
@@ -36,7 +39,13 @@ export function TextEditModal({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
 
-  if (!open) return null;
+  useEffect(() => {
+    if (!toastVisible) return;
+    const timer = setTimeout(() => setToastVisible(false), 2000);
+    return () => clearTimeout(timer);
+  }, [toastVisible]);
+
+  if (!open && !toastVisible) return null;
 
   function handleClose() {
     onOpenChange(false);
@@ -45,57 +54,77 @@ export function TextEditModal({
   function handleSave() {
     onChange(draft);
     onOpenChange(false);
+    setToastVisible(true);
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4" role="dialog" aria-modal="true" aria-labelledby={titleId}>
-      <div
-        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
-        onClick={handleClose}
-      />
-      <div className="relative w-full max-w-[720px] max-h-[80vh] flex flex-col rounded-2xl border border-white/[0.08] bg-[#121214] p-6 shadow-2xl">
-        <div className="flex items-center justify-between mb-4">
-          <h3 id={titleId} className="text-sm font-semibold text-[var(--text)]">{title}</h3>
-          <button
-            type="button"
+    <>
+      {open && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4" role="dialog" aria-modal="true" aria-labelledby={titleId}>
+          <div
+            className="absolute inset-0 bg-black/60 backdrop-blur-sm"
             onClick={handleClose}
-            className="text-[var(--muted)] hover:text-[var(--text)] transition-colors"
-          >
-            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
-          </button>
+          />
+          <div className="relative w-full max-w-[720px] max-h-[80vh] flex flex-col rounded-2xl border border-white/[0.08] bg-[#121214] p-6 shadow-2xl">
+            <div className="flex items-center justify-between mb-4">
+              <h3 id={titleId} className="text-sm font-semibold text-[var(--text)]">{title}</h3>
+              <button
+                type="button"
+                onClick={handleClose}
+                className="text-[var(--muted)] hover:text-[var(--text)] transition-colors"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
+              </button>
+            </div>
+            {subtitle ? (
+              <p className="mb-3 text-xs text-[var(--muted)]">{subtitle}</p>
+            ) : null}
+            <Textarea
+              autoComplete="off"
+              spellCheck={false}
+              value={draft}
+              onChange={(event) => setDraft(event.target.value)}
+              rows={16}
+              placeholder={placeholder}
+              readOnly={readOnly}
+              className={cn("flex-1 resize-none min-h-[300px]", readOnly && "opacity-60 cursor-default")}
+            />
+            <div className="flex flex-wrap items-center justify-end gap-2 mt-5 pt-4 border-t border-white/[0.06]">
+              <Button
+                type="button"
+                variant="ghost"
+                className="px-3 py-1.5 text-xs"
+                onClick={handleClose}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="button"
+                className="px-3 py-1.5 text-xs"
+                onClick={handleSave}
+                disabled={readOnly}
+              >
+                Save
+              </Button>
+            </div>
+          </div>
         </div>
-        {subtitle ? (
-          <p className="mb-3 text-xs text-[var(--muted)]">{subtitle}</p>
-        ) : null}
-        <Textarea
-          autoComplete="off"
-          spellCheck={false}
-          value={draft}
-          onChange={(event) => setDraft(event.target.value)}
-          rows={16}
-          placeholder={placeholder}
-          readOnly={readOnly}
-          className={cn("flex-1 resize-none min-h-[300px]", readOnly && "opacity-60 cursor-default")}
-        />
-        <div className="flex flex-wrap items-center justify-end gap-2 mt-5 pt-4 border-t border-white/[0.06]">
-          <Button
-            type="button"
-            variant="ghost"
-            className="px-3 py-1.5 text-xs"
-            onClick={handleClose}
+      )}
+      <AnimatePresence>
+        {toastVisible && (
+          <motion.div
+            key="save-toast"
+            initial={{ opacity: 0, y: 12 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 6 }}
+            transition={{ duration: 0.2, ease: [0.22, 1, 0.36, 1] }}
+            className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 flex items-center gap-2 rounded-lg border border-emerald-400/15 bg-emerald-500/12 px-4 py-2.5 text-sm text-emerald-300 shadow-[0_4px_24px_rgba(0,0,0,0.4)]"
           >
-            Cancel
-          </Button>
-          <Button
-            type="button"
-            className="px-3 py-1.5 text-xs"
-            onClick={handleSave}
-            disabled={readOnly}
-          >
-            Save
-          </Button>
-        </div>
-      </div>
-    </div>
+            <Check className="h-3.5 w-3.5" />
+            Saved
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </>
   );
 }

--- a/components/ui/text-edit-modal.tsx
+++ b/components/ui/text-edit-modal.tsx
@@ -115,7 +115,7 @@ export function TextEditModal({
             initial={{ opacity: 0, y: 12 }}
             animate={{ opacity: 1, y: 0, transition: { duration: 0.25, ease: [0.22, 1, 0.36, 1] } }}
             exit={{ opacity: 0, transition: { duration: 0.8, ease: "easeOut" } }}
-            className="fixed bottom-4 right-4 sm:bottom-6 sm:right-6 left-4 sm:left-auto z-50 flex items-center gap-2 rounded-lg border border-emerald-400/20 bg-emerald-900 px-4 py-2.5 text-sm text-emerald-200 shadow-[0_4px_24px_rgba(0,0,0,0.5)]"
+            className="fixed bottom-4 right-4 sm:bottom-6 sm:right-6 z-50 flex items-center gap-2 rounded-lg border border-emerald-400/20 bg-emerald-900 px-4 py-2.5 text-sm text-emerald-200 shadow-[0_4px_24px_rgba(0,0,0,0.5)]"
           >
             <Check className="h-3.5 w-3.5" />
             Saved successfully !


### PR DESCRIPTION
## Summary
- Add a shared `TextEditModal` component with textarea editing, save/cancel actions, and a success toast notification with smooth framer-motion animations
- Add a skill instructions edit modal with a preview card in the skills settings section
- Refactor the personas and providers sections to use the new `TextEditModal` component, replacing duplicated inline editing logic (net reduction of ~100 lines)
- Includes toast styling refinements: bottom-right positioning, mobile-friendly layout, and smooth fade-out exit animation

## Files changed
- `components/ui/text-edit-modal.tsx` — new shared modal component
- `components/settings/sections/skills-section.tsx` — skill edit modal + preview card
- `components/settings/sections/personas-section.tsx` — refactor to use TextEditModal
- `components/settings/sections/providers-section.tsx` — refactor to use TextEditModal