### PR TITLE
fix: resolve chat scrolling regression with layout-driven scroll tracking

### DIFF
--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Share2 } from "lucide-react";
 
@@ -60,7 +60,7 @@ const ANCHOR_LAYOUT_SCROLL_GRACE_MS = 300;
 const ANCHOR_PROGRAMMATIC_SCROLL_GRACE_MS = 900;
 
 type ScrollMode = "idle" | "anchored" | "following";
-const SCROLL_BOTTOM_PADDING = 260;
+const SCROLL_BOTTOM_PADDING = 180;
 
 type SnapshotReconciliation = {
   messages: Message[];
@@ -562,6 +562,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
       (message.status === "streaming" || message.status === "completed")
   );
   const queueRef = useRef<HTMLDivElement | null>(null);
+  const queueContentRef = useRef<HTMLDivElement | null>(null);
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
   const dragDepthRef = useRef(0);
   const messagesRef = useRef(payload.messages);
@@ -826,7 +827,9 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
     const containerRect = queueRef.current.getBoundingClientRect();
     const messageRect = messageEl.getBoundingClientRect();
     const scrollOffset = messageRect.top - containerRect.top + queueRef.current.scrollTop;
-    const scrollTarget = Math.max(0, scrollOffset - ANCHOR_SCROLL_TOP_INSET_PX);
+    const idealTarget = Math.max(0, scrollOffset - ANCHOR_SCROLL_TOP_INSET_PX);
+    const maxScrollTop = Math.max(0, queueRef.current.scrollHeight - queueRef.current.clientHeight);
+    const scrollTarget = Math.min(idealTarget, maxScrollTop);
 
     suppressNextScrollEventRef.current = true;
     if (queueRef.current.scrollTo) {
@@ -869,14 +872,15 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
     }
 
     event.preventDefault();
+
     if (queueRef.current.scrollTop > bottomTarget) {
       suppressNextScrollEventRef.current = true;
-      queueRef.current.scrollTo?.({ top: bottomTarget, behavior: "auto" });
       queueRef.current.scrollTop = bottomTarget;
       requestAnimationFrame(() => {
         suppressNextScrollEventRef.current = false;
       });
     }
+
     setIsConversationAtBottom(true);
     shouldAutoScrollRef.current = true;
     userScrollIntentRef.current = false;
@@ -949,22 +953,40 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
     return () => observer.disconnect();
   }, []);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!queueRef.current || !shouldAutoScrollRef.current) {
       return;
     }
 
-    requestAnimationFrame(() => {
-      if (!queueRef.current || !shouldAutoScrollRef.current) return;
-      setIsConversationAtBottom(true);
-      const top = getComposerAwareBottomTarget(queueRef.current, scrollPadding);
-      if (queueRef.current.scrollTo) {
-        queueRef.current.scrollTo({ top, behavior: "auto" });
-      } else {
-        queueRef.current.scrollTop = top;
-      }
-    });
+    setIsConversationAtBottom(true);
+    const top = getComposerAwareBottomTarget(queueRef.current, scrollPadding);
+    suppressNextScrollEventRef.current = true;
+    if (queueRef.current.scrollTo) {
+      queueRef.current.scrollTo({ top, behavior: "auto" });
+    } else {
+      queueRef.current.scrollTop = top;
+    }
+    suppressNextScrollEventRef.current = false;
   }, [messages, streamThinkingDisplay, streamAnswerDisplay, streamTimeline, scrollPadding]);
+
+  useEffect(() => {
+    const scrollContainer = queueRef.current;
+    const contentEl = queueContentRef.current;
+    if (!scrollContainer || !contentEl || !streamMessageId) return;
+
+    if (typeof ResizeObserver === "undefined") return;
+
+    const observer = new ResizeObserver(() => {
+      if (!shouldAutoScrollRef.current) return;
+      const top = getComposerAwareBottomTarget(scrollContainer, scrollPadding);
+      suppressNextScrollEventRef.current = true;
+      scrollContainer.scrollTop = top;
+      suppressNextScrollEventRef.current = false;
+    });
+    observer.observe(contentEl);
+
+    return () => observer.disconnect();
+  }, [streamMessageId, scrollPadding]);
 
   useEffect(() => {
     if (!pendingAnchorMessageIdRef.current || !queueRef.current) return;
@@ -2363,25 +2385,6 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
             return;
           }
 
-          const bottomTarget = getComposerAwareBottomTarget(queueRef.current, scrollPadding);
-          if (
-            scrollModeRef.current === "idle" &&
-            !isConversationActive &&
-            !streamMessageIdRef.current &&
-            queueRef.current.scrollTop > bottomTarget + ANCHOR_SCROLL_TOLERANCE_PX
-          ) {
-            suppressNextScrollEventRef.current = true;
-            queueRef.current.scrollTo?.({ top: bottomTarget, behavior: "auto" });
-            queueRef.current.scrollTop = bottomTarget;
-            setIsConversationAtBottom(true);
-            shouldAutoScrollRef.current = true;
-            userScrollIntentRef.current = false;
-            requestAnimationFrame(() => {
-              suppressNextScrollEventRef.current = false;
-            });
-            return;
-          }
-
           const nextIsAtBottom = isNearQueueBottom(queueRef.current, scrollPadding);
           setIsConversationAtBottom(nextIsAtBottom);
 
@@ -2446,6 +2449,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
         }}
       >
         <div
+          ref={queueContentRef}
           className="flex w-full flex-col gap-2.5 md:gap-4 px-2 md:px-0 pt-4"
           style={{ paddingBottom: scrollPadding }}
         >
@@ -2511,6 +2515,8 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
               {error}
             </div>
           ) : null}
+
+          {streamMessageId ? <div style={{ height: 36 }} /> : null}
         </div>
       </div>
 

--- a/tests/unit/chat-view.test.ts
+++ b/tests/unit/chat-view.test.ts
@@ -2879,7 +2879,7 @@ describe("chat view", () => {
     await flushAnimationFrame();
 
     await waitFor(() => {
-      expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ top: 620 }));
+      expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ top: 540 }));
     });
     expect(scrollTo).not.toHaveBeenCalledWith(expect.objectContaining({ top: 1080 }));
   });
@@ -2945,7 +2945,7 @@ describe("chat view", () => {
     await flushAnimationFrame();
 
     await waitFor(() => {
-      expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ top: 620 }));
+      expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ top: 540 }));
     });
     expect(scrollTo).not.toHaveBeenCalledWith(expect.objectContaining({ top: 1080 }));
   });
@@ -3004,11 +3004,11 @@ describe("chat view", () => {
     });
 
     await waitFor(() => {
-      expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ top: 620 }));
+      expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ top: 540 }));
     });
 
     scrollTo.mockClear();
-    scrollTop = 620;
+    scrollTop = 540;
 
     act(() => {
       wsMock.onMessage!({
@@ -3021,8 +3021,8 @@ describe("chat view", () => {
     await flushAnimationFrame();
     await flushAnimationFrame();
 
-    expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ top: 620 }));
-    expect(scrollTop).toBe(620);
+    expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ top: 540 }));
+    expect(scrollTop).toBe(540);
     expect(messageList).toHaveStyle({ paddingBottom: "360px" });
   });
 
@@ -3396,7 +3396,7 @@ describe("chat view", () => {
     });
 
     await waitFor(() => {
-      expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ top: 620 }));
+      expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ top: 540 }));
     });
 
     scrollTo.mockClear();
@@ -3414,7 +3414,7 @@ describe("chat view", () => {
     await flushAnimationFrame();
     await flushAnimationFrame();
 
-    expect(scrollTo).not.toHaveBeenCalledWith(expect.objectContaining({ top: 620 }));
+    expect(scrollTo).not.toHaveBeenCalledWith(expect.objectContaining({ top: 540 }));
   });
 
   it("does not clamp when scroll position matches the bottom target after streaming ends", async () => {
@@ -3472,11 +3472,11 @@ describe("chat view", () => {
     await flushAnimationFrame();
 
     scrollTo.mockClear();
-    scrollTop = 620;
+    scrollTop = 540;
     fireEvent.scroll(queue);
 
     expect(scrollTo).not.toHaveBeenCalled();
-    expect(scrollTop).toBe(620);
+    expect(scrollTop).toBe(540);
   });
 
   it("prevents downward wheel scrolling into padding-only space for short chats", async () => {
@@ -3528,11 +3528,11 @@ describe("chat view", () => {
 
     const defaultAllowed = fireEvent(queue, wheelEvent);
     if (defaultAllowed && !wheelEvent.defaultPrevented) {
-      scrollTop = 60;
+      scrollTop = scrollTop + 120;
     }
 
     expect(wheelEvent.defaultPrevented).toBe(true);
-    expect(scrollTop).toBe(0);
+    expect(scrollTop).toBe(20);
     expect(screen.queryByRole("button", { name: "Scroll to newest messages" })).toBeNull();
   });
 


### PR DESCRIPTION
## Summary

- **Replace `requestAnimationFrame`-based auto-scroll with synchronous `useLayoutEffect`** to eliminate one-frame flicker when new messages arrive during streaming
- **Add `ResizeObserver` on the content element** for real-time scroll position tracking during streaming, ensuring the view stays pinned to bottom as content grows
- **Clamp anchor scroll targets** to prevent scrolling beyond the scrollable bounds (`scrollHeight - clientHeight`)
- **Reduce `SCROLL_BOTTOM_PADDING`** from 260 to 180 for better viewport usage
- **Remove stale idle-mode scroll clamp** that fought against the user's scroll position in inactive conversations
- **Add bottom spacer during streaming** for smoother auto-scroll behavior
- **Update tests** to match the new scroll padding value and expected scroll targets