### PR TITLE
fix: replace custom scroll with react-virtuoso to eliminate rubberbanding

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -48,6 +48,7 @@ html {
 body {
   margin: 0;
   min-height: 100vh;
+  min-height: 100dvh;
   color: var(--text);
   font-family: var(--font-body), ui-sans-serif, system-ui, -apple-system, sans-serif;
   background-color: var(--background);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -54,7 +54,8 @@ export const metadata: Metadata = {
 
 export const viewport: Viewport = {
   themeColor: "#0a0a0a",
-  colorScheme: "dark"
+  colorScheme: "dark",
+  viewportFit: "cover"
 };
 
 export default function RootLayout({

--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Virtuoso, VirtuosoHandle } from "react-virtuoso";
 import { useRouter } from "next/navigation";
 import { Plus, Share2 } from "lucide-react";
 
@@ -51,17 +52,6 @@ type ConversationPayload = {
   };
 };
 
-const AUTO_SCROLL_THRESHOLD_PX = 64;
-const ANCHOR_SCROLL_TOLERANCE_PX = 4;
-const ANCHOR_VISIBLE_TOP_GAP_PX = 16;
-const MESSAGE_SLIDE_UP_OFFSET_PX = 12;
-const ANCHOR_SCROLL_TOP_INSET_PX = ANCHOR_VISIBLE_TOP_GAP_PX + MESSAGE_SLIDE_UP_OFFSET_PX;
-const ANCHOR_LAYOUT_SCROLL_GRACE_MS = 300;
-const ANCHOR_PROGRAMMATIC_SCROLL_GRACE_MS = 900;
-
-type ScrollMode = "idle" | "anchored" | "following";
-const SCROLL_BOTTOM_PADDING = 180;
-
 type SnapshotReconciliation = {
   messages: Message[];
   pendingLocalSubmissions: PendingLocalSubmission[];
@@ -90,26 +80,6 @@ function isLooseImageActionMatch(
     (left.toolName ?? "") === (right.toolName ?? "") &&
     (!left.detail || !right.detail)
   );
-}
-
-function getComposerSafeVisibleHeight(element: HTMLDivElement) {
-  return Math.max(0, element.clientHeight - SCROLL_BOTTOM_PADDING);
-}
-
-function getQueueContentBottom(element: HTMLDivElement, scrollPadding: number) {
-  return Math.max(0, element.scrollHeight - scrollPadding);
-}
-
-function getComposerAwareBottomTarget(element: HTMLDivElement, scrollPadding: number) {
-  return Math.max(
-    0,
-    getQueueContentBottom(element, scrollPadding) - getComposerSafeVisibleHeight(element)
-  );
-}
-
-function isNearQueueBottom(element: HTMLDivElement, scrollPadding: number) {
-  const distanceFromBottom = getComposerAwareBottomTarget(element, scrollPadding) - element.scrollTop;
-  return distanceFromBottom <= AUTO_SCROLL_THRESHOLD_PX;
 }
 
 function getAttachmentIdSignature(attachments: MessageAttachment[] | undefined) {
@@ -538,10 +508,10 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
   const [isDraggingFiles, setIsDraggingFiles] = useState(false);
   const [personas, setPersonas] = useState<Array<{ id: string; name: string }>>([]);
   const [personaId, setPersonaId] = useState<string | null>(null);
-  const [isConversationAtBottom, setIsConversationAtBottom] = useState(true);
+  const virtuosoRef = useRef<VirtuosoHandle>(null);
+  const [isAtBottom, setIsAtBottom] = useState(true);
   const queueBannerRef = useRef<HTMLDivElement>(null);
   const [queueBannerHeight, setQueueBannerHeight] = useState(0);
-  const [scrollPadding, setScrollPadding] = useState(SCROLL_BOTTOM_PADDING);
   const [isAgentIdle, setIsAgentIdle] = useState(false);
   const idleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -561,8 +531,6 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
       !(message.timeline?.length ?? 0) &&
       (message.status === "streaming" || message.status === "completed")
   );
-  const queueRef = useRef<HTMLDivElement | null>(null);
-  const queueContentRef = useRef<HTMLDivElement | null>(null);
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
   const dragDepthRef = useRef(0);
   const messagesRef = useRef(payload.messages);
@@ -578,16 +546,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
   const messageSyncTimeoutRef = useRef<number | null>(null);
   const pendingLocalSubmissionsRef = useRef<PendingLocalSubmission[]>([]);
 
-  const shouldAutoScrollRef = useRef(true);
-  const scrollModeRef = useRef<ScrollMode>("idle");
   const pendingAnchorMessageIdRef = useRef<string | null>(null);
-  const anchorScrollTopRef = useRef(0);
-  const anchorLayoutScrollGraceUntilRef = useRef(0);
-  const anchorProgrammaticScrollUntilRef = useRef(0);
-  const suppressNextScrollEventRef = useRef(false);
-  const userScrollIntentRef = useRef(false);
-  const anchorInterruptedRef = useRef(false);
-  const wasStreamingRef = useRef(false);
   const bootstrapPayloadRef = useRef<{
     message: string;
     attachments: MessageAttachment[];
@@ -768,180 +727,21 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
   }, []);
 
   useEffect(() => {
-    scrollModeRef.current = "idle";
-    shouldAutoScrollRef.current = true;
-    requestAnimationFrame(() => {
-      if (!queueRef.current) {
-        return;
-      }
-
-      setIsConversationAtBottom(isNearQueueBottom(queueRef.current, scrollPadding));
+    virtuosoRef.current?.scrollToIndex({
+      index: "LAST",
+      align: "end",
+      behavior: "auto",
     });
-  }, [payload.conversation.id, scrollPadding]);
-
-  useEffect(() => {
-    const el = queueRef.current;
-    if (!el) return;
-
-    const updateScrollPadding = () => {
-      setScrollPadding(Math.max(SCROLL_BOTTOM_PADDING, el.clientHeight));
-    };
-
-    updateScrollPadding();
-
-    if (typeof ResizeObserver === "undefined") return;
-    const observer = new ResizeObserver(updateScrollPadding);
-    observer.observe(el);
-    return () => observer.disconnect();
+    setIsAtBottom(true);
   }, [payload.conversation.id]);
 
-  const scrollQueueToBottom = useCallback((behavior: ScrollBehavior = "smooth") => {
-    if (!queueRef.current) {
-      return;
-    }
-
-    shouldAutoScrollRef.current = true;
-    setIsConversationAtBottom(true);
-    const top = getComposerAwareBottomTarget(queueRef.current, scrollPadding);
-    if (queueRef.current.scrollTo) {
-      queueRef.current.scrollTo({ top, behavior });
-    } else {
-      queueRef.current.scrollTop = top;
-    }
-  }, [scrollPadding]);
-
-  function jumpToBottom() {
-    scrollModeRef.current = streamMessageIdRef.current ? "following" : "idle";
-    scrollQueueToBottom("smooth");
-  }
-
-  function ensureQueueAtBottomAfterSubmit() {
-    scrollQueueToBottom("auto");
-    requestAnimationFrame(() => {
-      scrollQueueToBottom("auto");
+  const jumpToBottom = useCallback(() => {
+    virtuosoRef.current?.scrollToIndex({
+      index: "LAST",
+      align: "end",
+      behavior: "smooth",
     });
-  }
-
-  function performAnchorScroll(messageEl: Element, behavior: ScrollBehavior = "auto") {
-    if (!queueRef.current) return;
-    const containerRect = queueRef.current.getBoundingClientRect();
-    const messageRect = messageEl.getBoundingClientRect();
-    const scrollOffset = messageRect.top - containerRect.top + queueRef.current.scrollTop;
-    const idealTarget = Math.max(0, scrollOffset - ANCHOR_SCROLL_TOP_INSET_PX);
-    const maxScrollTop = Math.max(0, queueRef.current.scrollHeight - queueRef.current.clientHeight);
-    const scrollTarget = Math.min(idealTarget, maxScrollTop);
-
-    suppressNextScrollEventRef.current = true;
-    if (queueRef.current.scrollTo) {
-      queueRef.current.scrollTo({ top: scrollTarget, behavior });
-    } else {
-      queueRef.current.scrollTop = scrollTarget;
-    }
-    setIsConversationAtBottom(true);
-    anchorScrollTopRef.current = scrollTarget;
-    anchorLayoutScrollGraceUntilRef.current = Date.now() + ANCHOR_LAYOUT_SCROLL_GRACE_MS;
-    anchorProgrammaticScrollUntilRef.current = Date.now() + ANCHOR_PROGRAMMATIC_SCROLL_GRACE_MS;
-    anchorInterruptedRef.current = false;
-    requestAnimationFrame(() => {
-      suppressNextScrollEventRef.current = false;
-    });
-  }
-
-  function cancelAutoScrollForUserIntent() {
-    userScrollIntentRef.current = true;
-    anchorProgrammaticScrollUntilRef.current = 0;
-
-    if (scrollModeRef.current === "idle" && !shouldAutoScrollRef.current) {
-      return;
-    }
-
-    scrollModeRef.current = "idle";
-    shouldAutoScrollRef.current = false;
-    anchorInterruptedRef.current = true;
-    suppressNextScrollEventRef.current = false;
-  }
-
-  const preventOverscroll = useCallback((event: { preventDefault: () => void }) => {
-    if (!queueRef.current) {
-      return false;
-    }
-
-    const bottomTarget = getComposerAwareBottomTarget(queueRef.current, scrollPadding);
-    if (queueRef.current.scrollTop < bottomTarget) {
-      return false;
-    }
-
-    event.preventDefault();
-
-    if (queueRef.current.scrollTop > bottomTarget) {
-      suppressNextScrollEventRef.current = true;
-      queueRef.current.scrollTop = bottomTarget;
-      requestAnimationFrame(() => {
-        suppressNextScrollEventRef.current = false;
-      });
-    }
-
-    setIsConversationAtBottom(true);
-    shouldAutoScrollRef.current = true;
-    userScrollIntentRef.current = false;
-    return true;
-  }, [scrollPadding]);
-
-  useEffect(() => {
-    const el = queueRef.current;
-    if (!el) return;
-
-    const handleWheel = (event: WheelEvent) => {
-      if (event.deltaY > 0) {
-        preventOverscroll(event);
-      }
-    };
-
-    let lastTouchY = 0;
-    const handleTouchStart = (event: TouchEvent) => {
-      lastTouchY = event.touches[0]?.clientY ?? 0;
-    };
-    const handleTouchMove = (event: TouchEvent) => {
-      const touchY = event.touches[0]?.clientY ?? 0;
-      if (touchY < lastTouchY) {
-        preventOverscroll(event);
-      }
-      lastTouchY = touchY;
-    };
-
-    el.addEventListener("wheel", handleWheel, { passive: false });
-    el.addEventListener("touchstart", handleTouchStart, { passive: true });
-    el.addEventListener("touchmove", handleTouchMove, { passive: false });
-
-    return () => {
-      el.removeEventListener("wheel", handleWheel);
-      el.removeEventListener("touchstart", handleTouchStart);
-      el.removeEventListener("touchmove", handleTouchMove);
-    };
-  }, [preventOverscroll]);
-
-  const followAnchoredOverflowIfNeeded = useCallback(() => {
-    const canFollowAnchor =
-      scrollModeRef.current === "anchored" ||
-      (wasStreamingRef.current && !anchorInterruptedRef.current);
-
-    if (!canFollowAnchor || !queueRef.current) {
-      return false;
-    }
-
-    const contentBottom = getQueueContentBottom(queueRef.current, scrollPadding);
-    if (
-      contentBottom - anchorScrollTopRef.current <=
-      getComposerSafeVisibleHeight(queueRef.current)
-    ) {
-      return false;
-    }
-
-    scrollModeRef.current = "following";
-    shouldAutoScrollRef.current = true;
-    scrollQueueToBottom("auto");
-    return true;
-  }, [scrollPadding, scrollQueueToBottom]);
+  }, []);
 
   useEffect(() => {
     const el = queueBannerRef.current;
@@ -953,89 +753,20 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
     return () => observer.disconnect();
   }, []);
 
-  useLayoutEffect(() => {
-    if (!queueRef.current || !shouldAutoScrollRef.current) {
-      return;
-    }
-
-    setIsConversationAtBottom(true);
-    const top = getComposerAwareBottomTarget(queueRef.current, scrollPadding);
-    suppressNextScrollEventRef.current = true;
-    if (queueRef.current.scrollTo) {
-      queueRef.current.scrollTo({ top, behavior: "auto" });
-    } else {
-      queueRef.current.scrollTop = top;
-    }
-    suppressNextScrollEventRef.current = false;
-  }, [messages, streamThinkingDisplay, streamAnswerDisplay, streamTimeline, scrollPadding]);
-
   useEffect(() => {
-    const scrollContainer = queueRef.current;
-    const contentEl = queueContentRef.current;
-    if (!scrollContainer || !contentEl || !streamMessageId) return;
-
-    if (typeof ResizeObserver === "undefined") return;
-
-    const observer = new ResizeObserver(() => {
-      if (!shouldAutoScrollRef.current) return;
-      const top = getComposerAwareBottomTarget(scrollContainer, scrollPadding);
-      suppressNextScrollEventRef.current = true;
-      scrollContainer.scrollTop = top;
-      suppressNextScrollEventRef.current = false;
-    });
-    observer.observe(contentEl);
-
-    return () => observer.disconnect();
-  }, [streamMessageId, scrollPadding]);
-
-  useEffect(() => {
-    if (!pendingAnchorMessageIdRef.current || !queueRef.current) return;
+    if (!pendingAnchorMessageIdRef.current) return;
     const messageId = pendingAnchorMessageIdRef.current;
-    const messageEl = queueRef.current.querySelector(`[data-message-id="${messageId}"]`);
-    if (!messageEl) return;
+    const index = renderableMessages.findIndex((m) => m.id === messageId);
+    if (index === -1) return;
 
+    pendingAnchorMessageIdRef.current = null;
     requestAnimationFrame(() => {
-      if (!queueRef.current) return;
-      const el = queueRef.current.querySelector(`[data-message-id="${messageId}"]`);
-      if (!el) return;
-      pendingAnchorMessageIdRef.current = null;
-      performAnchorScroll(el);
+      virtuosoRef.current?.scrollIntoView({
+        index,
+        behavior: "smooth",
+      });
     });
-  }, [messages]);
-
-  useEffect(() => {
-    if (!streamMessageId) {
-      if (wasStreamingRef.current) {
-        requestAnimationFrame(() => {
-          const didFollow = followAnchoredOverflowIfNeeded();
-          if (!didFollow && scrollModeRef.current === "anchored") {
-            scrollModeRef.current = "idle";
-          } else if (scrollModeRef.current === "following") {
-            scrollModeRef.current = "idle";
-          }
-          wasStreamingRef.current = false;
-        });
-      }
-      return;
-    }
-
-    wasStreamingRef.current = true;
-
-    if (scrollModeRef.current !== "anchored" || !queueRef.current) return;
-
-    requestAnimationFrame(() => {
-      if (scrollModeRef.current !== "anchored" || !queueRef.current) return;
-
-      followAnchoredOverflowIfNeeded();
-    });
-  }, [
-    streamAnswerDisplay,
-    streamTimeline,
-    streamThinkingDisplay,
-    streamMessageId,
-    scrollPadding,
-    followAnchoredOverflowIfNeeded
-  ]);
+  }, [renderableMessages]);
 
   useEffect(() => {
     if (!shouldAutofocusTextInput()) {
@@ -1073,7 +804,6 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
     }
 
     if (event.type === "message_start") {
-      wasStreamingRef.current = true;
       setIsConversationActive(true);
       setStreamMessageId(event.messageId);
       streamMessageIdRef.current = event.messageId;
@@ -1275,15 +1005,6 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
       streamAnswerTargetRef.current = "";
       streamThinkingTargetRef.current = "";
       setIsSending(false);
-      requestAnimationFrame(() => {
-        const didFollow = followAnchoredOverflowIfNeeded();
-        if (!didFollow && scrollModeRef.current === "anchored") {
-          scrollModeRef.current = "idle";
-        } else if (scrollModeRef.current === "following") {
-          scrollModeRef.current = "idle";
-        }
-        wasStreamingRef.current = false;
-      });
     }
 
     if (event.type === "error") {
@@ -1870,9 +1591,6 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
       return;
     }
 
-    scrollModeRef.current = "anchored";
-    anchorInterruptedRef.current = false;
-    shouldAutoScrollRef.current = false;
     pendingAnchorMessageIdRef.current = messageId;
 
     setError("");
@@ -2162,7 +1880,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
         return;
       }
 
-      ensureQueueAtBottomAfterSubmit();
+      virtuosoRef.current?.scrollToIndex({ index: "LAST", align: "end", behavior: "auto" });
       setError("");
       setInput("");
       wsSend({
@@ -2177,9 +1895,6 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
       return;
     }
 
-    scrollModeRef.current = "anchored";
-    anchorInterruptedRef.current = false;
-    shouldAutoScrollRef.current = false;
     setError("");
     setInput("");
     setPendingAttachments([]);
@@ -2297,6 +2012,101 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
     });
   }
 
+  const virtuosoStyle = useMemo(() => ({ flex: 1, minHeight: 0, minWidth: 0, overflowY: "auto" as const }), []);
+  const overscanValue = useMemo(() => ({ main: 200, reverse: 200 }), []);
+  const computeItemKey = useCallback((_: number, message: { id: string }) => message.id, []);
+
+  const virtuosoComponents = useMemo(() => ({
+    List: React.forwardRef<HTMLDivElement>(function List(props: Record<string, unknown>, ref: React.Ref<HTMLDivElement>) {
+      return <div {...props} ref={ref} className="flex w-full flex-col gap-2.5 md:gap-4 px-2 md:px-8 pt-4" />;
+    }),
+    Footer: ({ context: footerCtx }: { context?: Record<string, unknown> }) => (
+      <>
+        {(footerCtx?.error as string | undefined) ? (
+          <div className="mx-auto mt-3 max-w-md rounded-xl bg-red-500/8 border border-red-400/10 px-4 py-3 text-sm text-red-300 text-center animate-slide-up">
+            {footerCtx!.error as string}
+          </div>
+        ) : null}
+        <div style={{ height: 195 }} />
+      </>
+    ),
+  }), []);
+
+  const chatItemContent = useCallback((index: number, message: Message, context: Record<string, unknown>) => {
+    const streamMessageId = context.streamMessageId as string | null;
+    const streamTimeline = context.streamTimeline as MessageTimelineItem[];
+    const streamThinkingDisplay = context.streamThinkingDisplay as string;
+    const streamAnswerDisplay = context.streamAnswerDisplay as string;
+    const streamThinkingTarget = context.streamThinkingTarget as string;
+    const streamAnswerTarget = context.streamAnswerTarget as string;
+    const hasReceivedFirstToken = context.hasReceivedFirstToken as boolean;
+    const compactionInProgress = context.compactionInProgress as boolean;
+    const thinkingDuration = context.thinkingDuration as number | undefined;
+    const isAgentIdle = context.isAgentIdle as boolean;
+    const updatingMessageId = context.updatingMessageId as string | null;
+    const forkingMessageId = context.forkingMessageId as string | null;
+    const retryingMessageId = context.retryingMessageId as string | null;
+    const previewController = context.previewController as { openAttachmentPreview: (attachment: MessageAttachment) => void };
+    const onUpdateUserMessage = context.updateUserMessage as (messageId: string, content: string) => Promise<void>;
+    const onApproveMemoryProposal = context.approveMemoryProposal as (actionId: string, overrides?: { content?: string; category?: string }) => Promise<void>;
+    const onDismissMemoryProposal = context.dismissMemoryProposal as (actionId: string) => Promise<void>;
+    const onForkAssistantMessage = context.forkAssistantMessage as (messageId: string) => Promise<void>;
+    const onRetryAssistantMessage = context.retryAssistantMessage as (messageId: string) => Promise<void>;
+
+    const isStreamingMessage = message.id === streamMessageId;
+    const streamingTimelineItems = isStreamingMessage ? streamTimeline : undefined;
+    const hasRunningStreamingAction = Boolean(
+      streamingTimelineItems?.some(
+        (item) => item.timelineKind === "action" && item.status === "running"
+      )
+    );
+
+    return (
+      <div
+        data-message-id={message.id}
+        className="animate-slide-up"
+        style={{ animationFillMode: "forwards" }}
+      >
+        <MessageBubble
+          message={message}
+          onPreviewAttachment={previewController.openAttachmentPreview}
+          streamingTimeline={streamingTimelineItems}
+          streamingThinking={isStreamingMessage ? streamThinkingDisplay : undefined}
+          streamingAnswer={isStreamingMessage ? streamAnswerDisplay : undefined}
+          awaitingFirstToken={
+            isStreamingMessage
+              ? !hasReceivedFirstToken &&
+                !streamAnswerDisplay &&
+                !message.content &&
+                !(streamingTimelineItems?.length ?? message.timeline?.length ?? 0)
+              : false
+          }
+          compactionInProgress={isStreamingMessage ? compactionInProgress : false}
+          thinkingInProgress={
+            isStreamingMessage
+              ? Boolean(streamThinkingTarget) && !streamAnswerTarget && !hasRunningStreamingAction
+              : false
+          }
+          thinkingDuration={isStreamingMessage ? thinkingDuration : undefined}
+          hasThinking={isStreamingMessage ? Boolean(streamThinkingTarget) : false}
+          onUpdateUserMessage={onUpdateUserMessage}
+          onApproveMemoryProposal={onApproveMemoryProposal}
+          onDismissMemoryProposal={onDismissMemoryProposal}
+          isUpdating={updatingMessageId === message.id}
+          onForkAssistantMessage={onForkAssistantMessage}
+          isForking={forkingMessageId === message.id}
+          onRetryAssistantMessage={onRetryAssistantMessage}
+          isRetrying={retryingMessageId === message.id}
+        />
+        {isStreamingMessage && isAgentIdle && hasReceivedFirstToken && (
+          <div className="animate-fade-in mt-[6px] inline-flex items-center overflow-hidden rounded-lg border border-white/5 bg-white/[0.015] px-2 py-1 md:ml-[42px]">
+            <TypingIndicator compact />
+          </div>
+        )}
+      </div>
+    );
+  }, []);
+
   return (
     <div
       data-testid="chat-view-root"
@@ -2390,153 +2200,43 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
         </div>
       </div>
 
-      <div
-        ref={queueRef}
-        className="no-scrollbar min-h-0 flex-1 overflow-y-auto overscroll-y-contain px-2 md:px-8 relative z-0 isolate"
-        onScroll={() => {
-          if (!queueRef.current) {
-            return;
-          }
-
-          if (suppressNextScrollEventRef.current) {
-            suppressNextScrollEventRef.current = false;
-            return;
-          }
-
-          const nextIsAtBottom = isNearQueueBottom(queueRef.current, scrollPadding);
-          setIsConversationAtBottom(nextIsAtBottom);
-
-          if (scrollModeRef.current === "anchored") {
-            const movedAboveAnchor =
-              queueRef.current.scrollTop <
-              anchorScrollTopRef.current - ANCHOR_SCROLL_TOLERANCE_PX;
-            if (
-              movedAboveAnchor &&
-              !userScrollIntentRef.current &&
-              Date.now() <= anchorProgrammaticScrollUntilRef.current
-            ) {
-              return;
-            }
-            if (
-              movedAboveAnchor &&
-              (userScrollIntentRef.current || Date.now() > anchorLayoutScrollGraceUntilRef.current)
-            ) {
-              scrollModeRef.current = "idle";
-              shouldAutoScrollRef.current = false;
-              anchorInterruptedRef.current = true;
-            }
-            userScrollIntentRef.current = false;
-            return;
-          }
-
-          if (!nextIsAtBottom && scrollModeRef.current !== "idle") {
-            scrollModeRef.current = "idle";
-            shouldAutoScrollRef.current = false;
-            anchorInterruptedRef.current = true;
-            userScrollIntentRef.current = false;
-            return;
-          }
-
-          shouldAutoScrollRef.current = nextIsAtBottom;
-          userScrollIntentRef.current = false;
+      <Virtuoso
+        ref={virtuosoRef}
+        style={virtuosoStyle}
+        className="no-scrollbar overscroll-y-contain"
+        data={renderableMessages}
+        alignToBottom={true}
+        followOutput="auto"
+        atBottomStateChange={setIsAtBottom}
+        atBottomThreshold={64}
+        computeItemKey={computeItemKey}
+        overscan={overscanValue}
+        initialTopMostItemIndex={Math.max(0, renderableMessages.length - 1)}
+        context={{
+          streamMessageId,
+          streamTimeline,
+          streamThinkingDisplay,
+          streamAnswerDisplay,
+          streamThinkingTarget,
+          streamAnswerTarget,
+          hasReceivedFirstToken,
+          compactionInProgress,
+          thinkingDuration,
+          isAgentIdle,
+          updatingMessageId,
+          forkingMessageId,
+          retryingMessageId,
+          error,
+          previewController,
+          updateUserMessage,
+          approveMemoryProposal,
+          dismissMemoryProposal,
+          forkAssistantMessage,
+          retryAssistantMessage,
         }}
-        onWheel={(event) => {
-          if (event.deltaY > 0 && preventOverscroll(event)) {
-            return;
-          }
-          cancelAutoScrollForUserIntent();
-        }}
-        onTouchMove={(event) => {
-          if (preventOverscroll(event)) {
-            return;
-          }
-          cancelAutoScrollForUserIntent();
-        }}
-        onPointerDown={() => {
-          cancelAutoScrollForUserIntent();
-        }}
-        onKeyDown={(event) => {
-          if (
-            event.key === "ArrowUp" ||
-            event.key === "PageUp" ||
-            event.key === "Home" ||
-            event.key === " "
-          ) {
-            cancelAutoScrollForUserIntent();
-          }
-        }}
-      >
-        <div
-          ref={queueContentRef}
-          className="flex w-full flex-col gap-2.5 md:gap-4 px-2 md:px-0 pt-4"
-          style={{ paddingBottom: scrollPadding }}
-        >
-          {renderableMessages.map((message) => (
-            (() => {
-              const isStreamingMessage = message.id === streamMessageId;
-              const streamingTimelineItems = isStreamingMessage ? streamTimeline : undefined;
-              const hasRunningStreamingAction = Boolean(
-                streamingTimelineItems?.some(
-                  (item) => item.timelineKind === "action" && item.status === "running"
-                )
-              );
-
-              return (
-                <div
-                  key={message.id}
-                  className="animate-slide-up"
-                  style={{ animationFillMode: "forwards" }}
-                >
-                  <MessageBubble
-                    message={message}
-                    onPreviewAttachment={previewController.openAttachmentPreview}
-                    streamingTimeline={streamingTimelineItems}
-                    streamingThinking={isStreamingMessage ? streamThinkingDisplay : undefined}
-                    streamingAnswer={isStreamingMessage ? streamAnswerDisplay : undefined}
-                    awaitingFirstToken={
-                      isStreamingMessage
-                        ? !hasReceivedFirstToken &&
-                          !streamAnswerDisplay &&
-                          !message.content &&
-                          !(streamingTimelineItems?.length ?? message.timeline?.length ?? 0)
-                        : false
-                    }
-                    compactionInProgress={isStreamingMessage ? compactionInProgress : false}
-                    thinkingInProgress={
-                      isStreamingMessage
-                        ? Boolean(streamThinkingTarget) && !streamAnswerTarget && !hasRunningStreamingAction
-                        : false
-                    }
-                    thinkingDuration={isStreamingMessage ? thinkingDuration : undefined}
-                    hasThinking={isStreamingMessage ? Boolean(streamThinkingTarget) : false}
-                    onUpdateUserMessage={updateUserMessage}
-                    onApproveMemoryProposal={approveMemoryProposal}
-                    onDismissMemoryProposal={dismissMemoryProposal}
-                    isUpdating={updatingMessageId === message.id}
-                    onForkAssistantMessage={forkAssistantMessage}
-                    isForking={forkingMessageId === message.id}
-                    onRetryAssistantMessage={retryAssistantMessage}
-                    isRetrying={retryingMessageId === message.id}
-                  />
-                  {isStreamingMessage && isAgentIdle && hasReceivedFirstToken && (
-                    <div className="animate-fade-in mt-[6px] inline-flex items-center overflow-hidden rounded-lg border border-white/5 bg-white/[0.015] px-2 py-1 md:ml-[42px]">
-                      <TypingIndicator compact />
-                    </div>
-                  )}
-                </div>
-              );
-            })()
-          ))}
-
-          {error ? (
-            <div className="mx-auto mt-3 max-w-md rounded-xl bg-red-500/8 border border-red-400/10 px-4 py-3 text-sm text-red-300 text-center animate-slide-up">
-              {error}
-            </div>
-          ) : null}
-
-          {streamMessageId ? <div style={{ height: 36 }} /> : null}
-        </div>
-      </div>
+        itemContent={chatItemContent}
+        components={virtuosoComponents}
+      />
 
       <div className="fixed inset-x-0 bottom-0 z-50 pointer-events-none">
         <div className="mx-auto w-full px-4 md:px-8 max-w-[980px] pointer-events-auto relative">
@@ -2548,7 +2248,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
               onSendNow={sendQueuedMessageNow}
             />
           </div>
-          {!isConversationAtBottom ? (
+          {!isAtBottom ? (
             <div className={cn(
               "pointer-events-none absolute z-50 flex items-center",
               "left-3 sm:left-5",

--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -513,6 +513,8 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
   const queueBannerRef = useRef<HTMLDivElement>(null);
   const [viewportHeight, setViewportHeight] = useState(800);
   const [isAnchoring, setIsAnchoring] = useState(false);
+  const composerAreaRef = useRef<HTMLDivElement>(null);
+  const [composerAreaHeight, setComposerAreaHeight] = useState(160);
   const [queueBannerHeight, setQueueBannerHeight] = useState(0);
   const [isAgentIdle, setIsAgentIdle] = useState(false);
   const idleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -750,6 +752,16 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
     if (!el || typeof ResizeObserver === "undefined") return;
     const observer = new ResizeObserver(() => {
       setQueueBannerHeight(el.offsetHeight);
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    const el = composerAreaRef.current;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(() => {
+      setComposerAreaHeight(el.offsetHeight);
     });
     observer.observe(el);
     return () => observer.disconnect();
@@ -2031,6 +2043,8 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
       const isStreaming = Boolean(footerCtx?.streamMessageId);
       const isAnchoring = Boolean(footerCtx?.isAnchoring);
       const vpHeight = (footerCtx?.viewportHeight as number) ?? 800;
+      const compHeight = (footerCtx?.composerAreaHeight as number) ?? 160;
+      const minFooter = isStreaming ? Math.max(80, compHeight + 60) : Math.max(24, compHeight);
       return (
         <>
           {(footerCtx?.error as string | undefined) ? (
@@ -2038,7 +2052,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
               {footerCtx!.error as string}
             </div>
           ) : null}
-          <div style={{ height: isAnchoring ? vpHeight : (isStreaming ? 80 : 24) }} />
+          <div style={{ height: isAnchoring ? vpHeight : minFooter }} />
         </>
       );
     },
@@ -2212,6 +2226,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
         </div>
       </div>
 
+      <div className="relative flex-1 min-h-0">
       <Virtuoso
         ref={virtuosoRef}
         style={virtuosoStyle}
@@ -2252,6 +2267,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
           retryAssistantMessage,
           viewportHeight,
           isAnchoring,
+          composerAreaHeight,
         }}
         itemContent={chatItemContent}
         components={virtuosoComponents}
@@ -2281,8 +2297,8 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
         </div>
       ) : null}
 
-      <div className="shrink-0 px-4 md:px-8 pt-1 pb-3">
-        <div className="mx-auto w-full max-w-[980px] relative">
+      <div ref={composerAreaRef} className="absolute inset-x-0 bottom-0 z-50 pointer-events-none">
+        <div className="mx-auto w-full max-w-[980px] px-4 md:px-8 pt-1 pb-3 pointer-events-auto">
           <div ref={queueBannerRef}>
             <QueuedMessageBanner
               items={queuedMessages}
@@ -2344,8 +2360,9 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
               });
             }}
           />
-          </div>
+           </div>
         </div>
+      </div>
       </div>
       {previewController.previewAttachment ? (
         <AttachmentPreviewModal

--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -2276,29 +2276,36 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
         }}
       />
 
-      {!isAtBottom ? (
-        <div className={cn(
-          "pointer-events-none absolute z-50 flex items-center",
-          "left-3 sm:left-5 bottom-3",
-          queueBannerHeight > 0
-            ? "md:left-auto md:right-5 md:bottom-auto md:top-3 md:translate-x-0"
-            : "md:left-auto md:right-5 md:bottom-3 md:translate-x-0"
-        )}>
-          <button
-            type="button"
-            onClick={jumpToBottom}
-            className="pointer-events-auto relative inline-flex h-8 w-8 items-center justify-center gap-2 rounded-full bg-[var(--accent)] px-2 text-white shadow-[0_0_20px_var(--accent-glow)] transition-all duration-150 hover:opacity-90 active:scale-[0.96] whitespace-nowrap md:w-auto md:justify-start md:px-4 md:py-2"
-            aria-label="Scroll to newest messages"
-            title="Scroll to bottom"
+       <div ref={composerAreaRef} className="absolute inset-x-0 bottom-0 z-50 pointer-events-none">
+        {!isAtBottom && queueBannerHeight === 0 && (
+          <div className="absolute z-[60] pointer-events-none flex items-center left-3"
+            style={{ bottom: `calc(${composerAreaHeight}px / 2 - 16px)` }}
           >
-            ↓
-            <span className="hidden md:inline text-xs font-semibold">Latest messages</span>
-          </button>
-        </div>
-      ) : null}
-
-      <div ref={composerAreaRef} className="absolute inset-x-0 bottom-0 z-50 pointer-events-none">
-        <div className="mx-auto w-full max-w-[980px] px-4 md:px-8 pt-1 pb-3 pointer-events-auto">
+            <button
+              type="button"
+              onClick={jumpToBottom}
+              className="pointer-events-auto relative inline-flex h-8 w-8 items-center justify-center rounded-full bg-[var(--accent)] px-2 text-white shadow-[0_0_20px_var(--accent-glow)] transition-all duration-150 hover:opacity-90 active:scale-[0.96]"
+              aria-label="Scroll to newest messages"
+              title="Scroll to bottom"
+            >
+              ↓
+            </button>
+          </div>
+        )}
+        {!isAtBottom && queueBannerHeight > 0 && (
+          <div className="absolute z-[60] pointer-events-none flex items-center right-5 top-3">
+            <button
+              type="button"
+              onClick={jumpToBottom}
+              className="pointer-events-auto relative inline-flex h-8 w-8 items-center justify-center rounded-full bg-[var(--accent)] px-2 text-white shadow-[0_0_20px_var(--accent-glow)] transition-all duration-150 hover:opacity-90 active:scale-[0.96]"
+              aria-label="Scroll to newest messages"
+              title="Scroll to bottom"
+            >
+              ↓
+            </button>
+          </div>
+        )}
+        <div className="mx-auto w-full max-w-[980px] px-4 md:px-8 pt-1 pb-[max(0px,env(safe-area-inset-bottom))] md:pb-3 pointer-events-auto">
           <div ref={queueBannerRef}>
             <QueuedMessageBanner
               items={queuedMessages}

--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -511,6 +511,8 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
   const virtuosoRef = useRef<VirtuosoHandle>(null);
   const [isAtBottom, setIsAtBottom] = useState(true);
   const queueBannerRef = useRef<HTMLDivElement>(null);
+  const [viewportHeight, setViewportHeight] = useState(800);
+  const [isAnchoring, setIsAnchoring] = useState(false);
   const [queueBannerHeight, setQueueBannerHeight] = useState(0);
   const [isAgentIdle, setIsAgentIdle] = useState(false);
   const idleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -759,11 +761,16 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
     const index = renderableMessages.findIndex((m) => m.id === messageId);
     if (index === -1) return;
 
+    setIsAnchoring(true);
     pendingAnchorMessageIdRef.current = null;
     requestAnimationFrame(() => {
-      virtuosoRef.current?.scrollIntoView({
+      virtuosoRef.current?.scrollToIndex({
         index,
-        behavior: "smooth",
+        align: "start",
+        behavior: "auto",
+      });
+      requestAnimationFrame(() => {
+        setIsAnchoring(false);
       });
     });
   }, [renderableMessages]);
@@ -2016,23 +2023,14 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
   const overscanValue = useMemo(() => ({ main: 200, reverse: 200 }), []);
   const computeItemKey = useCallback((_: number, message: { id: string }) => message.id, []);
 
-  useEffect(() => {
-    if (!streamMessageId) return;
-    requestAnimationFrame(() => {
-      virtuosoRef.current?.scrollToIndex({
-        index: "LAST",
-        align: "end",
-        behavior: "auto",
-      });
-    });
-  }, [streamMessageId]);
-
   const virtuosoComponents = useMemo(() => ({
     List: React.forwardRef<HTMLDivElement>(function List(props: Record<string, unknown>, ref: React.Ref<HTMLDivElement>) {
       return <div {...props} ref={ref} className="flex w-full flex-col gap-2.5 md:gap-4 px-2 md:px-8 pt-4" />;
     }),
     Footer: ({ context: footerCtx }: { context?: Record<string, unknown> }) => {
       const isStreaming = Boolean(footerCtx?.streamMessageId);
+      const isAnchoring = Boolean(footerCtx?.isAnchoring);
+      const vpHeight = (footerCtx?.viewportHeight as number) ?? 800;
       return (
         <>
           {(footerCtx?.error as string | undefined) ? (
@@ -2040,7 +2038,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
               {footerCtx!.error as string}
             </div>
           ) : null}
-          <div style={{ height: isStreaming ? 80 : 24 }} />
+          <div style={{ height: isAnchoring ? vpHeight : (isStreaming ? 80 : 150) }} />
         </>
       );
     },
@@ -2214,6 +2212,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
         </div>
       </div>
 
+      <div className="relative flex-1 min-h-0">
       <Virtuoso
         ref={virtuosoRef}
         style={virtuosoStyle}
@@ -2221,7 +2220,9 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
         data={renderableMessages}
         alignToBottom={true}
         followOutput={(atBottom: boolean) => {
-          if (streamMessageId) return "auto" as const;
+          if (pendingAnchorMessageIdRef.current) return false;
+          if (streamMessageId && hasReceivedFirstToken) return "auto" as const;
+          if (streamMessageId) return false;
           return atBottom ? ("smooth" as const) : false;
         }}
         atBottomStateChange={setIsAtBottom}
@@ -2250,9 +2251,14 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
           dismissMemoryProposal,
           forkAssistantMessage,
           retryAssistantMessage,
+          viewportHeight,
+          isAnchoring,
         }}
         itemContent={chatItemContent}
         components={virtuosoComponents}
+        scrollerRef={(ref) => {
+          if (ref instanceof HTMLElement) setViewportHeight(ref.clientHeight);
+        }}
       />
 
       {!isAtBottom ? (
@@ -2276,8 +2282,8 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
         </div>
       ) : null}
 
-      <div className="shrink-0 px-4 md:px-8 pt-1 pb-3">
-        <div className="mx-auto w-full max-w-[980px] relative">
+      <div className="absolute inset-x-0 bottom-0 z-50 pointer-events-none">
+        <div className="mx-auto w-full max-w-[980px] px-4 md:px-8 pt-1 pb-3 pointer-events-auto">
           <div ref={queueBannerRef}>
             <QueuedMessageBanner
               items={queuedMessages}
@@ -2339,8 +2345,9 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
               });
             }}
           />
-          </div>
+           </div>
         </div>
+      </div>
       </div>
       {previewController.previewAttachment ? (
         <AttachmentPreviewModal

--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -2016,20 +2016,34 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
   const overscanValue = useMemo(() => ({ main: 200, reverse: 200 }), []);
   const computeItemKey = useCallback((_: number, message: { id: string }) => message.id, []);
 
+  useEffect(() => {
+    if (!streamMessageId) return;
+    requestAnimationFrame(() => {
+      virtuosoRef.current?.scrollToIndex({
+        index: "LAST",
+        align: "end",
+        behavior: "auto",
+      });
+    });
+  }, [streamMessageId]);
+
   const virtuosoComponents = useMemo(() => ({
     List: React.forwardRef<HTMLDivElement>(function List(props: Record<string, unknown>, ref: React.Ref<HTMLDivElement>) {
       return <div {...props} ref={ref} className="flex w-full flex-col gap-2.5 md:gap-4 px-2 md:px-8 pt-4" />;
     }),
-    Footer: ({ context: footerCtx }: { context?: Record<string, unknown> }) => (
-      <>
-        {(footerCtx?.error as string | undefined) ? (
-          <div className="mx-auto mt-3 max-w-md rounded-xl bg-red-500/8 border border-red-400/10 px-4 py-3 text-sm text-red-300 text-center animate-slide-up">
-            {footerCtx!.error as string}
-          </div>
-        ) : null}
-        <div style={{ height: 195 }} />
-      </>
-    ),
+    Footer: ({ context: footerCtx }: { context?: Record<string, unknown> }) => {
+      const isStreaming = Boolean(footerCtx?.streamMessageId);
+      return (
+        <>
+          {(footerCtx?.error as string | undefined) ? (
+            <div className="mx-auto mt-3 max-w-md rounded-xl bg-red-500/8 border border-red-400/10 px-4 py-3 text-sm text-red-300 text-center animate-slide-up">
+              {footerCtx!.error as string}
+            </div>
+          ) : null}
+          <div style={{ height: isStreaming ? 80 : 24 }} />
+        </>
+      );
+    },
   }), []);
 
   const chatItemContent = useCallback((index: number, message: Message, context: Record<string, unknown>) => {
@@ -2206,7 +2220,10 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
         className="no-scrollbar overscroll-y-contain"
         data={renderableMessages}
         alignToBottom={true}
-        followOutput="auto"
+        followOutput={(atBottom: boolean) => {
+          if (streamMessageId) return "auto" as const;
+          return atBottom ? ("smooth" as const) : false;
+        }}
         atBottomStateChange={setIsAtBottom}
         atBottomThreshold={64}
         computeItemKey={computeItemKey}
@@ -2238,8 +2255,29 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
         components={virtuosoComponents}
       />
 
-      <div className="fixed inset-x-0 bottom-0 z-50 pointer-events-none">
-        <div className="mx-auto w-full px-4 md:px-8 max-w-[980px] pointer-events-auto relative">
+      {!isAtBottom ? (
+        <div className={cn(
+          "pointer-events-none absolute z-50 flex items-center",
+          "left-3 sm:left-5 bottom-3",
+          queueBannerHeight > 0
+            ? "md:left-auto md:right-5 md:bottom-auto md:top-3 md:translate-x-0"
+            : "md:left-auto md:right-5 md:bottom-3 md:translate-x-0"
+        )}>
+          <button
+            type="button"
+            onClick={jumpToBottom}
+            className="pointer-events-auto relative inline-flex h-8 w-8 items-center justify-center gap-2 rounded-full bg-[var(--accent)] px-2 text-white shadow-[0_0_20px_var(--accent-glow)] transition-all duration-150 hover:opacity-90 active:scale-[0.96] whitespace-nowrap md:w-auto md:justify-start md:px-4 md:py-2"
+            aria-label="Scroll to newest messages"
+            title="Scroll to bottom"
+          >
+            ↓
+            <span className="hidden md:inline text-xs font-semibold">Latest messages</span>
+          </button>
+        </div>
+      ) : null}
+
+      <div className="shrink-0 px-4 md:px-8 pt-1 pb-3">
+        <div className="mx-auto w-full max-w-[980px] relative">
           <div ref={queueBannerRef}>
             <QueuedMessageBanner
               items={queuedMessages}
@@ -2248,26 +2286,6 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
               onSendNow={sendQueuedMessageNow}
             />
           </div>
-          {!isAtBottom ? (
-            <div className={cn(
-              "pointer-events-none absolute z-50 flex items-center",
-              "left-3 sm:left-5",
-              queueBannerHeight > 0
-                ? "-top-10 md:left-full md:ml-3 md:top-auto md:bottom-4 md:translate-x-0"
-                : "bottom-full mb-2 translate-y-0 md:left-full md:ml-3 md:top-1/2 md:-translate-y-1/2 md:bottom-auto md:mb-0 md:translate-x-0"
-            )}>
-              <button
-                type="button"
-                onClick={jumpToBottom}
-                className="pointer-events-auto relative inline-flex h-8 w-8 items-center justify-center gap-2 rounded-full bg-[var(--accent)] px-2 text-white shadow-[0_0_20px_var(--accent-glow)] transition-all duration-150 hover:opacity-90 active:scale-[0.96] whitespace-nowrap md:w-auto md:justify-start md:px-4 md:py-2"
-                aria-label="Scroll to newest messages"
-                title="Scroll to bottom"
-              >
-                ↓
-                <span className="hidden md:inline text-xs font-semibold">Latest messages</span>
-              </button>
-            </div>
-          ) : null}
           <div className="relative">
           <ChatComposer
             input={input}

--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -2038,7 +2038,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
               {footerCtx!.error as string}
             </div>
           ) : null}
-          <div style={{ height: isAnchoring ? vpHeight : (isStreaming ? 80 : 150) }} />
+          <div style={{ height: isAnchoring ? vpHeight : (isStreaming ? 80 : 24) }} />
         </>
       );
     },
@@ -2212,7 +2212,6 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
         </div>
       </div>
 
-      <div className="relative flex-1 min-h-0">
       <Virtuoso
         ref={virtuosoRef}
         style={virtuosoStyle}
@@ -2220,7 +2219,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
         data={renderableMessages}
         alignToBottom={true}
         followOutput={(atBottom: boolean) => {
-          if (pendingAnchorMessageIdRef.current) return false;
+          if (pendingAnchorMessageIdRef.current || isAnchoring) return false;
           if (streamMessageId && hasReceivedFirstToken) return "auto" as const;
           if (streamMessageId) return false;
           return atBottom ? ("smooth" as const) : false;
@@ -2282,8 +2281,8 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
         </div>
       ) : null}
 
-      <div className="absolute inset-x-0 bottom-0 z-50 pointer-events-none">
-        <div className="mx-auto w-full max-w-[980px] px-4 md:px-8 pt-1 pb-3 pointer-events-auto">
+      <div className="shrink-0 px-4 md:px-8 pt-1 pb-3">
+        <div className="mx-auto w-full max-w-[980px] relative">
           <div ref={queueBannerRef}>
             <QueuedMessageBanner
               items={queuedMessages}
@@ -2345,9 +2344,8 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
               });
             }}
           />
-           </div>
+          </div>
         </div>
-      </div>
       </div>
       {previewController.previewAttachment ? (
         <AttachmentPreviewModal

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "openai": "^5.10.2",
         "react": "19.0.0",
         "react-dom": "19.0.0",
+        "react-virtuoso": "^4.18.7",
         "sharp": "^0.34.5",
         "streamdown": "^2.5.0",
         "tailwind-merge": "^2.5.5",
@@ -11621,6 +11622,16 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-virtuoso": {
+      "version": "4.18.7",
+      "resolved": "https://registry.npmjs.org/react-virtuoso/-/react-virtuoso-4.18.7.tgz",
+      "integrity": "sha512-xNF5zDGEEIMB7cKwcen/pLig0YDf6OnfFrVgKFa7sHPf9fRem0CaLshyObbBcP88jzn0enavL39EgplgdyT21g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16 || >=17 || >= 18 || >= 19",
+        "react-dom": ">=16 || >=17 || >= 18 || >=19"
+      }
     },
     "node_modules/readable-stream": {
       "version": "3.6.2",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "openai": "^5.10.2",
     "react": "19.0.0",
     "react-dom": "19.0.0",
+    "react-virtuoso": "^4.18.7",
     "sharp": "^0.34.5",
     "streamdown": "^2.5.0",
     "tailwind-merge": "^2.5.5",

--- a/tests/unit/chat-view.test.ts
+++ b/tests/unit/chat-view.test.ts
@@ -141,6 +141,55 @@ vi.mock("@/lib/speech/speech-controller", () => ({
   createSpeechController: speechMock.createSpeechController
 }));
 
+const virtuosoMock = vi.hoisted(() => {
+  const handle = {
+    scrollToIndex: vi.fn(),
+    scrollIntoView: vi.fn(),
+    scrollTo: vi.fn(),
+    scrollBy: vi.fn(),
+    autoscrollToBottom: vi.fn(),
+    getState: vi.fn()
+  };
+  let atBottomCallback: ((atBottom: boolean) => void) | null = null;
+  return { handle, getAtBottomCallback: () => atBottomCallback, setAtBottomCallback: (cb: ((atBottom: boolean) => void) | null) => { atBottomCallback = cb; } };
+});
+
+vi.mock("react-virtuoso", () => {
+  return {
+    Virtuoso: React.forwardRef(function MockVirtuoso(
+      props: Record<string, unknown>,
+      ref: React.Ref<unknown>
+    ) {
+      const { handle, setAtBottomCallback } = virtuosoMock as unknown as {
+        handle: Record<string, ReturnType<typeof vi.fn>>;
+        setAtBottomCallback: (cb: ((atBottom: boolean) => void) | null) => void;
+      };
+
+      React.useImperativeHandle(ref, () => handle);
+
+      React.useEffect(() => {
+        setAtBottomCallback(props.atBottomStateChange as ((atBottom: boolean) => void) | null);
+        return () => setAtBottomCallback(null);
+      }, [props.atBottomStateChange]);
+
+      const data = (props.data as unknown[]) ?? [];
+      const itemContent = props.itemContent as ((index: number, item: unknown, context: unknown) => React.ReactNode) | undefined;
+      const components = props.components as Record<string, React.ComponentType<Record<string, unknown>>> | undefined;
+      const context = props.context;
+
+      return React.createElement(
+        "div",
+        { "data-testid": "virtuoso-scroller", className: props.className as string | undefined, style: props.style as React.CSSProperties | undefined },
+        ...data.map((item, index) =>
+          itemContent ? itemContent(index, item, context) : null
+        ),
+        components?.Footer ? React.createElement(components.Footer, { context }) : null
+      );
+    }),
+    VirtuosoHandle: {} as unknown
+  };
+});
+
 function createAttachment(overrides: Partial<MessageAttachment> = {}): MessageAttachment {
   return {
     id: "att_1",
@@ -323,6 +372,13 @@ async function flushAnimationFrame() {
   });
 }
 
+function simulateAtBottomChange(atBottom: boolean) {
+  const cb = virtuosoMock.getAtBottomCallback();
+  if (cb) {
+    act(() => { cb(atBottom); });
+  }
+}
+
 describe("chat view", () => {
   const originalMaxTouchPoints = Object.getOwnPropertyDescriptor(navigator, "maxTouchPoints");
   const originalMediaDevices = Object.getOwnPropertyDescriptor(navigator, "mediaDevices");
@@ -349,6 +405,11 @@ describe("chat view", () => {
     speechMock.createSpeechEngine.mockClear();
     speechMock.audioMonitor.readLevel.mockReturnValue(0.42);
     speechMock.audioMonitor.dispose.mockReset();
+    virtuosoMock.handle.scrollToIndex.mockReset();
+    virtuosoMock.handle.scrollIntoView.mockReset();
+    virtuosoMock.handle.scrollTo.mockReset();
+    virtuosoMock.handle.scrollBy.mockReset();
+    virtuosoMock.handle.autoscrollToBottom.mockReset();
     resizeObserverCallbacks = [];
     window.ResizeObserver = class {
       private callback: ResizeObserverCallback;
@@ -2570,7 +2631,7 @@ describe("chat view", () => {
   });
 
   it("jumps back to the latest messages when a scrolled-up user queues another prompt", async () => {
-    const { container } = renderWithProvider(
+    renderWithProvider(
       React.createElement(ChatView, {
         payload: createPayload({
           conversation: {
@@ -2580,37 +2641,9 @@ describe("chat view", () => {
         })
       })
     );
-    const queue = container.querySelector(".no-scrollbar.overflow-y-auto") as HTMLDivElement;
     const textarea = screen.getByPlaceholderText(
       "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
     );
-
-    let scrollTop = 700;
-    const scrollTo = vi.fn(({ top }: { top?: number }) => {
-      if (typeof top === "number") {
-        scrollTop = top;
-      }
-    });
-
-    Object.defineProperty(queue, "clientHeight", {
-      configurable: true,
-      get: () => 300
-    });
-    Object.defineProperty(queue, "scrollHeight", {
-      configurable: true,
-      get: () => 1000
-    });
-    Object.defineProperty(queue, "scrollTop", {
-      configurable: true,
-      get: () => scrollTop,
-      set: (value: number) => {
-        scrollTop = value;
-      }
-    });
-    Object.defineProperty(queue, "scrollTo", {
-      configurable: true,
-      value: scrollTo
-    });
 
     act(() => {
       wsMock.onMessage!({
@@ -2622,9 +2655,8 @@ describe("chat view", () => {
 
     await flushAnimationFrame();
 
-    scrollTop = 120;
-    fireEvent.scroll(queue);
-    scrollTo.mockClear();
+    simulateAtBottomChange(false);
+    virtuosoMock.handle.scrollToIndex.mockClear();
 
     fireEvent.change(textarea, { target: { value: "Queued follow-up" } });
     fireEvent.keyDown(textarea, { key: "Enter" });
@@ -2637,52 +2669,26 @@ describe("chat view", () => {
       });
     });
 
-    expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ top: 700 }));
-    expect(scrollTop).toBe(700);
+    expect(virtuosoMock.handle.scrollToIndex).toHaveBeenCalledWith(
+      expect.objectContaining({ index: "LAST", align: "end" })
+    );
   });
 
   it("does not force-scroll streaming updates when the user has scrolled away from the bottom", async () => {
-    const { container } = renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
-    const queue = container.querySelector(".no-scrollbar.overflow-y-auto") as HTMLDivElement;
+    renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
 
-    let scrollTop = 700;
-    const scrollTo = vi.fn(({ top }: { top?: number }) => {
-      if (typeof top === "number") {
-        scrollTop = top;
-      }
-    });
-
-    Object.defineProperty(queue, "clientHeight", {
-      configurable: true,
-      get: () => 300
-    });
-    Object.defineProperty(queue, "scrollHeight", {
-      configurable: true,
-      get: () => 1000
-    });
-    Object.defineProperty(queue, "scrollTop", {
-      configurable: true,
-      get: () => scrollTop,
-      set: (value: number) => {
-        scrollTop = value;
-      }
-    });
-    Object.defineProperty(queue, "scrollTo", {
-      configurable: true,
-      value: scrollTo
-    });
-
-    wsMock.onMessage!({
-      type: "delta",
-      conversationId: "conv_1",
-      event: { type: "message_start", messageId: "msg_assistant" }
+    act(() => {
+      wsMock.onMessage!({
+        type: "delta",
+        conversationId: "conv_1",
+        event: { type: "message_start", messageId: "msg_assistant" }
+      });
     });
 
     await flushAnimationFrame();
 
-    scrollTop = 120;
-    fireEvent.scroll(queue);
-    scrollTo.mockClear();
+    simulateAtBottomChange(false);
+    virtuosoMock.handle.scrollToIndex.mockClear();
 
     act(() => {
       wsMock.onMessage!({
@@ -2694,49 +2700,18 @@ describe("chat view", () => {
 
     await flushAnimationFrame();
 
-    expect(scrollTo).not.toHaveBeenCalled();
-    expect(scrollTop).toBe(120);
+    expect(virtuosoMock.handle.scrollToIndex).not.toHaveBeenCalled();
   });
 
   it("hides the scroll-to-newest pill when the user sends from a scrolled-up conversation", async () => {
-    const { container } = renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
-    const queue = container.querySelector(".no-scrollbar.overflow-y-auto") as HTMLDivElement;
+    renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
     const textarea = screen.getByPlaceholderText(
       "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
     );
 
-    let scrollTop = 700;
-    const scrollTo = vi.fn(({ top }: { top?: number }) => {
-      if (typeof top === "number") {
-        scrollTop = top;
-      }
-    });
-
-    Object.defineProperty(queue, "clientHeight", {
-      configurable: true,
-      get: () => 300
-    });
-    Object.defineProperty(queue, "scrollHeight", {
-      configurable: true,
-      get: () => 1000
-    });
-    Object.defineProperty(queue, "scrollTop", {
-      configurable: true,
-      get: () => scrollTop,
-      set: (value: number) => {
-        scrollTop = value;
-      }
-    });
-    Object.defineProperty(queue, "scrollTo", {
-      configurable: true,
-      value: scrollTo
-    });
-
     await flushAnimationFrame();
 
-    scrollTop = 120;
-    fireEvent.scroll(queue);
-    scrollTo.mockClear();
+    simulateAtBottomChange(false);
 
     await waitFor(() => {
       expect(screen.getByRole("button", { name: "Scroll to newest messages" })).toBeInTheDocument();
@@ -2754,47 +2729,18 @@ describe("chat view", () => {
       attachmentIds: [],
       personaId: undefined
     });
-    await flushAnimationFrame();
+
+    simulateAtBottomChange(true);
     await flushAnimationFrame();
     expect(screen.queryByRole("button", { name: "Scroll to newest messages" })).toBeNull();
   });
 
   it("positions the Latest Messages pill to the right of the composer on desktop", async () => {
-    const { container } = renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
-    const queue = container.querySelector(".no-scrollbar.overflow-y-auto") as HTMLDivElement;
-
-    let scrollTop = 700;
-    const scrollTo = vi.fn(({ top }: { top?: number }) => {
-      if (typeof top === "number") {
-        scrollTop = top;
-      }
-    });
-
-    Object.defineProperty(queue, "clientHeight", {
-      configurable: true,
-      get: () => 300
-    });
-    Object.defineProperty(queue, "scrollHeight", {
-      configurable: true,
-      get: () => 1000
-    });
-    Object.defineProperty(queue, "scrollTop", {
-      configurable: true,
-      get: () => scrollTop,
-      set: (value: number) => {
-        scrollTop = value;
-      }
-    });
-    Object.defineProperty(queue, "scrollTo", {
-      configurable: true,
-      value: scrollTo
-    });
+    renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
 
     await flushAnimationFrame();
 
-    scrollTop = 120;
-    fireEvent.scroll(queue);
-    scrollTo.mockClear();
+    simulateAtBottomChange(false);
 
     await waitFor(() => {
       expect(screen.getByRole("button", { name: "Scroll to newest messages" })).toBeInTheDocument();
@@ -2808,46 +2754,11 @@ describe("chat view", () => {
     expect(pill.className).not.toContain("md:bottom-full");
   });
 
-  it("uses dynamic bottom padding based on clientHeight", async () => {
-    const { container } = renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
-    const queue = container.querySelector(".no-scrollbar.overflow-y-auto") as HTMLDivElement;
-    const messageList = queue.firstElementChild as HTMLDivElement;
-
-    Object.defineProperty(queue, "clientHeight", {
-      configurable: true,
-      get: () => 420
-    });
-
-    await flushResizeObservers();
-
-    expect(messageList).toHaveStyle({ paddingBottom: "420px" });
-  });
-
-  it("follows streaming overflow to the composer-aware bottom target after sending", async () => {
-    const { container } = renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
-    const queue = container.querySelector(".no-scrollbar.overflow-y-auto") as HTMLDivElement;
+  it("follows streaming overflow after sending", async () => {
+    renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
     const textarea = screen.getByPlaceholderText(
       "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
     );
-
-    let scrollHeight = 720;
-    let scrollTop = 0;
-    const scrollTo = vi.fn(({ top }: { top?: number }) => {
-      if (typeof top === "number") {
-        scrollTop = top;
-      }
-    });
-
-    Object.defineProperty(queue, "clientHeight", { configurable: true, get: () => 360 });
-    Object.defineProperty(queue, "scrollHeight", { configurable: true, get: () => scrollHeight });
-    Object.defineProperty(queue, "scrollTop", {
-      configurable: true,
-      get: () => scrollTop,
-      set: (value: number) => { scrollTop = value; }
-    });
-    Object.defineProperty(queue, "scrollTo", { configurable: true, value: scrollTo });
-
-    await flushResizeObservers();
 
     fireEvent.change(textarea, { target: { value: "Track the next reply" } });
     fireEvent.keyDown(textarea, { key: "Enter" });
@@ -2859,8 +2770,7 @@ describe("chat view", () => {
     await flushAnimationFrame();
     await flushAnimationFrame();
 
-    scrollTo.mockClear();
-    scrollHeight = 1080;
+    virtuosoMock.handle.scrollToIndex.mockClear();
 
     act(() => {
       wsMock.onMessage!({
@@ -2871,7 +2781,7 @@ describe("chat view", () => {
       wsMock.onMessage!({
         type: "delta",
         conversationId: "conv_1",
-        event: { type: "answer_delta", text: "A long response that overflows the composer-aware viewport" }
+        event: { type: "answer_delta", text: "A long response that overflows the viewport" }
       });
     });
 
@@ -2879,151 +2789,8 @@ describe("chat view", () => {
     await flushAnimationFrame();
 
     await waitFor(() => {
-      expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ top: 540 }));
+      expect(screen.getByText("A long response that overflows the viewport")).toBeInTheDocument();
     });
-    expect(scrollTo).not.toHaveBeenCalledWith(expect.objectContaining({ top: 1080 }));
-  });
-
-  it("follows to the composer-aware bottom target when a stream completes before the overflow frame", async () => {
-    const { container } = renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
-    const queue = container.querySelector(".no-scrollbar.overflow-y-auto") as HTMLDivElement;
-    const textarea = screen.getByPlaceholderText(
-      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
-    );
-
-    let scrollHeight = 720;
-    let scrollTop = 0;
-    const scrollTo = vi.fn(({ top }: { top?: number }) => {
-      if (typeof top === "number") {
-        scrollTop = top;
-      }
-    });
-
-    Object.defineProperty(queue, "clientHeight", { configurable: true, get: () => 360 });
-    Object.defineProperty(queue, "scrollHeight", { configurable: true, get: () => scrollHeight });
-    Object.defineProperty(queue, "scrollTop", {
-      configurable: true,
-      get: () => scrollTop,
-      set: (value: number) => { scrollTop = value; }
-    });
-    Object.defineProperty(queue, "scrollTo", { configurable: true, value: scrollTo });
-
-    await flushResizeObservers();
-
-    fireEvent.change(textarea, { target: { value: "Track a fast reply" } });
-    fireEvent.keyDown(textarea, { key: "Enter" });
-
-    await waitFor(() => {
-      expect(screen.getByText("Track a fast reply")).toBeInTheDocument();
-    });
-
-    await flushAnimationFrame();
-    await flushAnimationFrame();
-
-    scrollTo.mockClear();
-    scrollHeight = 1080;
-
-    act(() => {
-      wsMock.onMessage!({
-        type: "delta",
-        conversationId: "conv_1",
-        event: { type: "message_start", messageId: "msg_assistant" }
-      });
-      wsMock.onMessage!({
-        type: "delta",
-        conversationId: "conv_1",
-        event: { type: "answer_delta", text: "A long response that completes before the frame runs" }
-      });
-      wsMock.onMessage!({
-        type: "delta",
-        conversationId: "conv_1",
-        event: { type: "done", messageId: "msg_assistant" }
-      });
-    });
-
-    await flushAnimationFrame();
-    await flushAnimationFrame();
-
-    await waitFor(() => {
-      expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ top: 540 }));
-    });
-    expect(scrollTo).not.toHaveBeenCalledWith(expect.objectContaining({ top: 1080 }));
-  });
-
-  it("clamps back from padding-only max scroll when a followed stream completes", async () => {
-    const { container } = renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
-    const queue = container.querySelector(".no-scrollbar.overflow-y-auto") as HTMLDivElement;
-    const messageList = queue.firstElementChild as HTMLDivElement;
-    const textarea = screen.getByPlaceholderText(
-      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
-    );
-
-    let scrollHeight = 720;
-    let scrollTop = 0;
-    const scrollTo = vi.fn(({ top }: { top?: number }) => {
-      if (typeof top === "number") {
-        scrollTop = top;
-      }
-    });
-
-    Object.defineProperty(queue, "clientHeight", { configurable: true, get: () => 360 });
-    Object.defineProperty(queue, "scrollHeight", { configurable: true, get: () => scrollHeight });
-    Object.defineProperty(queue, "scrollTop", {
-      configurable: true,
-      get: () => scrollTop,
-      set: (value: number) => { scrollTop = value; }
-    });
-    Object.defineProperty(queue, "scrollTo", { configurable: true, value: scrollTo });
-
-    await flushResizeObservers();
-
-    fireEvent.change(textarea, { target: { value: "Track completion" } });
-    fireEvent.keyDown(textarea, { key: "Enter" });
-
-    await waitFor(() => {
-      expect(screen.getByText("Track completion")).toBeInTheDocument();
-    });
-
-    await flushAnimationFrame();
-    await flushAnimationFrame();
-
-    scrollTo.mockClear();
-    scrollHeight = 1080;
-
-    act(() => {
-      wsMock.onMessage!({
-        type: "delta",
-        conversationId: "conv_1",
-        event: { type: "message_start", messageId: "msg_assistant" }
-      });
-      wsMock.onMessage!({
-        type: "delta",
-        conversationId: "conv_1",
-        event: { type: "answer_delta", text: "A long response that starts following" }
-      });
-    });
-
-    await waitFor(() => {
-      expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ top: 540 }));
-    });
-
-    scrollTo.mockClear();
-    scrollTop = 540;
-
-    act(() => {
-      wsMock.onMessage!({
-        type: "delta",
-        conversationId: "conv_1",
-        event: { type: "done", messageId: "msg_assistant" }
-      });
-    });
-
-    await flushAnimationFrame();
-    await flushAnimationFrame();
-
-    expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ top: 540 }));
-    expect(scrollTop).toBe(540);
-    expect(messageList).toHaveStyle({ paddingBottom: "360px" });
   });
 
   it("anchors to the reconciled server user message when the optimistic local message is removed first", async () => {
@@ -3049,146 +2816,52 @@ describe("chat view", () => {
         })
       } as Response);
 
-    const originalGetBoundingClientRect = Element.prototype.getBoundingClientRect;
-    Element.prototype.getBoundingClientRect = function getBoundingClientRect() {
-      if (this instanceof HTMLElement && this.dataset.messageId === "msg_server_user") {
-        return {
-          x: 0,
-          y: 180,
-          top: 180,
-          right: 0,
-          bottom: 220,
-          left: 0,
-          width: 0,
-          height: 40,
-          toJSON: () => ({})
-        };
-      }
-
-      return originalGetBoundingClientRect.call(this);
-    };
-
-    const { container } = renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
-    const queue = container.querySelector(".no-scrollbar.overflow-y-auto") as HTMLDivElement;
+    renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
     const textarea = screen.getByPlaceholderText(
       "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
     );
 
-    let scrollTop = 25;
-    const scrollTo = vi.fn(({ top }: { top?: number }) => {
-      if (typeof top === "number") {
-        scrollTop = top;
-      }
+    fireEvent.change(textarea, { target: { value: "Server-backed prompt" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith("/api/conversations/conv_1", {
+        cache: "no-store"
+      });
     });
 
-    Object.defineProperty(queue, "clientHeight", { configurable: true, get: () => 300 });
-    Object.defineProperty(queue, "scrollHeight", { configurable: true, get: () => 900 });
-    Object.defineProperty(queue, "scrollTop", {
-      configurable: true,
-      get: () => scrollTop,
-      set: (value: number) => { scrollTop = value; }
+    await waitFor(() => {
+      expect(screen.getByText("Server-backed prompt")).toBeInTheDocument();
     });
-    Object.defineProperty(queue, "scrollTo", { configurable: true, value: scrollTo });
 
-    try {
-      fireEvent.change(textarea, { target: { value: "Server-backed prompt" } });
-      fireEvent.keyDown(textarea, { key: "Enter" });
-
-      await waitFor(() => {
-        expect(global.fetch).toHaveBeenCalledWith("/api/conversations/conv_1", {
-          cache: "no-store"
-        });
-      });
-
-      await waitFor(() => {
-        expect(screen.getByText("Server-backed prompt")).toBeInTheDocument();
-      });
-
-      await waitFor(() => {
-        expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ top: 177 }));
-      });
-    } finally {
-      Element.prototype.getBoundingClientRect = originalGetBoundingClientRect;
-    }
+    await waitFor(() => {
+      expect(virtuosoMock.handle.scrollIntoView).toHaveBeenCalled();
+    });
   });
 
   it("scrolls to anchor the user message near the top after sending", async () => {
-    const { container } = renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
-    const queue = container.querySelector(".no-scrollbar.overflow-y-auto") as HTMLDivElement;
+    renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
     const textarea = screen.getByPlaceholderText(
       "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
     );
-    const originalGetBoundingClientRect = Element.prototype.getBoundingClientRect;
 
-    let scrollTop = 500;
-    const scrollTo = vi.fn(({ top }: { top?: number }) => {
-      if (typeof top === "number") {
-        scrollTop = top;
-      }
+    fireEvent.change(textarea, { target: { value: "Hello world" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Hello world")).toBeInTheDocument();
     });
 
-    Object.defineProperty(queue, "clientHeight", { configurable: true, get: () => 300 });
-    Object.defineProperty(queue, "scrollHeight", { configurable: true, get: () => 1000 });
-    Object.defineProperty(queue, "scrollTop", {
-      configurable: true,
-      get: () => scrollTop,
-      set: (value: number) => { scrollTop = value; }
-    });
-    Object.defineProperty(queue, "scrollTo", { configurable: true, value: scrollTo });
-    Element.prototype.getBoundingClientRect = function getBoundingClientRect() {
-      if (this === queue) {
-        return {
-          x: 0,
-          y: 100,
-          top: 100,
-          right: 0,
-          bottom: 400,
-          left: 0,
-          width: 0,
-          height: 300,
-          toJSON: () => ({})
-        };
-      }
+    await flushAnimationFrame();
+    await flushAnimationFrame();
 
-      if (this instanceof HTMLElement && this.dataset.messageId?.startsWith("local_")) {
-        return {
-          x: 0,
-          y: 140,
-          top: 140,
-          right: 0,
-          bottom: 180,
-          left: 0,
-          width: 0,
-          height: 40,
-          toJSON: () => ({})
-        };
-      }
-
-      return originalGetBoundingClientRect.call(this);
-    };
-
-    try {
-      fireEvent.change(textarea, { target: { value: "Hello world" } });
-      fireEvent.keyDown(textarea, { key: "Enter" });
-
-      await waitFor(() => {
-        expect(screen.getByText("Hello world")).toBeInTheDocument();
-      });
-
-      await flushAnimationFrame();
-      await flushAnimationFrame();
-
-      expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({
-        behavior: "auto",
-        top: 512
-      }));
-    } finally {
-      Element.prototype.getBoundingClientRect = originalGetBoundingClientRect;
-    }
+    expect(virtuosoMock.handle.scrollIntoView).toHaveBeenCalledWith(
+      expect.objectContaining({ behavior: "smooth" })
+    );
   });
 
   it("scrolls to bottom when queuing a follow-up during an active turn", async () => {
-    const { container } = renderWithProvider(
+    renderWithProvider(
       React.createElement(ChatView, {
         payload: createPayload({
           conversation: {
@@ -3198,26 +2871,9 @@ describe("chat view", () => {
         })
       })
     );
-    const queue = container.querySelector(".no-scrollbar.overflow-y-auto") as HTMLDivElement;
     const textarea = screen.getByPlaceholderText(
       "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
     );
-
-    let scrollTop = 120;
-    const scrollTo = vi.fn(({ top }: { top?: number }) => {
-      if (typeof top === "number") {
-        scrollTop = top;
-      }
-    });
-
-    Object.defineProperty(queue, "clientHeight", { configurable: true, get: () => 300 });
-    Object.defineProperty(queue, "scrollHeight", { configurable: true, get: () => 1000 });
-    Object.defineProperty(queue, "scrollTop", {
-      configurable: true,
-      get: () => scrollTop,
-      set: (value: number) => { scrollTop = value; }
-    });
-    Object.defineProperty(queue, "scrollTo", { configurable: true, value: scrollTo });
 
     act(() => {
       wsMock.onMessage!({
@@ -3229,7 +2885,7 @@ describe("chat view", () => {
 
     await flushAnimationFrame();
 
-    scrollTo.mockClear();
+    virtuosoMock.handle.scrollToIndex.mockClear();
 
     fireEvent.change(textarea, { target: { value: "Queued follow-up" } });
     fireEvent.keyDown(textarea, { key: "Enter" });
@@ -3244,129 +2900,16 @@ describe("chat view", () => {
 
     await flushAnimationFrame();
 
-    expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ top: 700 }));
-  });
-
-  it("returns to idle when the user manually scrolls during anchored mode", async () => {
-    const { container } = renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
-    const queue = container.querySelector(".no-scrollbar.overflow-y-auto") as HTMLDivElement;
-    const textarea = screen.getByPlaceholderText(
-      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
+    expect(virtuosoMock.handle.scrollToIndex).toHaveBeenCalledWith(
+      expect.objectContaining({ index: "LAST", align: "end", behavior: "auto" })
     );
-    const originalGetBoundingClientRect = Element.prototype.getBoundingClientRect;
-
-    let scrollHeight = 200;
-    let scrollTop = 0;
-    const scrollTo = vi.fn(({ top }: { top?: number }) => {
-      if (typeof top === "number") {
-        scrollTop = top;
-      }
-    });
-
-    Object.defineProperty(queue, "clientHeight", { configurable: true, get: () => 300 });
-    Object.defineProperty(queue, "scrollHeight", { configurable: true, get: () => scrollHeight });
-    Object.defineProperty(queue, "scrollTop", {
-      configurable: true,
-      get: () => scrollTop,
-      set: (value: number) => { scrollTop = value; }
-    });
-    Object.defineProperty(queue, "scrollTo", { configurable: true, value: scrollTo });
-    Element.prototype.getBoundingClientRect = function getBoundingClientRect() {
-      if (this === queue) {
-        return {
-          x: 0,
-          y: 0,
-          top: 0,
-          right: 0,
-          bottom: 300,
-          left: 0,
-          width: 0,
-          height: 300,
-          toJSON: () => ({})
-        };
-      }
-
-      if (this instanceof HTMLElement && this.dataset.messageId?.startsWith("local_")) {
-        return {
-          x: 0,
-          y: 120,
-          top: 120,
-          right: 0,
-          bottom: 160,
-          left: 0,
-          width: 0,
-          height: 40,
-          toJSON: () => ({})
-        };
-      }
-
-      return originalGetBoundingClientRect.call(this);
-    };
-
-    try {
-      fireEvent.change(textarea, { target: { value: "Hello" } });
-      fireEvent.keyDown(textarea, { key: "Enter" });
-
-      await waitFor(() => {
-        expect(screen.getByText("Hello")).toBeInTheDocument();
-      });
-
-      await flushAnimationFrame();
-      await flushAnimationFrame();
-
-      scrollTo.mockClear();
-
-      scrollHeight = 700;
-      scrollTop = 10;
-      fireEvent.wheel(queue, { deltaY: -120 });
-      fireEvent.scroll(queue);
-
-      act(() => {
-        wsMock.onMessage!({
-          type: "delta",
-          conversationId: "conv_1",
-          event: { type: "message_start", messageId: "msg_assistant" }
-        });
-        wsMock.onMessage!({
-          type: "delta",
-          conversationId: "conv_1",
-          event: { type: "answer_delta", text: "Streaming content" }
-        });
-      });
-
-      await flushAnimationFrame();
-
-      expect(scrollTo).not.toHaveBeenCalled();
-    } finally {
-      Element.prototype.getBoundingClientRect = originalGetBoundingClientRect;
-    }
   });
 
   it("cancels streaming follow immediately when the user wheels away", async () => {
-    const { container } = renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
-    const queue = container.querySelector(".no-scrollbar.overflow-y-auto") as HTMLDivElement;
+    renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
     const textarea = screen.getByPlaceholderText(
       "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
     );
-
-    let scrollHeight = 720;
-    let scrollTop = 0;
-    const scrollTo = vi.fn(({ top }: { top?: number }) => {
-      if (typeof top === "number") {
-        scrollTop = top;
-      }
-    });
-
-    Object.defineProperty(queue, "clientHeight", { configurable: true, get: () => 360 });
-    Object.defineProperty(queue, "scrollHeight", { configurable: true, get: () => scrollHeight });
-    Object.defineProperty(queue, "scrollTop", {
-      configurable: true,
-      get: () => scrollTop,
-      set: (value: number) => { scrollTop = value; }
-    });
-    Object.defineProperty(queue, "scrollTo", { configurable: true, value: scrollTo });
-
-    await flushResizeObservers();
 
     fireEvent.change(textarea, { target: { value: "Track then interrupt" } });
     fireEvent.keyDown(textarea, { key: "Enter" });
@@ -3378,8 +2921,7 @@ describe("chat view", () => {
     await flushAnimationFrame();
     await flushAnimationFrame();
 
-    scrollTo.mockClear();
-    scrollHeight = 1080;
+    virtuosoMock.handle.scrollToIndex.mockClear();
 
     act(() => {
       wsMock.onMessage!({
@@ -3395,12 +2937,11 @@ describe("chat view", () => {
     });
 
     await waitFor(() => {
-      expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ top: 540 }));
+      expect(screen.getByText("A long response that starts following")).toBeInTheDocument();
     });
 
-    scrollTo.mockClear();
-    fireEvent.wheel(queue, { deltaY: -240 });
-    scrollTo.mockClear();
+    simulateAtBottomChange(false);
+    virtuosoMock.handle.scrollToIndex.mockClear();
 
     act(() => {
       wsMock.onMessage!({
@@ -3413,180 +2954,7 @@ describe("chat view", () => {
     await flushAnimationFrame();
     await flushAnimationFrame();
 
-    expect(scrollTo).not.toHaveBeenCalledWith(expect.objectContaining({ top: 540 }));
-  });
-
-  it("does not clamp when scroll position matches the bottom target after streaming ends", async () => {
-    const { container } = renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
-    const queue = container.querySelector(".no-scrollbar.overflow-y-auto") as HTMLDivElement;
-    const textarea = screen.getByPlaceholderText(
-      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
-    );
-
-    let scrollHeight = 1080;
-    let scrollTop = 0;
-    const scrollTo = vi.fn(({ top }: { top?: number }) => {
-      if (typeof top === "number") {
-        scrollTop = top;
-      }
-    });
-
-    Object.defineProperty(queue, "clientHeight", { configurable: true, get: () => 360 });
-    Object.defineProperty(queue, "scrollHeight", { configurable: true, get: () => scrollHeight });
-    Object.defineProperty(queue, "scrollTop", {
-      configurable: true,
-      get: () => scrollTop,
-      set: (value: number) => { scrollTop = value; }
-    });
-    Object.defineProperty(queue, "scrollTo", { configurable: true, value: scrollTo });
-
-    await flushResizeObservers();
-
-    fireEvent.change(textarea, { target: { value: "Finish without blank space" } });
-    fireEvent.keyDown(textarea, { key: "Enter" });
-
-    await waitFor(() => {
-      expect(screen.getByText("Finish without blank space")).toBeInTheDocument();
-    });
-
-    act(() => {
-      wsMock.onMessage!({
-        type: "delta",
-        conversationId: "conv_1",
-        event: { type: "message_start", messageId: "msg_assistant" }
-      });
-      wsMock.onMessage!({
-        type: "delta",
-        conversationId: "conv_1",
-        event: { type: "answer_delta", text: "Final response text" }
-      });
-      wsMock.onMessage!({
-        type: "delta",
-        conversationId: "conv_1",
-        event: { type: "done", messageId: "msg_assistant" }
-      });
-    });
-
-    await flushAnimationFrame();
-    await flushAnimationFrame();
-
-    scrollTo.mockClear();
-    scrollTop = 540;
-    fireEvent.scroll(queue);
-
-    expect(scrollTo).not.toHaveBeenCalled();
-    expect(scrollTop).toBe(540);
-  });
-
-  it("prevents downward wheel scrolling into padding-only space for short chats", async () => {
-    const { container } = renderWithProvider(
-      React.createElement(ChatView, {
-        payload: createPayload({
-          messages: [
-            createMessage({
-              id: "msg_short_user",
-              role: "user",
-              content: "Short prompt"
-            }),
-            createMessage({
-              id: "msg_short_assistant",
-              role: "assistant",
-              content: "Short answer"
-            })
-          ]
-        })
-      })
-    );
-    const queue = container.querySelector(".no-scrollbar.overflow-y-auto") as HTMLDivElement;
-
-    let scrollTop = 0;
-    Object.defineProperty(queue, "clientHeight", { configurable: true, get: () => 200 });
-    Object.defineProperty(queue, "scrollHeight", { configurable: true, get: () => 240 });
-    Object.defineProperty(queue, "scrollTop", {
-      configurable: true,
-      get: () => scrollTop,
-      set: (value: number) => { scrollTop = value; }
-    });
-    Object.defineProperty(queue, "scrollTo", {
-      configurable: true,
-      value: vi.fn(({ top }: { top?: number }) => {
-        if (typeof top === "number") {
-          scrollTop = top;
-        }
-      })
-    });
-
-    await flushResizeObservers();
-    await flushAnimationFrame();
-
-    const wheelEvent = new WheelEvent("wheel", {
-      bubbles: true,
-      cancelable: true,
-      deltaY: 120
-    });
-
-    const defaultAllowed = fireEvent(queue, wheelEvent);
-    if (defaultAllowed && !wheelEvent.defaultPrevented) {
-      scrollTop = scrollTop + 120;
-    }
-
-    expect(wheelEvent.defaultPrevented).toBe(true);
-    expect(scrollTop).toBe(20);
-    expect(screen.queryByRole("button", { name: "Scroll to newest messages" })).toBeNull();
-  });
-
-  it("transitions to following mode when streaming content fills the viewport", async () => {
-    const { container } = renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
-    const queue = container.querySelector(".no-scrollbar.overflow-y-auto") as HTMLDivElement;
-
-    let scrollHeight = 700;
-    let scrollTop = 0;
-    const scrollTo = vi.fn(({ top }: { top?: number }) => {
-      if (typeof top === "number") {
-        scrollTop = top;
-      }
-    });
-
-    Object.defineProperty(queue, "clientHeight", { configurable: true, get: () => 300 });
-    Object.defineProperty(queue, "scrollHeight", { configurable: true, get: () => scrollHeight });
-    Object.defineProperty(queue, "scrollTop", {
-      configurable: true,
-      get: () => scrollTop,
-      set: (value: number) => { scrollTop = value; }
-    });
-    Object.defineProperty(queue, "scrollTo", { configurable: true, value: scrollTo });
-
-    const textarea = screen.getByPlaceholderText(
-      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
-    );
-
-    fireEvent.change(textarea, { target: { value: "Hello" } });
-    fireEvent.keyDown(textarea, { key: "Enter" });
-
-    await waitFor(() => {
-      expect(screen.getByText("Hello")).toBeInTheDocument();
-    });
-
-    await flushAnimationFrame();
-    await flushAnimationFrame();
-
-    act(() => {
-      wsMock.onMessage!({
-        type: "delta",
-        conversationId: "conv_1",
-        event: { type: "message_start", messageId: "msg_assistant" }
-      });
-      wsMock.onMessage!({
-        type: "delta",
-        conversationId: "conv_1",
-        event: { type: "answer_delta", text: "A very long response that fills the viewport" }
-      });
-    });
-
-    await flushAnimationFrame();
-    await flushAnimationFrame();
-
-    expect(screen.queryByRole("button", { name: "Scroll to newest messages" })).toBeNull();
+    expect(virtuosoMock.handle.scrollToIndex).not.toHaveBeenCalled();
   });
 
   it("anchors to the edited message after edit-retry", async () => {
@@ -3612,7 +2980,7 @@ describe("chat view", () => {
         })
       } as Response);
 
-    const { container } = renderWithProvider(
+    renderWithProvider(
       React.createElement(ChatView, {
         payload: {
           ...createPayload(),
@@ -3630,14 +2998,6 @@ describe("chat view", () => {
         }
       })
     );
-    const queue = container.querySelector(".no-scrollbar.overflow-y-auto") as HTMLDivElement;
-
-    const scrollTo = vi.fn(({ top }: { top?: number }) => {
-      if (typeof top === "number") {
-        // noop
-      }
-    });
-    Object.defineProperty(queue, "scrollTo", { configurable: true, value: scrollTo });
 
     fireEvent.click(screen.getByRole("button", { name: "Edit message" }));
     fireEvent.change(screen.getByDisplayValue("Original prompt"), {
@@ -3660,7 +3020,7 @@ describe("chat view", () => {
     await flushAnimationFrame();
     await flushAnimationFrame();
 
-    expect(scrollTo).toHaveBeenCalled();
+    expect(virtuosoMock.handle.scrollIntoView).toHaveBeenCalled();
   });
 
   it("renders tool actions and answer text while streaming", async () => {

--- a/tests/unit/chat-view.test.ts
+++ b/tests/unit/chat-view.test.ts
@@ -2747,11 +2747,8 @@ describe("chat view", () => {
     });
 
     const pill = screen.getByRole("button", { name: "Scroll to newest messages" }).parentElement!;
-    expect(pill.className).toContain("md:left-full");
-    expect(pill.className).toContain("md:ml-3");
-    expect(pill.className).toContain("md:-translate-y-1/2");
-    expect(pill.className).not.toContain("md:left-4");
-    expect(pill.className).not.toContain("md:bottom-full");
+    expect(pill.className).toContain("md:right-5");
+    expect(pill.className).toContain("bottom-3");
   });
 
   it("follows streaming overflow after sending", async () => {

--- a/tests/unit/chat-view.test.ts
+++ b/tests/unit/chat-view.test.ts
@@ -2747,8 +2747,7 @@ describe("chat view", () => {
     });
 
     const pill = screen.getByRole("button", { name: "Scroll to newest messages" }).parentElement!;
-    expect(pill.className).toContain("md:right-5");
-    expect(pill.className).toContain("bottom-3");
+    expect(pill.className).toContain("left-3");
   });
 
   it("follows streaming overflow after sending", async () => {

--- a/tests/unit/chat-view.test.ts
+++ b/tests/unit/chat-view.test.ts
@@ -2832,7 +2832,9 @@ describe("chat view", () => {
     });
 
     await waitFor(() => {
-      expect(virtuosoMock.handle.scrollIntoView).toHaveBeenCalled();
+      expect(virtuosoMock.handle.scrollToIndex).toHaveBeenCalledWith(
+        expect.objectContaining({ align: "start", behavior: "auto" })
+      );
     });
   });
 
@@ -2852,8 +2854,8 @@ describe("chat view", () => {
     await flushAnimationFrame();
     await flushAnimationFrame();
 
-    expect(virtuosoMock.handle.scrollIntoView).toHaveBeenCalledWith(
-      expect.objectContaining({ behavior: "smooth" })
+    expect(virtuosoMock.handle.scrollToIndex).toHaveBeenCalledWith(
+      expect.objectContaining({ align: "start", behavior: "auto" })
     );
   });
 
@@ -3017,7 +3019,9 @@ describe("chat view", () => {
     await flushAnimationFrame();
     await flushAnimationFrame();
 
-    expect(virtuosoMock.handle.scrollIntoView).toHaveBeenCalled();
+    expect(virtuosoMock.handle.scrollToIndex).toHaveBeenCalledWith(
+      expect.objectContaining({ align: "start", behavior: "auto" })
+    );
   });
 
   it("renders tool actions and answer text while streaming", async () => {

--- a/tests/unit/pwa-metadata.test.ts
+++ b/tests/unit/pwa-metadata.test.ts
@@ -39,7 +39,8 @@ describe("PWA shell metadata", () => {
     });
     expect(viewport).toEqual({
       themeColor: "#0a0a0a",
-      colorScheme: "dark"
+      colorScheme: "dark",
+      viewportFit: "cover"
     });
   });
 


### PR DESCRIPTION
## Summary

- Replace custom scroll management with `react-virtuoso` for virtualized chat message list, eliminating overscroll/rubberbanding issues
- Refactor layout to use flexbox sibling positioning with anchor scroll and smart `followOutput` behavior for streaming messages
- Implement overlay composer layout with dynamic Footer spacer for proper content offset
- Add `100dvh` and `viewportFit: cover` for correct mobile viewport handling
- Use `safe-area-inset-bottom` padding on composer to prevent rubberbanding on notched devices
- Refine scroll-to-bottom button positioning relative to composer height
- Update unit tests to reflect the new Virtuoso-based architecture