### PR TITLE
feat: add reusable Toast component for save feedback

### DIFF
--- a/components/settings/sections/account-section.tsx
+++ b/components/settings/sections/account-section.tsx
@@ -1,23 +1,23 @@
 "use client";
 
-import { type FormEvent, useState } from "react";
+import { type FormEvent } from "react";
 import { useRouter } from "next/navigation";
-import { Shield, Check } from "lucide-react";
+import { Shield } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Toast } from "@/components/ui/toast";
 import type { AuthUser } from "@/lib/types";
+import { useToastState } from "@/hooks/use-toast-state";
 
 export function AccountSection({ user }: { user: AuthUser }) {
   const router = useRouter();
-  const [error, setError] = useState("");
-  const [accountSuccess, setAccountSuccess] = useState("");
+  const toast = useToastState();
   const isEnvManaged = user.passwordManagedBy === "env";
 
   async function handleAccount(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    setError("");
-    setAccountSuccess("");
+    toast.dismissToast();
     const formData = new FormData(event.currentTarget);
     const response = await fetch("/api/auth/account", {
       method: "PUT",
@@ -29,10 +29,10 @@ export function AccountSection({ user }: { user: AuthUser }) {
     });
     const result = (await response.json()) as { error?: string };
     if (!response.ok) {
-      setError(result.error ?? "Unable to update account");
+      toast.showToast("error", result.error ?? "Unable to update account");
       return;
     }
-    setAccountSuccess("Account updated. Sign in again if you changed the password.");
+    toast.showToast("success", "Account updated. Sign in again if you changed the password.");
     router.refresh();
   }
 
@@ -93,21 +93,15 @@ export function AccountSection({ user }: { user: AuthUser }) {
                 Save
               </Button>
             </div>
-            {accountSuccess ? (
-              <div className="flex items-center gap-1.5 text-sm text-emerald-400">
-                <Check className="h-3.5 w-3.5" />
-                {accountSuccess}
-              </div>
-            ) : null}
           </form>
         )}
       </div>
 
-      {error ? (
-        <div className="rounded-xl bg-red-500/8 border border-red-400/10 px-4 py-3 text-sm text-red-300">
-          {error}
-        </div>
-      ) : null}
+      <Toast
+        visible={toast.visible}
+        variant={toast.variant}
+        message={toast.message}
+      />
     </div>
   );
 }

--- a/components/settings/sections/automations-section.tsx
+++ b/components/settings/sections/automations-section.tsx
@@ -1,13 +1,15 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { CalendarDays, Check, Clock3, Plus, Trash2 } from "lucide-react";
+import { CalendarDays, Clock3, Plus, Trash2 } from "lucide-react";
 
 import { ProfileCard } from "@/components/settings/profile-card";
 import { SettingsSplitPane } from "@/components/settings/settings-split-pane";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import { Toast } from "@/components/ui/toast";
+import { useToastState } from "@/hooks/use-toast-state";
 import type { Automation, Persona } from "@/lib/types";
 
 type SettingsPayload = {
@@ -93,8 +95,7 @@ export function AutomationsSection() {
   const [selectedAutomationId, setSelectedAutomationId] = useState<string | null>(null);
   const [mobileDetailVisible, setMobileDetailVisible] = useState(false);
   const [isAddingNew, setIsAddingNew] = useState(false);
-  const [error, setError] = useState("");
-  const [success, setSuccess] = useState("");
+  const toast = useToastState();
   const [isLoading, setIsLoading] = useState(true);
 
   async function loadData() {
@@ -149,8 +150,7 @@ export function AutomationsSection() {
     setSelectedAutomationId(automation.id);
     setIsAddingNew(false);
     setForm(automationToForm(automation));
-    setError("");
-    setSuccess("");
+    toast.dismissToast();
     setMobileDetailVisible(true);
   }
 
@@ -158,16 +158,14 @@ export function AutomationsSection() {
     setSelectedAutomationId(null);
     setIsAddingNew(true);
     setForm(createDefaultForm(defaultProviderProfileId || providerProfiles[0]?.id || ""));
-    setError("");
-    setSuccess("");
+    toast.dismissToast();
     setMobileDetailVisible(true);
   }
 
   function resetSelection() {
     setSelectedAutomationId(null);
     setIsAddingNew(false);
-    setError("");
-    setSuccess("");
+    toast.dismissToast();
     setMobileDetailVisible(false);
     setForm(createDefaultForm(defaultProviderProfileId || providerProfiles[0]?.id || ""));
   }
@@ -190,31 +188,26 @@ export function AutomationsSection() {
     const resolvedProviderProfileId = form.providerProfileId || defaultProviderProfileId || providerProfiles[0]?.id || "";
 
     if (!form.name.trim() || !form.prompt.trim()) {
-      setError("Name and prompt are required");
-      setSuccess("");
+      toast.showToast("error", "Name and prompt are required");
       return;
     }
 
     if (!resolvedProviderProfileId) {
-      setError("Choose a provider profile");
-      setSuccess("");
+      toast.showToast("error", "Choose a provider profile");
       return;
     }
 
     if (form.scheduleKind === "interval" && form.intervalMinutes < 5) {
-      setError("Interval must be at least 5 minutes");
-      setSuccess("");
+      toast.showToast("error", "Interval must be at least 5 minutes");
       return;
     }
 
     if (form.scheduleKind === "calendar" && form.calendarFrequency === "weekly" && form.daysOfWeek.length === 0) {
-      setError("Choose at least one day for weekly automations");
-      setSuccess("");
+      toast.showToast("error", "Choose at least one day for weekly automations");
       return;
     }
 
-    setError("");
-    setSuccess("");
+    toast.dismissToast();
 
     const payload = {
       name: form.name.trim(),
@@ -244,8 +237,7 @@ export function AutomationsSection() {
       const failure = (await response.json().catch(() => ({ error: "Unable to save automation" }))) as {
         error?: string;
       };
-      setError(failure.error ?? "Unable to save automation");
-      setSuccess("");
+      toast.showToast("error", failure.error ?? "Unable to save automation");
       return;
     }
 
@@ -255,7 +247,7 @@ export function AutomationsSection() {
     setIsAddingNew(false);
     setForm(automationToForm(data.automation));
     setMobileDetailVisible(true);
-    setSuccess("Automation saved.");
+    toast.showToast("success", "Automation saved.");
   }
 
   async function deleteSelectedAutomation() {
@@ -271,8 +263,7 @@ export function AutomationsSection() {
       const failure = (await response.json().catch(() => ({ error: "Unable to delete automation" }))) as {
         error?: string;
       };
-      setError(failure.error ?? "Unable to delete automation");
-      setSuccess("");
+      toast.showToast("error", failure.error ?? "Unable to delete automation");
       return;
     }
 
@@ -564,18 +555,11 @@ export function AutomationsSection() {
                   </div>
                 </div>
 
-                {/* Messages */}
-                {success ? (
-                  <div className="flex items-center gap-1.5 pt-2 text-sm text-emerald-400">
-                    <Check className="h-3.5 w-3.5" />
-                    {success}
-                  </div>
-                ) : null}
-                {error ? (
-                  <div className="rounded-lg border border-red-400/10 bg-red-500/8 px-4 py-3 text-sm text-red-300">
-                    {error}
-                  </div>
-                ) : null}
+                <Toast
+                  visible={toast.visible}
+                  variant={toast.variant}
+                  message={toast.message}
+                />
               </div>
             ) : (
               <div className="flex flex-col items-center justify-center py-24 text-center">

--- a/components/settings/sections/general-section.tsx
+++ b/components/settings/sections/general-section.tsx
@@ -5,6 +5,8 @@ import { useRouter } from "next/navigation";
 import { Info } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { Toast } from "@/components/ui/toast";
+import { useToastState } from "@/hooks/use-toast-state";
 import type { AppSettings, ConversationRetention, ImageGenerationBackend } from "@/lib/types";
 
 type GeneralSectionSettings = AppSettings & {
@@ -34,8 +36,7 @@ export function GeneralSection({
   const [hasEditedExaApiKey, setHasEditedExaApiKey] = useState(false);
   const [hasEditedTavilyApiKey, setHasEditedTavilyApiKey] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
-  const [success, setSuccess] = useState("");
-  const [error, setError] = useState("");
+  const toast = useToastState();
   const hasStoredExaApiKey = settings.hasExaApiKey ?? Boolean(settings.exaApiKey);
   const hasStoredTavilyApiKey = settings.hasTavilyApiKey ?? Boolean(settings.tavilyApiKey);
 
@@ -67,8 +68,7 @@ export function GeneralSection({
         ];
 
   function resetMessages() {
-    setError("");
-    setSuccess("");
+    toast.dismissToast();
   }
 
   function handleSpeechEngineChange(nextEngine: AppSettings["sttEngine"]) {
@@ -108,7 +108,7 @@ export function GeneralSection({
 
     const validationError = getSearchValidationError();
     if (validationError) {
-      setError(validationError);
+      toast.showToast("error", validationError);
       return;
     }
 
@@ -174,7 +174,7 @@ export function GeneralSection({
       const generalResult = (await generalResponse.json()) as { error?: string };
 
       if (!generalResponse.ok) {
-        setError(generalResult.error ?? "Unable to save settings");
+        toast.showToast("error", generalResult.error ?? "Unable to save settings");
         return;
       }
 
@@ -182,12 +182,12 @@ export function GeneralSection({
         const imageResult = (await imageResponse.json()) as { error?: string };
 
         if (!imageResponse.ok) {
-          setError(imageResult.error ?? "Unable to save image generation settings");
+          toast.showToast("error", imageResult.error ?? "Unable to save image generation settings");
           return;
         }
       }
 
-      setSuccess("Settings saved.");
+      toast.showToast("success", "Settings saved.");
       router.refresh();
     } finally {
       setIsSaving(false);
@@ -489,13 +489,11 @@ export function GeneralSection({
           Save
         </Button>
       </div>
-      {success ? <span className="text-sm text-emerald-400">{success}</span> : null}
-
-      {error ? (
-        <div className="rounded-xl border border-red-400/10 bg-red-500/8 px-4 py-3 text-sm text-red-300">
-          {error}
-        </div>
-      ) : null}
+      <Toast
+        visible={toast.visible}
+        variant={toast.variant}
+        message={toast.message}
+      />
     </div>
   );
 }

--- a/components/settings/sections/mcp-servers-section.tsx
+++ b/components/settings/sections/mcp-servers-section.tsx
@@ -146,7 +146,7 @@ export function McpServersSection() {
       setMobileDetailVisible(true);
     }
 
-    toast.showToast("success", "Server saved.");
+    toast.showToast("success", "MCP saved.");
   }
 
   async function testMcpServer(serverId?: string) {

--- a/components/settings/sections/mcp-servers-section.tsx
+++ b/components/settings/sections/mcp-servers-section.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Check, Plus, Trash2 } from "lucide-react";
+import { Plus, Trash2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import { Toast } from "@/components/ui/toast";
+import { useToastState } from "@/hooks/use-toast-state";
 import type { McpServer, McpTransport } from "@/lib/types";
 import { ProfileCard } from "@/components/settings/profile-card";
 import { SettingsSplitPane } from "@/components/settings/settings-split-pane";
@@ -24,8 +26,7 @@ export function McpServersSection() {
   const [mcpRowTestResults, setMcpRowTestResults] = useState<Record<string, { text: string; isSuccess: boolean }>>({});
   const [mcpTestingTarget, setMcpTestingTarget] = useState<string | null>(null);
   const [mcpEnabledDraft, setMcpEnabledDraft] = useState(true);
-  const [error, setError] = useState("");
-  const [success, setSuccess] = useState("");
+  const toast = useToastState();
 
   const [selectedServerId, setSelectedServerId] = useState<string | null>(null);
   const [mobileDetailVisible, setMobileDetailVisible] = useState(false);
@@ -44,9 +45,6 @@ export function McpServersSection() {
     if (!mcpName.trim()) return;
     if (mcpTransport === "streamable_http" && !mcpUrl.trim()) return;
     if (mcpTransport === "stdio" && !mcpCommand.trim()) return;
-
-    setSuccess("");
-    setError("");
 
     let headersObj: Record<string, string> = {};
     if (mcpTransport === "streamable_http" && mcpHeaders.trim()) {
@@ -101,7 +99,7 @@ export function McpServersSection() {
       });
       if (!patchRes.ok) {
         const errorData = await patchRes.json().catch(() => null);
-        setError(errorData?.error ?? "Failed to update server");
+        toast.showToast("error", errorData?.error ?? "Failed to update server");
         return;
       }
     } else {
@@ -112,7 +110,7 @@ export function McpServersSection() {
       });
       if (!postRes.ok) {
         const errorData = await postRes.json().catch(() => null);
-        setError(errorData?.error ?? "Failed to add server");
+        toast.showToast("error", errorData?.error ?? "Failed to add server");
         return;
       }
       const created = (await postRes.json()) as { server: McpServer };
@@ -148,13 +146,10 @@ export function McpServersSection() {
       setMobileDetailVisible(true);
     }
 
-    setError("");
-    setSuccess("Server saved.");
+    toast.showToast("success", "Server saved.");
   }
 
   async function testMcpServer(serverId?: string) {
-    setError("");
-    setSuccess("");
     const target = serverId ?? "draft";
     setMcpTestingTarget(target);
 
@@ -214,7 +209,7 @@ export function McpServersSection() {
       }
 
       if (!response.ok) {
-        setError(fullMessage);
+        toast.showToast("error", fullMessage);
       }
     } catch (caughtError) {
       const message = caughtError instanceof Error ? caughtError.message : "MCP connection test failed";
@@ -226,7 +221,7 @@ export function McpServersSection() {
       } else {
         setMcpDraftTestResult({ text: message, isSuccess: false });
       }
-      setError(message);
+      toast.showToast("error", message);
     } finally {
       setMcpTestingTarget(null);
     }
@@ -473,23 +468,16 @@ export function McpServersSection() {
               </div>
               </div>
 
-              {success ? (
-                <div className="flex items-center gap-1.5 pt-2 text-sm text-emerald-400">
-                  <Check className="h-3.5 w-3.5" />
-                  {success}
-                </div>
-              ) : null}
+              <Toast
+                visible={toast.visible}
+                variant={toast.variant}
+                message={toast.message}
+              />
 
               {mcpDraftTestResult && (
                 <p className={`pt-2 text-sm ${mcpDraftTestResult.isSuccess ? "text-emerald-400" : "text-red-300"}`}>
                   {mcpDraftTestResult.text}
                 </p>
-              )}
-
-              {error && (
-                <div className="rounded-lg border border-red-400/10 bg-red-500/8 px-4 py-3 text-sm text-red-300">
-                  {error}
-                </div>
               )}
             </div>
           ) : (

--- a/components/settings/sections/memories-section.tsx
+++ b/components/settings/sections/memories-section.tsx
@@ -6,6 +6,8 @@ import { Brain, Search, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import { Toast } from "@/components/ui/toast";
+import { useToastState } from "@/hooks/use-toast-state";
 import type { AppSettings, MemoryCategory, UserMemory } from "@/lib/types";
 
 import { SettingsSplitPane } from "../settings-split-pane";
@@ -45,6 +47,7 @@ export function MemoriesSection() {
   const [editContent, setEditContent] = useState("");
   const [editCategory, setEditCategory] = useState<MemoryCategory>("other");
   const [mobileDetailVisible, setMobileDetailVisible] = useState(false);
+  const toast = useToastState();
 
   const fetchMemories = useCallback(async (params?: string) => {
     const url = params ? `/api/memories?${params}` : "/api/memories";
@@ -72,41 +75,68 @@ export function MemoriesSection() {
   }, [filterCategory, searchQuery, fetchMemories]);
 
   async function saveSettings(patch: Partial<AppSettings>) {
-    const res = await fetch("/api/settings/general", {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ ...settings, ...patch })
-    });
-    const data = (await res.json()) as { settings: AppSettings };
-    setSettings(data.settings);
+    try {
+      const res = await fetch("/api/settings/general", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ...settings, ...patch })
+      });
+      if (!res.ok) {
+        toast.showToast("error", "Failed to save settings.");
+        return;
+      }
+      const data = (await res.json()) as { settings: AppSettings };
+      setSettings(data.settings);
+      toast.showToast("success", "Settings saved.");
+    } catch {
+      toast.showToast("error", "Failed to save settings.");
+    }
   }
 
   async function saveMemory() {
     if (!selectedMemoryId || !editContent.trim()) return;
 
-    await fetch(`/api/memories/${selectedMemoryId}`, {
-      method: "PATCH",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        content: editContent.trim(),
-        category: editCategory
-      })
-    });
+    try {
+      const res = await fetch(`/api/memories/${selectedMemoryId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          content: editContent.trim(),
+          category: editCategory
+        })
+      });
+      if (!res.ok) {
+        toast.showToast("error", "Failed to save memory.");
+        return;
+      }
 
-    const params = new URLSearchParams();
-    if (filterCategory !== "all") params.set("category", filterCategory);
-    if (searchQuery.trim()) params.set("search", searchQuery.trim());
-    await fetchMemories(params.toString() || undefined);
-    setSelectedMemoryId(null);
-    setMobileDetailVisible(false);
+      const params = new URLSearchParams();
+      if (filterCategory !== "all") params.set("category", filterCategory);
+      if (searchQuery.trim()) params.set("search", searchQuery.trim());
+      await fetchMemories(params.toString() || undefined);
+      setSelectedMemoryId(null);
+      setMobileDetailVisible(false);
+      toast.showToast("success", "Memory saved.");
+    } catch {
+      toast.showToast("error", "Failed to save memory.");
+    }
   }
 
   async function deleteMemory(id: string) {
-    await fetch(`/api/memories/${id}`, { method: "DELETE" });
-    setMemories((prev) => prev.filter((m) => m.id !== id));
-    if (selectedMemoryId === id) {
-      setSelectedMemoryId(null);
-      setMobileDetailVisible(false);
+    try {
+      const res = await fetch(`/api/memories/${id}`, { method: "DELETE" });
+      if (!res.ok) {
+        toast.showToast("error", "Failed to delete memory.");
+        return;
+      }
+      setMemories((prev) => prev.filter((m) => m.id !== id));
+      if (selectedMemoryId === id) {
+        setSelectedMemoryId(null);
+        setMobileDetailVisible(false);
+      }
+      toast.showToast("success", "Memory deleted.");
+    } catch {
+      toast.showToast("error", "Failed to delete memory.");
     }
   }
 
@@ -335,6 +365,11 @@ export function MemoriesSection() {
             )}
           </div>
         }
+      />
+      <Toast
+        visible={toast.visible}
+        variant={toast.variant}
+        message={toast.message}
       />
     </div>
   );

--- a/components/settings/sections/personas-section.tsx
+++ b/components/settings/sections/personas-section.tsx
@@ -6,6 +6,8 @@ import { Plus, FileText } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { TextEditModal } from "@/components/ui/text-edit-modal";
+import { Toast } from "@/components/ui/toast";
+import { useToastState } from "@/hooks/use-toast-state";
 import type { Persona } from "@/lib/types";
 
 import { SettingsSplitPane } from "../settings-split-pane";
@@ -20,6 +22,7 @@ export function PersonasSection() {
   const [mobileDetailVisible, setMobileDetailVisible] = useState(false);
   const [isAddingNew, setIsAddingNew] = useState(false);
   const [isPersonaContentOpen, setIsPersonaContentOpen] = useState(false);
+  const toast = useToastState();
 
   useEffect(() => {
     fetch("/api/personas")
@@ -31,40 +34,67 @@ export function PersonasSection() {
   }, []);
 
   async function savePersona() {
-    if (!personaName.trim() || !personaContent.trim()) return;
-
-    if (editingPersonaId) {
-      await fetch(`/api/personas/${editingPersonaId}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          name: personaName,
-          content: personaContent
-        })
-      });
-    } else {
-      await fetch("/api/personas", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          name: personaName,
-          content: personaContent
-        })
-      });
+    if (!personaName.trim() || !personaContent.trim()) {
+      toast.showToast("error", "Name and system instructions are required.");
+      return;
     }
 
-    const res = await fetch("/api/personas");
-    const data = (await res.json()) as { personas: Persona[] };
-    setPersonas(data.personas);
-    resetPersonaForm();
+    try {
+      if (editingPersonaId) {
+        const res = await fetch(`/api/personas/${editingPersonaId}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: personaName,
+            content: personaContent
+          })
+        });
+        if (!res.ok) {
+          const data = await res.json().catch(() => null);
+          toast.showToast("error", (data as { error?: string })?.error ?? "Failed to save persona");
+          return;
+        }
+      } else {
+        const res = await fetch("/api/personas", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: personaName,
+            content: personaContent
+          })
+        });
+        if (!res.ok) {
+          const data = await res.json().catch(() => null);
+          toast.showToast("error", (data as { error?: string })?.error ?? "Failed to create persona");
+          return;
+        }
+      }
+
+      const res = await fetch("/api/personas");
+      const data = (await res.json()) as { personas: Persona[] };
+      setPersonas(data.personas);
+      resetPersonaForm();
+      toast.showToast("success", "Persona saved.");
+    } catch {
+      toast.showToast("error", "Failed to save persona.");
+    }
   }
 
   async function deletePersona(id: string) {
-    await fetch(`/api/personas/${id}`, { method: "DELETE" });
-    setPersonas((prev) => prev.filter((p) => p.id !== id));
-    if (selectedPersonaId === id) {
-      setSelectedPersonaId(null);
-      setMobileDetailVisible(false);
+    try {
+      const res = await fetch(`/api/personas/${id}`, { method: "DELETE" });
+      if (!res.ok) {
+        toast.showToast("error", "Failed to delete persona.");
+        return;
+      }
+      setPersonas((prev) => prev.filter((p) => p.id !== id));
+      if (selectedPersonaId === id) {
+        setSelectedPersonaId(null);
+        setMobileDetailVisible(false);
+      }
+      toast.showToast("success", "Persona deleted.");
+    } catch {
+      toast.showToast("error", "Failed to delete persona.");
     }
   }
 
@@ -243,6 +273,11 @@ export function PersonasSection() {
             )}
           </div>
         }
+      />
+      <Toast
+        visible={toast.visible}
+        variant={toast.variant}
+        message={toast.message}
       />
     </div>
   );

--- a/components/settings/sections/providers-section.tsx
+++ b/components/settings/sections/providers-section.tsx
@@ -332,7 +332,7 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
     toast.dismissToast();
 
     if (await saveSettings()) {
-      toast.showToast("success", "Settings saved.");
+      toast.showToast("success", "Provider saved.");
     }
   }
 

--- a/components/settings/sections/providers-section.tsx
+++ b/components/settings/sections/providers-section.tsx
@@ -4,7 +4,6 @@ import { type FormEvent, useEffect, useMemo, useState } from "react";
 import {
   Plus,
   Trash2,
-  Check,
   Eye,
   EyeOff,
   Zap
@@ -14,6 +13,8 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { TextEditModal } from "@/components/ui/text-edit-modal";
+import { Toast } from "@/components/ui/toast";
+import { useToastState } from "@/hooks/use-toast-state";
 import { createId } from "@/lib/ids";
 import { DEFAULT_PROVIDER_SETTINGS } from "@/lib/constants";
 import {
@@ -72,8 +73,7 @@ type ProviderProfileDraft = SettingsPayload["providerProfiles"][number] & {
 };
 
 export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
-  const [error, setError] = useState("");
-  const [success, setSuccess] = useState("");
+  const toast = useToastState();
   const [testResult, setTestResult] = useState<{ text: string; isSuccess: boolean } | null>(null);
   const [defaultProviderProfileId, setDefaultProviderProfileId] = useState(
     settings.defaultProviderProfileId ?? settings.providerProfiles[0]?.id ?? ""
@@ -320,7 +320,7 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
 
     const result = (await response.json()) as { error?: string };
     if (!response.ok) {
-      setError(result.error ?? "Unable to save settings");
+      toast.showToast("error", result.error ?? "Unable to save settings");
       return false;
     }
 
@@ -329,11 +329,10 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
 
   async function handleSettings(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    setError("");
-    setSuccess("");
+    toast.dismissToast();
 
     if (await saveSettings()) {
-      setSuccess("Settings saved.");
+      toast.showToast("success", "Settings saved.");
     }
   }
 
@@ -353,11 +352,10 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
     if (!activeProviderProfile || activeProviderProfile.id === defaultProviderProfileId) {
       return;
     }
-    setError("");
-    setSuccess("");
+    toast.dismissToast();
     if (await saveSettingsWithDefault(activeProviderProfile.id)) {
       setDefaultProviderProfileId(activeProviderProfile.id);
-      setSuccess("Default provider updated.");
+      toast.showToast("success", "Default provider updated.");
     }
   }
 
@@ -996,21 +994,10 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
                 </div>
 
                 {/* Messages */}
-                {success ? (
-                  <div className="flex items-center gap-1.5 pt-2 text-sm text-emerald-400">
-                    <Check className="h-3.5 w-3.5" />
-                    {success}
-                  </div>
-                ) : null}
                 {testResult ? (
                   <p className={`pt-2 text-sm ${testResult.isSuccess ? "text-emerald-400" : "text-red-300"}`}>
                     {testResult.text}
                   </p>
-                ) : null}
-                {error ? (
-                  <div className="rounded-lg border border-red-400/10 bg-red-500/8 px-4 py-3 text-sm text-red-300">
-                    {error}
-                  </div>
                 ) : null}
 
                 <TextEditModal
@@ -1020,6 +1007,11 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
                   onChange={saveSystemPrompt}
                   title="Edit system prompt"
                   subtitle="Applied to new conversations only"
+                />
+                <Toast
+                  visible={toast.visible}
+                  variant={toast.variant}
+                  message={toast.message}
                 />
               </div>
             ) : null}

--- a/components/settings/sections/skills-section.tsx
+++ b/components/settings/sections/skills-section.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { Check, Plus, FileText, Upload } from "lucide-react";
+import { Plus, FileText, Upload } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { TextEditModal } from "@/components/ui/text-edit-modal";
+import { Toast } from "@/components/ui/toast";
+import { useToastState } from "@/hooks/use-toast-state";
 import { parseSkillContentMetadata } from "@/lib/skill-metadata";
 import type { Skill } from "@/lib/types";
 
@@ -21,8 +23,7 @@ export function SkillsSection() {
   const [selectedSkillId, setSelectedSkillId] = useState<string | null>(null);
   const [mobileDetailVisible, setMobileDetailVisible] = useState(false);
   const [isAddingNew, setIsAddingNew] = useState(false);
-  const [skillError, setSkillError] = useState("");
-  const [skillSuccess, setSkillSuccess] = useState("");
+  const toast = useToastState();
   const [skillEnabledDraft, setSkillEnabledDraft] = useState(true);
   const [isInstructionsOpen, setIsInstructionsOpen] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -38,8 +39,7 @@ export function SkillsSection() {
 
   async function saveSkill() {
     if (!skillName.trim() || !skillDescription.trim() || !skillContent.trim()) return;
-    setSkillError("");
-    setSkillSuccess("");
+    toast.dismissToast();
 
     let savedId = editingSkillId;
     const isBuiltin = editingSkillId?.startsWith("builtin-") ?? false;
@@ -65,7 +65,7 @@ export function SkillsSection() {
         body: JSON.stringify(payload)
       });
       if (!updateRes.ok) {
-        setSkillError("Failed to save skill.");
+        toast.showToast("error", "Failed to save skill.");
         return;
       }
     } else {
@@ -79,7 +79,7 @@ export function SkillsSection() {
         })
       });
       if (!createRes.ok) {
-        setSkillError("Failed to save skill.");
+        toast.showToast("error", "Failed to save skill.");
         return;
       }
       const createdData = (await createRes.json().catch(() => null)) as { skill?: Skill } | null;
@@ -119,7 +119,7 @@ export function SkillsSection() {
       }
     }
 
-    setSkillSuccess("Skill saved.");
+    toast.showToast("success", "Skill saved.");
     setIsAddingNew(false);
     setMobileDetailVisible(true);
   }
@@ -132,7 +132,7 @@ export function SkillsSection() {
   async function deleteSkill(id: string) {
     await fetch(`/api/skills/${id}`, { method: "DELETE" });
     setSkills((prev) => prev.filter((s) => s.id !== id));
-    setSkillSuccess("");
+    toast.dismissToast();
     if (selectedSkillId === id) {
       setSelectedSkillId(null);
       setMobileDetailVisible(false);
@@ -145,7 +145,7 @@ export function SkillsSection() {
     setSkillDescription(skill.description);
     setSkillContent(skill.content);
     setSkillEnabledDraft(skill.enabled);
-    setSkillSuccess("");
+    toast.dismissToast();
     setSelectedSkillId(skill.id);
     setIsAddingNew(false);
     setMobileDetailVisible(true);
@@ -157,7 +157,7 @@ export function SkillsSection() {
     setSkillDescription("");
     setSkillContent("");
     setSkillEnabledDraft(true);
-    setSkillSuccess("");
+    toast.dismissToast();
     setSelectedSkillId(null);
     setIsAddingNew(true);
     setMobileDetailVisible(true);
@@ -192,7 +192,7 @@ export function SkillsSection() {
     setSelectedSkillId(null);
     setIsAddingNew(false);
     setMobileDetailVisible(false);
-    setSkillSuccess("");
+    toast.dismissToast();
   }
 
   const selectedSkill = skills.find((s) => s.id === selectedSkillId);
@@ -380,17 +380,11 @@ export function SkillsSection() {
                   placeholder="Enter the full skill instructions..."
                   readOnly={isBuiltin}
                 />
-                {skillSuccess ? (
-                  <div className="flex items-center gap-1.5 text-sm text-emerald-400">
-                    <Check className="h-3.5 w-3.5" />
-                    {skillSuccess}
-                  </div>
-                ) : null}
-                {skillError ? (
-                  <div className="text-sm text-red-400">
-                    {skillError}
-                  </div>
-                ) : null}
+                <Toast
+                  visible={toast.visible}
+                  variant={toast.variant}
+                  message={toast.message}
+                />
               </>
             ) : (
               <div className="flex flex-col items-center justify-center py-24 text-center">

--- a/components/settings/sections/users-section.tsx
+++ b/components/settings/sections/users-section.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { AlertTriangle, Plus, Trash2, UserRound } from "lucide-react";
+import { Plus, Trash2, UserRound } from "lucide-react";
 
 import { ProfileCard } from "@/components/settings/profile-card";
 import { SettingsSplitPane } from "@/components/settings/settings-split-pane";
@@ -9,6 +9,8 @@ import { Badge } from "@/components/settings/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Toast } from "@/components/ui/toast";
+import { useToastState } from "@/hooks/use-toast-state";
 import type { PersistedUser, UserRole } from "@/lib/types";
 
 function readErrorMessage(payload: unknown, fallback: string) {
@@ -45,8 +47,7 @@ export function UsersSection({ users }: { users: PersistedUser[] }) {
   const [draftPassword, setDraftPassword] = useState("");
   const [draftRole, setDraftRole] = useState<UserRole>(users[0]?.role ?? "user");
   const [isSaving, setIsSaving] = useState(false);
-  const [error, setError] = useState("");
-  const [success, setSuccess] = useState("");
+  const toast = useToastState();
 
   const selectedUser = useMemo(
     () => userRows.find((user) => user.id === selectedUserId) ?? null,
@@ -63,8 +64,7 @@ export function UsersSection({ users }: { users: PersistedUser[] }) {
     setSelectedUserId(user.id);
     setIsAddingNew(false);
     setMobileDetailVisible(true);
-    setError("");
-    setSuccess("");
+    toast.dismissToast();
     loadDraft(user);
   }
 
@@ -75,8 +75,7 @@ export function UsersSection({ users }: { users: PersistedUser[] }) {
     setDraftUsername("");
     setDraftPassword("");
     setDraftRole("user");
-    setError("");
-    setSuccess("");
+    toast.dismissToast();
   }
 
   async function refreshUsers(nextSelectedUserId?: string | null) {
@@ -100,12 +99,12 @@ export function UsersSection({ users }: { users: PersistedUser[] }) {
 
   async function saveUser() {
     if (!draftUsername.trim()) {
-      setError("Username is required.");
+      toast.showToast("error", "Username is required.");
       return;
     }
 
     if (isAddingNew && draftPassword.length < 8) {
-      setError("New users must have a password with at least 8 characters.");
+      toast.showToast("error", "New users must have a password with at least 8 characters.");
       return;
     }
 
@@ -114,8 +113,7 @@ export function UsersSection({ users }: { users: PersistedUser[] }) {
     }
 
     setIsSaving(true);
-    setError("");
-    setSuccess("");
+    toast.dismissToast();
 
     try {
       const response = await fetch(
@@ -133,15 +131,15 @@ export function UsersSection({ users }: { users: PersistedUser[] }) {
       const payload = (await response.json()) as { user?: PersistedUser; error?: string };
 
       if (!response.ok) {
-        setError(readErrorMessage(payload, "Unable to save user"));
+        toast.showToast("error", readErrorMessage(payload, "Unable to save user"));
         return;
       }
 
       await refreshUsers(payload.user?.id ?? selectedUserId);
-      setSuccess(isAddingNew ? "User created." : "User updated.");
+      toast.showToast("success", isAddingNew ? "User created." : "User updated.");
       setMobileDetailVisible(true);
     } catch (caughtError) {
-      setError(caughtError instanceof Error ? caughtError.message : "Unable to save user");
+      toast.showToast("error", caughtError instanceof Error ? caughtError.message : "Unable to save user");
     } finally {
       setIsSaving(false);
     }
@@ -157,8 +155,7 @@ export function UsersSection({ users }: { users: PersistedUser[] }) {
     }
 
     setIsSaving(true);
-    setError("");
-    setSuccess("");
+    toast.dismissToast();
 
     try {
       const response = await fetch(`/api/users/${selectedUser.id}`, {
@@ -167,15 +164,15 @@ export function UsersSection({ users }: { users: PersistedUser[] }) {
       const payload = (await response.json()) as { error?: string };
 
       if (!response.ok) {
-        setError(readErrorMessage(payload, "Unable to delete user"));
+        toast.showToast("error", readErrorMessage(payload, "Unable to delete user"));
         return;
       }
 
       await refreshUsers(null);
-      setSuccess("User deleted.");
+      toast.showToast("success", "User deleted.");
       setMobileDetailVisible(false);
     } catch (caughtError) {
-      setError(caughtError instanceof Error ? caughtError.message : "Unable to delete user");
+      toast.showToast("error", caughtError instanceof Error ? caughtError.message : "Unable to delete user");
     } finally {
       setIsSaving(false);
     }
@@ -370,18 +367,11 @@ export function UsersSection({ users }: { users: PersistedUser[] }) {
 
               <div className={sectionDivider} />
 
-              {success ? (
-                <div className="flex items-center gap-1.5 text-sm text-emerald-400">
-                  {success}
-                </div>
-              ) : null}
-
-              {error ? (
-                <div className="flex items-center gap-2 text-sm text-red-200">
-                  <AlertTriangle className="h-4 w-4" />
-                  <span>{error}</span>
-                </div>
-              ) : null}
+              <Toast
+                visible={toast.visible}
+                variant={toast.variant}
+                message={toast.message}
+              />
             </div>
           ) : (
             emptyState

--- a/components/ui/text-edit-modal.tsx
+++ b/components/ui/text-edit-modal.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { useEffect, useId, useState } from "react";
-import { AnimatePresence, motion } from "framer-motion";
-import { Check } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
+import { Toast } from "@/components/ui/toast";
+import { useToastState } from "@/hooks/use-toast-state";
 
 type TextEditModalProps = {
   open: boolean;
@@ -30,7 +30,7 @@ export function TextEditModal({
 }: TextEditModalProps) {
   const titleId = useId();
   const [draft, setDraft] = useState(value);
-  const [toastVisible, setToastVisible] = useState(false);
+  const toast = useToastState();
 
   useEffect(() => {
     if (open) {
@@ -39,12 +39,6 @@ export function TextEditModal({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
 
-  useEffect(() => {
-    if (!toastVisible) return;
-    const timer = setTimeout(() => setToastVisible(false), 2000);
-    return () => clearTimeout(timer);
-  }, [toastVisible]);
-
   function handleClose() {
     onOpenChange(false);
   }
@@ -52,7 +46,7 @@ export function TextEditModal({
   function handleSave() {
     onChange(draft);
     onOpenChange(false);
-    setToastVisible(true);
+    toast.showToast("success", "Saved successfully !");
   }
 
   return (
@@ -108,20 +102,11 @@ export function TextEditModal({
           </div>
         </div>
       )}
-      <AnimatePresence>
-        {toastVisible && (
-          <motion.div
-            key="save-toast"
-            initial={{ opacity: 0, y: 12 }}
-            animate={{ opacity: 1, y: 0, transition: { duration: 0.25, ease: [0.22, 1, 0.36, 1] } }}
-            exit={{ opacity: 0, transition: { duration: 0.8, ease: "easeOut" } }}
-            className="fixed bottom-4 right-4 sm:bottom-6 sm:right-6 z-50 flex items-center gap-2 rounded-lg border border-emerald-400/20 bg-emerald-900 px-4 py-2.5 text-sm text-emerald-200 shadow-[0_4px_24px_rgba(0,0,0,0.5)]"
-          >
-            <Check className="h-3.5 w-3.5" />
-            Saved successfully !
-          </motion.div>
-        )}
-      </AnimatePresence>
+      <Toast
+        visible={toast.visible}
+        variant={toast.variant}
+        message={toast.message}
+      />
     </>
   );
 }

--- a/components/ui/toast.tsx
+++ b/components/ui/toast.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { AnimatePresence, motion } from "framer-motion";
+import { Check, Info, X, AlertTriangle } from "lucide-react";
+
+type ToastVariant = "success" | "error" | "warning" | "info";
+
+type ToastProps = {
+  visible: boolean;
+  variant: ToastVariant;
+  message: string;
+  onDismiss?: () => void;
+};
+
+const VARIANT_STYLES: Record<
+  ToastVariant,
+  { bg: string; border: string; text: string; icon: React.ElementType }
+> = {
+  success: {
+    bg: "bg-emerald-900",
+    border: "border-emerald-400/20",
+    text: "text-emerald-200",
+    icon: Check,
+  },
+  error: {
+    bg: "bg-red-900",
+    border: "border-red-400/20",
+    text: "text-red-200",
+    icon: X,
+  },
+  warning: {
+    bg: "bg-amber-900",
+    border: "border-amber-400/20",
+    text: "text-amber-200",
+    icon: AlertTriangle,
+  },
+  info: {
+    bg: "bg-blue-900",
+    border: "border-blue-400/20",
+    text: "text-blue-200",
+    icon: Info,
+  },
+};
+
+export function Toast({ visible, variant, message, onDismiss }: ToastProps) {
+  const style = VARIANT_STYLES[variant];
+  const IconComponent = style.icon;
+
+  return (
+    <AnimatePresence onExitComplete={onDismiss}>
+      {visible && (
+        <motion.div
+          key="toast"
+          initial={{ opacity: 0, y: 12 }}
+          animate={{
+            opacity: 1,
+            y: 0,
+            transition: { duration: 0.25, ease: [0.22, 1, 0.36, 1] },
+          }}
+          exit={{ opacity: 0, transition: { duration: 0.8, ease: "easeOut" } }}
+          className={`fixed bottom-4 right-4 sm:bottom-6 sm:right-6 z-50 flex items-center gap-2 rounded-lg border ${style.border} ${style.bg} px-4 py-2.5 text-sm ${style.text} shadow-[0_4px_24px_rgba(0,0,0,0.5)]`}
+        >
+          <IconComponent className="h-3.5 w-3.5" />
+          {message}
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}
+
+export type { ToastProps, ToastVariant };

--- a/hooks/use-toast-state.ts
+++ b/hooks/use-toast-state.ts
@@ -1,0 +1,33 @@
+import { useCallback, useRef, useState } from "react";
+
+type ToastVariant = "success" | "error" | "warning" | "info";
+
+type ToastState = {
+  visible: boolean;
+  message: string;
+  variant: ToastVariant;
+};
+
+export function useToastState() {
+  const [state, setState] = useState<ToastState>({
+    visible: false,
+    message: "",
+    variant: "success",
+  });
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const showToast = useCallback((variant: ToastVariant, message: string) => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    setState({ visible: true, message, variant });
+    timerRef.current = setTimeout(() => {
+      setState((prev) => ({ ...prev, visible: false }));
+    }, 2000);
+  }, []);
+
+  const dismissToast = useCallback(() => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    setState((prev) => ({ ...prev, visible: false }));
+  }, []);
+
+  return { ...state, showToast, dismissToast };
+}


### PR DESCRIPTION
## Summary

- Add a reusable `Toast` UI component and `useToastState` hook to replace ad-hoc inline save feedback across all settings sections
- Replace inline feedback patterns in 9 settings sections: account, automations, general, MCP servers, memories, personas, providers, skills, and users
- Refactor `TextEditModal` to use the shared Toast component
- Use contextual toast messages (e.g., "MCP saved.", "Provider saved.") instead of generic "Settings saved."