### PR TITLE
feat: add confirmation modal for deletion actions across settings

### DIFF
--- a/components/settings/sections/automations-section.tsx
+++ b/components/settings/sections/automations-section.tsx
@@ -6,6 +6,7 @@ import { CalendarDays, Clock3, Plus, Trash2 } from "lucide-react";
 import { ProfileCard } from "@/components/settings/profile-card";
 import { SettingsSplitPane } from "@/components/settings/settings-split-pane";
 import { Button } from "@/components/ui/button";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Toast } from "@/components/ui/toast";
@@ -97,6 +98,7 @@ export function AutomationsSection() {
   const [isAddingNew, setIsAddingNew] = useState(false);
   const toast = useToastState();
   const [isLoading, setIsLoading] = useState(true);
+  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
 
   async function loadData() {
     setIsLoading(true);
@@ -271,6 +273,11 @@ export function AutomationsSection() {
     resetSelection();
   }
 
+  function handleDeleteConfirm() {
+    deleteSelectedAutomation();
+    setDeleteConfirmOpen(false);
+  }
+
   const showDetail = isAddingNew || Boolean(selectedAutomationId);
 
   const fieldLabel = "block text-[13px] font-medium text-[var(--muted)] mb-1.5";
@@ -345,16 +352,6 @@ export function AutomationsSection() {
                         Configure the prompt, execution profile, and cadence for this scheduled automation.
                       </p>
                     </div>
-                    {selectedAutomationId ? (
-                      <button
-                        type="button"
-                        onClick={deleteSelectedAutomation}
-                        className="inline-flex items-center gap-1.5 px-2.5 py-1.5 text-xs text-red-400/80 transition-colors hover:text-red-300"
-                      >
-                        <Trash2 className="h-3.5 w-3.5" />
-                        Delete
-                      </button>
-                    ) : null}
                   </div>
                 </div>
 
@@ -545,13 +542,25 @@ export function AutomationsSection() {
 
                 {/* Actions */}
                 <div className={`${sectionDivider} py-5`}>
-                  <div className="flex flex-wrap items-center gap-2">
-                    <Button type="button" className="px-3 py-1.5 text-xs" onClick={() => void saveAutomation()}>
-                      Save
-                    </Button>
-                    <Button type="button" variant="ghost" className="px-2.5 py-1.5 text-xs" onClick={resetSelection}>
-                      Cancel
-                    </Button>
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Button type="button" className="px-3 py-1.5 text-xs" onClick={() => void saveAutomation()}>
+                        Save
+                      </Button>
+                      <Button type="button" variant="ghost" className="px-2.5 py-1.5 text-xs" onClick={resetSelection}>
+                        Cancel
+                      </Button>
+                    </div>
+                    {selectedAutomationId ? (
+                      <button
+                        type="button"
+                        onClick={() => setDeleteConfirmOpen(true)}
+                        className="inline-flex items-center gap-1.5 px-2.5 py-1.5 text-xs text-red-400/80 transition-colors hover:text-red-300"
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                        Delete
+                      </button>
+                    ) : null}
                   </div>
                 </div>
 
@@ -559,6 +568,17 @@ export function AutomationsSection() {
                   visible={toast.visible}
                   variant={toast.variant}
                   message={toast.message}
+                />
+                <ConfirmDialog
+                  open={deleteConfirmOpen}
+                  onOpenChange={setDeleteConfirmOpen}
+                  title="Delete automation?"
+                  description={
+                    <>
+                      <strong className="text-[var(--text)] font-medium">{form.name || "This automation"}</strong> will be permanently deleted. This action cannot be undone.
+                    </>
+                  }
+                  onConfirm={handleDeleteConfirm}
                 />
               </div>
             ) : (

--- a/components/settings/sections/mcp-servers-section.tsx
+++ b/components/settings/sections/mcp-servers-section.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { Plus, Trash2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Toast } from "@/components/ui/toast";
@@ -31,6 +32,8 @@ export function McpServersSection() {
   const [selectedServerId, setSelectedServerId] = useState<string | null>(null);
   const [mobileDetailVisible, setMobileDetailVisible] = useState(false);
   const [isAddingNew, setIsAddingNew] = useState(false);
+  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
+  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
 
   useEffect(() => {
     fetch("/api/mcp-servers")
@@ -235,6 +238,14 @@ export function McpServersSection() {
       setIsAddingNew(false);
       setMobileDetailVisible(false);
     }
+  }
+
+  function handleDeleteConfirm() {
+    if (pendingDeleteId) {
+      deleteMcpServer(pendingDeleteId);
+    }
+    setDeleteConfirmOpen(false);
+    setPendingDeleteId(null);
   }
 
   function editMcpServer(server: McpServer) {
@@ -458,7 +469,10 @@ export function McpServersSection() {
                 {editingMcpId && (
                   <button
                     type="button"
-                    onClick={() => deleteMcpServer(editingMcpId)}
+                    onClick={() => {
+                      setPendingDeleteId(editingMcpId);
+                      setDeleteConfirmOpen(true);
+                    }}
                     className="inline-flex items-center gap-1.5 px-2.5 py-1.5 text-xs text-red-400/80 transition-colors hover:text-red-300"
                   >
                     <Trash2 className="h-3.5 w-3.5" />
@@ -467,6 +481,18 @@ export function McpServersSection() {
                 )}
               </div>
               </div>
+
+              <ConfirmDialog
+                open={deleteConfirmOpen}
+                onOpenChange={setDeleteConfirmOpen}
+                title="Delete MCP server?"
+                description={
+                  <>
+                    <strong className="text-[var(--text)] font-medium">{selectedServer?.name || "This server"}</strong> will be permanently deleted. This action cannot be undone.
+                  </>
+                }
+                onConfirm={handleDeleteConfirm}
+              />
 
               <Toast
                 visible={toast.visible}

--- a/components/settings/sections/memories-section.tsx
+++ b/components/settings/sections/memories-section.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, useCallback } from "react";
 import { Brain, Search, Trash2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Toast } from "@/components/ui/toast";
@@ -47,6 +48,8 @@ export function MemoriesSection() {
   const [editContent, setEditContent] = useState("");
   const [editCategory, setEditCategory] = useState<MemoryCategory>("other");
   const [mobileDetailVisible, setMobileDetailVisible] = useState(false);
+  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
+  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
   const toast = useToastState();
 
   const fetchMemories = useCallback(async (params?: string) => {
@@ -138,6 +141,14 @@ export function MemoriesSection() {
     } catch {
       toast.showToast("error", "Failed to delete memory.");
     }
+  }
+
+  function handleDeleteConfirm() {
+    if (pendingDeleteId) {
+      deleteMemory(pendingDeleteId);
+    }
+    setDeleteConfirmOpen(false);
+    setPendingDeleteId(null);
   }
 
   function handleSelectMemory(memory: UserMemory) {
@@ -260,27 +271,14 @@ export function MemoriesSection() {
                 </div>
               ) : (
                 memories.map((memory) => (
-                  <div key={memory.id} className="group relative">
-                    <ProfileCard
-                      isActive={memory.id === selectedMemoryId}
-                      onClick={() => handleSelectMemory(memory)}
-                      title={memory.content.length > 80 ? `${memory.content.slice(0, 80)}...` : memory.content}
-                      subtitle={formatRelativeTime(memory.updatedAt)}
-                      badges={[{ variant: "violet", label: memory.category }]}
-                      rightSlot={
-                        <button
-                          type="button"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            deleteMemory(memory.id);
-                          }}
-                          className="opacity-0 group-hover:opacity-100 flex h-6 w-6 items-center justify-center rounded-md text-[var(--muted)] hover:text-red-400 hover:bg-red-500/10 transition-all"
-                        >
-                          <Trash2 className="h-3 w-3" />
-                        </button>
-                      }
-                    />
-                  </div>
+                  <ProfileCard
+                    key={memory.id}
+                    isActive={memory.id === selectedMemoryId}
+                    onClick={() => handleSelectMemory(memory)}
+                    title={memory.content.length > 80 ? `${memory.content.slice(0, 80)}...` : memory.content}
+                    subtitle={formatRelativeTime(memory.updatedAt)}
+                    badges={[{ variant: "violet", label: memory.category }]}
+                  />
                 ))
               )}
             </div>
@@ -293,20 +291,12 @@ export function MemoriesSection() {
             {selectedMemory ? (
               <>
                 <div className="space-y-4">
-                  <div className="flex items-center justify-between">
+                  <div>
                     <h3 className="text-base font-semibold text-[var(--text)]">Edit Memory</h3>
-                    <button
-                      type="button"
-                      onClick={() => deleteMemory(selectedMemory.id)}
-                      className="inline-flex items-center gap-1.5 px-2.5 py-1.5 text-xs text-red-400/80 transition-colors hover:text-red-300"
-                    >
-                      <Trash2 className="h-3 w-3" />
-                      Delete
-                    </button>
-                  </div>
-                  <div className="flex gap-4 text-xs text-[var(--muted)]">
-                    <span>Created {formatRelativeTime(selectedMemory.createdAt)}</span>
-                    <span>Updated {formatRelativeTime(selectedMemory.updatedAt)}</span>
+                    <div className="mt-1 flex gap-4 text-xs text-[var(--muted)]">
+                      <span>Created {formatRelativeTime(selectedMemory.createdAt)}</span>
+                      <span>Updated {formatRelativeTime(selectedMemory.updatedAt)}</span>
+                    </div>
                   </div>
                 </div>
 
@@ -336,21 +326,36 @@ export function MemoriesSection() {
                   </div>
                 </div>
 
-                <div className="flex flex-wrap items-center gap-2">
-                  <Button type="button" className="px-3 py-1.5 text-xs" onClick={saveMemory}>
-                    Save
-                  </Button>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    className="px-2.5 py-1.5 text-xs"
-                    onClick={() => {
-                      setSelectedMemoryId(null);
-                      setMobileDetailVisible(false);
-                    }}
-                  >
-                    Cancel
-                  </Button>
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Button type="button" className="px-3 py-1.5 text-xs" onClick={saveMemory}>
+                      Save
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      className="px-2.5 py-1.5 text-xs"
+                      onClick={() => {
+                        setSelectedMemoryId(null);
+                        setMobileDetailVisible(false);
+                      }}
+                    >
+                      Cancel
+                    </Button>
+                  </div>
+                  {selectedMemory ? (
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setPendingDeleteId(selectedMemory.id);
+                        setDeleteConfirmOpen(true);
+                      }}
+                      className="inline-flex items-center gap-1.5 px-2.5 py-1.5 text-xs text-red-400/80 transition-colors hover:text-red-300"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                      Delete
+                    </button>
+                  ) : null}
                 </div>
               </>
             ) : (
@@ -370,6 +375,17 @@ export function MemoriesSection() {
         visible={toast.visible}
         variant={toast.variant}
         message={toast.message}
+      />
+      <ConfirmDialog
+        open={deleteConfirmOpen}
+        onOpenChange={setDeleteConfirmOpen}
+        title="Delete memory?"
+        description={
+          <>
+            <strong className="text-[var(--text)] font-medium">{selectedMemory?.content?.slice(0, 60) || "This memory"}</strong> will be permanently deleted. This action cannot be undone.
+          </>
+        }
+        onConfirm={handleDeleteConfirm}
       />
     </div>
   );

--- a/components/settings/sections/personas-section.tsx
+++ b/components/settings/sections/personas-section.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Plus, FileText } from "lucide-react";
+import { Plus, FileText, Trash2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { Input } from "@/components/ui/input";
 import { TextEditModal } from "@/components/ui/text-edit-modal";
 import { Toast } from "@/components/ui/toast";
@@ -22,6 +23,8 @@ export function PersonasSection() {
   const [mobileDetailVisible, setMobileDetailVisible] = useState(false);
   const [isAddingNew, setIsAddingNew] = useState(false);
   const [isPersonaContentOpen, setIsPersonaContentOpen] = useState(false);
+  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
+  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
   const toast = useToastState();
 
   useEffect(() => {
@@ -96,6 +99,14 @@ export function PersonasSection() {
     } catch {
       toast.showToast("error", "Failed to delete persona.");
     }
+  }
+
+  function handleDeleteConfirm() {
+    if (pendingDeleteId) {
+      deletePersona(pendingDeleteId);
+    }
+    setDeleteConfirmOpen(false);
+    setPendingDeleteId(null);
   }
 
   function handleSelectPersona(persona: Persona) {
@@ -195,15 +206,6 @@ export function PersonasSection() {
                           : "Edit the name and system instructions for this persona."}
                       </p>
                     </div>
-                    {!isAddingNew && selectedPersona ? (
-                      <button
-                        type="button"
-                        onClick={() => deletePersona(selectedPersona.id)}
-                        className="inline-flex items-center gap-1.5 px-2.5 py-1.5 text-xs text-red-400/80 transition-colors hover:text-red-300"
-                      >
-                        Delete
-                      </button>
-                    ) : null}
                   </div>
                 </div>
 
@@ -242,13 +244,28 @@ export function PersonasSection() {
 
                 {/* Actions */}
                 <div className={`${sectionDivider} py-5`}>
-                  <div className="flex flex-wrap items-center gap-2">
-                    <Button type="button" className="px-3 py-1.5 text-xs" onClick={savePersona}>
-                      Save
-                    </Button>
-                    <Button type="button" variant="ghost" className="px-2.5 py-1.5 text-xs" onClick={resetPersonaForm}>
-                      Cancel
-                    </Button>
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Button type="button" className="px-3 py-1.5 text-xs" onClick={savePersona}>
+                        Save
+                      </Button>
+                      <Button type="button" variant="ghost" className="px-2.5 py-1.5 text-xs" onClick={resetPersonaForm}>
+                        Cancel
+                      </Button>
+                    </div>
+                    {!isAddingNew && selectedPersona ? (
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setPendingDeleteId(selectedPersona.id);
+                          setDeleteConfirmOpen(true);
+                        }}
+                        className="inline-flex items-center gap-1.5 px-2.5 py-1.5 text-xs text-red-400/80 transition-colors hover:text-red-300"
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                        Delete
+                      </button>
+                    ) : null}
                   </div>
                 </div>
 
@@ -278,6 +295,17 @@ export function PersonasSection() {
         visible={toast.visible}
         variant={toast.variant}
         message={toast.message}
+      />
+      <ConfirmDialog
+        open={deleteConfirmOpen}
+        onOpenChange={setDeleteConfirmOpen}
+        title="Delete persona?"
+        description={
+          <>
+            <strong className="text-[var(--text)] font-medium">{selectedPersona?.name ?? "This persona"}</strong> will be permanently deleted. This action cannot be undone.
+          </>
+        }
+        onConfirm={handleDeleteConfirm}
       />
     </div>
   );

--- a/components/settings/sections/providers-section.tsx
+++ b/components/settings/sections/providers-section.tsx
@@ -11,6 +11,7 @@ import {
 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { TextEditModal } from "@/components/ui/text-edit-modal";
@@ -94,6 +95,8 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
   const [mcpServers, setMcpServers] = useState<McpServer[]>([]);
   const [copilotModels, setCopilotModels] = useState<Array<{ id: string; name: string; maxContextWindowTokens: number | null }>>([]);
   const [isSystemPromptOpen, setIsSystemPromptOpen] = useState(false);
+  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
+  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
   const maskedApiKeyValue = "••••••••";
 
   useEffect(() => {
@@ -266,6 +269,14 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
     if (defaultProviderProfileId === profileId) {
       setDefaultProviderProfileId(fallbackProfileId);
     }
+  }
+
+  function handleDeleteConfirm() {
+    if (pendingDeleteId) {
+      removeProviderProfile(pendingDeleteId);
+    }
+    setDeleteConfirmOpen(false);
+    setPendingDeleteId(null);
   }
 
   async function handleDuplicateProviderProfile() {
@@ -1036,7 +1047,10 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
                     </div>
                     <button
                       type="button"
-                      onClick={() => removeProviderProfile(activeProviderProfile.id)}
+                      onClick={() => {
+                        setPendingDeleteId(activeProviderProfile.id);
+                        setDeleteConfirmOpen(true);
+                      }}
                       disabled={providerProfiles.length === 1}
                       className="inline-flex items-center gap-1.5 px-2.5 py-1.5 text-xs text-red-400/80 transition-colors hover:text-red-300 disabled:cursor-not-allowed disabled:opacity-50"
                     >
@@ -1052,6 +1066,18 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
                     {testResult.text}
                   </p>
                 ) : null}
+
+                <ConfirmDialog
+                  open={deleteConfirmOpen}
+                  onOpenChange={setDeleteConfirmOpen}
+                  title="Delete provider?"
+                  description={
+                    <>
+                      <strong className="text-[var(--text)] font-medium">{activeProviderProfile?.name || "This provider"}</strong> will be permanently deleted. This action cannot be undone.
+                    </>
+                  }
+                  onConfirm={handleDeleteConfirm}
+                />
 
                 <TextEditModal
                   open={isSystemPromptOpen}

--- a/components/settings/sections/skills-section.tsx
+++ b/components/settings/sections/skills-section.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { Plus, FileText, Upload } from "lucide-react";
+import { Plus, FileText, Upload, Trash2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { Input } from "@/components/ui/input";
 import { TextEditModal } from "@/components/ui/text-edit-modal";
 import { Toast } from "@/components/ui/toast";
@@ -26,6 +27,8 @@ export function SkillsSection() {
   const toast = useToastState();
   const [skillEnabledDraft, setSkillEnabledDraft] = useState(true);
   const [isInstructionsOpen, setIsInstructionsOpen] = useState(false);
+  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
+  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -137,6 +140,14 @@ export function SkillsSection() {
       setSelectedSkillId(null);
       setMobileDetailVisible(false);
     }
+  }
+
+  function handleDeleteConfirm() {
+    if (pendingDeleteId) {
+      deleteSkill(pendingDeleteId);
+    }
+    setDeleteConfirmOpen(false);
+    setPendingDeleteId(null);
   }
 
   function handleSelectSkill(skill: Skill) {
@@ -279,16 +290,6 @@ export function SkillsSection() {
                       </p>
                     ) : null}
                   </div>
-
-                  {!isAddingNew && !isBuiltin && selectedSkill ? (
-                    <button
-                      type="button"
-                      onClick={() => deleteSkill(selectedSkill.id)}
-                      className="inline-flex items-center gap-1.5 px-2.5 py-1.5 text-xs text-red-400/80 transition-colors hover:text-red-300"
-                    >
-                      Delete
-                    </button>
-                  ) : null}
                 </div>
 
                 <div className={sectionDivider} />
@@ -362,13 +363,28 @@ export function SkillsSection() {
                   </div>
                 ) : null}
 
-                <div className="flex flex-wrap items-center gap-2">
-                  <Button type="button" className="px-3 py-1.5 text-xs" onClick={saveSkill}>
-                    Save
-                  </Button>
-                  <Button type="button" variant="ghost" className="px-2.5 py-1.5 text-xs" onClick={resetSkillForm}>
-                    {isBuiltin ? "Close" : "Cancel"}
-                  </Button>
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Button type="button" className="px-3 py-1.5 text-xs" onClick={saveSkill}>
+                      Save
+                    </Button>
+                    <Button type="button" variant="ghost" className="px-2.5 py-1.5 text-xs" onClick={resetSkillForm}>
+                      {isBuiltin ? "Close" : "Cancel"}
+                    </Button>
+                  </div>
+                  {!isAddingNew && !isBuiltin && selectedSkill ? (
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setPendingDeleteId(selectedSkill.id);
+                        setDeleteConfirmOpen(true);
+                      }}
+                      className="inline-flex items-center gap-1.5 px-2.5 py-1.5 text-xs text-red-400/80 transition-colors hover:text-red-300"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                      Delete
+                    </button>
+                  ) : null}
                 </div>
                 <TextEditModal
                   open={isInstructionsOpen}
@@ -379,6 +395,17 @@ export function SkillsSection() {
                   subtitle="Skill instructions are applied when the skill is activated"
                   placeholder="Enter the full skill instructions..."
                   readOnly={isBuiltin}
+                />
+                <ConfirmDialog
+                  open={deleteConfirmOpen}
+                  onOpenChange={setDeleteConfirmOpen}
+                  title="Delete skill?"
+                  description={
+                    <>
+                      <strong className="text-[var(--text)] font-medium">{selectedSkill?.name || "This skill"}</strong> will be permanently deleted. This action cannot be undone.
+                    </>
+                  }
+                  onConfirm={handleDeleteConfirm}
                 />
                 <Toast
                   visible={toast.visible}

--- a/components/ui/confirm-dialog.tsx
+++ b/components/ui/confirm-dialog.tsx
@@ -72,8 +72,8 @@ export function ConfirmDialog({
           <Button
             type="button"
             variant="ghost"
-            size="xs"
             autoFocus
+            className="px-4 py-2 text-xs"
             onClick={() => onOpenChange(false)}
           >
             Cancel
@@ -81,7 +81,7 @@ export function ConfirmDialog({
           <Button
             type="button"
             variant={variant === "danger" ? "destructive" : "default"}
-            size="xs"
+            className="px-4 py-2 text-xs"
             onClick={onConfirm}
           >
             {confirmLabel}

--- a/components/ui/confirm-dialog.tsx
+++ b/components/ui/confirm-dialog.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { type ReactNode, useEffect, useId } from "react";
+import { Trash2 } from "lucide-react";
+
+type ConfirmDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description: ReactNode;
+  confirmLabel?: string;
+  onConfirm: () => void;
+};
+
+export function ConfirmDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmLabel = "Delete",
+  onConfirm,
+}: ConfirmDialogProps) {
+  const titleId = useId();
+
+  useEffect(() => {
+    if (!open) return;
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        onOpenChange(false);
+      }
+    }
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [open, onOpenChange]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={titleId}
+    >
+      <div
+        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+        onClick={() => onOpenChange(false)}
+      />
+      <div className="relative w-full max-w-sm rounded-2xl border border-white/[0.08] bg-[#121214] p-6 shadow-2xl">
+        <div className="flex items-center gap-3 mb-4">
+          <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-[10px] bg-red-500/10 border border-red-500/20">
+            <Trash2 className="h-[18px] w-[18px] text-red-400" />
+          </div>
+          <h3
+            id={titleId}
+            className="text-sm font-semibold text-[var(--text)]"
+          >
+            {title}
+          </h3>
+        </div>
+        <p className="text-sm text-[#71717a] leading-relaxed mb-5">
+          {description}
+        </p>
+        <div className="flex items-center justify-end gap-2">
+          <button
+            type="button"
+            className="px-3 py-1.5 text-xs text-[var(--muted)] rounded-xl hover:bg-white/5 transition-colors"
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            autoFocus
+            className="px-3.5 py-1.5 text-xs font-medium text-red-300 rounded-xl bg-red-500/15 border border-red-500/25 hover:bg-red-500/25 transition-colors"
+            onClick={onConfirm}
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/ui/confirm-dialog.tsx
+++ b/components/ui/confirm-dialog.tsx
@@ -2,6 +2,7 @@
 
 import { type ReactNode, useEffect, useId } from "react";
 import { Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
 
 type ConfirmDialogProps = {
   open: boolean;
@@ -23,6 +24,7 @@ export function ConfirmDialog({
   variant = "danger",
 }: ConfirmDialogProps) {
   const titleId = useId();
+  const descId = useId();
 
   useEffect(() => {
     if (!open) return;
@@ -43,6 +45,7 @@ export function ConfirmDialog({
       role="dialog"
       aria-modal="true"
       aria-labelledby={titleId}
+      aria-describedby={descId}
     >
       <div
         className="absolute inset-0 bg-black/60 backdrop-blur-sm"
@@ -50,9 +53,11 @@ export function ConfirmDialog({
       />
       <div className="relative w-full max-w-sm rounded-2xl border border-white/[0.08] bg-[#121214] p-6 shadow-2xl">
         <div className="flex items-center gap-3 mb-4">
-          <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-[10px] bg-red-500/10 border border-red-500/20">
-            <Trash2 className="h-[18px] w-[18px] text-red-400" />
-          </div>
+          {variant === "danger" && (
+            <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-[10px] bg-red-500/10 border border-red-500/20">
+              <Trash2 className="h-[18px] w-[18px] text-red-400" />
+            </div>
+          )}
           <h3
             id={titleId}
             className="text-sm font-semibold text-[var(--text)]"
@@ -60,29 +65,27 @@ export function ConfirmDialog({
             {title}
           </h3>
         </div>
-        <p className="text-sm text-[#71717a] leading-relaxed mb-5">
+        <p id={descId} className="text-sm text-[#71717a] leading-relaxed mb-5">
           {description}
         </p>
         <div className="flex items-center justify-end gap-2">
-          <button
+          <Button
             type="button"
-            className="px-3 py-1.5 text-xs text-[var(--muted)] rounded-xl hover:bg-white/5 transition-colors"
+            variant="ghost"
+            size="xs"
+            autoFocus
             onClick={() => onOpenChange(false)}
           >
             Cancel
-          </button>
-          <button
+          </Button>
+          <Button
             type="button"
-            autoFocus
-            className={
-              variant === "danger"
-                ? "px-3.5 py-1.5 text-xs font-medium text-red-300 rounded-xl bg-red-500/15 border border-red-500/25 hover:bg-red-500/25 transition-colors"
-                : "px-3.5 py-1.5 text-xs font-medium text-[var(--text)] rounded-xl bg-[var(--accent)] hover:opacity-90 transition-colors"
-            }
+            variant={variant === "danger" ? "destructive" : "default"}
+            size="xs"
             onClick={onConfirm}
           >
             {confirmLabel}
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/components/ui/confirm-dialog.tsx
+++ b/components/ui/confirm-dialog.tsx
@@ -10,6 +10,7 @@ type ConfirmDialogProps = {
   description: ReactNode;
   confirmLabel?: string;
   onConfirm: () => void;
+  variant?: "danger" | "default";
 };
 
 export function ConfirmDialog({
@@ -19,6 +20,7 @@ export function ConfirmDialog({
   description,
   confirmLabel = "Delete",
   onConfirm,
+  variant = "danger",
 }: ConfirmDialogProps) {
   const titleId = useId();
 
@@ -72,7 +74,11 @@ export function ConfirmDialog({
           <button
             type="button"
             autoFocus
-            className="px-3.5 py-1.5 text-xs font-medium text-red-300 rounded-xl bg-red-500/15 border border-red-500/25 hover:bg-red-500/25 transition-colors"
+            className={
+              variant === "danger"
+                ? "px-3.5 py-1.5 text-xs font-medium text-red-300 rounded-xl bg-red-500/15 border border-red-500/25 hover:bg-red-500/25 transition-colors"
+                : "px-3.5 py-1.5 text-xs font-medium text-[var(--text)] rounded-xl bg-[var(--accent)] hover:opacity-90 transition-colors"
+            }
             onClick={onConfirm}
           >
             {confirmLabel}

--- a/tests/unit/confirm-dialog.test.tsx
+++ b/tests/unit/confirm-dialog.test.tsx
@@ -1,0 +1,137 @@
+// @vitest-environment jsdom
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+
+describe("ConfirmDialog", () => {
+  it("renders title and description when open", () => {
+    render(
+      <ConfirmDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        title="Delete persona?"
+        description="This persona will be permanently deleted."
+        onConfirm={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("Delete persona?")).toBeInTheDocument();
+    expect(screen.getByText("This persona will be permanently deleted.")).toBeInTheDocument();
+  });
+
+  it("calls onConfirm when confirm button is clicked", () => {
+    const onConfirm = vi.fn();
+    render(
+      <ConfirmDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        title="Delete persona?"
+        description="Are you sure?"
+        onConfirm={onConfirm}
+      />
+    );
+
+    fireEvent.click(screen.getByText("Delete"));
+    expect(onConfirm).toHaveBeenCalledOnce();
+  });
+
+  it("calls onOpenChange(false) when Cancel is clicked", () => {
+    const onOpenChange = vi.fn();
+    render(
+      <ConfirmDialog
+        open={true}
+        onOpenChange={onOpenChange}
+        title="Delete persona?"
+        description="Are you sure?"
+        onConfirm={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByText("Cancel"));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("calls onOpenChange(false) when backdrop is clicked", () => {
+    const onOpenChange = vi.fn();
+    render(
+      <ConfirmDialog
+        open={true}
+        onOpenChange={onOpenChange}
+        title="Delete persona?"
+        description="Are you sure?"
+        onConfirm={vi.fn()}
+      />
+    );
+
+    const backdrop = screen.getByRole("dialog").querySelector(".absolute.inset-0");
+    expect(backdrop).toBeTruthy();
+    fireEvent.click(backdrop!);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("calls onOpenChange(false) when Escape is pressed", () => {
+    const onOpenChange = vi.fn();
+    render(
+      <ConfirmDialog
+        open={true}
+        onOpenChange={onOpenChange}
+        title="Delete persona?"
+        description="Are you sure?"
+        onConfirm={vi.fn()}
+      />
+    );
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("does not render when open is false", () => {
+    render(
+      <ConfirmDialog
+        open={false}
+        onOpenChange={vi.fn()}
+        title="Delete persona?"
+        description="Are you sure?"
+        onConfirm={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("renders custom confirmLabel when provided", () => {
+    render(
+      <ConfirmDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        title="Remove item?"
+        description="Are you sure?"
+        onConfirm={vi.fn()}
+        confirmLabel="Remove"
+      />
+    );
+
+    expect(screen.getByText("Remove")).toBeInTheDocument();
+  });
+
+  it("renders ReactNode description", () => {
+    render(
+      <ConfirmDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        title="Delete persona?"
+        description={
+          <>
+            <strong>My Persona</strong> will be permanently deleted.
+          </>
+        }
+        onConfirm={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("My Persona")).toBeInTheDocument();
+    expect(screen.getByText("will be permanently deleted.")).toBeInTheDocument();
+  });
+});

--- a/tests/unit/confirm-dialog.test.tsx
+++ b/tests/unit/confirm-dialog.test.tsx
@@ -116,6 +116,24 @@ describe("ConfirmDialog", () => {
     expect(screen.getByText("Remove")).toBeInTheDocument();
   });
 
+  it("renders default variant with primary styling when variant is default", () => {
+    render(
+      <ConfirmDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        title="Confirm action?"
+        description="Are you sure?"
+        onConfirm={vi.fn()}
+        variant="default"
+        confirmLabel="Confirm"
+      />
+    );
+
+    const confirmButton = screen.getByText("Confirm");
+    expect(confirmButton).toBeInTheDocument();
+    expect(confirmButton.className).toContain("bg-[var(--accent)]");
+  });
+
   it("renders ReactNode description", () => {
     render(
       <ConfirmDialog

--- a/tests/unit/confirm-dialog.test.tsx
+++ b/tests/unit/confirm-dialog.test.tsx
@@ -131,7 +131,7 @@ describe("ConfirmDialog", () => {
 
     const confirmButton = screen.getByText("Confirm");
     expect(confirmButton).toBeInTheDocument();
-    expect(confirmButton.className).toContain("bg-[var(--accent)]");
+    expect(confirmButton.className).toContain("bg-primary");
   });
 
   it("renders ReactNode description", () => {


### PR DESCRIPTION
## Summary

- Add a reusable `ConfirmDialog` component with support for `danger` and `default` variants, accessible focus management, and responsive styling
- Wire the `ConfirmDialog` into all settings sections that support deletion: **personas**, **automations**, **memories**, **providers**, **MCP servers**, and **skills**
- Replace direct delete handlers with a confirmation flow so users must explicitly confirm before any destructive action
- Replace `xs` button size with explicit Tailwind classes in the confirm dialog for consistent sizing
- Add unit tests for the `ConfirmDialog` component

## Changed files

| File | Change |
|------|--------|
| `components/ui/confirm-dialog.tsx` | New reusable confirmation dialog component |
| `tests/unit/confirm-dialog.test.tsx` | Unit tests for the dialog |
| `components/settings/sections/personas-section.tsx` | Wired confirm dialog for persona deletion |
| `components/settings/sections/automations-section.tsx` | Wired confirm dialog for automation deletion |
| `components/settings/sections/memories-section.tsx` | Wired confirm dialog for memory deletion |
| `components/settings/sections/providers-section.tsx` | Wired confirm dialog for provider deletion |
| `components/settings/sections/mcp-servers-section.tsx` | Wired confirm dialog for MCP server deletion |
| `components/settings/sections/skills-section.tsx` | Wired confirm dialog for skill deletion |