### PR TITLE
fix: improve mobile upload card layout and thumbnail rendering

### DIFF
--- a/components/chat-composer.tsx
+++ b/components/chat-composer.tsx
@@ -333,10 +333,10 @@ export function ChatComposer({
                 initial={{ scale: 0.9, opacity: 0 }}
                 animate={{ scale: 1, opacity: 1 }}
                 exit={{ scale: 0.9, opacity: 0 }}
-                className="flex items-center gap-2 rounded-2xl border border-white/10 bg-white/5 p-1.5 pr-2.5 text-sm text-white/80 backdrop-blur-md"
+                className="flex items-center gap-2 rounded-2xl border border-white/10 bg-white/5 p-1.5 pr-2.5 text-sm text-white/80 backdrop-blur-md min-h-[48px]"
               >
                 {attachment.kind === "image" ? (
-                  <div className="relative h-9 w-9 overflow-hidden rounded-xl border border-white/10">
+                  <div className="relative h-9 w-9 shrink-0 overflow-hidden rounded-xl border border-white/10 bg-white/10">
                     {/* eslint-disable-next-line @next/next/no-img-element -- Pending attachment thumbnails are API-served user files that next/image cannot safely optimize. */}
                     <img
                       src={`/api/attachments/${attachment.id}`}


### PR DESCRIPTION
## Summary

- Add `min-h-[48px]` to the attachment pill in the chat composer to ensure adequate touch target height on mobile devices
- Add `shrink-0` to the thumbnail container to prevent flex layout from squishing the image preview
- Add `bg-white/10` fallback background to the thumbnail for better visual state while loading

These changes fix layout issues with the file upload preview card when displayed on mobile screen sizes.