### PR TITLE
style: update 'Latest' scroll pill to match header accent styling

### DIFF
--- a/components/chat-composer.tsx
+++ b/components/chat-composer.tsx
@@ -273,7 +273,7 @@ export function ChatComposer({
             type="button"
             onClick={onJumpToBottom}
             style={{ fontSize: '10px' }}
-            className="relative flex h-full items-center gap-0.5 rounded-t-md border border-b-0 border-violet-500/50 border-dashed bg-zinc-900/90 backdrop-blur-2xl px-2.5 font-bold uppercase tracking-wider text-violet-300 transition-all duration-150 active:scale-[0.96]"
+            className="relative flex h-full items-center gap-0.5 rounded-t-md border border-b-0 border-[var(--accent)] bg-[var(--accent)] px-2.5 font-bold uppercase tracking-wider text-white shadow-[0_0_16px_var(--accent-glow)] transition-all duration-150 hover:opacity-90 active:scale-[0.96]"
             aria-label="Scroll to latest messages"
             title="Scroll to latest"
           >


### PR DESCRIPTION
## Summary

- Restyle the "↓ LATEST" scroll-to-bottom pill to use a solid accent-colored background (`bg-[var(--accent)]`) with white text and a glow shadow, matching the "+" new-chat button in the header
- Remove the previous dotted violet border (`border-dashed border-violet-500/50`)
- The "Temporary" label pill remains unchanged