### PR TITLE
feat: add 'none' reasoning effort to disable thinking/reasoning

### DIFF
--- a/components/settings/sections/providers-section.tsx
+++ b/components/settings/sections/providers-section.tsx
@@ -782,6 +782,7 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
                         }
                         className={selectLike}
                       >
+                        <option value="none">disabled</option>
                         <option value="low">low</option>
                         <option value="medium">medium</option>
                         <option value="high">high</option>
@@ -803,6 +804,7 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
                             <option value="chat_completions">chat_completions</option>
                           </select>
                         </div>
+                        {activeProviderProfile.reasoningEffort !== "none" && (
                         <div>
                           <label className={fieldLabel}>Reasoning summary</label>
                           <label className="flex h-[42px] items-center gap-3 rounded-lg border border-white/[0.06] bg-white/[0.03] px-3 text-sm text-[var(--muted)] cursor-pointer">
@@ -816,6 +818,7 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
                             Show reasoning when supported
                           </label>
                         </div>
+                        )}
                       </>
                     )}
                     <div>

--- a/lib/model-registry.ts
+++ b/lib/model-registry.ts
@@ -15,7 +15,7 @@ export const MODEL_REGISTRY: ModelCapabilityOverride[] = [
   { prefix: "gpt-oss", reasoning: { apiModes: ["responses"] }, vision: { apiModes: ["responses"] }, extraBody: "thinking" },
   { prefix: "gpt-4.1", vision: true },
   { prefix: "gpt-4o", vision: true },
-  { prefix: "glm-5v", reasoning: true, vision: true },
+  { prefix: "glm-5v", reasoning: true, vision: true, extraBody: "thinking" },
   { prefix: "glm-5", reasoning: true, extraBody: "thinking" },
   { prefix: "glm-4.7", reasoning: true, extraBody: "thinking" },
   { prefix: "kimi-", reasoning: true, vision: true, strictExtraRejection: true },

--- a/lib/provider.ts
+++ b/lib/provider.ts
@@ -13,6 +13,7 @@ import type {
   PromptMessage,
   ProviderProfile,
   ProviderProfileWithApiKey,
+  ReasoningEffort,
   ToolDefinition,
   ProviderToolCall
 } from "@/lib/types";
@@ -209,7 +210,10 @@ function buildChatCompletionMessages(messages: PromptMessage[], settings?: Provi
 
 function normalizeReasoningEffort(
   effort: ProviderProfile["reasoningEffort"]
-): "low" | "medium" | "high" {
+): "low" | "medium" | "high" | undefined {
+  if (effort === "none") {
+    return undefined;
+  }
   if (effort === "xhigh") {
     return "high";
   }
@@ -219,6 +223,10 @@ function normalizeReasoningEffort(
 
 function buildReasoningConfig(settings: ProviderProfile) {
   if (!supportsVisibleReasoning(settings.model, settings.apiMode)) {
+    return undefined;
+  }
+
+  if (settings.reasoningEffort === "none") {
     return undefined;
   }
 
@@ -242,17 +250,27 @@ function buildChatCompletionsOptions(settings: ProviderProfile) {
   }
 
   const caps = resolveCapabilities(settings.model, settings.apiMode);
+
+  if (settings.reasoningEffort === "none") {
+    if (caps.extraBody === "thinking") {
+      return {
+        thinking: {
+          type: "disabled"
+        }
+      } as const;
+    }
+    return {};
+  }
+
   const effort = normalizeReasoningEffort(settings.reasoningEffort);
 
   if (settings.apiBaseUrl.includes("ollama.com")) {
     const ollamaEffort = settings.reasoningSummaryEnabled ? effort : "none";
 
     return {
-      extra_body: {
-        reasoning_effort: ollamaEffort,
-        reasoning: {
-          effort: ollamaEffort
-        }
+      reasoning_effort: ollamaEffort,
+      reasoning: {
+        effort: ollamaEffort
       }
     } as const;
   }
@@ -263,10 +281,8 @@ function buildChatCompletionsOptions(settings: ProviderProfile) {
 
   if (caps.extraBody === "thinking") {
     return {
-      extra_body: {
-        thinking: {
-          type: settings.reasoningSummaryEnabled ? "enabled" : "disabled"
-        }
+      thinking: {
+        type: settings.reasoningSummaryEnabled ? "enabled" : "disabled"
       }
     } as const;
   }
@@ -385,7 +401,7 @@ export async function callProviderText(input: {
 }) {
   const { settings } = input;
   const profile = input.purpose === "title"
-    ? { ...settings, reasoningEffort: "low" as const, reasoningSummaryEnabled: false }
+    ? { ...settings, reasoningEffort: (settings.reasoningEffort === "none" ? "none" : "low") as ReasoningEffort, reasoningSummaryEnabled: false }
     : settings;
   const contextualPrompt = withDateContextSystemMessage([{
     role: "user",
@@ -429,7 +445,7 @@ export async function callProviderText(input: {
     temperature: profile.temperature,
     max_completion_tokens: Math.min(profile.maxOutputTokens, 4000),
     ...buildChatCompletionsOptions(profile)
-  });
+  } as any);
 
   const text = normalizeLineBreaks(
     typeof response.choices[0]?.message?.content === "string"

--- a/lib/settings.ts
+++ b/lib/settings.ts
@@ -26,7 +26,7 @@ const runtimeSettingsSchema = z.object({
   systemPrompt: z.string().min(0),
   temperature: z.coerce.number().min(0).max(2),
   maxOutputTokens: z.coerce.number().int().min(128).max(32768),
-  reasoningEffort: z.enum(["low", "medium", "high", "xhigh"]),
+  reasoningEffort: z.enum(["none", "low", "medium", "high", "xhigh"]),
   reasoningSummaryEnabled: z.coerce.boolean(),
   modelContextLimit: z.coerce.number().int().min(4096).max(2_000_000),
   compactionThreshold: z.coerce.number().min(0.5).max(0.95),

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -17,7 +17,7 @@ export type GoogleNanoBananaModel =
 
 export type ChatInputMode = "chat" | "image";
 
-export type ReasoningEffort = "low" | "medium" | "high" | "xhigh";
+export type ReasoningEffort = "none" | "low" | "medium" | "high" | "xhigh";
 
 export type VisionMode = "none" | "native" | "mcp";
 

--- a/tests/unit/provider.test.ts
+++ b/tests/unit/provider.test.ts
@@ -268,11 +268,9 @@ describe("provider integration", () => {
 
     expect(chatCreate).toHaveBeenCalledWith(
       expect.objectContaining({
-        extra_body: {
-          reasoning_effort: "none",
-          reasoning: {
-            effort: "none"
-          }
+        reasoning_effort: "none",
+        reasoning: {
+          effort: "none"
         }
       })
     );
@@ -924,10 +922,8 @@ describe("provider integration", () => {
 
     expect(chatCreate).toHaveBeenCalledWith(
       expect.objectContaining({
-        extra_body: {
-          thinking: {
-            type: "enabled"
-          }
+        thinking: {
+          type: "enabled"
         }
       }),
       expect.objectContaining({
@@ -1182,11 +1178,9 @@ describe("provider integration", () => {
 
     expect(chatCreate).toHaveBeenCalledWith(
       expect.objectContaining({
-        extra_body: {
-          reasoning_effort: "medium",
-          reasoning: {
-            effort: "medium"
-          }
+        reasoning_effort: "medium",
+        reasoning: {
+          effort: "medium"
         }
       }),
       expect.objectContaining({


### PR DESCRIPTION
## Summary

- Add `none` as a valid `ReasoningEffort` value, allowing users to fully disable reasoning/thinking for any model
- New `disabled` option appears in the reasoning effort dropdown in provider settings UI
- When effort is `none`:
  - Models with `extraBody: "thinking"` (e.g. GLM) send `thinking: { type: "disabled" }`
  - Models using the responses API return no reasoning config
  - The reasoning summary toggle is hidden from the UI
- Fix Ollama and thinking-based models to send reasoning config at the top level instead of nested in `extra_body`
- Add `extraBody: "thinking"` to the `glm-5v` model registry entry
- Title generation preserves the user's reasoning effort setting (no longer forces `low` when set to `none`)
- Update unit tests to match the corrected config structure