### PR TITLE
fix: close thinking and tool bubbles on click outside selection

### DIFF
--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -175,7 +175,14 @@ function CollapsibleActionRow({
         </span>
       </button>
       {isOpen && (action.detail || action.resultSummary) ? (
-        <div className="px-2.5 pb-2">
+        <div
+          className="px-2.5 pb-2"
+          onClick={() => {
+            if (!window.getSelection()?.toString()) {
+              onToggle();
+            }
+          }}
+        >
           {action.detail ? (
             <pre className="overflow-x-auto rounded-md bg-black/30 p-2 text-[11px] leading-5 whitespace-pre-wrap break-words font-mono">
               <AnsiText text={action.detail} defaultTextClassName="text-white/45" />
@@ -1094,7 +1101,14 @@ export function MessageBubble({
                 </button>
 
                 {thinkingOpen && thinkingContent ? (
-                  <div className="markdown-body thinking-markdown-body mt-1.5">
+                  <div
+                    className="markdown-body thinking-markdown-body mt-1.5"
+                    onClick={() => {
+                      if (!window.getSelection()?.toString()) {
+                        setThinkingOpen(false);
+                      }
+                    }}
+                  >
                     <Streamdown
                       remend={STREAMDOWN_REMEND}
                       parseMarkdownIntoBlocksFn={STREAMDOWN_PARSE_BLOCKS}


### PR DESCRIPTION
## Summary

- Add click-to-close behavior for the thinking (reasoning) bubble — clicking anywhere inside the expanded thinking content collapses it
- Add click-to-close behavior for tool/action detail panels — clicking inside the expanded detail area toggles it closed
- Both interactions check for an active text selection first, so copying text from within these panels still works without accidentally closing them