### PR TITLE
refactor: move scroll-to-bottom button into chat composer

### DIFF
--- a/components/chat-composer.tsx
+++ b/components/chat-composer.tsx
@@ -62,6 +62,8 @@ type ChatComposerProps = {
   isTemporary?: boolean;
   showTemporaryToggle?: boolean;
   onTemporaryChange?: (value: boolean) => void;
+  isAtBottom?: boolean;
+  onJumpToBottom?: () => void;
 };
 
 function CustomDropdown<T extends { id: string; name: string }>({
@@ -222,6 +224,8 @@ export function ChatComposer({
   isTemporary = false,
   showTemporaryToggle = false,
   onTemporaryChange,
+  isAtBottom = true,
+  onJumpToBottom,
 }: ChatComposerProps) {
   const fileInputRef = React.useRef<HTMLInputElement | null>(null);
   const [mounted, setMounted] = useState(false);
@@ -263,6 +267,20 @@ export function ChatComposer({
 
   return (
     <div className="relative">
+      {!isAtBottom && (
+        <div className="absolute -top-[19px] left-4 z-0 flex items-start h-[24px]">
+          <button
+            type="button"
+            onClick={onJumpToBottom}
+            style={{ fontSize: '10px' }}
+            className="relative flex h-full items-center gap-0.5 rounded-t-md border border-b-0 border-violet-500/50 border-dashed bg-zinc-900/90 backdrop-blur-2xl px-2.5 font-bold uppercase tracking-wider text-violet-300 transition-all duration-150 active:scale-[0.96]"
+            aria-label="Scroll to latest messages"
+            title="Scroll to latest"
+          >
+            ↓ Latest
+          </button>
+        </div>
+      )}
       {isTemporary && !showTemporaryToggle && (
         <div className="absolute -top-[19px] right-4 z-10 flex items-center h-[19px]">
           <div className="relative flex h-full items-center rounded-t-md border border-b-0 border-violet-500/50 border-dashed bg-zinc-900/70 backdrop-blur-2xl px-2.5 text-[10px] font-bold uppercase tracking-wider text-violet-300">
@@ -294,7 +312,7 @@ export function ChatComposer({
       )}
     <div
       className={cn(
-        "relative rounded-[22px] sm:rounded-[26px] border bg-zinc-900/70 backdrop-blur-2xl p-1.5 sm:p-2 shadow-[0_0_40px_rgba(0,0,0,0.5)] transition-all duration-500 focus-within:border-[var(--accent)]/30 focus-within:shadow-[0_0_50px_rgba(0,0,0,0.6),0_0_20px_var(--accent-soft)]",
+        "relative z-[1] rounded-[22px] sm:rounded-[26px] border bg-zinc-900/70 backdrop-blur-2xl p-1.5 sm:p-2 shadow-[0_0_40px_rgba(0,0,0,0.5)] transition-all duration-500 focus-within:border-[var(--accent)]/30 focus-within:shadow-[0_0_50px_rgba(0,0,0,0.6),0_0_20px_var(--accent-soft)]",
         isTemporary ? "border-violet-500/50 border-dashed" : "border-white/10",
         className
       )}

--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -2276,36 +2276,8 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
         }}
       />
 
-       <div ref={composerAreaRef} className="absolute inset-x-0 bottom-0 z-50 pointer-events-none">
-        {!isAtBottom && queueBannerHeight === 0 && (
-          <div className="absolute z-[60] pointer-events-none flex items-center left-3"
-            style={{ bottom: `calc(${composerAreaHeight}px / 2 - 16px)` }}
-          >
-            <button
-              type="button"
-              onClick={jumpToBottom}
-              className="pointer-events-auto relative inline-flex h-8 w-8 items-center justify-center rounded-full bg-[var(--accent)] px-2 text-white shadow-[0_0_20px_var(--accent-glow)] transition-all duration-150 hover:opacity-90 active:scale-[0.96]"
-              aria-label="Scroll to newest messages"
-              title="Scroll to bottom"
-            >
-              ↓
-            </button>
-          </div>
-        )}
-        {!isAtBottom && queueBannerHeight > 0 && (
-          <div className="absolute z-[60] pointer-events-none flex items-center right-5 top-3">
-            <button
-              type="button"
-              onClick={jumpToBottom}
-              className="pointer-events-auto relative inline-flex h-8 w-8 items-center justify-center rounded-full bg-[var(--accent)] px-2 text-white shadow-[0_0_20px_var(--accent-glow)] transition-all duration-150 hover:opacity-90 active:scale-[0.96]"
-              aria-label="Scroll to newest messages"
-              title="Scroll to bottom"
-            >
-              ↓
-            </button>
-          </div>
-        )}
-        <div className="mx-auto w-full max-w-[980px] px-4 md:px-8 pt-1 pb-[max(0px,env(safe-area-inset-bottom))] md:pb-3 pointer-events-auto">
+        <div ref={composerAreaRef} className="absolute inset-x-0 bottom-0 z-50 pointer-events-none">
+         <div className="mx-auto w-full max-w-[980px] px-4 md:px-8 pt-1 pb-[max(0px,env(safe-area-inset-bottom))] md:pb-3 pointer-events-auto">
           <div ref={queueBannerRef}>
             <QueuedMessageBanner
               items={queuedMessages}
@@ -2353,6 +2325,8 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
                 body: JSON.stringify({ isTemporary: value })
               }).catch(() => {});
             }}
+            isAtBottom={isAtBottom}
+            onJumpToBottom={jumpToBottom}
             onStartSpeech={() => {
               setError("");
               void startSpeech();

--- a/tests/unit/chat-view.test.ts
+++ b/tests/unit/chat-view.test.ts
@@ -2714,7 +2714,7 @@ describe("chat view", () => {
     simulateAtBottomChange(false);
 
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Scroll to newest messages" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Scroll to latest messages" })).toBeInTheDocument();
     });
 
     fireEvent.change(textarea, { target: { value: "Follow the latest reply" } });
@@ -2732,7 +2732,7 @@ describe("chat view", () => {
 
     simulateAtBottomChange(true);
     await flushAnimationFrame();
-    expect(screen.queryByRole("button", { name: "Scroll to newest messages" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Scroll to latest messages" })).toBeNull();
   });
 
   it("positions the Latest Messages pill to the right of the composer on desktop", async () => {
@@ -2743,11 +2743,11 @@ describe("chat view", () => {
     simulateAtBottomChange(false);
 
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Scroll to newest messages" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Scroll to latest messages" })).toBeInTheDocument();
     });
 
-    const pill = screen.getByRole("button", { name: "Scroll to newest messages" }).parentElement!;
-    expect(pill.className).toContain("left-3");
+    const pill = screen.getByRole("button", { name: "Scroll to latest messages" }).parentElement!;
+    expect(pill.className).toContain("left-4");
   });
 
   it("follows streaming overflow after sending", async () => {


### PR DESCRIPTION
## Summary

- Relocates the "scroll to latest" button from `chat-view.tsx` into `chat-composer.tsx`, rendering it as a small tab ("↓ Latest") above the composer input
- Removes the two separate floating button variants (non-queued and queued states) that previously lived in `chat-view.tsx`, replacing them with a single cleaner element inside the composer
- Adds `isAtBottom` and `onJumpToBottom` props to `ChatComposerProps` to drive the new button
- Updates unit tests to reflect the new button label ("Scroll to latest messages") and adjusted positioning class (`left-4`)