### PR TITLE
fix: handle conversation_title_updated WebSocket event

### DIFF
--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -1187,6 +1187,17 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
         case "delta":
           handleDelta(msg.event as ChatStreamEvent);
           break;
+        case "conversation_title_updated":
+          if (msg.conversationId === payload.conversation.id) {
+            setConversationTitle(msg.title);
+            setTitleGenerationStatus("completed");
+            dispatchConversationTitleUpdated({
+              conversationId: msg.conversationId,
+              title: msg.title
+            });
+            stopTitlePolling();
+          }
+          break;
       }
     }
   });

--- a/tests/unit/chat-view.test.ts
+++ b/tests/unit/chat-view.test.ts
@@ -1466,6 +1466,64 @@ describe("chat view", () => {
     expect(screen.queryByRole("button", { name: "Thinking ..." })).toBeNull();
   });
 
+  it("updates the header title when a conversation_title_updated WebSocket message arrives", async () => {
+    renderWithProvider(
+      React.createElement(ChatView, {
+        payload: createPayload({
+          conversation: {
+            ...createPayload().conversation,
+            title: "Conversation",
+            titleGenerationStatus: "pending"
+          }
+        })
+      })
+    );
+
+    expect(screen.getByText("Conversation")).toBeInTheDocument();
+
+    act(() => {
+      wsMock.onMessage!({
+        type: "conversation_title_updated",
+        conversationId: "conv_1",
+        title: "Deployment Checklist"
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Deployment Checklist")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Conversation")).toBeNull();
+    expect(conversationEventMock.dispatchConversationTitleUpdated).toHaveBeenCalledWith({
+      conversationId: "conv_1",
+      title: "Deployment Checklist"
+    });
+  });
+
+  it("ignores conversation_title_updated for a different conversation", async () => {
+    renderWithProvider(
+      React.createElement(ChatView, {
+        payload: createPayload({
+          conversation: {
+            ...createPayload().conversation,
+            title: "My Chat",
+            titleGenerationStatus: "completed"
+          }
+        })
+      })
+    );
+
+    act(() => {
+      wsMock.onMessage!({
+        type: "conversation_title_updated",
+        conversationId: "conv_other",
+        title: "Other Title"
+      });
+    });
+
+    expect(screen.getByText("My Chat")).toBeInTheDocument();
+    expect(screen.queryByText("Other Title")).toBeNull();
+  });
+
   it("hydrates queued messages from a WebSocket snapshot", async () => {
     renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
 


### PR DESCRIPTION
## Summary

- **Fix regression** where conversation titles were not updated when the server pushed a `conversation_title_updated` event via WebSocket
- Added a handler in the WebSocket message switch for the `conversation_title_updated` event type
- Updates local conversation title state, marks title generation as completed, dispatches the event to the conversation store, and stops title polling
- Ignores title updates for conversations other than the currently active one
- Added two unit tests covering the happy path and the cross-conversation guard