### PR TITLE
style: fix markdown table width to allow content-driven sizing

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -297,7 +297,7 @@ select {
 }
 
 .markdown-body table {
-  width: 100%;
+  min-width: 100%;
   margin: 0rem 0;
   border-collapse: collapse;
   font-size: 0.94em;
@@ -309,6 +309,7 @@ select {
   padding: 0.55rem 0.7rem;
   text-align: left;
   vertical-align: top;
+  white-space: nowrap;
 }
 
 .markdown-body th {


### PR DESCRIPTION
## Summary

- Changed `.markdown-body table` width from `width: 100%` to `min-width: 100%` so tables can expand beyond the container width when content requires it
- Added `white-space: nowrap` to `.markdown-body td` to prevent table cell content from wrapping, allowing natural content-driven column sizing

This fixes the issue where markdown tables with wide content were being squeezed into the container width, making them hard to read.