### PR TITLE
fix: improve markdown bullet list and blockquote normalization

### DIFF
--- a/lib/assistant-runtime.ts
+++ b/lib/assistant-runtime.ts
@@ -99,7 +99,31 @@ const MARKDOWN_FORMATTING_DIRECTIVE =
 \n\
 5. **Blank lines**: Always use blank lines to separate block-level elements from each other — headings, horizontal rules, tables, fenced code blocks, and lists must each be surrounded by blank lines.\n\
 \n\
-6. **General**: Always output valid GitHub Flavored Markdown. Do not use raw HTML when a markdown equivalent exists.";
+6. **Lists**: Always start a list on a new line. There must be a blank line between any preceding text and the first list item. Never place a bullet (`*` or `-`) or numbered item on the same line as other content. This applies to sub-lists as well — each nested list item must appear on its own indented line, not run into the parent item.\n\
+\n\
+7. **General**: Always output valid GitHub Flavored Markdown. Do not use raw HTML when a markdown equivalent exists.\n\
+\n\
+---\n\
+\n\
+Further guidelines:\n\
+\n\
+**I. Response Guiding Principles**\n\
+\n\
+* **Use the Formatting Toolkit given below effectively:** Use the formatting tools to create a clear, scannable, organized and easy to digest response, avoiding dense walls of text. Prioritize scannability that achieves clarity at a glance.\n\
+\n\
+**II. Your Formatting Toolkit**\n\
+\n\
+* **Headings (##, ###):** To create a clear hierarchy.\n\
+\n\
+* **Horizontal Rules (---):** To visually separate distinct sections or ideas.\n\
+\n\
+* **Bolding (**...**):** To emphasize key phrases and guide the user's eye. Use it judiciously.\n\
+\n\
+* **Bullet Points (*):** To break down information into digestible lists.\n\
+\n\
+* **Tables:** To organize and compare data for quick reference.\n\
+\n\
+* **Blockquotes (>):** To highlight important notes, examples, or quotes.";
 
 function mcpToolFunctionName(serverSlug: string, toolName: string) {
   return `mcp_${serverSlug}_${toolName}`;

--- a/lib/markdown-normalization.ts
+++ b/lib/markdown-normalization.ts
@@ -10,6 +10,7 @@ const INLINE_ORDERED_MARKER = /([^\s\d.)_<>(#`])(\d{1,3}[.)]\s)/g;
 const INLINE_HEADING_MARKER = /([^\s#_|>#`])(#{1,6}\s\S)/g;
 const INLINE_STAR_MARKER_EMPHASIS = /(\*{1,3})([ \t]+)([*+]\s(?:\[[ x]\]\s)?)/g;
 const INLINE_STAR_MARKER_INLINE = /(\S)([ \t]+)([*+]\s(?:\[[ x]\]\s)?)/g;
+const INLINE_STAR_MARKER_NO_SPACE = /(\S)([*+]\s(?:\[[ x]\]\s)?)/g;
 const INLINE_BLOCKQUOTE_MARKER_EMPHASIS = /(\*{1,3})([ \t]*)(>(?:[ \t]|$))/gm;
 const INLINE_BLOCKQUOTE_MARKER_INLINE = /(\S)([ \t]+)(>(?:[ \t]*>)+[ \t]?)/gm;
 
@@ -64,6 +65,27 @@ function fixHorizontalRuleFusion(text: string): string {
   return result;
 }
 
+function lineIndentAt(fullString: string, offset: number): string {
+  const lineStart = fullString.lastIndexOf("\n", offset - 1) + 1;
+  const lineText = fullString.slice(lineStart);
+  const indent = lineText.match(/^[ \t]*/);
+  return indent ? indent[0] : "";
+}
+
+function lineIsListItem(fullString: string, offset: number): boolean {
+  const lineStart = fullString.lastIndexOf("\n", offset - 1) + 1;
+  const lineText = fullString.slice(lineStart);
+  return /^\s*([-*+]|\d{1,3}[.)])\s/.test(lineText);
+}
+
+function subItemIndentAt(fullString: string, offset: number): string {
+  const indent = lineIndentAt(fullString, offset);
+  if (lineIsListItem(fullString, offset)) {
+    return indent + "  ";
+  }
+  return indent;
+}
+
 function fixInlineBlockMarkersInner(text: string): string {
   let result = text;
 
@@ -81,9 +103,10 @@ function fixInlineBlockMarkersInner(text: string): string {
     return `${before}\n${marker}`;
   });
 
-  result = result.replace(INLINE_STAR_MARKER_EMPHASIS, (match, emphasis, spaces, marker) => {
+  result = result.replace(INLINE_STAR_MARKER_EMPHASIS, (match, emphasis, spaces, marker, offset, fullString) => {
     if (spaces.includes("\n")) return match;
-    return `${emphasis}\n${marker}`;
+    const indent = subItemIndentAt(fullString, offset);
+    return `${emphasis}\n${indent}${marker}`;
   });
 
   result = result.replace(INLINE_STAR_MARKER_INLINE, (match, before, spaces, marker, offset, fullString) => {
@@ -92,12 +115,23 @@ function fixInlineBlockMarkersInner(text: string): string {
     const afterIdx = offset + before.length + spaces.length + marker.length;
     const afterChar = fullString[afterIdx];
     if (/\d/.test(before) && afterChar && /\d/.test(afterChar)) return match;
-    return `${before}\n${spaces}${marker}`;
+    const indent = subItemIndentAt(fullString, offset);
+    return `${before}\n${indent}${marker}`;
   });
 
-  result = result.replace(INLINE_BLOCKQUOTE_MARKER_EMPHASIS, (match, emphasis, spaces, marker) => {
+  result = result.replace(INLINE_STAR_MARKER_NO_SPACE, (match, before, marker, offset, fullString) => {
+    if (before === "*" || before === "+") return match;
+    const afterIdx = offset + before.length + marker.length;
+    const afterChar = fullString[afterIdx];
+    if (/\d/.test(before) && afterChar && /\d/.test(afterChar)) return match;
+    const indent = subItemIndentAt(fullString, offset);
+    return `${before}\n${indent}${marker}`;
+  });
+
+  result = result.replace(INLINE_BLOCKQUOTE_MARKER_EMPHASIS, (match, emphasis, spaces, marker, offset, fullString) => {
     if (spaces.includes("\n")) return match;
-    return `${emphasis}\n${spaces}${marker}`;
+    const indent = subItemIndentAt(fullString, offset);
+    return `${emphasis}\n${indent}${marker}`;
   });
 
   result = result.replace(INLINE_BLOCKQUOTE_MARKER_INLINE, (match, before, spaces, marker, offset, fullString) => {
@@ -107,7 +141,8 @@ function fixInlineBlockMarkersInner(text: string): string {
     const afterChar = fullString[afterIdx];
     if (/\d/.test(before) && afterChar && /\d/.test(afterChar)) return match;
     if (/[<>=!]=?/.test(before) && afterChar && /\d/.test(afterChar)) return match;
-    return `${before}\n${spaces}${marker}`;
+    const indent = subItemIndentAt(fullString, offset);
+    return `${before}\n${indent}${marker}`;
   });
 
   return result;

--- a/lib/markdown-normalization.ts
+++ b/lib/markdown-normalization.ts
@@ -6,8 +6,12 @@ const HR_FUSED_AFTER = /(?<=\S)(-{3,})$/gm;
 
 const INLINE_TABLE_OPENER = /([^\s|])(\| [^ |-])/g;
 const INLINE_LIST_MARKER = /([^\s*_|>#`])([-]\s(?:\[[ x]\]\s)?)/g;
-const INLINE_ORDERED_MARKER = /([^\s\d.)_<>(#`])(\d+[.)]\s)/g;
+const INLINE_ORDERED_MARKER = /([^\s\d.)_<>(#`])(\d{1,3}[.)]\s)/g;
 const INLINE_HEADING_MARKER = /([^\s#_|>#`])(#{1,6}\s\S)/g;
+const INLINE_STAR_MARKER_EMPHASIS = /(\*{1,3})([ \t]+)([*+]\s(?:\[[ x]\]\s)?)/g;
+const INLINE_STAR_MARKER_INLINE = /(\S)([ \t]+)([*+]\s(?:\[[ x]\]\s)?)/g;
+const INLINE_BLOCKQUOTE_MARKER_EMPHASIS = /(\*{1,3})([ \t]*)(>(?:[ \t]|$))/gm;
+const INLINE_BLOCKQUOTE_MARKER_INLINE = /(\S)([ \t]+)(>(?:[ \t]*>)+[ \t]?)/gm;
 
 function splitAroundCodeFences(text: string): { text: string; insideCode: boolean }[] {
   const parts: { text: string; insideCode: boolean }[] = [];
@@ -77,6 +81,35 @@ function fixInlineBlockMarkersInner(text: string): string {
     return `${before}\n${marker}`;
   });
 
+  result = result.replace(INLINE_STAR_MARKER_EMPHASIS, (match, emphasis, spaces, marker) => {
+    if (spaces.includes("\n")) return match;
+    return `${emphasis}\n${marker}`;
+  });
+
+  result = result.replace(INLINE_STAR_MARKER_INLINE, (match, before, spaces, marker, offset, fullString) => {
+    if (spaces.includes("\n")) return match;
+    if (before === "*" || before === "+") return match;
+    const afterIdx = offset + before.length + spaces.length + marker.length;
+    const afterChar = fullString[afterIdx];
+    if (/\d/.test(before) && afterChar && /\d/.test(afterChar)) return match;
+    return `${before}\n${spaces}${marker}`;
+  });
+
+  result = result.replace(INLINE_BLOCKQUOTE_MARKER_EMPHASIS, (match, emphasis, spaces, marker) => {
+    if (spaces.includes("\n")) return match;
+    return `${emphasis}\n${spaces}${marker}`;
+  });
+
+  result = result.replace(INLINE_BLOCKQUOTE_MARKER_INLINE, (match, before, spaces, marker, offset, fullString) => {
+    if (spaces.includes("\n")) return match;
+    if (before === ">") return match;
+    const afterIdx = offset + before.length + spaces.length + marker.length;
+    const afterChar = fullString[afterIdx];
+    if (/\d/.test(before) && afterChar && /\d/.test(afterChar)) return match;
+    if (/[<>=!]=?/.test(before) && afterChar && /\d/.test(afterChar)) return match;
+    return `${before}\n${spaces}${marker}`;
+  });
+
   return result;
 }
 
@@ -94,7 +127,7 @@ function classifyLine(line: string): BlockKind {
   if (/^>\s?/.test(trimmed)) return "blockquote";
   if (/^\|/.test(trimmed)) return "table";
   if (/^[-*+]\s/.test(trimmed)) return "unordered-list";
-  if (/^\d+[.)]\s/.test(trimmed)) return "ordered-list";
+  if (/^\d{1,3}[.)]\s/.test(trimmed)) return "ordered-list";
   if (/^(-{3,}|\*{3,}|_{3,})\s*$/.test(trimmed)) return "hr";
   return "other";
 }

--- a/tests/unit/markdown-normalization.test.ts
+++ b/tests/unit/markdown-normalization.test.ts
@@ -1,0 +1,156 @@
+import { normalizeMarkdown } from "@/lib/markdown-normalization";
+
+describe("normalizeMarkdown", () => {
+  describe("inline bullet markers", () => {
+    it("splits inline * marker after emphasis on list item line into sub-item", () => {
+      expect(normalizeMarkdown("* **Hardware**  * Sub-item")).toBe(
+        "* **Hardware**\n  * Sub-item"
+      );
+    });
+
+    it("splits inline * marker after text on list item line into sub-item", () => {
+      expect(normalizeMarkdown("* item * sub")).toBe("* item\n  * sub");
+    });
+
+    it("splits inline * marker on non-list line at same indent", () => {
+      expect(normalizeMarkdown("text * item")).toBe("text\n\n* item");
+    });
+
+    it("splits inline + marker on list item line", () => {
+      expect(normalizeMarkdown("* item + sub")).toBe("* item\n  + sub");
+    });
+
+    it("splits * * item as emphasis-list on list line", () => {
+      expect(normalizeMarkdown("* * item")).toBe("*\n  * item");
+    });
+
+    it("does not split when before char is +", () => {
+      expect(normalizeMarkdown("+ + item")).toBe("+ + item");
+    });
+
+    it("preserves 5 * 3 as multiplication", () => {
+      expect(normalizeMarkdown("5 * 3")).toBe("5 * 3");
+    });
+
+    it("splits inline * marker with no space after text", () => {
+      expect(normalizeMarkdown("word* item")).toBe("word\n\n* item");
+    });
+
+    it("does not split no-space when before char is *", () => {
+      expect(normalizeMarkdown("*** item")).toBe("*** item");
+    });
+
+    it("does not split no-space digit guard", () => {
+      expect(normalizeMarkdown("5*3")).toBe("5*3");
+    });
+  });
+
+  describe("nested inline markers", () => {
+    it("produces correct multi-level nesting from collapsed inline markers", () => {
+      const result = normalizeMarkdown(
+        "* **Hardware**  * Consumer Electronics    * Smart Home"
+      );
+      expect(result).toBe(
+        "* **Hardware**\n  * Consumer Electronics\n    * Smart Home"
+      );
+    });
+
+    it("indents sub-items deeper on already-indented list lines", () => {
+      const result = normalizeMarkdown(
+        "  * Consumer Electronics    * Smart Home"
+      );
+      expect(result).toBe(
+        "  * Consumer Electronics\n    * Smart Home"
+      );
+    });
+  });
+
+  describe("inline ordered markers", () => {
+    it("splits inline ordered marker after text", () => {
+      expect(normalizeMarkdown("text3. item")).toBe("text\n\n3. item");
+    });
+
+    it("does not split when before char is a digit (version number)", () => {
+      expect(normalizeMarkdown("v1.2 item")).toBe("v1.2 item");
+    });
+  });
+
+  describe("inline dash markers", () => {
+    it("splits inline dash marker after text", () => {
+      expect(normalizeMarkdown("text- item")).toBe("text\n\n- item");
+    });
+
+    it("does not split when before char is |", () => {
+      expect(normalizeMarkdown("text| - item")).toBe("text| - item");
+    });
+
+    it("does not split when before char is >", () => {
+      expect(normalizeMarkdown("text> - item")).toBe("text> - item");
+    });
+
+    it("does not split when before char is -", () => {
+      expect(normalizeMarkdown("text-- item")).toBe("text-- item");
+    });
+  });
+
+  describe("inline heading markers", () => {
+    it("splits inline heading marker immediately after text", () => {
+      expect(normalizeMarkdown("text## Heading")).toBe("text\n\n## Heading");
+    });
+
+    it("does not split heading after space", () => {
+      expect(normalizeMarkdown("text ## Heading")).toBe("text ## Heading");
+    });
+  });
+
+  describe("inline table markers", () => {
+    it("splits inline table opener after text", () => {
+      expect(normalizeMarkdown("text| data")).toBe("text\n\n| data");
+    });
+  });
+
+  describe("inline blockquote markers", () => {
+    it("splits inline nested blockquote after emphasis on list line", () => {
+      const result = normalizeMarkdown("* **bold**  > > nested");
+      expect(result).toBe("* **bold**\n\n  > > nested");
+    });
+
+    it("splits inline nested blockquote after text", () => {
+      expect(normalizeMarkdown("text  > > nested")).toBe("text\n\n> > nested");
+    });
+
+    it("does not split when before char is >", () => {
+      expect(normalizeMarkdown("> > > deep")).toBe("> > > deep");
+    });
+
+    it("does not split comparison operator >= with digits", () => {
+      expect(normalizeMarkdown("x >= 3 > > deep")).toBe("x >= 3\n\n> > deep");
+    });
+
+    it("does not split digit guard for blockquote", () => {
+      const result = normalizeMarkdown("5 > > deep");
+      expect(result).toContain("5");
+      expect(result).toContain("> > deep");
+    });
+  });
+
+  describe("ATX heading fix", () => {
+    it("adds space after # when missing", () => {
+      expect(normalizeMarkdown("##Heading")).toBe("## Heading");
+    });
+  });
+
+  describe("horizontal rule fusion fix", () => {
+    it("separates fused --- before text", () => {
+      const result = normalizeMarkdown("text---more");
+      expect(result).toContain("---");
+    });
+  });
+
+  describe("code fence protection", () => {
+    it("does not modify content inside code fences", () => {
+      const input = "```\n* item * sub\n```";
+      expect(normalizeMarkdown(input)).toBe(input);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **Add regex patterns for inline star (`*`/`+`) bullet markers** that appear immediately after emphasis text or inline content, ensuring they get split onto their own line
- **Add regex patterns for inline blockquote markers** (`>`) that appear after emphasis or inline content, with the same line-splitting normalization
- **Tighten ordered list marker regex** to match only 1-3 digits (prevents false positives on longer number sequences)
- **Expand the markdown formatting directive** in the system prompt:
  - Add explicit "Lists" rule requiring blank lines before list items and prohibiting inline bullet/numbered items
  - Add a formatting toolkit section with guidance on headings, horizontal rules, bolding, bullet points, tables, and blockquotes

These changes ensure that streamed markdown output from the assistant is correctly normalized — bullet lists, ordered lists, and blockquotes that appear inline are properly split onto new lines for correct rendering.