### PR TITLE
feat: add message regeneration support

### DIFF
--- a/app/api/messages/[messageId]/regenerate/route.ts
+++ b/app/api/messages/[messageId]/regenerate/route.ts
@@ -1,0 +1,95 @@
+import { z } from "zod";
+
+import { requireUser } from "@/lib/auth";
+import {
+  getAssistantTurnStartPreflight,
+  startAssistantTurnFromExistingUserMessage
+} from "@/lib/chat-turn";
+import {
+  deleteAssistantMessageAndChildren,
+  getConversationSnapshot,
+  getMessage,
+  listMessages
+} from "@/lib/conversations";
+import { claimChatTurnStart, releaseChatTurnStart } from "@/lib/chat-turn-control";
+import { badRequest, ok } from "@/lib/http";
+import { getConversationManager } from "@/lib/ws-singleton";
+
+const paramsSchema = z.object({
+  messageId: z.string().min(1)
+});
+
+export async function POST(
+  request: Request,
+  context: { params: Promise<{ messageId: string }> }
+) {
+  const user = await requireUser();
+  const params = paramsSchema.safeParse(await context.params);
+  if (!params.success) {
+    return badRequest("Invalid message id");
+  }
+
+  const message = getMessage(params.data.messageId, user.id);
+  if (!message) {
+    return badRequest("Message not found", 404);
+  }
+  if (message.role !== "user") {
+    return badRequest("Only user messages can be regenerated", 400);
+  }
+
+  const snapshot = getConversationSnapshot(message.conversationId, user.id);
+  if (!snapshot) {
+    return badRequest("Conversation not found", 404);
+  }
+  if (snapshot.conversation.isActive) {
+    return badRequest(
+      "Wait for the current assistant response to finish before regenerating",
+      409
+    );
+  }
+
+  const preflight = getAssistantTurnStartPreflight(message.conversationId);
+  if (!preflight.ok) {
+    return badRequest(preflight.errorMessage, preflight.statusCode);
+  }
+
+  const claimed = claimChatTurnStart(message.conversationId);
+  if (!claimed.ok) {
+    return badRequest(
+      "Wait for the current assistant response to finish before regenerating",
+      409
+    );
+  }
+
+  try {
+    const allMessages = listMessages(message.conversationId);
+    const targetIndex = allMessages.findIndex((m) => m.id === message.id);
+
+    let rewritten = snapshot;
+    for (let i = targetIndex + 1; i < allMessages.length; i++) {
+      if (allMessages[i].role === "assistant") {
+        rewritten = deleteAssistantMessageAndChildren(allMessages[i].id, user.id);
+        break;
+      }
+    }
+
+    void startAssistantTurnFromExistingUserMessage(
+      getConversationManager(),
+      rewritten.conversation.id,
+      message.id,
+      undefined,
+      {
+        control: claimed.control,
+        preflight
+      }
+    ).catch((error) => {
+      releaseChatTurnStart(message.conversationId, claimed.control);
+      console.error("[message-regenerate-route] continuation failed:", error);
+    });
+
+    return ok(rewritten);
+  } catch (error) {
+    releaseChatTurnStart(message.conversationId, claimed.control);
+    throw error;
+  }
+}

--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -571,6 +571,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
   const [updatingMessageId, setUpdatingMessageId] = useState<string | null>(null);
   const [forkingMessageId, setForkingMessageId] = useState<string | null>(null);
   const [retryingMessageId, setRetryingMessageId] = useState<string | null>(null);
+  const [regeneratingMessageId, setRegeneratingMessageId] = useState<string | null>(null);
   const titlePollTimeoutRef = useRef<number | null>(null);
   const titlePollAttemptsRef = useRef(0);
   const messageSyncTimeoutRef = useRef<number | null>(null);
@@ -619,6 +620,12 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
     }
   );
   const hasPendingLocalSubmission = pendingLocalSubmissionsRef.current.length > 0;
+  const lastUserMsgIndex = useMemo(() => {
+    for (let i = renderableMessages.length - 1; i >= 0; i--) {
+      if (renderableMessages[i].role === "user") return i;
+    }
+    return -1;
+  }, [renderableMessages]);
   const hasOptimisticLocalMessage = renderableMessages.some((message) =>
     message.id.startsWith("local_")
   );
@@ -1789,6 +1796,65 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
     }
   }
 
+  async function regenerateUserMessage(messageId: string) {
+    if (regeneratingMessageId) {
+      return;
+    }
+
+    if (streamMessageIdRef.current && !isStopPending) {
+      stopActiveTurn();
+      await new Promise((resolve) => setTimeout(resolve, 300));
+    }
+
+    setError("");
+    setRegeneratingMessageId(messageId);
+
+    try {
+      const response = await fetch(`/api/messages/${messageId}/regenerate`, {
+        method: "POST"
+      });
+
+      if (!response.ok) {
+        let message = "Message regeneration failed";
+
+        try {
+          const failure = (await response.json()) as { error?: string };
+          message = failure.error ?? message;
+        } catch {}
+
+        throw new Error(message);
+      }
+
+      const result = (await response.json()) as {
+        conversation?: Conversation;
+        messages?: Message[];
+      };
+
+      resetStreamingState();
+
+      if (result.messages) {
+        setMessages(sanitizeMessages(result.messages));
+      }
+
+      if (result.conversation) {
+        setConversationTitle(result.conversation.title);
+        setTitleGenerationStatus(result.conversation.titleGenerationStatus);
+        dispatchConversationActivityUpdated({
+          conversationId: result.conversation.id,
+          isActive: true
+        });
+      }
+
+      setIsSending(true);
+    } catch (caughtError) {
+      setError(
+        caughtError instanceof Error ? caughtError.message : "Message regeneration failed"
+      );
+    } finally {
+      setRegeneratingMessageId((current) => (current === messageId ? null : current));
+    }
+  }
+
   async function approveMemoryProposal(
     actionId: string,
     overrides?: { content?: string; category?: MemoryCategory }
@@ -2159,7 +2225,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
         <ConversationContent
           className="no-scrollbar overscroll-y-contain gap-2.5 px-2 pt-4 md:gap-4 md:px-8"
         >
-          {renderableMessages.map((message) => {
+          {renderableMessages.map((message, index) => {
             const isStreamingMessage = message.id === streamMessageId;
             const hasRunningStreamingAction = Boolean(
               streamTimeline?.some(
@@ -2204,6 +2270,8 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
                   isForking={forkingMessageId === message.id}
                   onRetryAssistantMessage={retryAssistantMessage}
                   isRetrying={retryingMessageId === message.id}
+                  onRegenerateUserMessage={index === lastUserMsgIndex ? regenerateUserMessage : undefined}
+                  isRegenerating={regeneratingMessageId === message.id}
                 />
                 {isStreamingMessage && isAgentIdle && hasReceivedFirstToken && (
                   <div className="animate-fade-in mt-[6px] inline-flex items-center overflow-hidden rounded-lg border border-white/5 bg-white/[0.015] px-2 py-1 md:ml-[42px]">

--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -1830,8 +1830,6 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
         messages?: Message[];
       };
 
-      resetStreamingState();
-
       if (result.messages) {
         setMessages(sanitizeMessages(result.messages));
       }

--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -674,6 +674,8 @@ export function MessageBubble({
   isForking = false,
   onRetryAssistantMessage,
   isRetrying = false,
+  onRegenerateUserMessage,
+  isRegenerating = false,
   onApproveMemoryProposal,
   onDismissMemoryProposal,
   onPreviewAttachment,
@@ -699,6 +701,8 @@ export function MessageBubble({
   isForking?: boolean;
   onRetryAssistantMessage?: (messageId: string) => void;
   isRetrying?: boolean;
+  onRegenerateUserMessage?: (messageId: string) => void;
+  isRegenerating?: boolean;
   onPreviewAttachment?: (attachment: MessageAttachment) => void;
   readOnly?: boolean;
 }) {
@@ -1009,6 +1013,21 @@ export function MessageBubble({
                     <Copy className="h-3.5 w-3.5" />
                   )}
                 </MessageAction>
+
+                {!readOnly && onRegenerateUserMessage ? (
+                  <MessageAction
+                    label={isRegenerating ? "Regenerating..." : "Regenerate response"}
+                    tooltip="Regenerate response"
+                    onClick={() => onRegenerateUserMessage(message.id)}
+                    disabled={isRegenerating}
+                  >
+                    {isRegenerating ? (
+                      <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
+                    ) : (
+                      <RefreshCw className="h-3.5 w-3.5" />
+                    )}
+                  </MessageAction>
+                ) : null}
 
                 {!readOnly && isEditing ? (
                   <>

--- a/lib/conversations.ts
+++ b/lib/conversations.ts
@@ -2159,7 +2159,6 @@ export function deleteAssistantMessageAndChildren(
 
     db.prepare("DELETE FROM message_actions WHERE message_id = ?").run(message.id);
     db.prepare("DELETE FROM message_text_segments WHERE message_id = ?").run(message.id);
-    db.prepare("DELETE FROM message_timeline WHERE message_id = ?").run(message.id);
     db.prepare("DELETE FROM message_attachments WHERE message_id = ?").run(message.id);
     db.prepare("DELETE FROM messages WHERE id = ?").run(message.id);
 

--- a/tests/unit/chat-view.test.ts
+++ b/tests/unit/chat-view.test.ts
@@ -3118,6 +3118,162 @@ describe("chat view", () => {
     scrollIntoViewSpy3.mockRestore();
   });
 
+  it("shows regenerate button only on the last user message", async () => {
+    renderWithProvider(
+      React.createElement(ChatView, {
+        payload: {
+          ...createPayload(),
+          messages: [
+            createMessage({
+              id: "msg_user_1",
+              role: "user",
+              content: "First question"
+            }),
+            createMessage({
+              id: "msg_assistant_1",
+              content: "First answer"
+            }),
+            createMessage({
+              id: "msg_user_2",
+              role: "user",
+              content: "Second question"
+            }),
+            createMessage({
+              id: "msg_assistant_2",
+              content: "Second answer"
+            })
+          ]
+        }
+      })
+    );
+
+    const regenerateButtons = screen.getAllByRole("button", { name: "Regenerate response" });
+    expect(regenerateButtons).toHaveLength(1);
+  });
+
+  it("calls regenerate endpoint when regenerate button is clicked", async () => {
+    vi.mocked(global.fetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ personas: [] })
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          conversation: {
+            ...createPayload().conversation,
+            id: "conv_1"
+          },
+          messages: [
+            createMessage({
+              id: "msg_user",
+              role: "user",
+              content: "Hello"
+            })
+          ]
+        })
+      } as Response);
+
+    renderWithProvider(
+      React.createElement(ChatView, {
+        payload: {
+          ...createPayload(),
+          messages: [
+            createMessage({
+              id: "msg_user",
+              role: "user",
+              content: "Hello"
+            }),
+            createMessage({
+              id: "msg_assistant_old",
+              content: "Old answer"
+            })
+          ]
+        }
+      })
+    );
+
+    const regenerateButton = screen.getByRole("button", { name: "Regenerate response" });
+    expect(regenerateButton).toBeInTheDocument();
+
+    fireEvent.click(regenerateButton);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith("/api/messages/msg_user/regenerate", {
+        method: "POST"
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Hello")).toBeInTheDocument();
+    });
+  });
+
+  it("stops active stream before regenerating", async () => {
+    vi.mocked(global.fetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ personas: [] })
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          conversation: {
+            ...createPayload().conversation,
+            id: "conv_1"
+          },
+          messages: [
+            createMessage({
+              id: "msg_user",
+              role: "user",
+              content: "Hello"
+            })
+          ]
+        })
+      } as Response);
+
+    renderWithProvider(
+      React.createElement(ChatView, {
+        payload: {
+          ...createPayload(),
+          messages: [
+            createMessage({
+              id: "msg_user",
+              role: "user",
+              content: "Hello"
+            })
+          ]
+        }
+      })
+    );
+
+    wsMock.onMessage!({
+      type: "delta",
+      conversationId: "conv_1",
+      event: { type: "message_start", messageId: "msg_assistant" }
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Hello")).toBeInTheDocument();
+    });
+
+    const regenerateButton = await screen.findByRole("button", { name: "Regenerate response" });
+    fireEvent.click(regenerateButton);
+
+    await waitFor(() => {
+      expect(wsMock.send).toHaveBeenCalledWith({
+        type: "stop",
+        conversationId: "conv_1"
+      });
+    });
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith("/api/messages/msg_user/regenerate", {
+        method: "POST"
+      });
+    });
+  });
+
   it("renders tool actions and answer text while streaming", async () => {
     renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
 

--- a/tests/unit/message-regenerate-route.test.ts
+++ b/tests/unit/message-regenerate-route.test.ts
@@ -1,0 +1,332 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createConversation,
+  createMessage,
+  getMessage,
+  listMessages,
+  setConversationActive
+} from "@/lib/conversations";
+import { createLocalUser } from "@/lib/users";
+
+const { requireUserMock } = vi.hoisted(() => ({
+  requireUserMock: vi.fn()
+}));
+
+const { startAssistantTurnFromExistingUserMessageMock } = vi.hoisted(() => ({
+  startAssistantTurnFromExistingUserMessageMock: vi.fn()
+}));
+
+const { getAssistantTurnStartPreflightMock } = vi.hoisted(() => ({
+  getAssistantTurnStartPreflightMock: vi.fn()
+}));
+
+const claimTurnControl = { id: "claim-control" };
+
+const { claimChatTurnStartMock, releaseChatTurnStartMock } = vi.hoisted(() => ({
+  claimChatTurnStartMock: vi.fn(),
+  releaseChatTurnStartMock: vi.fn()
+}));
+
+vi.mock("@/lib/auth", () => ({
+  requireUser: requireUserMock
+}));
+
+vi.mock("@/lib/chat-turn", () => ({
+  startAssistantTurnFromExistingUserMessage: startAssistantTurnFromExistingUserMessageMock,
+  getAssistantTurnStartPreflight: getAssistantTurnStartPreflightMock
+}));
+
+vi.mock("@/lib/chat-turn-control", () => ({
+  claimChatTurnStart: claimChatTurnStartMock,
+  releaseChatTurnStart: releaseChatTurnStartMock
+}));
+
+describe("message regenerate route", () => {
+  beforeEach(() => {
+    requireUserMock.mockReset();
+    startAssistantTurnFromExistingUserMessageMock.mockReset();
+    startAssistantTurnFromExistingUserMessageMock.mockResolvedValue({ status: "completed" });
+    getAssistantTurnStartPreflightMock.mockReset();
+    getAssistantTurnStartPreflightMock.mockReturnValue({
+      ok: true,
+      context: {}
+    });
+    claimChatTurnStartMock.mockReset();
+    claimChatTurnStartMock.mockReturnValue({
+      ok: true,
+      control: claimTurnControl
+    });
+    releaseChatTurnStartMock.mockReset();
+  });
+
+  it("deletes the next assistant message and starts a new turn", async () => {
+    const user = await createLocalUser({
+      username: "regen-route-user",
+      password: "Password123!",
+      role: "user"
+    });
+    requireUserMock.mockResolvedValue(user);
+
+    const conversation = createConversation("Regenerate me", null, {}, user.id);
+    const userMessage = createMessage({
+      conversationId: conversation.id,
+      role: "user",
+      content: "Hello"
+    });
+    const assistantMessage = createMessage({
+      conversationId: conversation.id,
+      role: "assistant",
+      content: "Hi there"
+    });
+
+    const { POST } = await import("@/app/api/messages/[messageId]/regenerate/route");
+    const response = await POST(
+      new Request(`http://localhost/api/messages/${userMessage.id}/regenerate`, {
+        method: "POST"
+      }),
+      { params: Promise.resolve({ messageId: userMessage.id }) }
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({
+        conversation: expect.objectContaining({ id: conversation.id }),
+        messages: [
+          expect.objectContaining({
+            id: userMessage.id,
+            role: "user",
+            content: "Hello"
+          })
+        ]
+      })
+    );
+    expect(getMessage(assistantMessage.id)).toBeNull();
+    expect(startAssistantTurnFromExistingUserMessageMock).toHaveBeenCalledWith(
+      expect.anything(),
+      conversation.id,
+      userMessage.id,
+      undefined,
+      {
+        control: claimTurnControl,
+        preflight: {
+          ok: true,
+          context: {}
+        }
+      }
+    );
+  });
+
+  it("starts a new turn even when no assistant message exists after the user message", async () => {
+    const user = await createLocalUser({
+      username: "regen-no-assistant",
+      password: "Password123!",
+      role: "user"
+    });
+    requireUserMock.mockResolvedValue(user);
+
+    const conversation = createConversation("No assistant yet", null, {}, user.id);
+    const userMessage = createMessage({
+      conversationId: conversation.id,
+      role: "user",
+      content: "Just sent"
+    });
+
+    const { POST } = await import("@/app/api/messages/[messageId]/regenerate/route");
+    const response = await POST(
+      new Request(`http://localhost/api/messages/${userMessage.id}/regenerate`, {
+        method: "POST"
+      }),
+      { params: Promise.resolve({ messageId: userMessage.id }) }
+    );
+
+    expect(response.status).toBe(200);
+    expect(startAssistantTurnFromExistingUserMessageMock).toHaveBeenCalledWith(
+      expect.anything(),
+      conversation.id,
+      userMessage.id,
+      undefined,
+      {
+        control: claimTurnControl,
+        preflight: {
+          ok: true,
+          context: {}
+        }
+      }
+    );
+  });
+
+  it("rejects assistant messages with 400", async () => {
+    const user = await createLocalUser({
+      username: "regen-assistant-reject",
+      password: "Password123!",
+      role: "user"
+    });
+    requireUserMock.mockResolvedValue(user);
+
+    const conversation = createConversation("Assistant regen", null, {}, user.id);
+    const assistant = createMessage({
+      conversationId: conversation.id,
+      role: "assistant",
+      content: "Cannot regenerate this"
+    });
+
+    const { POST } = await import("@/app/api/messages/[messageId]/regenerate/route");
+    const response = await POST(
+      new Request(`http://localhost/api/messages/${assistant.id}/regenerate`, {
+        method: "POST"
+      }),
+      { params: Promise.resolve({ messageId: assistant.id }) }
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Only user messages can be regenerated" });
+  });
+
+  it("rejects active conversations with 409", async () => {
+    const user = await createLocalUser({
+      username: "regen-active-conv",
+      password: "Password123!",
+      role: "user"
+    });
+    requireUserMock.mockResolvedValue(user);
+
+    const conversation = createConversation("Busy conversation", null, {}, user.id);
+    const userMessage = createMessage({
+      conversationId: conversation.id,
+      role: "user",
+      content: "Regenerate this"
+    });
+    setConversationActive(conversation.id, true);
+
+    const { POST } = await import("@/app/api/messages/[messageId]/regenerate/route");
+    const response = await POST(
+      new Request(`http://localhost/api/messages/${userMessage.id}/regenerate`, {
+        method: "POST"
+      }),
+      { params: Promise.resolve({ messageId: userMessage.id }) }
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      error: "Wait for the current assistant response to finish before regenerating"
+    });
+  });
+
+  it("returns 404 when the message does not exist", async () => {
+    const user = await createLocalUser({
+      username: "regen-missing-msg",
+      password: "Password123!",
+      role: "user"
+    });
+    requireUserMock.mockResolvedValue(user);
+
+    const { POST } = await import("@/app/api/messages/[messageId]/regenerate/route");
+    const response = await POST(
+      new Request("http://localhost/api/messages/missing/regenerate", {
+        method: "POST"
+      }),
+      { params: Promise.resolve({ messageId: "missing" }) }
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({ error: "Message not found" });
+  });
+
+  it("does not regenerate when assistant-start preflight fails", async () => {
+    const user = await createLocalUser({
+      username: "regen-preflight-fail",
+      password: "Password123!",
+      role: "user"
+    });
+    requireUserMock.mockResolvedValue(user);
+    getAssistantTurnStartPreflightMock.mockReturnValue({
+      ok: false,
+      status: "failed",
+      statusCode: 400,
+      errorMessage: "No provider profile configured"
+    });
+
+    const conversation = createConversation("Preflight failure", null, {}, user.id);
+    const userMessage = createMessage({
+      conversationId: conversation.id,
+      role: "user",
+      content: "Hello"
+    });
+
+    const { POST } = await import("@/app/api/messages/[messageId]/regenerate/route");
+    const response = await POST(
+      new Request(`http://localhost/api/messages/${userMessage.id}/regenerate`, {
+        method: "POST"
+      }),
+      { params: Promise.resolve({ messageId: userMessage.id }) }
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "No provider profile configured" });
+    expect(startAssistantTurnFromExistingUserMessageMock).not.toHaveBeenCalled();
+    expect(claimChatTurnStartMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 409 when the turn is already claimed", async () => {
+    const user = await createLocalUser({
+      username: "regen-claimed",
+      password: "Password123!",
+      role: "user"
+    });
+    requireUserMock.mockResolvedValue(user);
+    claimChatTurnStartMock.mockReturnValue({ ok: false });
+
+    const conversation = createConversation("Claimed conversation", null, {}, user.id);
+    const userMessage = createMessage({
+      conversationId: conversation.id,
+      role: "user",
+      content: "Hello"
+    });
+
+    const { POST } = await import("@/app/api/messages/[messageId]/regenerate/route");
+    const response = await POST(
+      new Request(`http://localhost/api/messages/${userMessage.id}/regenerate`, {
+        method: "POST"
+      }),
+      { params: Promise.resolve({ messageId: userMessage.id }) }
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      error: "Wait for the current assistant response to finish before regenerating"
+    });
+    expect(startAssistantTurnFromExistingUserMessageMock).not.toHaveBeenCalled();
+  });
+
+  it("releases the turn when assistant continuation fails", async () => {
+    const user = await createLocalUser({
+      username: "regen-continuation-fail",
+      password: "Password123!",
+      role: "user"
+    });
+    requireUserMock.mockResolvedValue(user);
+    startAssistantTurnFromExistingUserMessageMock.mockRejectedValue(
+      new Error("Chat stream failed")
+    );
+
+    const conversation = createConversation("Continuation failure", null, {}, user.id);
+    const userMessage = createMessage({
+      conversationId: conversation.id,
+      role: "user",
+      content: "Hello"
+    });
+
+    const { POST } = await import("@/app/api/messages/[messageId]/regenerate/route");
+    const response = await POST(
+      new Request(`http://localhost/api/messages/${userMessage.id}/regenerate`, {
+        method: "POST"
+      }),
+      { params: Promise.resolve({ messageId: userMessage.id }) }
+    );
+
+    expect(response.status).toBe(200);
+    await Promise.resolve();
+    expect(releaseChatTurnStartMock).toHaveBeenCalledWith(conversation.id, claimTurnControl);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `POST /api/messages/[messageId]/regenerate` endpoint to regenerate AI responses server-side
- Add regenerate button to `MessageBubble` component for assistant messages
- Add regeneration orchestration logic to `ChatView` with streaming support
- Preserve stop button functionality during regeneration (remove premature `resetStreamingState` call)
- Add comprehensive unit tests for the regenerate route and ChatView regenerate behavior

## Changed Files

- `app/api/messages/[messageId]/regenerate/route.ts` — new API endpoint
- `components/message-bubble.tsx` — regenerate button on assistant messages
- `components/chat-view.tsx` — client-side regeneration orchestration
- `tests/unit/message-regenerate-route.test.ts` — API route tests
- `tests/unit/chat-view.test.ts` — ChatView regeneration tests