### PR TITLE
fix: add safe-area-inset support for PWA on iOS

### DIFF
--- a/components/shell.tsx
+++ b/components/shell.tsx
@@ -303,6 +303,7 @@ export function Shell({
         } ${
           isDesktopSidebarOpen ? "md:translate-x-0" : "md:-translate-x-full"
         }`}
+        style={{ paddingTop: 'env(safe-area-inset-top, 0px)' }}
       >
         {isSettingsPage ? (
           <SettingsNav
@@ -344,10 +345,10 @@ export function Shell({
         </button>
       ) : null}
 
-      <div className={`relative flex min-h-0 min-w-0 flex-1 flex-col w-full overflow-hidden pt-14 md:pt-0 transition-all duration-300 ease-out ${
+      <div className={`relative flex min-h-0 min-w-0 flex-1 flex-col w-full overflow-hidden md:pt-0 transition-all duration-300 ease-out ${
         isDesktopSidebarOpen ? "md:pl-[280px]" : "md:pl-0"
-      }`}>
-        <div className="fixed top-0 left-0 right-0 z-30 flex h-14 items-center justify-between px-4 md:hidden bg-[var(--background)]/80 backdrop-blur-xl border-b border-white/4">
+      }`} style={{ paddingTop: 'calc(3.5rem + env(safe-area-inset-top, 0px))' }}>
+        <div className="fixed top-0 left-0 right-0 z-30 flex items-center justify-between px-4 md:hidden bg-[var(--background)]/80 backdrop-blur-xl border-b border-white/4" style={{ paddingTop: 'env(safe-area-inset-top, 0px)', height: 'calc(3.5rem + env(safe-area-inset-top, 0px))' }}>
           <button
             type="button"
             className="p-2 -ml-2 text-[var(--text)] hover:bg-white/5 rounded-lg transition-colors duration-200"


### PR DESCRIPTION
## Summary

- Added `env(safe-area-inset-top)` padding to the sidebar, main content area, and mobile header to properly handle iOS safe areas when installed as a PWA
- Removed hardcoded `pt-14` class from the main content wrapper and replaced with a dynamic `padding-top` that accounts for both the header height and safe area inset
- Updated the mobile header to dynamically size itself based on safe area insets
- Fixes a regression where content was obscured by the iOS notch/status bar in PWA mode