### PR TITLE
feat: consolidate and strengthen markdown normalization for AI output rendering

### DIFF
--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -5,7 +5,7 @@ import { Brain, Check, ChevronDown, ChevronRight, Copy, FileText, GitFork, Loade
 import { Streamdown, parseMarkdownIntoBlocks } from "streamdown";
 import { code } from "@streamdown/code";
 import { mermaid } from "@streamdown/mermaid";
-import { MARKDOWN_REMEND_HANDLERS, normalizeMarkdown } from "@/lib/markdown-normalization";
+import { normalizeMarkdown } from "@/lib/markdown-normalization";
 import {
   AttachmentPreviewModal,
   useAttachmentUrlBuilder,
@@ -32,7 +32,6 @@ import {
 } from "@/components/ai-elements/message";
 
 const STREAMDOWN_PLUGINS = { code, mermaid };
-const STREAMDOWN_REMEND = { handlers: MARKDOWN_REMEND_HANDLERS };
 const STREAMDOWN_PARSE_BLOCKS = (markdown: string) =>
   parseMarkdownIntoBlocks(markdown);
 const COPY_RESET_DELAY_MS = 1600;
@@ -97,7 +96,6 @@ function renderAssistantMarkdown(content: string, isStreaming: boolean) {
   return (
     <Streamdown
       plugins={STREAMDOWN_PLUGINS}
-      remend={STREAMDOWN_REMEND}
       parseMarkdownIntoBlocksFn={STREAMDOWN_PARSE_BLOCKS}
       caret={isStreaming ? "block" : undefined}
       isAnimating={isStreaming}
@@ -991,7 +989,7 @@ export function MessageBubble({
                 />
               ) : content ? (
                 <div ref={contentRef} className="markdown-body">
-                  <Streamdown mode="static" plugins={STREAMDOWN_PLUGINS} remend={STREAMDOWN_REMEND} parseMarkdownIntoBlocksFn={STREAMDOWN_PARSE_BLOCKS}>{md(content)}</Streamdown>
+                  <Streamdown mode="static" plugins={STREAMDOWN_PLUGINS} parseMarkdownIntoBlocksFn={STREAMDOWN_PARSE_BLOCKS}>{md(content)}</Streamdown>
                 </div>
               ) : null}
               {message.attachments?.length ? (
@@ -1129,7 +1127,6 @@ export function MessageBubble({
                     }}
                   >
                     <Streamdown
-                      remend={STREAMDOWN_REMEND}
                       parseMarkdownIntoBlocksFn={STREAMDOWN_PARSE_BLOCKS}
                       caret={thinkingInProgress ? "block" : undefined}
                       isAnimating={thinkingInProgress}

--- a/lib/assistant-runtime.ts
+++ b/lib/assistant-runtime.ts
@@ -87,21 +87,29 @@ const MERMAID_DIAGRAM_DIRECTIVE =
   "When you need to present diagrams (flowcharts, sequence diagrams, class diagrams, state diagrams, ER diagrams, Gantt charts, pie charts, mind maps, or any other diagram type), use mermaid.js syntax inside a fenced code block with the `mermaid` language identifier. For example:\n\n```mermaid\ngraph TD\n    A[Start] --> B{Decision}\n    B -->|Yes| C[Success]\n    B -->|No| D[Try Again]\n```\n\nAlways prefer mermaid diagrams over ASCII art or text-based diagrams.";
 
 const MARKDOWN_FORMATTING_DIRECTIVE =
-  "Follow these markdown formatting rules strictly in every response:\n\
+  "You MUST follow these markdown formatting rules in EVERY response. Violations break the rendering:\n\
 \n\
-1. **Headings**: Always place at least one space after the # markers. Write `## Title`, never `##Title`.\n\
+1. **Block elements MUST start on a new line.** Headings (`#`, `##`, `###`), bullet lists (`*`, `-`, `+`), numbered lists (`1.`, `2.`), blockquotes (`>`), tables (`|`), horizontal rules (`---`), and fenced code blocks (```) must ALWAYS begin on their own line — NEVER on the same line as other text.\n\
+   - WRONG: `Here is my list:* item1* item2`\n\
+   - RIGHT: `Here is my list:\\n\\n* item1\\n* item2`\n\
+   - WRONG: `Some text### Next Section`\n\
+   - RIGHT: `Some text\\n\\n### Next Section`\n\
 \n\
-2. **Horizontal rules**: Always place horizontal rules (`---`, `***`, or `___`) on their own line with a blank line before and after. Never put text on the same line as a horizontal rule. `---First text` and `text---` are invalid.\n\
+2. **Blank lines are mandatory between block elements.** Every heading, list, table, blockquote, code block, and horizontal rule MUST be separated from adjacent content by a blank line (two newlines). There are no exceptions.\n\
 \n\
-3. **Tables**: Use proper GitHub Flavored Markdown table syntax. Include a header row, a separator row with `|---|---|` or `| --- | --- |`, and consistent column counts across all rows.\n\
+3. **Headings require a space after the # markers.** Write `## Title`, NEVER `##Title`. The space is not optional.\n\
 \n\
-4. **Fenced code blocks**: Always close every opened fenced code block with matching backtick fences. Never leave a code block unclosed.\n\
+4. **Horizontal rules must stand alone.** `---`, `***`, and `___` must appear on their own line with blank lines before and after. `text---` and `---text` are invalid.\n\
 \n\
-5. **Blank lines**: Always use blank lines to separate block-level elements from each other — headings, horizontal rules, tables, fenced code blocks, and lists must each be surrounded by blank lines.\n\
+5. **Tables must use proper GFM syntax.** Include a header row, a separator row (`|---|`), and consistent column counts. Never collapse multiple rows onto one line.\n\
 \n\
-6. **Lists**: Always start a list on a new line. There must be a blank line between any preceding text and the first list item. Never place a bullet (`*` or `-`) or numbered item on the same line as other content. This applies to sub-lists as well — each nested list item must appear on its own indented line, not run into the parent item.\n\
+6. **Code blocks must be closed.** Every opening fence (``` or ~~~) must have a matching closing fence. Never leave a code block open.\n\
 \n\
-7. **General**: Always output valid GitHub Flavored Markdown. Do not use raw HTML when a markdown equivalent exists.\n\
+7. **List items must each be on their own line.** Never place multiple list items on the same line. Nested list items must be indented on their own line.\n\
+\n\
+8. **Blockquotes must start on a new line.** The `>` character must be at the start of a line, never inline with other text.\n\
+\n\
+9. **Always output valid GitHub Flavored Markdown.** Do not use raw HTML when a markdown equivalent exists.\n\
 \n\
 ---\n\
 \n\

--- a/lib/markdown-normalization.ts
+++ b/lib/markdown-normalization.ts
@@ -50,6 +50,30 @@ function fixCollapsedTableRows(text: string): string {
   return r;
 }
 
+function isClosingStar(text: string, starPos: number): boolean {
+  const lineStart = text.lastIndexOf("\n", starPos - 1) + 1;
+  const lineText = text.slice(lineStart);
+  let depth = 0;
+  let i = 0;
+  while (lineStart + i < starPos) {
+    if (lineText[i] === "\\") { i += 2; continue; }
+    if (i === 0 && /^[*+\-]\s/.test(lineText)) { i += 2; continue; }
+    if (lineText[i] === "`") {
+      const j = lineText.indexOf("`", i + 1);
+      i = j === -1 ? lineText.length : j + 1;
+      continue;
+    }
+    if (lineText[i] === "*" && i + 1 < lineText.length && lineText[i + 1] === "*") {
+      depth += 2; i += 2;
+    } else if (lineText[i] === "*") {
+      depth += 1; i += 1;
+    } else {
+      i += 1;
+    }
+  }
+  return depth % 2 !== 0;
+}
+
 function lineIndentAt(text: string, offset: number): string {
   const lineStart = text.lastIndexOf("\n", offset - 1) + 1;
   const lineText = text.slice(lineStart);
@@ -183,6 +207,7 @@ function expandLineInline(line: string): string {
       const afterIdx = offset + before.length + spaces.length + marker.length;
       const afterChar = fullString[afterIdx];
       if (/\d/.test(before) && afterChar && /\d/.test(afterChar)) return match;
+      if (marker[0] === "*" && before === "*" && isClosingStar(fullString, offset + before.length + spaces.length)) return match;
       const indent = subItemIndentAt(fullString, offset);
       return `${before}\n${indent}${marker}`;
     },
@@ -201,10 +226,13 @@ function expandLineInline(line: string): string {
       const afterIdx = offset + before.length + marker.length;
       const afterChar = fullString[afterIdx];
       if (/\d/.test(before) && afterChar && /\d/.test(afterChar)) return match;
+      if (marker[0] === "*" && isClosingStar(fullString, offset + before.length)) return match;
       const indent = lineIndentAt(fullString, offset);
       return `${before}\n${indent}${marker}`;
     },
   );
+
+  r = r.replace(/([.])(>(?:[ \t]|$))/gm, "$1\n$2");
 
   r = r.replace(
     /(\*{1,3})([ \t]*)(>(?:[ \t]|$))/gm,
@@ -356,7 +384,12 @@ export function normalizeMarkdown(text: string): string {
       continue;
     }
 
-    const expanded = expandLineInline(line);
+    let expanded = expandLineInline(line);
+    for (let pass = 0; pass < 3; pass++) {
+      const next = expandLineInline(expanded);
+      if (next === expanded) break;
+      expanded = next;
+    }
     const subLines = expanded.split("\n");
 
     for (let j = 0; j < subLines.length; j++) {

--- a/lib/markdown-normalization.ts
+++ b/lib/markdown-normalization.ts
@@ -227,9 +227,33 @@ function expandLineInline(line: string): string {
   return r;
 }
 
+function closeUnclosedInline(lines: string[]): void {
+  for (let i = 0; i < lines.length - 1; i++) {
+    const line = lines[i];
+    const nextTrimmed = lines[i + 1].trimStart();
+    if (!/^[-*+]\s/.test(nextTrimmed)) continue;
+    if (/^\|/.test(line.trimStart())) continue;
+
+    const match = line.match(/(^|[\s(])(\*{1,3})(\S[^*\n]*)$/);
+    if (!match) continue;
+    const opener = match[2];
+    const text = match[3];
+    const openerLen = opener.length;
+    const closer = "*".repeat(openerLen);
+    if (text.endsWith(closer)) continue;
+    let closeCount = 0;
+    for (let j = 0; j < text.length - openerLen + 1; j++) {
+      if (text.slice(j, j + openerLen) === closer) closeCount++;
+    }
+    if (closeCount % 2 !== 0) continue;
+    lines[i] = line + closer;
+  }
+}
+
 export function normalizeMarkdown(text: string): string {
   const preprocessed = fixCollapsedTableRows(text);
   const lines = preprocessed.split("\n");
+  closeUnclosedInline(lines);
   const output: string[] = [];
   let insideFence = false;
   let insideTable = false;

--- a/lib/markdown-normalization.ts
+++ b/lib/markdown-normalization.ts
@@ -1,162 +1,17 @@
 import type { RemendHandler } from "remend";
 
-const ATX_HEADING_NO_SPACE = /^(#{1,6})([^#\s\n])/gm;
-const HR_FUSED_BEFORE = /^(-{3,})(?=[^\n])/gm;
-const HR_FUSED_AFTER = /(?<=\S)(-{3,})$/gm;
-
-const INLINE_TABLE_OPENER = /([^\s|])(\| [^ |-])/g;
-const INLINE_LIST_MARKER = /([^\s*_|>#`])([-]\s(?:\[[ x]\]\s)?)/g;
-const INLINE_ORDERED_MARKER = /([^\s\d.)_<>(#`])(\d{1,3}[.)]\s)/g;
-const INLINE_HEADING_MARKER = /([^\s#_|>#`])(#{1,6}\s\S)/g;
-const INLINE_STAR_MARKER_EMPHASIS = /(\*{1,3})([ \t]+)([*+]\s(?:\[[ x]\]\s)?)/g;
-const INLINE_STAR_MARKER_INLINE = /(\S)([ \t]+)([*+]\s(?:\[[ x]\]\s)?)/g;
-const INLINE_STAR_MARKER_NO_SPACE = /(\S)([*+]\s(?:\[[ x]\]\s)?)/g;
-const INLINE_BLOCKQUOTE_MARKER_EMPHASIS = /(\*{1,3})([ \t]*)(>(?:[ \t]|$))/gm;
-const INLINE_BLOCKQUOTE_MARKER_INLINE = /(\S)([ \t]+)(>(?:[ \t]*>)+[ \t]?)/gm;
-
-function splitAroundCodeFences(text: string): { text: string; insideCode: boolean }[] {
-  const parts: { text: string; insideCode: boolean }[] = [];
-  const fenceRegex = /^(`{3,})/gm;
-  let lastEnd = 0;
-
-  while (true) {
-    const match = fenceRegex.exec(text);
-    if (!match) break;
-
-    const fenceStart = match.index;
-    const fenceLen = match[1].length;
-    const afterFence = fenceStart + fenceLen;
-    const rest = text.slice(afterFence);
-    const closeFence = rest.match(new RegExp(`\n((?:[ \t]*\n)?)` + "`".repeat(fenceLen) + `[ \t]*$`, "m"));
-
-    if (closeFence) {
-      const codeEnd = afterFence + (closeFence.index ?? 0) + closeFence[0].length;
-      if (fenceStart > lastEnd) {
-        parts.push({ text: text.slice(lastEnd, fenceStart), insideCode: false });
-      }
-      parts.push({ text: text.slice(fenceStart, codeEnd), insideCode: true });
-      lastEnd = codeEnd;
-      fenceRegex.lastIndex = codeEnd;
-    } else {
-      break;
-    }
-  }
-
-  if (lastEnd < text.length) {
-    parts.push({ text: text.slice(lastEnd), insideCode: false });
-  }
-
-  return parts.length > 0 ? parts : [{ text, insideCode: false }];
-}
-
-function applyOutsideCodeBlocks(text: string, fn: (t: string) => string): string {
-  const parts = splitAroundCodeFences(text);
-  return parts.map((part) => (part.insideCode ? part.text : fn(part.text))).join("");
-}
-
-function fixAtxHeadingSpace(text: string): string {
-  return text.replace(ATX_HEADING_NO_SPACE, "$1 $2");
-}
-
-function fixHorizontalRuleFusion(text: string): string {
-  let result = text;
-  result = result.replace(HR_FUSED_BEFORE, "\n\n---\n\n");
-  result = result.replace(HR_FUSED_AFTER, "\n\n---\n\n");
-  return result;
-}
-
-function lineIndentAt(fullString: string, offset: number): string {
-  const lineStart = fullString.lastIndexOf("\n", offset - 1) + 1;
-  const lineText = fullString.slice(lineStart);
-  const indent = lineText.match(/^[ \t]*/);
-  return indent ? indent[0] : "";
-}
-
-function lineIsListItem(fullString: string, offset: number): boolean {
-  const lineStart = fullString.lastIndexOf("\n", offset - 1) + 1;
-  const lineText = fullString.slice(lineStart);
-  return /^\s*([-*+]|\d{1,3}[.)])\s/.test(lineText);
-}
-
-function subItemIndentAt(fullString: string, offset: number): string {
-  const indent = lineIndentAt(fullString, offset);
-  if (lineIsListItem(fullString, offset)) {
-    return indent + "  ";
-  }
-  return indent;
-}
-
-function fixInlineBlockMarkersInner(text: string): string {
-  let result = text;
-
-  result = result.replace(INLINE_HEADING_MARKER, "$1\n$2");
-
-  result = result.replace(INLINE_TABLE_OPENER, "$1\n$2");
-
-  result = result.replace(INLINE_ORDERED_MARKER, (match, before, marker) => {
-    if (/[0-9.]/.test(before)) return match;
-    return `${before}\n${marker}`;
-  });
-
-  result = result.replace(INLINE_LIST_MARKER, (match, before, marker) => {
-    if (before === "|" || before === ">" || before === "-") return match;
-    return `${before}\n${marker}`;
-  });
-
-  result = result.replace(INLINE_STAR_MARKER_EMPHASIS, (match, emphasis, spaces, marker, offset, fullString) => {
-    if (spaces.includes("\n")) return match;
-    const indent = subItemIndentAt(fullString, offset);
-    return `${emphasis}\n${indent}${marker}`;
-  });
-
-  result = result.replace(INLINE_STAR_MARKER_INLINE, (match, before, spaces, marker, offset, fullString) => {
-    if (spaces.includes("\n")) return match;
-    if (before === "*" || before === "+") return match;
-    const afterIdx = offset + before.length + spaces.length + marker.length;
-    const afterChar = fullString[afterIdx];
-    if (/\d/.test(before) && afterChar && /\d/.test(afterChar)) return match;
-    const indent = subItemIndentAt(fullString, offset);
-    return `${before}\n${indent}${marker}`;
-  });
-
-  result = result.replace(INLINE_STAR_MARKER_NO_SPACE, (match, before, marker, offset, fullString) => {
-    if (before === "*" || before === "+") return match;
-    const afterIdx = offset + before.length + marker.length;
-    const afterChar = fullString[afterIdx];
-    if (/\d/.test(before) && afterChar && /\d/.test(afterChar)) return match;
-    const indent = subItemIndentAt(fullString, offset);
-    return `${before}\n${indent}${marker}`;
-  });
-
-  result = result.replace(INLINE_BLOCKQUOTE_MARKER_EMPHASIS, (match, emphasis, spaces, marker, offset, fullString) => {
-    if (spaces.includes("\n")) return match;
-    const indent = subItemIndentAt(fullString, offset);
-    return `${emphasis}\n${indent}${marker}`;
-  });
-
-  result = result.replace(INLINE_BLOCKQUOTE_MARKER_INLINE, (match, before, spaces, marker, offset, fullString) => {
-    if (spaces.includes("\n")) return match;
-    if (before === ">") return match;
-    const afterIdx = offset + before.length + spaces.length + marker.length;
-    const afterChar = fullString[afterIdx];
-    if (/\d/.test(before) && afterChar && /\d/.test(afterChar)) return match;
-    if (/[<>=!]=?/.test(before) && afterChar && /\d/.test(afterChar)) return match;
-    const indent = subItemIndentAt(fullString, offset);
-    return `${before}\n${indent}${marker}`;
-  });
-
-  return result;
-}
-
-function fixInlineBlockMarkers(text: string): string {
-  return applyOutsideCodeBlocks(text, fixInlineBlockMarkersInner);
-}
-
-type BlockKind = "heading" | "code-fence" | "blockquote" | "table" | "unordered-list" | "ordered-list" | "hr" | "other";
+type BlockKind =
+  | "heading"
+  | "code-fence"
+  | "blockquote"
+  | "table"
+  | "unordered-list"
+  | "ordered-list"
+  | "hr"
+  | "other";
 
 function classifyLine(line: string): BlockKind {
   const trimmed = line.trimStart();
-
   if (/^#{1,6}\s/.test(trimmed)) return "heading";
   if (/^`{3,}/.test(trimmed)) return "code-fence";
   if (/^>\s?/.test(trimmed)) return "blockquote";
@@ -167,25 +22,183 @@ function classifyLine(line: string): BlockKind {
   return "other";
 }
 
-function needsBlankLineBetween(prevKind: BlockKind, currentKind: BlockKind, currentIndent: number): boolean {
-  if (currentIndent > 0 && (currentKind === "unordered-list" || currentKind === "ordered-list")) {
+function needsBlankLineBetween(
+  prevKind: BlockKind,
+  currentKind: BlockKind,
+  currentIndent: number,
+): boolean {
+  if (
+    currentIndent > 0 &&
+    (currentKind === "unordered-list" || currentKind === "ordered-list")
+  ) {
     return false;
   }
-
   if (prevKind === "heading" || currentKind === "heading") {
     return true;
   }
-
   if (prevKind === currentKind) {
     return false;
   }
-
   return true;
 }
 
-function ensureBlockBlankLines(text: string): string {
-  const lines = text.split("\n");
-  const result: string[] = [];
+function fixCollapsedTableRows(text: string): string {
+  let r = text;
+  r = r.replace(/\|\|(?=\s*[`!*\w])/g, "|\n|");
+  r = r.replace(/(\|) (\| \w)/g, "$1\n$2");
+  r = r.replace(/(\|)(#{1,6}\s\S)/g, "$1\n$2");
+  return r;
+}
+
+function lineIndentAt(text: string, offset: number): string {
+  const lineStart = text.lastIndexOf("\n", offset - 1) + 1;
+  const lineText = text.slice(lineStart);
+  const indent = lineText.match(/^[ \t]*/);
+  return indent ? indent[0] : "";
+}
+
+function lineIsListItem(text: string, offset: number): boolean {
+  const lineStart = text.lastIndexOf("\n", offset - 1) + 1;
+  const lineText = text.slice(lineStart);
+  return /^\s*([-*+]|\d{1,3}[.)])\s/.test(lineText);
+}
+
+function subItemIndentAt(text: string, offset: number): string {
+  const indent = lineIndentAt(text, offset);
+  if (lineIsListItem(text, offset)) {
+    return indent + "  ";
+  }
+  return indent;
+}
+
+function expandLineInline(line: string): string {
+  let r = line;
+
+  r = r.replace(/^(#{1,6})([^#\s\n])/, "$1 $2");
+
+  r = r.replace(/^(-{3,})(?=[^\n])/, "\n$1\n");
+  r = r.replace(/(?<=\S)(-{3,})$/, "\n$1\n");
+
+  r = r.replace(/([^\s#_|>#`])(#{1,6}\s\S)/g, "$1\n$2");
+
+  r = r.replace(/([^\s|])(\| [^ |-])/g, "$1\n$2");
+
+  r = r.replace(
+    /([^\s\d.)_<>(#`])(\d{1,3}[.)]\s)/g,
+    (match, before: string, marker: string) => {
+      if (/[0-9.]/.test(before)) return match;
+      return `${before}\n${marker}`;
+    },
+  );
+
+  r = r.replace(
+    /([^\s*_|>#`])([-]\s(?:\[[ x]\]\s)?)/g,
+    (match, before: string, _marker: string) => {
+      if (before === "|" || before === ">" || before === "-") return match;
+      return `${before}\n${_marker}`;
+    },
+  );
+
+  r = r.replace(
+    /(\*{1,3})([ \t]+)([*+]\s(?:\[[ x]\]\s)?)/g,
+    (
+      match: string,
+      emphasis: string,
+      spaces: string,
+      marker: string,
+      offset: number,
+      fullString: string,
+    ) => {
+      if (spaces.includes("\n")) return match;
+      const indent = subItemIndentAt(fullString, offset);
+      return `${emphasis}\n${indent}${marker}`;
+    },
+  );
+
+  r = r.replace(
+    /(\S)([ \t]+)([*+]\s(?:\[[ x]\]\s)?)/g,
+    (
+      match: string,
+      before: string,
+      spaces: string,
+      marker: string,
+      offset: number,
+      fullString: string,
+    ) => {
+      if (spaces.includes("\n")) return match;
+      if (before === "*" || before === "+") return match;
+      const afterIdx = offset + before.length + spaces.length + marker.length;
+      const afterChar = fullString[afterIdx];
+      if (/\d/.test(before) && afterChar && /\d/.test(afterChar)) return match;
+      const indent = subItemIndentAt(fullString, offset);
+      return `${before}\n${indent}${marker}`;
+    },
+  );
+
+  r = r.replace(
+    /(\S)([*+]\s(?:\[[ x]\]\s)?)/g,
+    (
+      match: string,
+      before: string,
+      marker: string,
+      offset: number,
+      fullString: string,
+    ) => {
+      if (before === "*" || before === "+") return match;
+      const afterIdx = offset + before.length + marker.length;
+      const afterChar = fullString[afterIdx];
+      if (/\d/.test(before) && afterChar && /\d/.test(afterChar)) return match;
+      const indent = subItemIndentAt(fullString, offset);
+      return `${before}\n${indent}${marker}`;
+    },
+  );
+
+  r = r.replace(
+    /(\*{1,3})([ \t]*)(>(?:[ \t]|$))/gm,
+    (
+      _match: string,
+      emphasis: string,
+      spaces: string,
+      marker: string,
+      offset: number,
+      fullString: string,
+    ) => {
+      if (spaces.includes("\n")) return _match;
+      const indent = subItemIndentAt(fullString, offset);
+      return `${emphasis}\n${indent}${marker}`;
+    },
+  );
+
+  r = r.replace(
+    /(\S)([ \t]+)(>(?:[ \t]*>)+[ \t]?)/gm,
+    (
+      _match: string,
+      before: string,
+      spaces: string,
+      marker: string,
+      offset: number,
+      fullString: string,
+    ) => {
+      if (spaces.includes("\n")) return _match;
+      if (before === ">") return _match;
+      const afterIdx = offset + before.length + spaces.length + marker.length;
+      const afterChar = fullString[afterIdx];
+      if (/\d/.test(before) && afterChar && /\d/.test(afterChar))
+        return _match;
+      if (/[<>=!]=?/.test(before) && afterChar && /\d/.test(afterChar))
+        return _match;
+      const indent = subItemIndentAt(fullString, offset);
+      return `${before}\n${indent}${marker}`;
+    },
+  );
+
+  return r;
+}
+
+export function normalizeMarkdown(text: string): string {
+  const preprocessed = fixCollapsedTableRows(text);
+  const lines = preprocessed.split("\n");
+  const output: string[] = [];
   let insideFence = false;
   let insideTable = false;
   let prevBlockKind: BlockKind | null = null;
@@ -197,11 +210,11 @@ function ensureBlockBlankLines(text: string): string {
 
     if (/^`{3,}/.test(trimmed) && !insideFence) {
       insideFence = true;
-      const prevLine = result.length > 0 ? result[result.length - 1] : "";
-      if (i > 0 && prevLine.trim() !== "") {
-        result.push("");
+      const prevLine = output.length > 0 ? output[output.length - 1] : "";
+      if (output.length > 0 && prevLine.trim() !== "") {
+        output.push("");
       }
-      result.push(line);
+      output.push(line);
       prevBlockKind = "code-fence";
       rootListKind = null;
       continue;
@@ -209,97 +222,91 @@ function ensureBlockBlankLines(text: string): string {
 
     if (/^`{3,}/.test(trimmed) && insideFence) {
       insideFence = false;
-      result.push(line);
+      output.push(line);
       prevBlockKind = "code-fence";
       rootListKind = null;
       continue;
     }
 
     if (insideFence) {
-      result.push(line);
+      output.push(line);
       continue;
     }
 
-    if (/^\|/.test(trimmed)) {
-      if (!insideTable) {
-        insideTable = true;
-        const prevLine = result.length > 0 ? result[result.length - 1] : "";
-        if (i > 0 && prevLine.trim() !== "" && prevBlockKind !== "table") {
-          result.push("");
+    const expanded = expandLineInline(line);
+    const subLines = expanded.split("\n");
+
+    for (const subLine of subLines) {
+      const subTrimmed = subLine.trimStart();
+
+      if (/^\|/.test(subTrimmed)) {
+        if (!insideTable) {
+          insideTable = true;
+          const prevLine =
+            output.length > 0 ? output[output.length - 1] : "";
+          if (
+            output.length > 0 &&
+            prevLine.trim() !== "" &&
+            prevBlockKind !== "table"
+          ) {
+            output.push("");
+          }
         }
-      }
-      result.push(line);
-      prevBlockKind = "table";
-      rootListKind = null;
-      continue;
-    }
-
-    if (insideTable && trimmed !== "" && !/^\|/.test(trimmed)) {
-      insideTable = false;
-    }
-
-    const kind = classifyLine(line);
-    const indent = line.length - trimmed.length;
-    const prevLine = result.length > 0 ? result[result.length - 1] : "";
-    const prevIsBlank = prevLine.trim() === "";
-
-    if (indent === 0 && (kind === "ordered-list" || kind === "unordered-list")) {
-      if (rootListKind === kind && !prevIsBlank) {
-        result.push(line);
-        prevBlockKind = kind;
+        output.push(subLine);
+        prevBlockKind = "table";
+        rootListKind = null;
         continue;
       }
-      rootListKind = kind;
-    } else if (indent > 0 && (kind === "ordered-list" || kind === "unordered-list")) {
-      result.push(line);
+
+      if (insideTable && subTrimmed !== "" && !/^\|/.test(subTrimmed)) {
+        insideTable = false;
+      }
+
+      const kind = classifyLine(subLine);
+      const indent = subLine.length - subTrimmed.length;
+      const prevLine =
+        output.length > 0 ? output[output.length - 1] : "";
+      const prevIsBlank = prevLine.trim() === "";
+
+      if (
+        indent === 0 &&
+        (kind === "ordered-list" || kind === "unordered-list")
+      ) {
+        if (rootListKind === kind && !prevIsBlank) {
+          output.push(subLine);
+          prevBlockKind = kind;
+          continue;
+        }
+        rootListKind = kind;
+      } else if (
+        indent > 0 &&
+        (kind === "ordered-list" || kind === "unordered-list")
+      ) {
+        output.push(subLine);
+        prevBlockKind = kind;
+        continue;
+      } else if (
+        kind !== "ordered-list" &&
+        kind !== "unordered-list"
+      ) {
+        rootListKind = null;
+      }
+
+      if (
+        output.length > 0 &&
+        !prevIsBlank &&
+        prevBlockKind !== null &&
+        needsBlankLineBetween(prevBlockKind, kind, indent)
+      ) {
+        output.push("");
+      }
+
+      output.push(subLine);
       prevBlockKind = kind;
-      continue;
-    } else if (kind !== "ordered-list" && kind !== "unordered-list") {
-      rootListKind = null;
     }
-
-    if (i > 0 && !prevIsBlank && prevBlockKind !== null && needsBlankLineBetween(prevBlockKind, kind, indent)) {
-      result.push("");
-    }
-
-    result.push(line);
-    prevBlockKind = kind;
   }
 
-  return result.join("\n");
+  return output.join("\n");
 }
 
-function fixCollapsedTableRowsInner(text: string): string {
-  let result = text;
-  result = result.replace(/\|\|(?=\s*[`!*\w])/g, "|\n|");
-  result = result.replace(/(\|) (\| \w)/g, "$1\n$2");
-  result = result.replace(/(\|)(#{1,6}\s\S)/g, "$1\n$2");
-  return result;
-}
-
-function fixCollapsedTableRows(text: string): string {
-  return applyOutsideCodeBlocks(text, fixCollapsedTableRowsInner);
-}
-
-export function normalizeMarkdown(text: string): string {
-  let result = text;
-  result = applyOutsideCodeBlocks(result, fixAtxHeadingSpace);
-  result = applyOutsideCodeBlocks(result, fixHorizontalRuleFusion);
-  result = fixInlineBlockMarkers(result);
-  result = fixCollapsedTableRows(result);
-  result = ensureBlockBlankLines(result);
-  return result;
-}
-
-export const MARKDOWN_REMEND_HANDLERS: RemendHandler[] = [
-  {
-    name: "fix-atx-heading-space",
-    handle: fixAtxHeadingSpace,
-    priority: -5,
-  },
-  {
-    name: "fix-horizontal-rule-fusion",
-    handle: fixHorizontalRuleFusion,
-    priority: -5,
-  },
-];
+export const MARKDOWN_REMEND_HANDLERS: RemendHandler[] = [];

--- a/lib/markdown-normalization.ts
+++ b/lib/markdown-normalization.ts
@@ -92,6 +92,29 @@ function expandLineInline(line: string): string {
   );
 
   r = r.replace(
+    /(\))(\d{1,3}[.)]\s)/g,
+    (match, before: string, marker: string) => {
+      return `${before}\n${marker}`;
+    },
+  );
+
+  r = r.replace(
+    /(\S)([ \t]+)(\d{1,3}[.)]\s)/g,
+    (match, before: string, _spaces: string, marker: string) => {
+      if (/\d/.test(before) && /\d/.test(marker)) return match;
+      return `${before}\n${marker}`;
+    },
+  );
+
+  r = r.replace(
+    /(\S)(`{3,})/g,
+    (match, before: string, fence: string) => {
+      if (before === "`") return match;
+      return `${before}\n${fence}`;
+    },
+  );
+
+  r = r.replace(
     /([^\s*_|>#`])([-]\s(?:\[[ x]\]\s)?)/g,
     (match, before: string, _marker: string) => {
       if (before === "|" || before === ">" || before === "-") return match;

--- a/lib/markdown-normalization.ts
+++ b/lib/markdown-normalization.ts
@@ -327,10 +327,34 @@ export function normalizeMarkdown(text: string): string {
       continue;
     }
 
+    if (trimmed === "") {
+      let lookAhead = i + 1;
+      while (lookAhead < collapsed.length && collapsed[lookAhead].trim() === "") {
+        lookAhead++;
+      }
+      if (lookAhead < collapsed.length) {
+        const nextTrimmed = collapsed[lookAhead].trimStart();
+        const nextKind = classifyLine(collapsed[lookAhead]);
+        if (
+          prevBlockKind !== null &&
+          (prevBlockKind === "ordered-list" || prevBlockKind === "unordered-list") &&
+          (nextKind === "ordered-list" || nextKind === "unordered-list")
+        ) {
+          prevBlockKind = nextKind;
+          continue;
+        }
+      }
+      output.push(line);
+      prevBlockKind = "other";
+      rootListKind = null;
+      continue;
+    }
+
     const expanded = expandLineInline(line);
     const subLines = expanded.split("\n");
 
-    for (const subLine of subLines) {
+    for (let j = 0; j < subLines.length; j++) {
+      const subLine = subLines[j];
       const subTrimmed = subLine.trimStart();
 
       if (/^\|/.test(subTrimmed)) {

--- a/lib/markdown-normalization.ts
+++ b/lib/markdown-normalization.ts
@@ -93,24 +93,30 @@ function expandLineInline(line: string): string {
 
   r = r.replace(
     /([^\s\d.)_<>(#`])(\d{1,3}[.)]\s)/g,
-    (match, before: string, marker: string) => {
+    (match, before: string, marker: string, offset: number, fullString: string) => {
       if (/[0-9.]/.test(before)) return match;
+      if (/[A-Za-z]/.test(before) && marker.includes(")")) return match;
       return `${before}\n${marker}`;
     },
   );
 
   r = r.replace(
     /(\))(\d{1,3}[.)]\s)/g,
-    (match, before: string, marker: string) => {
-      return `${before}\n${marker}`;
+    (match, before: string, marker: string, offset: number, fullString: string) => {
+      const charBeforeParen = fullString[offset - 1];
+      if (/[A-Za-z]/.test(charBeforeParen)) return match;
+      const indent = lineIndentAt(fullString, offset);
+      return `${before}\n${indent}${marker}`;
     },
   );
 
   r = r.replace(
     /(\S)([ \t]+)(\d{1,3}[.)]\s)/g,
-    (match, before: string, _spaces: string, marker: string) => {
+    (match, before: string, _spaces: string, marker: string, offset: number, fullString: string) => {
       if (/\d/.test(before) && /\d/.test(marker)) return match;
-      return `${before}\n${marker}`;
+      if (before === ")" && offset > 0 && /[A-Za-z]/.test(fullString[offset - 1])) return match;
+      const indent = lineIndentAt(fullString, offset);
+      return `${before}\n${indent}${marker}`;
     },
   );
 
@@ -195,7 +201,7 @@ function expandLineInline(line: string): string {
       const afterIdx = offset + before.length + marker.length;
       const afterChar = fullString[afterIdx];
       if (/\d/.test(before) && afterChar && /\d/.test(afterChar)) return match;
-      const indent = subItemIndentAt(fullString, offset);
+      const indent = lineIndentAt(fullString, offset);
       return `${before}\n${indent}${marker}`;
     },
   );

--- a/lib/markdown-normalization.ts
+++ b/lib/markdown-normalization.ts
@@ -254,14 +254,25 @@ export function normalizeMarkdown(text: string): string {
   const preprocessed = fixCollapsedTableRows(text);
   const lines = preprocessed.split("\n");
   closeUnclosedInline(lines);
+  const collapsed: string[] = [];
+  let blankRun = 0;
+  for (const ln of lines) {
+    if (ln.trim() === "") {
+      blankRun++;
+      if (blankRun <= 1) collapsed.push(ln);
+    } else {
+      blankRun = 0;
+      collapsed.push(ln);
+    }
+  }
   const output: string[] = [];
   let insideFence = false;
   let insideTable = false;
   let prevBlockKind: BlockKind | null = null;
   let rootListKind: BlockKind | null = null;
 
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
+  for (let i = 0; i < collapsed.length; i++) {
+    const line = collapsed[i];
     const trimmed = line.trimStart();
 
     if (/^`{3,}/.test(trimmed) && !insideFence) {
@@ -284,7 +295,7 @@ export function normalizeMarkdown(text: string): string {
         prevBlockKind = "code-fence";
         rootListKind = null;
         if (closingMatch[2].trim()) {
-          lines.splice(i + 1, 0, closingMatch[2].trimStart());
+          collapsed.splice(i + 1, 0, closingMatch[2].trimStart());
         }
       } else {
         output.push(line);

--- a/lib/markdown-normalization.ts
+++ b/lib/markdown-normalization.ts
@@ -72,7 +72,13 @@ function subItemIndentAt(text: string, offset: number): string {
 }
 
 function expandLineInline(line: string): string {
-  if (/^\|/.test(line.trimStart())) return line;
+  if (/^\|/.test(line.trimStart())) {
+    let t = line;
+    t = t.replace(/\|\|/g, "|\n|");
+    t = t.replace(/(\S \| )(\| \S)/g, "$1\n$2");
+    t = t.replace(/^\| \| /gm, "| ");
+    return t;
+  }
 
   let r = line;
 

--- a/lib/markdown-normalization.ts
+++ b/lib/markdown-normalization.ts
@@ -223,6 +223,7 @@ function expandLineInline(line: string): string {
       fullString: string,
     ) => {
       if (before === "*" || before === "+") return match;
+      if (/\d/.test(before) && marker[0] === "*" && (offset === 0 || /\s/.test(fullString[offset - 1]))) return match;
       const afterIdx = offset + before.length + marker.length;
       const afterChar = fullString[afterIdx];
       if (/\d/.test(before) && afterChar && /\d/.test(afterChar)) return match;
@@ -317,6 +318,7 @@ export function normalizeMarkdown(text: string): string {
   const output: string[] = [];
   let insideFence = false;
   let insideTable = false;
+  let tableHasSeparator = false;
   let prevBlockKind: BlockKind | null = null;
   let rootListKind: BlockKind | null = null;
 
@@ -399,6 +401,7 @@ export function normalizeMarkdown(text: string): string {
       if (/^\|/.test(subTrimmed)) {
         if (!insideTable) {
           insideTable = true;
+          tableHasSeparator = false;
           const prevLine =
             output.length > 0 ? output[output.length - 1] : "";
           if (
@@ -407,6 +410,27 @@ export function normalizeMarkdown(text: string): string {
             prevBlockKind !== "table"
           ) {
             output.push("");
+          }
+          output.push(subLine);
+          prevBlockKind = "table";
+          rootListKind = null;
+          continue;
+        }
+        const isSeparator = /^[\s|:\-]+$/.test(subTrimmed);
+        if (isSeparator) {
+          tableHasSeparator = true;
+          output.push(subLine);
+          prevBlockKind = "table";
+          rootListKind = null;
+          continue;
+        }
+        if (!tableHasSeparator && prevBlockKind === "table") {
+          const prevOut = output[output.length - 1];
+          const prevCols = (prevOut.match(/\|/g) || []).length - 1;
+          const colCount = (subTrimmed.match(/\|/g) || []).length - 1;
+          if (colCount > 1 && colCount === prevCols) {
+            output.push("|" + "---|".repeat(colCount));
+            tableHasSeparator = true;
           }
         }
         output.push(subLine);
@@ -417,6 +441,7 @@ export function normalizeMarkdown(text: string): string {
 
       if (insideTable && subTrimmed !== "" && !/^\|/.test(subTrimmed)) {
         insideTable = false;
+        tableHasSeparator = false;
       }
 
       if (subTrimmed === "") {

--- a/lib/markdown-normalization.ts
+++ b/lib/markdown-normalization.ts
@@ -72,6 +72,8 @@ function subItemIndentAt(text: string, offset: number): string {
 }
 
 function expandLineInline(line: string): string {
+  if (/^\|/.test(line.trimStart())) return line;
+
   let r = line;
 
   r = r.replace(/^(#{1,6})([^#\s\n])/, "$1 $2");
@@ -111,6 +113,13 @@ function expandLineInline(line: string): string {
     (match, before: string, fence: string) => {
       if (before === "`") return match;
       return `${before}\n${fence}`;
+    },
+  );
+
+  r = r.replace(
+    /(`{3,})([^\n`])/g,
+    (match, fence: string, after: string) => {
+      return `${fence}\n${after}`;
     },
   );
 
@@ -243,16 +252,19 @@ export function normalizeMarkdown(text: string): string {
       continue;
     }
 
-    if (/^`{3,}/.test(trimmed) && insideFence) {
-      insideFence = false;
-      output.push(line);
-      prevBlockKind = "code-fence";
-      rootListKind = null;
-      continue;
-    }
-
     if (insideFence) {
-      output.push(line);
+      const closingMatch = line.match(/^([ \t]*`{3,})(.*)/);
+      if (closingMatch) {
+        insideFence = false;
+        output.push(closingMatch[1]);
+        prevBlockKind = "code-fence";
+        rootListKind = null;
+        if (closingMatch[2].trim()) {
+          lines.splice(i + 1, 0, closingMatch[2].trimStart());
+        }
+      } else {
+        output.push(line);
+      }
       continue;
     }
 

--- a/lib/markdown-normalization.ts
+++ b/lib/markdown-normalization.ts
@@ -262,6 +262,13 @@ export function normalizeMarkdown(text: string): string {
         insideTable = false;
       }
 
+      if (subTrimmed === "") {
+        output.push(subLine);
+        prevBlockKind = "other";
+        rootListKind = null;
+        continue;
+      }
+
       const kind = classifyLine(subLine);
       const indent = subLine.length - subTrimmed.length;
       const prevLine =

--- a/lib/markdown-normalization.ts
+++ b/lib/markdown-normalization.ts
@@ -307,7 +307,16 @@ export function normalizeMarkdown(text: string): string {
           collapsed.splice(i + 1, 0, closingMatch[2].trimStart());
         }
       } else {
-        output.push(line);
+        const inlineClose = line.match(/(.*?)(`{3,})\s*$/);
+        if (inlineClose && inlineClose[1].trim()) {
+          output.push(inlineClose[1]);
+          insideFence = false;
+          output.push(inlineClose[2]);
+          prevBlockKind = "code-fence";
+          rootListKind = null;
+        } else {
+          output.push(line);
+        }
       }
       continue;
     }

--- a/lib/markdown-normalization.ts
+++ b/lib/markdown-normalization.ts
@@ -146,15 +146,24 @@ function expandLineInline(line: string): string {
 
   r = r.replace(
     /(\S)(`{3,})/g,
-    (match, before: string, fence: string) => {
+    (match, before: string, fence: string, offset: number, fullString: string) => {
       if (before === "`") return match;
+      const afterFence = fullString.slice(offset + before.length + fence.length);
+      const closingIdx = afterFence.indexOf(fence);
+      if (closingIdx !== -1 && !/\n/.test(afterFence.slice(0, closingIdx))) return match;
+      const beforeFence = fullString.slice(0, offset + before.length);
+      const openerIdx = beforeFence.lastIndexOf(fence);
+      if (openerIdx !== -1 && !/\n/.test(beforeFence.slice(openerIdx + fence.length))) return match;
       return `${before}\n${fence}`;
     },
   );
 
   r = r.replace(
     /(`{3,})([^\n`])/g,
-    (match, fence: string, after: string) => {
+    (match, fence: string, after: string, offset: number, fullString: string) => {
+      const afterFull = fullString.slice(offset + fence.length);
+      const closingIdx = afterFull.indexOf(fence);
+      if (closingIdx !== -1 && !/\n/.test(afterFull.slice(0, closingIdx))) return match;
       return `${fence}\n${after}`;
     },
   );

--- a/lib/markdown-normalization.ts
+++ b/lib/markdown-normalization.ts
@@ -75,7 +75,7 @@ function expandLineInline(line: string): string {
   if (/^\|/.test(line.trimStart())) {
     let t = line;
     t = t.replace(/\|\|/g, "|\n|");
-    t = t.replace(/(\S \| )(\| \S)/g, "$1\n$2");
+    t = t.replace(/(\|) (\| [A-Za-z✅❌0-9])/g, "$1\n$2");
     t = t.replace(/^\| \| /gm, "| ");
     return t;
   }

--- a/lib/markdown-normalization.ts
+++ b/lib/markdown-normalization.ts
@@ -132,6 +132,15 @@ function expandLineInline(line: string): string {
   );
 
   r = r.replace(
+    /(\S)([ \t]+)([-]\s(?:\[[ x]\]\s))/g,
+    (match, before: string, _spaces: string, marker: string, offset: number, full: string) => {
+      if (_spaces.includes("\n")) return match;
+      const indent = subItemIndentAt(full, offset);
+      return `${before}\n${indent}${marker}`;
+    },
+  );
+
+  r = r.replace(
     /(\*{1,3})([ \t]+)([*+]\s(?:\[[ x]\]\s)?)/g,
     (
       match: string,

--- a/tests/unit/markdown-normalization.test.ts
+++ b/tests/unit/markdown-normalization.test.ts
@@ -378,4 +378,27 @@ describe("normalizeMarkdown", () => {
       expect(result).toBe("see docs - [reference here](url)");
     });
   });
+
+  describe("blank lines between list items", () => {
+    it("removes blank line between nested and parent list items", () => {
+      const result = normalizeMarkdown("- Level 1\n  - Level 2a\n  - Level 2b\n\n- Level 1 again");
+      expect(result).not.toMatch(/Level 2b\n\n- Level 1/);
+      expect(result).toMatch(/Level 2b\n- Level 1/);
+    });
+
+    it("removes multiple blank lines between list items", () => {
+      const result = normalizeMarkdown("- Level 1\n  - Level 2a\n  - Level 2b\n\n\n- Level 1 again");
+      expect(result).not.toMatch(/Level 2b\n\n/);
+    });
+
+    it("preserves blank line between list and paragraph", () => {
+      const result = normalizeMarkdown("- item1\n- item2\n\nSome paragraph");
+      expect(result).toContain("item2\n\nSome paragraph");
+    });
+
+    it("removes blank lines between ordered list items", () => {
+      const result = normalizeMarkdown("1. First\n2. Second\n\n3. Third");
+      expect(result).not.toMatch(/Second\n\n3\./);
+    });
+  });
 });

--- a/tests/unit/markdown-normalization.test.ts
+++ b/tests/unit/markdown-normalization.test.ts
@@ -43,6 +43,18 @@ describe("normalizeMarkdown", () => {
     it("does not split no-space digit guard", () => {
       expect(normalizeMarkdown("5*3")).toBe("5*3");
     });
+
+    it("does not split closing emphasis * as list marker", () => {
+      expect(normalizeMarkdown("This is *confidential* info")).toBe(
+        "This is *confidential* info"
+      );
+    });
+
+    it("does not split closing bold ** as list marker", () => {
+      expect(normalizeMarkdown("This is **bold** text")).toBe(
+        "This is **bold** text"
+      );
+    });
   });
 
   describe("nested inline markers", () => {

--- a/tests/unit/markdown-normalization.test.ts
+++ b/tests/unit/markdown-normalization.test.ts
@@ -239,4 +239,48 @@ describe("normalizeMarkdown", () => {
       expect(second).toBe(first);
     });
   });
+
+  describe("triple backtick after text", () => {
+    it("separates closing fence from text", () => {
+      const result = normalizeMarkdown("--set resources.limits.memory=8Gi```");
+      expect(result).toBe("--set resources.limits.memory=8Gi\n\n```");
+    });
+
+    it("separates opening fence from text", () => {
+      const result = normalizeMarkdown("some code:```");
+      expect(result).toContain("some code:\n\n```");
+    });
+  });
+
+  describe("ordered list after closing paren", () => {
+    it("splits ordered list after closing parenthesis", () => {
+      const result = normalizeMarkdown(
+        "Docker Engine (version 24.0+)2. Kubernetes cluster (v1.28+)"
+      );
+      expect(result).toContain("24.0+)\n\n2. Kubernetes");
+    });
+
+    it("preserves version number in parentheses", () => {
+      expect(normalizeMarkdown("requires (v2.0) to run")).toBe(
+        "requires (v2.0) to run"
+      );
+    });
+  });
+
+  describe("space before ordered list marker", () => {
+    it("splits ordered list after space when not a decimal number", () => {
+      const result = normalizeMarkdown(
+        "1. Minimum16 GB RAM 2.8 CPU cores 3. 100 GB SSD storage"
+      );
+      expect(result).toContain("CPU cores\n3. 100 GB SSD storage");
+    });
+
+    it("preserves decimal numbers like 2.8", () => {
+      expect(normalizeMarkdown("RAM 2.8 GHz")).toBe("RAM 2.8 GHz");
+    });
+
+    it("preserves IP addresses", () => {
+      expect(normalizeMarkdown("192.168.1.1")).toBe("192.168.1.1");
+    });
+  });
 });

--- a/tests/unit/markdown-normalization.test.ts
+++ b/tests/unit/markdown-normalization.test.ts
@@ -200,6 +200,25 @@ describe("normalizeMarkdown", () => {
       const result = normalizeMarkdown("|a||b|");
       expect(result).toBe("|a|\n|b|");
     });
+
+    it("splits glued header-separator-data rows", () => {
+      const result = normalizeMarkdown(
+        "| Param | Type ||---|---|| | int | number | | str | string |"
+      );
+      const lines = result.split("\n");
+      expect(lines).toContain("| Param | Type |");
+      expect(lines).toContain("|---|---|");
+      expect(lines).toContain("| int | number |");
+      expect(lines).toContain("| str | string |");
+    });
+
+    it("splits data rows glued with pipe-space-pipe", () => {
+      const result = normalizeMarkdown(
+        "| H1 | H2 |\n|---|---|\n| a | b | | c | d |"
+      );
+      expect(result).toContain("| a | b |");
+      expect(result).toContain("| c | d |");
+    });
   });
 
   describe("code fence protection (extended)", () => {

--- a/tests/unit/markdown-normalization.test.ts
+++ b/tests/unit/markdown-normalization.test.ts
@@ -153,4 +153,90 @@ describe("normalizeMarkdown", () => {
       expect(normalizeMarkdown(input)).toBe(input);
     });
   });
+
+  describe("horizontal rule fusion", () => {
+    it("separates --- fused after text", () => {
+      const result = normalizeMarkdown("some text---");
+      expect(result).toContain("---");
+      expect(result).not.toBe("some text---");
+    });
+
+    it("separates --- fused before text", () => {
+      const result = normalizeMarkdown("---some text");
+      expect(result).toContain("---");
+      expect(result).not.toBe("---some text");
+    });
+
+    it("separates --- fused between text", () => {
+      const result = normalizeMarkdown("text---more");
+      expect(result).toContain("---");
+    });
+  });
+
+  describe("blank line enforcement", () => {
+    it("inserts blank line before heading after paragraph", () => {
+      const result = normalizeMarkdown("Some text\n## Heading");
+      expect(result).toBe("Some text\n\n## Heading");
+    });
+
+    it("inserts blank line before code fence", () => {
+      const result = normalizeMarkdown("Some text\n```js\ncode\n```");
+      expect(result).toContain("Some text\n\n```");
+    });
+
+    it("preserves existing blank lines", () => {
+      const input = "Some text\n\n## Heading";
+      expect(normalizeMarkdown(input)).toBe(input);
+    });
+
+    it("inserts blank line between list and heading", () => {
+      const result = normalizeMarkdown("- item\n- item2\n## Heading");
+      expect(result).toContain("- item2\n\n## Heading");
+    });
+  });
+
+  describe("collapsed table rows", () => {
+    it("splits || into separate rows", () => {
+      const result = normalizeMarkdown("|a||b|");
+      expect(result).toBe("|a|\n|b|");
+    });
+  });
+
+  describe("code fence protection (extended)", () => {
+    it("does not modify inline markers inside code fences", () => {
+      const input = "```\n* item * sub\n```";
+      expect(normalizeMarkdown(input)).toBe(input);
+    });
+
+    it("does not modify ATX heading inside code fences", () => {
+      const input = "```\n##NoSpace\n```";
+      expect(normalizeMarkdown(input)).toBe(input);
+    });
+
+    it("normalizes outside code fences but preserves inside", () => {
+      const result = normalizeMarkdown("text## Heading\n```\ntext- not a list\n```\nmore- item");
+      expect(result).toContain("## Heading");
+      expect(result).toContain("text- not a list");
+      expect(result).toContain("- item");
+    });
+  });
+
+  describe("combined scenarios", () => {
+    it("handles multiple issues in one document", () => {
+      const result = normalizeMarkdown(
+        "Intro## Overview\ntext- item1- item2\n```\nraw## code\n```\n##NoSpace"
+      );
+      expect(result).toContain("## Overview");
+      expect(result).toContain("- item1");
+      expect(result).toContain("raw## code");
+      expect(result).toContain("## NoSpace");
+    });
+
+    it("is idempotent", () => {
+      const input = "text- item\n##Heading";
+      const first = normalizeMarkdown(input);
+      const second = normalizeMarkdown(first);
+      expect(second).toBe(first);
+    });
+  });
 });

--- a/tests/unit/markdown-normalization.test.ts
+++ b/tests/unit/markdown-normalization.test.ts
@@ -326,4 +326,24 @@ describe("normalizeMarkdown", () => {
       expect(result).toContain("*confidential*");
     });
   });
+
+  describe("inline checklist splitting (space-dash-bracket)", () => {
+    it("splits checklist items joined by space-dash-bracket", () => {
+      const result = normalizeMarkdown(
+        "Disaster relief protocols established - [x] Medical aid networks active - [ ] Evacuation fleet fully funded"
+      );
+      expect(result).toContain("established\n\n- [x] Medical aid networks active");
+      expect(result).toContain("Medical aid networks active\n- [ ] Evacuation fleet fully funded");
+    });
+
+    it("does not split plain dash between words", () => {
+      const result = normalizeMarkdown("5 - 3 = 2");
+      expect(result).toBe("5 - 3 = 2");
+    });
+
+    it("does not split markdown link after dash", () => {
+      const result = normalizeMarkdown("see docs - [reference here](url)");
+      expect(result).toBe("see docs - [reference here](url)");
+    });
+  });
 });

--- a/tests/unit/markdown-normalization.test.ts
+++ b/tests/unit/markdown-normalization.test.ts
@@ -401,4 +401,42 @@ describe("normalizeMarkdown", () => {
       expect(result).not.toMatch(/Second\n\n3\./);
     });
   });
+
+  describe("parenthetical ordered list guards", () => {
+    it("does not split P0) into separate lines", () => {
+      const result = normalizeMarkdown("1. Critical (P0)      2. High (P1)");
+      expect(result).toContain("Critical (P0)");
+      expect(result).toContain("2. High (P1)");
+      expect(result).not.toMatch(/\(P\n/);
+    });
+
+    it("does not split letter+digit) pattern", () => {
+      const result = normalizeMarkdown("      4. Low (P3)---");
+      expect(result).toContain("Low (P3)");
+    });
+
+    it("splits ordered list with ) syntax", () => {
+      const result = normalizeMarkdown("1) first 2) second");
+      expect(result).toContain("1) first");
+      expect(result).toContain("2) second");
+    });
+
+    it("preserves indent for space-separated ordered items", () => {
+      const result = normalizeMarkdown("      1. Critical (P0)      2. High (P1)");
+      expect(result).toContain("      2. High (P1)");
+    });
+  });
+
+  describe("glued unordered list at same level", () => {
+    it("keeps glued * items at same indent level", () => {
+      const result = normalizeMarkdown("* item1* item2* item3");
+      expect(result).not.toMatch(/\n  \*/);
+      expect(result).toContain("* item1\n* item2\n* item3");
+    });
+
+    it("keeps glued - items at same indent level", () => {
+      const result = normalizeMarkdown("- item1- item2- item3");
+      expect(result).not.toMatch(/\n  -/);
+    });
+  });
 });

--- a/tests/unit/markdown-normalization.test.ts
+++ b/tests/unit/markdown-normalization.test.ts
@@ -219,6 +219,19 @@ describe("normalizeMarkdown", () => {
       expect(result).toContain("text- not a list");
       expect(result).toContain("- item");
     });
+
+    it("splits inline closing fence from code content", () => {
+      const result = normalizeMarkdown(
+        "```python\ndb = DatabaseConnection()\nprint(\"Connected!\")```\n\n### Next"
+      );
+      expect(result).toContain('print("Connected!")\n```');
+      expect(result).toContain("### Next");
+    });
+
+    it("preserves normal code fence closing", () => {
+      const input = "```\ncode\n```\nafter";
+      expect(normalizeMarkdown(input)).toContain("code\n```\n\nafter");
+    });
   });
 
   describe("combined scenarios", () => {

--- a/tests/unit/markdown-normalization.test.ts
+++ b/tests/unit/markdown-normalization.test.ts
@@ -283,4 +283,47 @@ describe("normalizeMarkdown", () => {
       expect(normalizeMarkdown("192.168.1.1")).toBe("192.168.1.1");
     });
   });
+
+  describe("unclosed inline before list", () => {
+    it("closes unclosed italic before bullet list", () => {
+      const result = normalizeMarkdown(
+        "Contains *confidential\n* information regarding"
+      );
+      expect(result).toContain("*confidential*");
+      expect(result).toContain("\n\n* information");
+    });
+
+    it("closes unclosed bold before bullet list", () => {
+      const result = normalizeMarkdown(
+        "Contains **confidential\n* information regarding"
+      );
+      expect(result).toContain("**confidential**");
+    });
+
+    it("does not add closer when italic is already closed", () => {
+      const result = normalizeMarkdown(
+        "This is *confidential*\n* next item"
+      );
+      expect(result).toBe("This is *confidential*\n\n* next item");
+    });
+
+    it("does not close italic when next line is not a list", () => {
+      const result = normalizeMarkdown(
+        "Contains *confidential\nSome other text"
+      );
+      expect(result).toBe("Contains *confidential\nSome other text");
+    });
+
+    it("preserves multiplication before list", () => {
+      const result = normalizeMarkdown("5 * 3 equals 15\n* list item");
+      expect(result).toContain("5 * 3 equals 15");
+    });
+
+    it("closes unclosed italic before dash list", () => {
+      const result = normalizeMarkdown(
+        "Contains *confidential\n- information regarding"
+      );
+      expect(result).toContain("*confidential*");
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- **Consolidated `normalizeMarkdown` into a single-pass scanner**, removing separate `remend` handlers for a simpler, more maintainable architecture
- **Strengthened the markdown formatting system prompt** with MUST language to enforce consistent AI output formatting
- **Added edge case tests** covering a wide range of markdown normalization scenarios

### Bug fixes across the normalizer:
- Handle inline code fences, ordered lists after parens, and space-before ordered markers
- Handle closing fences with trailing text; skip inline expansion in table rows
- Close unclosed italic/bold when the next line is a list item
- Collapse consecutive blank lines to a single blank line
- Split inline checklist items with space-dash-bracket pattern
- Split inline closing code fence from code content
- Split glued table rows (header-separator and data rows)
- Suppress blank lines between list items
- Improve glued table row splitting with correct regex patterns
- Prevent false splits on parenthetical (P0); preserve list indent; use `lineIndentAt` for same-level splits
- Protect closed emphasis from list split; add `isClosingStar` guard; split glued blockquotes
- Guard digit+star (e.g. `9*` footnote); auto-insert missing table separator rows

### Files changed
- `lib/markdown-normalization.ts` — major refactor of the normalizer
- `lib/assistant-runtime.ts` — updated formatting prompt
- `components/message-bubble.tsx` — minor rendering adjustments
- `tests/unit/markdown-normalization.test.ts` — comprehensive test coverage