### PR TITLE
feat: markdown normalization for model system prompt

### DIFF
--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -2,10 +2,10 @@
 
 import React, { useEffect, useRef, useState } from "react";
 import { Brain, Check, ChevronDown, ChevronRight, Copy, FileText, GitFork, LoaderCircle, Pencil, RefreshCw, Square, X } from "lucide-react";
-import type { RemendHandler } from "remend";
-import { Streamdown } from "streamdown";
+import { Streamdown, parseMarkdownIntoBlocks } from "streamdown";
 import { code } from "@streamdown/code";
 import { mermaid } from "@streamdown/mermaid";
+import { MARKDOWN_REMEND_HANDLERS, normalizeMarkdown } from "@/lib/markdown-normalization";
 import {
   AttachmentPreviewModal,
   useAttachmentUrlBuilder,
@@ -32,7 +32,14 @@ import {
 } from "@/components/ai-elements/message";
 
 const STREAMDOWN_PLUGINS = { code, mermaid };
+const STREAMDOWN_REMEND = { handlers: MARKDOWN_REMEND_HANDLERS };
+const STREAMDOWN_PARSE_BLOCKS = (markdown: string) =>
+  parseMarkdownIntoBlocks(markdown);
 const COPY_RESET_DELAY_MS = 1600;
+
+function md(content: string): string {
+  return normalizeMarkdown(content);
+}
 
 function getAnsiForegroundClassName(foregroundColor: ReturnType<typeof parseAnsiText>[number]["foregroundColor"]) {
   switch (foregroundColor) {
@@ -90,10 +97,12 @@ function renderAssistantMarkdown(content: string, isStreaming: boolean) {
   return (
     <Streamdown
       plugins={STREAMDOWN_PLUGINS}
+      remend={STREAMDOWN_REMEND}
+      parseMarkdownIntoBlocksFn={STREAMDOWN_PARSE_BLOCKS}
       caret={isStreaming ? "block" : undefined}
       isAnimating={isStreaming}
     >
-      {content}
+      {md(content)}
     </Streamdown>
   );
 }
@@ -971,7 +980,7 @@ export function MessageBubble({
                 />
               ) : content ? (
                 <div ref={contentRef} className="markdown-body">
-                  <Streamdown mode="static" plugins={STREAMDOWN_PLUGINS}>{content}</Streamdown>
+                  <Streamdown mode="static" plugins={STREAMDOWN_PLUGINS} remend={STREAMDOWN_REMEND} parseMarkdownIntoBlocksFn={STREAMDOWN_PARSE_BLOCKS}>{md(content)}</Streamdown>
                 </div>
               ) : null}
               {message.attachments?.length ? (
@@ -1087,9 +1096,11 @@ export function MessageBubble({
                 {thinkingOpen && thinkingContent ? (
                   <div className="markdown-body thinking-markdown-body mt-1.5">
                     <Streamdown
+                      remend={STREAMDOWN_REMEND}
+                      parseMarkdownIntoBlocksFn={STREAMDOWN_PARSE_BLOCKS}
                       caret={thinkingInProgress ? "block" : undefined}
                       isAnimating={thinkingInProgress}
-                    >{thinkingContent}</Streamdown>
+                    >{md(thinkingContent)}</Streamdown>
                   </div>
                 ) : null}
               </div>

--- a/lib/assistant-runtime.ts
+++ b/lib/assistant-runtime.ts
@@ -86,6 +86,21 @@ const NON_NATIVE_VISION_DIRECTIVE =
 const MERMAID_DIAGRAM_DIRECTIVE =
   "When you need to present diagrams (flowcharts, sequence diagrams, class diagrams, state diagrams, ER diagrams, Gantt charts, pie charts, mind maps, or any other diagram type), use mermaid.js syntax inside a fenced code block with the `mermaid` language identifier. For example:\n\n```mermaid\ngraph TD\n    A[Start] --> B{Decision}\n    B -->|Yes| C[Success]\n    B -->|No| D[Try Again]\n```\n\nAlways prefer mermaid diagrams over ASCII art or text-based diagrams.";
 
+const MARKDOWN_FORMATTING_DIRECTIVE =
+  "Follow these markdown formatting rules strictly in every response:\n\
+\n\
+1. **Headings**: Always place at least one space after the # markers. Write `## Title`, never `##Title`.\n\
+\n\
+2. **Horizontal rules**: Always place horizontal rules (`---`, `***`, or `___`) on their own line with a blank line before and after. Never put text on the same line as a horizontal rule. `---First text` and `text---` are invalid.\n\
+\n\
+3. **Tables**: Use proper GitHub Flavored Markdown table syntax. Include a header row, a separator row with `|---|---|` or `| --- | --- |`, and consistent column counts across all rows.\n\
+\n\
+4. **Fenced code blocks**: Always close every opened fenced code block with matching backtick fences. Never leave a code block unclosed.\n\
+\n\
+5. **Blank lines**: Always use blank lines to separate block-level elements from each other — headings, horizontal rules, tables, fenced code blocks, and lists must each be surrounded by blank lines.\n\
+\n\
+6. **General**: Always output valid GitHub Flavored Markdown. Do not use raw HTML when a markdown equivalent exists.";
+
 function mcpToolFunctionName(serverSlug: string, toolName: string) {
   return `mcp_${serverSlug}_${toolName}`;
 }
@@ -1314,6 +1329,7 @@ export async function resolveAssistantTurn(input: {
   }
 
   promptMessages = mergeSystemMessage(promptMessages, MERMAID_DIAGRAM_DIRECTIVE);
+  promptMessages = mergeSystemMessage(promptMessages, MARKDOWN_FORMATTING_DIRECTIVE);
 
   let timelineSortOrder = 0;
 

--- a/lib/markdown-normalization.ts
+++ b/lib/markdown-normalization.ts
@@ -1,0 +1,237 @@
+import type { RemendHandler } from "remend";
+
+const ATX_HEADING_NO_SPACE = /^(#{1,6})([^#\s\n])/gm;
+const HR_FUSED_BEFORE = /^(-{3,})(?=[^\n])/gm;
+const HR_FUSED_AFTER = /(?<=\S)(-{3,})$/gm;
+
+const INLINE_TABLE_OPENER = /([^\s|])(\| [^ |-])/g;
+const INLINE_LIST_MARKER = /([^\s*_|>#`])([-]\s(?:\[[ x]\]\s)?)/g;
+const INLINE_ORDERED_MARKER = /([^\s\d.)_<>(#`])(\d+[.)]\s)/g;
+const INLINE_HEADING_MARKER = /([^\s#_|>#`])(#{1,6}\s\S)/g;
+
+function splitAroundCodeFences(text: string): { text: string; insideCode: boolean }[] {
+  const parts: { text: string; insideCode: boolean }[] = [];
+  const fenceRegex = /^(`{3,})/gm;
+  let lastEnd = 0;
+
+  while (true) {
+    const match = fenceRegex.exec(text);
+    if (!match) break;
+
+    const fenceStart = match.index;
+    const fenceLen = match[1].length;
+    const afterFence = fenceStart + fenceLen;
+    const rest = text.slice(afterFence);
+    const closeFence = rest.match(new RegExp(`\n((?:[ \t]*\n)?)` + "`".repeat(fenceLen) + `[ \t]*$`, "m"));
+
+    if (closeFence) {
+      const codeEnd = afterFence + (closeFence.index ?? 0) + closeFence[0].length;
+      if (fenceStart > lastEnd) {
+        parts.push({ text: text.slice(lastEnd, fenceStart), insideCode: false });
+      }
+      parts.push({ text: text.slice(fenceStart, codeEnd), insideCode: true });
+      lastEnd = codeEnd;
+      fenceRegex.lastIndex = codeEnd;
+    } else {
+      break;
+    }
+  }
+
+  if (lastEnd < text.length) {
+    parts.push({ text: text.slice(lastEnd), insideCode: false });
+  }
+
+  return parts.length > 0 ? parts : [{ text, insideCode: false }];
+}
+
+function applyOutsideCodeBlocks(text: string, fn: (t: string) => string): string {
+  const parts = splitAroundCodeFences(text);
+  return parts.map((part) => (part.insideCode ? part.text : fn(part.text))).join("");
+}
+
+function fixAtxHeadingSpace(text: string): string {
+  return text.replace(ATX_HEADING_NO_SPACE, "$1 $2");
+}
+
+function fixHorizontalRuleFusion(text: string): string {
+  let result = text;
+  result = result.replace(HR_FUSED_BEFORE, "\n\n---\n\n");
+  result = result.replace(HR_FUSED_AFTER, "\n\n---\n\n");
+  return result;
+}
+
+function fixInlineBlockMarkersInner(text: string): string {
+  let result = text;
+
+  result = result.replace(INLINE_HEADING_MARKER, "$1\n$2");
+
+  result = result.replace(INLINE_TABLE_OPENER, "$1\n$2");
+
+  result = result.replace(INLINE_ORDERED_MARKER, (match, before, marker) => {
+    if (/[0-9.]/.test(before)) return match;
+    return `${before}\n${marker}`;
+  });
+
+  result = result.replace(INLINE_LIST_MARKER, (match, before, marker) => {
+    if (before === "|" || before === ">" || before === "-") return match;
+    return `${before}\n${marker}`;
+  });
+
+  return result;
+}
+
+function fixInlineBlockMarkers(text: string): string {
+  return applyOutsideCodeBlocks(text, fixInlineBlockMarkersInner);
+}
+
+type BlockKind = "heading" | "code-fence" | "blockquote" | "table" | "unordered-list" | "ordered-list" | "hr" | "other";
+
+function classifyLine(line: string): BlockKind {
+  const trimmed = line.trimStart();
+
+  if (/^#{1,6}\s/.test(trimmed)) return "heading";
+  if (/^`{3,}/.test(trimmed)) return "code-fence";
+  if (/^>\s?/.test(trimmed)) return "blockquote";
+  if (/^\|/.test(trimmed)) return "table";
+  if (/^[-*+]\s/.test(trimmed)) return "unordered-list";
+  if (/^\d+[.)]\s/.test(trimmed)) return "ordered-list";
+  if (/^(-{3,}|\*{3,}|_{3,})\s*$/.test(trimmed)) return "hr";
+  return "other";
+}
+
+function needsBlankLineBetween(prevKind: BlockKind, currentKind: BlockKind, currentIndent: number): boolean {
+  if (currentIndent > 0 && (currentKind === "unordered-list" || currentKind === "ordered-list")) {
+    return false;
+  }
+
+  if (prevKind === "heading" || currentKind === "heading") {
+    return true;
+  }
+
+  if (prevKind === currentKind) {
+    return false;
+  }
+
+  return true;
+}
+
+function ensureBlockBlankLines(text: string): string {
+  const lines = text.split("\n");
+  const result: string[] = [];
+  let insideFence = false;
+  let insideTable = false;
+  let prevBlockKind: BlockKind | null = null;
+  let rootListKind: BlockKind | null = null;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const trimmed = line.trimStart();
+
+    if (/^`{3,}/.test(trimmed) && !insideFence) {
+      insideFence = true;
+      const prevLine = result.length > 0 ? result[result.length - 1] : "";
+      if (i > 0 && prevLine.trim() !== "") {
+        result.push("");
+      }
+      result.push(line);
+      prevBlockKind = "code-fence";
+      rootListKind = null;
+      continue;
+    }
+
+    if (/^`{3,}/.test(trimmed) && insideFence) {
+      insideFence = false;
+      result.push(line);
+      prevBlockKind = "code-fence";
+      rootListKind = null;
+      continue;
+    }
+
+    if (insideFence) {
+      result.push(line);
+      continue;
+    }
+
+    if (/^\|/.test(trimmed)) {
+      if (!insideTable) {
+        insideTable = true;
+        const prevLine = result.length > 0 ? result[result.length - 1] : "";
+        if (i > 0 && prevLine.trim() !== "" && prevBlockKind !== "table") {
+          result.push("");
+        }
+      }
+      result.push(line);
+      prevBlockKind = "table";
+      rootListKind = null;
+      continue;
+    }
+
+    if (insideTable && trimmed !== "" && !/^\|/.test(trimmed)) {
+      insideTable = false;
+    }
+
+    const kind = classifyLine(line);
+    const indent = line.length - trimmed.length;
+    const prevLine = result.length > 0 ? result[result.length - 1] : "";
+    const prevIsBlank = prevLine.trim() === "";
+
+    if (indent === 0 && (kind === "ordered-list" || kind === "unordered-list")) {
+      if (rootListKind === kind && !prevIsBlank) {
+        result.push(line);
+        prevBlockKind = kind;
+        continue;
+      }
+      rootListKind = kind;
+    } else if (indent > 0 && (kind === "ordered-list" || kind === "unordered-list")) {
+      result.push(line);
+      prevBlockKind = kind;
+      continue;
+    } else if (kind !== "ordered-list" && kind !== "unordered-list") {
+      rootListKind = null;
+    }
+
+    if (i > 0 && !prevIsBlank && prevBlockKind !== null && needsBlankLineBetween(prevBlockKind, kind, indent)) {
+      result.push("");
+    }
+
+    result.push(line);
+    prevBlockKind = kind;
+  }
+
+  return result.join("\n");
+}
+
+function fixCollapsedTableRowsInner(text: string): string {
+  let result = text;
+  result = result.replace(/\|\|(?=\s*[`!*\w])/g, "|\n|");
+  result = result.replace(/(\|) (\| \w)/g, "$1\n$2");
+  result = result.replace(/(\|)(#{1,6}\s\S)/g, "$1\n$2");
+  return result;
+}
+
+function fixCollapsedTableRows(text: string): string {
+  return applyOutsideCodeBlocks(text, fixCollapsedTableRowsInner);
+}
+
+export function normalizeMarkdown(text: string): string {
+  let result = text;
+  result = applyOutsideCodeBlocks(result, fixAtxHeadingSpace);
+  result = applyOutsideCodeBlocks(result, fixHorizontalRuleFusion);
+  result = fixInlineBlockMarkers(result);
+  result = fixCollapsedTableRows(result);
+  result = ensureBlockBlankLines(result);
+  return result;
+}
+
+export const MARKDOWN_REMEND_HANDLERS: RemendHandler[] = [
+  {
+    name: "fix-atx-heading-space",
+    handle: fixAtxHeadingSpace,
+    priority: -5,
+  },
+  {
+    name: "fix-horizontal-rule-fusion",
+    handle: fixHorizontalRuleFusion,
+    priority: -5,
+  },
+];


### PR DESCRIPTION
## Summary

- **System prompt directive**: Adds a markdown formatting directive to the assistant system prompt, instructing models to output valid GitHub Flavored Markdown with proper heading spacing, horizontal rules, table syntax, code block closure, and blank line separation between block elements.
- **Runtime markdown normalization** (`lib/markdown-normalization.ts`): New module that fixes common markdown issues at render time:
  - ATX heading space insertion (`##Title` → `## Title`)
  - Horizontal rule fusion correction (inline `---` → standalone rule)
  - Inline block marker separation (fused headings, tables, lists)
  - Collapsed table row expansion
  - Block-level blank line enforcement
- **Streamdown integration**: Wires `normalizeMarkdown()` and remend incremental handlers into all three Streamdown rendering paths (streaming, static, thinking) via a shared `md()` helper and `STREAMDOWN_REMEND` config.

## Files changed
- `lib/markdown-normalization.ts` — new file with all normalization logic
- `lib/assistant-runtime.ts` — adds `MARKDOWN_FORMATTING_DIRECTIVE` to system prompt
- `components/message-bubble.tsx` — integrates normalization into Streamdown components