### PR TITLE
fix: preserve raw line breaks in assistant markdown content

### DIFF
--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -715,8 +715,9 @@ export function MessageBubble({
   const rawThinking = streamingThinking ?? message.thinkingContent;
   const actions = message.actions ?? [];
   const liveTimeline = streamingTimeline ?? message.timeline;
-  const content = normalizeLineBreaks(rawContent);
-  const thinkingContent = normalizeLineBreaks(rawThinking);
+  const content = rawContent;
+  const contentForComparison = normalizeLineBreaks(rawContent);
+  const thinkingContent = rawThinking;
   const timeline = liveTimeline ?? actions.map((action) => ({
     ...action,
     timelineKind: "action" as const
@@ -788,13 +789,13 @@ export function MessageBubble({
     .join("");
   const normalizedConsumedText = normalizeLineBreaks(consumedText);
 
-  if (content && content.length > normalizedConsumedText.length) {
+  if (contentForComparison && contentForComparison.length > normalizedConsumedText.length) {
     assistantBlocks.push({
       id: `content_${message.id}_remaining`,
       timelineKind: "text",
       sortOrder: assistantBlocks.length,
       createdAt: message.createdAt,
-      content: content.slice(normalizedConsumedText.length)
+      content: contentForComparison.slice(normalizedConsumedText.length)
     });
   }
 

--- a/lib/assistant-image-markdown.ts
+++ b/lib/assistant-image-markdown.ts
@@ -3,7 +3,6 @@ import {
   decodeMarkdownTarget,
   findMarkdownTargets,
   isExternalMarkdownTarget,
-  normalizeProtectedMarkdownContent,
   parseAssistantDataImageTarget
 } from "@/lib/assistant-markdown-parsing";
 
@@ -96,5 +95,5 @@ export function stripAttachmentStyleImageMarkdown(
     return content;
   }
 
-  return normalizeProtectedMarkdownContent(sanitized.content);
+  return sanitized.content;
 }

--- a/lib/text-utils.ts
+++ b/lib/text-utils.ts
@@ -9,13 +9,6 @@ export function normalizeLineBreaks(text: string) {
     .replace(/\\r/g, "\n");
 }
 
-export function normalizeMarkdownLineBreaks(text: string) {
-  return normalizeLineBreaks(text).replace(/\n{3,}/g, (match) => {
-    const extras = match.length - 2;
-    return "\n\n" + "\u00A0\n\n".repeat(extras);
-  });
-}
-
 export function formatTimestamp(value: string) {
   return new Intl.DateTimeFormat("en", {
     month: "short",

--- a/tests/unit/assistant-image-markdown.test.ts
+++ b/tests/unit/assistant-image-markdown.test.ts
@@ -51,6 +51,8 @@ describe("stripAttachmentStyleImageMarkdown", () => {
       [
         "I've generated an image for you.",
         "",
+        "",
+        "",
         "The real attachment preview should render below."
       ].join("\n")
     );
@@ -74,6 +76,8 @@ describe("stripAttachmentStyleImageMarkdown", () => {
     expect(stripAttachmentStyleImageMarkdown(content, [createImageAttachment()])).toBe(
       [
         "I've generated an image for you.",
+        "",
+        "",
         "",
         "The real attachment preview should render below."
       ].join("\n")
@@ -102,6 +106,8 @@ describe("stripAttachmentStyleImageMarkdown", () => {
       [
         "I've generated an image for you.",
         "",
+        "",
+        "",
         "The real attachment preview should render below."
       ].join("\n")
     );
@@ -120,7 +126,9 @@ describe("stripAttachmentStyleImageMarkdown", () => {
       [
         "```md",
         "![Generated Image](data:image/png;base64,Zm9v)",
-        "```"
+        "```",
+        "",
+        ""
       ].join("\n")
     );
   });
@@ -153,7 +161,9 @@ describe("stripAttachmentStyleImageMarkdown", () => {
         "",
         "  ```md",
         "  ![Generated Image](data:image/png;base64,Zm9v)",
-        "  ```"
+        "  ```",
+        "",
+        ""
       ].join("\n")
     );
   });
@@ -168,7 +178,7 @@ describe("stripAttachmentStyleImageMarkdown", () => {
     ].join("\n");
 
     expect(stripAttachmentStyleImageMarkdown(content, [createTextAttachment()])).toBe(
-      ["> ```md", "> ![Generated Image](data:image/png;base64,Zm9v)", "> still code"].join("\n")
+      ["> ```md", "> ![Generated Image](data:image/png;base64,Zm9v)", "> still code", "", ""].join("\n")
     );
   });
 
@@ -189,7 +199,9 @@ describe("stripAttachmentStyleImageMarkdown", () => {
         "![Generated Image](data:image/png;base64,Zm9v)",
         "```notclose",
         "still code",
-        "```"
+        "```",
+        "",
+        ""
       ].join("\n")
     );
   });
@@ -207,7 +219,9 @@ describe("stripAttachmentStyleImageMarkdown", () => {
       [
         "~~~md",
         "![Generated Image](data:image/png;base64,Zm9v)",
-        "~~~"
+        "~~~",
+        "",
+        ""
       ].join("\n")
     );
   });
@@ -223,7 +237,9 @@ describe("stripAttachmentStyleImageMarkdown", () => {
     expect(stripAttachmentStyleImageMarkdown(content, [createTextAttachment()])).toBe(
       [
         "    ![Generated Image](data:image/png;base64,Zm9v)",
-        "    still code"
+        "    still code",
+        "",
+        ""
       ].join("\n")
     );
   });
@@ -231,7 +247,7 @@ describe("stripAttachmentStyleImageMarkdown", () => {
   it("does not treat list continuation lines as indented code blocks", () => {
     const content = ["- item", "    [Report](notes.txt)"].join("\n");
 
-    expect(stripAttachmentStyleImageMarkdown(content, [createTextAttachment()])).toBe("- item");
+    expect(stripAttachmentStyleImageMarkdown(content, [createTextAttachment()])).toBe("- item\n    ");
   });
 
   it("removes local markdown file links when the assistant message already has text attachments", () => {
@@ -246,6 +262,8 @@ describe("stripAttachmentStyleImageMarkdown", () => {
     expect(stripAttachmentStyleImageMarkdown(content, [createTextAttachment()])).toBe(
       [
         "Here is the report you asked for.",
+        "",
+        "",
         "",
         "The external reference should remain: [Spec](https://example.com/spec.pdf)"
       ].join("\n")
@@ -269,19 +287,19 @@ describe("stripAttachmentStyleImageMarkdown", () => {
           relativePath: "conv_test/notes with space.txt"
         })
       ])
-    ).toBe("Here are the reports you asked for.");
+    ).toBe("Here are the reports you asked for.\n\n\n");
   });
 
   it("removes reference-style local markdown links when the assistant message already has matching text attachments", () => {
     const content = ["Here is the report:", "", "[Report][report]", "", "[report]: notes.txt"].join("\n");
 
-    expect(stripAttachmentStyleImageMarkdown(content, [createTextAttachment()])).toBe("Here is the report:");
+    expect(stripAttachmentStyleImageMarkdown(content, [createTextAttachment()])).toBe("Here is the report:\n\n\n\n");
   });
 
   it("removes local absolute markdown links when the assistant message already has matching text attachments", () => {
     const content = ["Here is the report:", "", "[Report](/tmp/notes.txt)"].join("\n");
 
-    expect(stripAttachmentStyleImageMarkdown(content, [createTextAttachment()])).toBe("Here is the report:");
+    expect(stripAttachmentStyleImageMarkdown(content, [createTextAttachment()])).toBe("Here is the report:\n\n");
   });
 
   it("keeps shared reference definitions when only the image reference is stripped", () => {
@@ -299,7 +317,7 @@ describe("stripAttachmentStyleImageMarkdown", () => {
         content,
         [createImageAttachment({ filename: "generated.png", relativePath: "conv_test/generated.png" })]
       )
-    ).toBe(["Keep the text reference:", "", "[Report][shared]", "", "[shared]: generated.png"].join("\n"));
+    ).toBe(["Keep the text reference:", "", "[Report][shared]", "", "", "[shared]: generated.png"].join("\n"));
   });
 
   it("strips parsed markdown targets with parentheses, angle brackets, and escaped closers when attachments match", () => {
@@ -317,7 +335,7 @@ describe("stripAttachmentStyleImageMarkdown", () => {
         createTextAttachment({ filename: "notes with space.txt" }),
         createTextAttachment({ filename: "file)name.txt" })
       ])
-    ).toBe("Matched links:");
+    ).toBe("Matched links:\n\n\n\n");
   });
 
   it("does not over-strip unrelated link suffixes", () => {

--- a/tests/unit/transport-utils.test.ts
+++ b/tests/unit/transport-utils.test.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 
 import { badRequest, ok } from "@/lib/http";
 import { encodeSseEvent, encodeSseFlushMarker, encodeSsePrelude } from "@/lib/sse";
-import { formatTimestamp, normalizeLineBreaks, normalizeMarkdownLineBreaks } from "@/lib/text-utils";
+import { formatTimestamp, normalizeLineBreaks } from "@/lib/text-utils";
 import { cn } from "@/lib/utils";
 
 describe("transport helpers", () => {
@@ -30,6 +30,5 @@ describe("transport helpers", () => {
     expect(formatTimestamp("2026-03-26T15:20:00.000Z")).toMatch(/Mar/);
     expect(normalizeLineBreaks("One\\nTwo")).toBe("One\nTwo");
     expect(normalizeLineBreaks("One\\\\nTwo")).toBe("One\nTwo");
-    expect(normalizeMarkdownLineBreaks("One\\\\n\\\\n\\\\nTwo")).toBe("One\n\n\u00A0\n\nTwo");
   });
 });


### PR DESCRIPTION
## Summary

- **Stop normalizing line breaks in displayed assistant content** — the raw markdown content is now passed through as-is, preserving original line break formatting.
- **Use normalized content only for comparison logic** — a separate `contentForComparison` variable (normalized) is used only for consumed-text slicing in the timeline, so display and comparison concerns are separated.
- **Remove `normalizeProtectedMarkdownContent` usage** in `stripAttachmentStyleImageMarkdown` — the function now returns sanitized content directly without re-normalizing line breaks.
- **Update unit tests** to reflect the new behaviour where trailing newlines are preserved in the output.