### PR TITLE
fix: resolve desktop PWA regression from mobile header inline styles

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -584,6 +584,28 @@ select {
   --radius-4xl: calc(var(--radius) * 2.6);
 }
 
+@layer utilities {
+  .pt-safe-mobile {
+    padding-top: env(safe-area-inset-top, 0px);
+  }
+  @media (min-width: 768px) {
+    .pt-safe-mobile {
+      padding-top: 0;
+    }
+  }
+  .pt-mobile-header {
+    padding-top: calc(3.5rem + env(safe-area-inset-top, 0px));
+  }
+  @media (min-width: 768px) {
+    .pt-mobile-header {
+      padding-top: 0;
+    }
+  }
+  .h-mobile-header {
+    height: calc(3.5rem + env(safe-area-inset-top, 0px));
+  }
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;

--- a/components/shell.tsx
+++ b/components/shell.tsx
@@ -345,10 +345,10 @@ export function Shell({
         </button>
       ) : null}
 
-      <div className={`relative flex min-h-0 min-w-0 flex-1 flex-col w-full overflow-hidden md:pt-0 transition-all duration-300 ease-out ${
+      <div className={`relative flex min-h-0 min-w-0 flex-1 flex-col w-full overflow-hidden pt-mobile-header transition-all duration-300 ease-out ${
         isDesktopSidebarOpen ? "md:pl-[280px]" : "md:pl-0"
-      }`} style={{ paddingTop: 'calc(3.5rem + env(safe-area-inset-top, 0px))' }}>
-        <div className="fixed top-0 left-0 right-0 z-30 flex items-center justify-between px-4 md:hidden bg-[var(--background)]/80 backdrop-blur-xl border-b border-white/4" style={{ paddingTop: 'env(safe-area-inset-top, 0px)', height: 'calc(3.5rem + env(safe-area-inset-top, 0px))' }}>
+      }`}>
+        <div className="fixed top-0 left-0 right-0 z-30 flex items-center justify-between px-4 pt-safe-mobile h-mobile-header md:hidden bg-[var(--background)]/80 backdrop-blur-xl border-b border-white/4">
           <button
             type="button"
             className="p-2 -ml-2 text-[var(--text)] hover:bg-white/5 rounded-lg transition-colors duration-200"


### PR DESCRIPTION
## Summary
- Replaces inline `style` attributes on the mobile header with Tailwind utility classes (`pt-safe-mobile`, `pt-mobile-header`, `h-mobile-header`) defined in `globals.css`
- Desktop breakpoints (`md:`) properly reset mobile-specific padding/height to `0`, preventing safe-area-inset styles from leaking into desktop view
- Fixes regression where desktop PWA view showed incorrect top padding inherited from mobile safe-area styles

## Test Plan
- [ ] Verify mobile view still has correct safe-area-inset-top padding for the header
- [ ] Verify desktop view has no top padding on the main content area
- [ ] Verify desktop sidebar open/close layout is unaffected
- [ ] Verify mobile header height and positioning remain correct