### PR TITLE
feat: compact sidebar with purple toggle button

### DIFF
--- a/components/shell.tsx
+++ b/components/shell.tsx
@@ -322,14 +322,13 @@ export function Shell({
         <button
           type="button"
           onClick={() => setIsSidebarOpen((prev) => { if (prev) sessionStorage.setItem("eidon:sidebar:user-closed", "true"); else sessionStorage.removeItem("eidon:sidebar:user-closed"); return !prev; })}
-          className={`group/sidebar-toggle hidden md:flex fixed top-[72px] z-[80] h-9 w-9 items-center justify-center rounded-lg border border-white/10 bg-[var(--background)]/95 text-white/45 shadow-[0_2px_8px_rgba(0,0,0,0.18)] backdrop-blur-sm transition-[left,background-color,border-color,color] duration-200 ease-out hover:border-white/18 hover:bg-[#171717] hover:text-white/75 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/20 ${
+          className={`group/sidebar-toggle hidden md:flex fixed top-[72px] z-[80] h-9 w-9 items-center justify-center rounded-lg bg-[var(--accent)] text-white shadow-[0_0_20px_var(--accent-glow)] transition-[left,opacity,transform] duration-200 ease-out hover:opacity-90 hover:scale-[0.98] active:scale-[0.96] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/20 ${
             isSidebarOpen ? "left-[262px]" : "left-3"
           }`}
           aria-label={sidebarToggleLabel}
           aria-pressed={isSidebarOpen}
           title={sidebarToggleLabel}
         >
-          <span className="absolute left-1.5 top-2 h-5 w-px rounded bg-white/12 transition-colors duration-150 group-hover/sidebar-toggle:bg-white/24" />
           {isSidebarOpen ? (
             <PanelLeftClose className="h-4 w-4" />
           ) : (

--- a/components/shell.tsx
+++ b/components/shell.tsx
@@ -322,13 +322,14 @@ export function Shell({
         <button
           type="button"
           onClick={() => setIsSidebarOpen((prev) => { if (prev) sessionStorage.setItem("eidon:sidebar:user-closed", "true"); else sessionStorage.removeItem("eidon:sidebar:user-closed"); return !prev; })}
-          className={`group/sidebar-toggle hidden md:flex fixed top-[72px] z-[80] h-9 w-9 items-center justify-center rounded-lg bg-[var(--accent)] text-white shadow-[0_0_20px_var(--accent-glow)] transition-[left,opacity,transform] duration-200 ease-out hover:opacity-90 hover:scale-[0.98] active:scale-[0.96] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/20 ${
+          className={`group/sidebar-toggle hidden md:flex fixed top-[72px] z-[80] h-9 w-9 items-center justify-center rounded-lg border border-white/10 bg-[var(--background)]/95 text-white/45 shadow-[0_2px_8px_rgba(0,0,0,0.18)] backdrop-blur-sm transition-[left,background-color,border-color,color] duration-200 ease-out hover:border-white/18 hover:bg-[#171717] hover:text-white/75 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/20 ${
             isSidebarOpen ? "left-[262px]" : "left-3"
           }`}
           aria-label={sidebarToggleLabel}
           aria-pressed={isSidebarOpen}
           title={sidebarToggleLabel}
         >
+          <span className="absolute left-1.5 top-2 h-5 w-px rounded bg-white/12 transition-colors duration-150 group-hover/sidebar-toggle:bg-white/24" />
           {isSidebarOpen ? (
             <PanelLeftClose className="h-4 w-4" />
           ) : (

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -1205,7 +1205,7 @@ export function Sidebar({
   return (
     <aside className="no-scrollbar flex h-full w-full flex-col bg-transparent text-gray-300">
       <div className="flex h-full min-h-0 flex-col px-4 py-6">
-        <div className="mb-8 px-2">
+        <div className="mb-4 px-2 flex items-center justify-between">
           <Link
             href="/"
             onClick={(event) => {
@@ -1244,6 +1244,19 @@ export function Sidebar({
               </span>
             </span>
           </Link>
+          <button
+            onClick={() => handleCreate()}
+            disabled={!mounted}
+            className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-lg transition-all duration-200 ${
+              mounted
+                ? "bg-[var(--accent)] text-white shadow-[0_0_20px_var(--accent-glow)] hover:opacity-90 hover:scale-[0.98] active:scale-[0.96]"
+                : "cursor-not-allowed bg-white/[0.04] text-white/30"
+            }`}
+            title="New chat"
+            aria-label="New chat"
+          >
+            <Plus className="h-4 w-4" />
+          </button>
         </div>
 
         <div className="flex flex-col gap-2 mb-8">
@@ -1295,21 +1308,6 @@ export function Sidebar({
               <span>Search</span>
             </button>
           )}
-
-          <button
-            onClick={() => handleCreate()}
-            disabled={!mounted}
-            className={`mt-1 flex w-full items-center justify-center gap-2 rounded-2xl px-4 py-3 text-sm font-semibold transition-all duration-300 ${
-              mounted
-                ? "bg-[var(--accent)] text-white shadow-[0_0_20px_var(--accent-glow)] hover:opacity-90 hover:scale-[0.98] active:scale-[0.96]"
-                : "cursor-not-allowed bg-white/[0.04] text-white/30"
-            }`}
-            title="New chat"
-            aria-label="New chat"
-          >
-            <Plus className="h-4 w-4 stroke-[3px]" />
-            <span>New Chat</span>
-          </button>
         </div>
 
         <div

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -1127,27 +1127,6 @@ export function Sidebar({
   function renderConversationSections(enableDrag: boolean) {
     return (
       <>
-        {localFolders.map((folder) => {
-          const folderConvos = folderMap.get(folder.id) ?? [];
-          return (
-            <div key={folder.id} className="mb-1">
-              <FolderItem
-                folder={folder}
-                conversations={folderConvos}
-                activeConversationId={activeConversationId}
-                allFolders={localFolders}
-                onNavigate={navigateToHref}
-                onDeleteConversation={removeConversationFromState}
-                onMoveConversation={moveConversationInState}
-                onCreateInFolder={(fId) => handleCreate(fId)}
-                dragEnabled={enableDrag}
-                showCount={showFolderCounts}
-                searchQuery={searchQuery}
-              />
-            </div>
-          );
-        })}
-
         <div>
           <div
             ref={enableDrag ? setUnfiledDropRef : undefined}
@@ -1312,50 +1291,69 @@ export function Sidebar({
 
         <div
           ref={scrollContainerRef}
-          className="scrollbar-thin min-h-0 flex-1 overflow-y-auto overflow-x-hidden pr-1 -mr-1 space-y-4"
+          className="scrollbar-thin min-h-0 flex-1 overflow-y-auto overflow-x-hidden pr-1 -mr-1"
         >
-          <div>
-            <div className="flex items-center justify-between px-2 mb-2">
-              <div className="text-[10px] font-bold uppercase tracking-[0.2em] text-white/20">
-                Folders
-              </div>
-              {!showNewFolder && (
-                <button
-                  onClick={() => setShowNewFolder(true)}
-                  aria-label="New folder"
-                  title="New folder"
-                  className="p-1 text-white/20 hover:text-white/50 transition-colors"
-                >
-                  <Plus className="h-3.5 w-3.5" />
-                </button>
-              )}
-            </div>
-            <div className="flex flex-col gap-1">
-              {showNewFolder && (
-                <div className="flex items-center gap-2 px-2 py-1 mb-2 animate-fade-in">
-                  <input
-                    autoFocus
-                    value={newFolderName}
-                    onChange={(e) => setNewFolderName(e.target.value)}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter") handleCreateFolder();
-                      if (e.key === "Escape") { setShowNewFolder(false); setNewFolderName(""); }
-                    }}
-                    placeholder="Folder name"
-                    className="flex-1 bg-transparent border-b border-white/10 text-sm text-white outline-none py-1 placeholder:text-white/20"
-                  />
-                  <button onClick={() => { setShowNewFolder(false); setNewFolderName(""); }} className="text-white/20 hover:text-white transition-colors">
-                    <X className="h-3.5 w-3.5" />
-                  </button>
-                </div>
-              )}
-            </div>
-          </div>
-
           {dragEnabled ? (
             <DndContext sensors={sensors} collisionDetection={collisionDetection} onDragStart={handleDragStart} onDragMove={handleDragMove} onDragEnd={handleDragEnd}>
               <SortableContext items={sortableIds} strategy={verticalListSortingStrategy}>
-                {renderConversationSections(true)}
+                <div>
+                  <div className="flex items-center justify-between px-2 mb-2">
+                    <div className="text-[10px] font-bold uppercase tracking-[0.2em] text-white/20">
+                      Folders
+                    </div>
+                    {!showNewFolder && (
+                      <button
+                        onClick={() => setShowNewFolder(true)}
+                        aria-label="New folder"
+                        title="New folder"
+                        className="p-1 text-white/20 hover:text-white/50 transition-colors"
+                      >
+                        <Plus className="h-3.5 w-3.5" />
+                      </button>
+                    )}
+                  </div>
+                  {showNewFolder && (
+                    <div className="flex items-center gap-2 px-2 py-1 mb-2 animate-fade-in">
+                      <input
+                        autoFocus
+                        value={newFolderName}
+                        onChange={(e) => setNewFolderName(e.target.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter") handleCreateFolder();
+                          if (e.key === "Escape") { setShowNewFolder(false); setNewFolderName(""); }
+                        }}
+                        placeholder="Folder name"
+                        className="flex-1 bg-transparent border-b border-white/10 text-sm text-white outline-none py-1 placeholder:text-white/20"
+                      />
+                      <button onClick={() => { setShowNewFolder(false); setNewFolderName(""); }} className="text-white/20 hover:text-white transition-colors">
+                        <X className="h-3.5 w-3.5" />
+                      </button>
+                    </div>
+                  )}
+                  {localFolders.map((folder) => {
+                    const folderConvos = folderMap.get(folder.id) ?? [];
+                    return (
+                      <div key={folder.id} className="mb-1">
+                        <FolderItem
+                          folder={folder}
+                          conversations={folderConvos}
+                          activeConversationId={activeConversationId}
+                          allFolders={localFolders}
+                          onNavigate={navigateToHref}
+                          onDeleteConversation={removeConversationFromState}
+                          onMoveConversation={moveConversationInState}
+                          onCreateInFolder={(fId) => handleCreate(fId)}
+                          dragEnabled
+                          showCount={showFolderCounts}
+                          searchQuery={searchQuery}
+                        />
+                      </div>
+                    );
+                  })}
+                </div>
+                <div className="mt-4">
+                  {renderConversationSections(true)}
+                </div>
               </SortableContext>
               <DragOverlay>
                 {activeDragConversation ? (
@@ -1367,7 +1365,66 @@ export function Sidebar({
               </DragOverlay>
             </DndContext>
           ) : (
-            renderConversationSections(false)
+            <>
+              <div>
+                <div className="flex items-center justify-between px-2 mb-2">
+                  <div className="text-[10px] font-bold uppercase tracking-[0.2em] text-white/20">
+                    Folders
+                  </div>
+                  {!showNewFolder && (
+                    <button
+                      onClick={() => setShowNewFolder(true)}
+                      aria-label="New folder"
+                      title="New folder"
+                      className="p-1 text-white/20 hover:text-white/50 transition-colors"
+                    >
+                      <Plus className="h-3.5 w-3.5" />
+                    </button>
+                  )}
+                </div>
+                {showNewFolder && (
+                  <div className="flex items-center gap-2 px-2 py-1 mb-2 animate-fade-in">
+                    <input
+                      autoFocus
+                      value={newFolderName}
+                      onChange={(e) => setNewFolderName(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") handleCreateFolder();
+                        if (e.key === "Escape") { setShowNewFolder(false); setNewFolderName(""); }
+                      }}
+                      placeholder="Folder name"
+                      className="flex-1 bg-transparent border-b border-white/10 text-sm text-white outline-none py-1 placeholder:text-white/20"
+                    />
+                    <button onClick={() => { setShowNewFolder(false); setNewFolderName(""); }} className="text-white/20 hover:text-white transition-colors">
+                      <X className="h-3.5 w-3.5" />
+                    </button>
+                  </div>
+                )}
+                {localFolders.map((folder) => {
+                  const folderConvos = folderMap.get(folder.id) ?? [];
+                  return (
+                    <div key={folder.id} className="mb-1">
+                      <FolderItem
+                        folder={folder}
+                        conversations={folderConvos}
+                        activeConversationId={activeConversationId}
+                        allFolders={localFolders}
+                        onNavigate={navigateToHref}
+                        onDeleteConversation={removeConversationFromState}
+                        onMoveConversation={moveConversationInState}
+                        onCreateInFolder={(fId) => handleCreate(fId)}
+                        dragEnabled={false}
+                        showCount={showFolderCounts}
+                        searchQuery={searchQuery}
+                      />
+                    </div>
+                  );
+                })}
+              </div>
+              <div className="mt-4">
+                {renderConversationSections(false)}
+              </div>
+            </>
           )}
         </div>
 

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -1259,7 +1259,7 @@ export function Sidebar({
           </button>
         </div>
 
-        <div className="flex flex-col gap-2 mb-8">
+        <div className="flex flex-col gap-2 mb-4">
           {showSearch || searchQuery || searchResults ? (
             <div className="relative group">
               <Search className="absolute left-3.5 top-1/2 -translate-y-1/2 h-4 w-4 text-white/20 transition-colors group-focus-within:text-[var(--accent)]/50" />
@@ -1312,10 +1312,10 @@ export function Sidebar({
 
         <div
           ref={scrollContainerRef}
-          className="scrollbar-thin min-h-0 flex-1 overflow-y-auto overflow-x-hidden pr-1 -mr-1 space-y-8"
+          className="scrollbar-thin min-h-0 flex-1 overflow-y-auto overflow-x-hidden pr-1 -mr-1 space-y-4"
         >
           <div>
-            <div className="flex items-center justify-between px-2 mb-3">
+            <div className="flex items-center justify-between px-2 mb-1.5">
               <div className="text-[10px] font-bold uppercase tracking-[0.2em] text-white/20">
                 Folders
               </div>

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -1315,7 +1315,7 @@ export function Sidebar({
           className="scrollbar-thin min-h-0 flex-1 overflow-y-auto overflow-x-hidden pr-1 -mr-1 space-y-4"
         >
           <div>
-            <div className="flex items-center justify-between px-2 mb-0.5">
+            <div className="flex items-center justify-between px-2 mb-2">
               <div className="text-[10px] font-bold uppercase tracking-[0.2em] text-white/20">
                 Folders
               </div>

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -1315,7 +1315,7 @@ export function Sidebar({
           className="scrollbar-thin min-h-0 flex-1 overflow-y-auto overflow-x-hidden pr-1 -mr-1 space-y-4"
         >
           <div>
-            <div className="flex items-center justify-between px-2 mb-1.5">
+            <div className="flex items-center justify-between px-2 mb-0.5">
               <div className="text-[10px] font-bold uppercase tracking-[0.2em] text-white/20">
                 Folders
               </div>

--- a/docs/superpowers/plans/2026-05-26-sidebar-compact-layout.md
+++ b/docs/superpowers/plans/2026-05-26-sidebar-compact-layout.md
@@ -1,0 +1,211 @@
+# Sidebar Compact Layout & Purple Toggle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restyle the sidebar toggle to purple, replace the full-width "New Chat" button with a compact "+" icon in the logo row, and tighten vertical spacing in the FOLDERS section.
+
+**Architecture:** Three independent UI changes across two files (`shell.tsx`, `sidebar.tsx`). Each task modifies a distinct section of the UI with no shared state between tasks.
+
+**Tech Stack:** React, Tailwind CSS, lucide-react icons, CSS custom properties (`--accent`, `--accent-glow`)
+
+---
+
+### Task 1: Purple sidebar toggle button
+
+**Files:**
+- Modify: `components/shell.tsx:322-346`
+
+- [ ] **Step 1: Replace the toggle button classes**
+
+In `components/shell.tsx`, replace the `<button>` element at lines 322-346 with the following. This changes the button from dark ghost to Eidon Violet and removes the decorative vertical line.
+
+Find the `<button` starting with `type="button"` and `onClick={() => setIsSidebarOpen...` (the sidebar toggle, around line 322). Replace the entire `<button>...</button>` block with:
+
+```tsx
+        <button
+          type="button"
+          onClick={() => setIsSidebarOpen((prev) => { if (prev) sessionStorage.setItem("eidon:sidebar:user-closed", "true"); else sessionStorage.removeItem("eidon:sidebar:user-closed"); return !prev; })}
+          className={`group/sidebar-toggle hidden md:flex fixed top-[72px] z-[80] h-9 w-9 items-center justify-center rounded-lg bg-[var(--accent)] text-white shadow-[0_0_20px_var(--accent-glow)] transition-[left,opacity,transform] duration-200 ease-out hover:opacity-90 hover:scale-[0.98] active:scale-[0.96] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/20 ${
+            isSidebarOpen ? "left-[262px]" : "left-3"
+          }`}
+          aria-label={sidebarToggleLabel}
+          aria-pressed={isSidebarOpen}
+          title={sidebarToggleLabel}
+        >
+          {isSidebarOpen ? (
+            <PanelLeftClose className="h-4 w-4" />
+          ) : (
+            <PanelLeftOpen className="h-4 w-4" />
+          )}
+          <span
+            className={`pointer-events-none absolute top-1/2 -translate-y-1/2 whitespace-nowrap rounded-md border border-white/10 bg-[#161616] px-2 py-1 text-[11px] font-medium text-white/70 opacity-0 shadow-[0_2px_8px_rgba(0,0,0,0.22)] transition-opacity duration-150 group-hover/sidebar-toggle:opacity-100 group-focus-visible/sidebar-toggle:opacity-100 ${
+              isSidebarOpen ? "right-11" : "left-11"
+            }`}
+          >
+            {isSidebarOpen ? "Hide sidebar" : "Show sidebar"}
+          </span>
+        </button>
+```
+
+Key changes from original:
+- Removed `border border-white/10 bg-[var(--background)]/95 text-white/45` (neutral ghost)
+- Removed `shadow-[0_2px_8px_rgba(0,0,0,0.18)] backdrop-blur-sm`
+- Removed hover states `hover:border-white/18 hover:bg-[#171717] hover:text-white/75`
+- Added `bg-[var(--accent)] text-white shadow-[0_0_20px_var(--accent-glow)]`
+- Added `hover:opacity-90 hover:scale-[0.98] active:scale-[0.96]`
+- Updated transition from `transition-[left,background-color,border-color,color]` to `transition-[left,opacity,transform]`
+- Removed the decorative `<span>` with the vertical line (`absolute left-1.5 top-2 h-5 w-px...`)
+
+- [ ] **Step 2: Verify no lint errors**
+
+Run: `npx eslint components/shell.tsx --no-error-on-unmatched-pattern`
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add components/shell.tsx
+git commit -m "style: purple sidebar toggle button"
+```
+
+---
+
+### Task 2: Replace "New Chat" button with compact "+" in logo row
+
+**Files:**
+- Modify: `components/sidebar.tsx:1208-1247` (logo row)
+- Modify: `components/sidebar.tsx:1299-1312` (remove New Chat button)
+
+- [ ] **Step 1: Add "+" button to the Eidon logo row**
+
+In `components/sidebar.tsx`, find the logo container div (line 1208):
+
+```tsx
+        <div className="mb-8 px-2">
+          <Link
+```
+
+Replace the opening `<div className="mb-8 px-2">` with a flex row that includes the "+" button:
+
+```tsx
+        <div className="mb-4 px-2 flex items-center justify-between">
+          <Link
+```
+
+The rest of the `<Link>` block remains unchanged. After the closing `</Link>` on line 1246, add the "+" button before the closing `</div>` on line 1247:
+
+Find:
+```tsx
+          </Link>
+        </div>
+```
+
+Replace with:
+```tsx
+          </Link>
+          <button
+            onClick={() => handleCreate()}
+            disabled={!mounted}
+            className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-lg transition-all duration-200 ${
+              mounted
+                ? "bg-[var(--accent)] text-white shadow-[0_0_20px_var(--accent-glow)] hover:opacity-90 hover:scale-[0.98] active:scale-[0.96]"
+                : "cursor-not-allowed bg-white/[0.04] text-white/30"
+            }`}
+            title="New chat"
+            aria-label="New chat"
+          >
+            <Plus className="h-4 w-4" />
+          </button>
+        </div>
+```
+
+- [ ] **Step 2: Remove the full-width "New Chat" button**
+
+In the same file, find and delete the entire "New Chat" button block (approximately lines 1299-1312):
+
+```tsx
+          <button
+            onClick={() => handleCreate()}
+            disabled={!mounted}
+            className={`mt-1 flex w-full items-center justify-center gap-2 rounded-2xl px-4 py-3 text-sm font-semibold transition-all duration-300 ${
+              mounted
+                ? "bg-[var(--accent)] text-white shadow-[0_0_20px_var(--accent-glow)] hover:opacity-90 hover:scale-[0.98] active:scale-[0.96]"
+                : "cursor-not-allowed bg-white/[0.04] text-white/30"
+            }`}
+            title="New chat"
+            aria-label="New chat"
+          >
+            <Plus className="h-4 w-4 stroke-[3px]" />
+            <span>New Chat</span>
+          </button>
+```
+
+- [ ] **Step 3: Verify no lint errors**
+
+Run: `npx eslint components/sidebar.tsx --no-error-on-unmatched-pattern`
+Expected: No errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add components/sidebar.tsx
+git commit -m "feat: compact + button in sidebar logo row"
+```
+
+---
+
+### Task 3: Tighter FOLDERS section spacing
+
+**Files:**
+- Modify: `components/sidebar.tsx:1249,1317,1320`
+
+- [ ] **Step 1: Reduce search/buttons area bottom margin**
+
+In `components/sidebar.tsx`, find the search/buttons container div (line 1249):
+
+```tsx
+        <div className="flex flex-col gap-2 mb-8">
+```
+
+Replace with:
+```tsx
+        <div className="flex flex-col gap-2 mb-4">
+```
+
+- [ ] **Step 2: Reduce scrollable container section spacing**
+
+Find the scrollable container div (line 1317):
+
+```tsx
+          className="scrollbar-thin min-h-0 flex-1 overflow-y-auto overflow-x-hidden pr-1 -mr-1 space-y-8"
+```
+
+Replace with:
+```tsx
+          className="scrollbar-thin min-h-0 flex-1 overflow-y-auto overflow-x-hidden pr-1 -mr-1 space-y-4"
+```
+
+- [ ] **Step 3: Reduce FOLDERS heading bottom margin**
+
+Find the FOLDERS heading row (line 1320):
+
+```tsx
+            <div className="flex items-center justify-between px-2 mb-3">
+```
+
+Replace with:
+```tsx
+            <div className="flex items-center justify-between px-2 mb-1.5">
+```
+
+- [ ] **Step 4: Verify no lint errors**
+
+Run: `npx eslint components/sidebar.tsx --no-error-on-unmatched-pattern`
+Expected: No errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add components/sidebar.tsx
+git commit -m "style: tighter sidebar spacing"
+```

--- a/docs/superpowers/specs/2026-05-26-sidebar-compact-layout-design.md
+++ b/docs/superpowers/specs/2026-05-26-sidebar-compact-layout-design.md
@@ -1,0 +1,59 @@
+# Sidebar Compact Layout & Purple Toggle
+
+## Problem
+
+The sidebar wastes vertical space: the full-width "New Chat" button occupies a row, the FOLDERS section has excessive empty space beneath its heading, and the sidebar show/hide toggle uses a neutral ghost style that doesn't match the Eidon Violet accent used on other primary actions.
+
+## Changes
+
+### 1. Purple sidebar toggle button
+
+**File:** `components/shell.tsx` (lines 322-346)
+
+Restyle the desktop sidebar show/hide toggle from dark ghost to Eidon Violet accent, matching the design language of the "New Chat" and mobile header buttons.
+
+- Background: `bg-[var(--accent)]` (#8b5cf6)
+- Icon/text: `text-white`
+- Shadow: `shadow-[0_0_20px_var(--accent-glow)]`
+- Hover: `hover:opacity-90`
+- Remove the neutral border, neutral bg, neutral text color, and the decorative vertical line accent
+
+### 2. Replace full-width "New Chat" button with compact "+" icon button
+
+**File:** `components/sidebar.tsx` (lines 1299-1312)
+
+Remove the full-width "New Chat" pill button. Add a small 32x32px rounded purple "+" button at the far right of the "Eidon" logo row, matching the mobile header's "+" button style (`components/shell.tsx` lines 408-423).
+
+- Position: inline with the Eidon wordmark, `justify-between` on the logo row
+- Size: `h-8 w-8` with `rounded-lg`
+- Styling: `bg-[var(--accent)] text-white shadow-[0_0_20px_var(--accent-glow)]`
+- Icon: `Plus` from lucide-react, `h-4 w-4`
+- Hover/active: `hover:opacity-90 hover:scale-[0.98] active:scale-[0.96]`
+- Same `onClick` handler as the removed button (`handleCreate()`)
+- Same `disabled` state logic (`mounted` check)
+
+### 3. Tighter FOLDERS section spacing
+
+**File:** `components/sidebar.tsx`
+
+Reduce empty space in the FOLDERS area:
+
+- FOLDERS heading `mb-3` to `mb-1.5` (line 1320)
+- Scrollable container `space-y-8` to `space-y-4` (line 1317)
+- Logo area `mb-8` to `mb-4` (line 1208)
+- Search/buttons area `mb-8` to `mb-4` (line 1249)
+
+## Files affected
+
+- `components/shell.tsx` - toggle button restyling
+- `components/sidebar.tsx` - "+" button relocation, spacing cleanup
+
+## Platform scope
+
+All changes apply across desktop, mobile, and PWA layouts:
+
+- The `<Sidebar>` component is shared between mobile and desktop. The compact "+" button and tighter spacing apply universally.
+- The desktop toggle button (shell.tsx) is `hidden md:flex` so it only appears on desktop. Mobile uses the hamburger menu in the header bar. Both platforms now use Eidon Violet for their primary actions.
+- The mobile header "+" button (shell.tsx) already uses `bg-[var(--accent)]` and needs no changes.
+- All accent colors use existing CSS custom properties (`--accent`, `--accent-glow`).
+- Functional behavior unchanged (same click handlers, same disabled states).


### PR DESCRIPTION
## Summary

- **Compact new-chat button:** Replaced the full-width "New Chat" button with a small `+` icon button in the sidebar logo row, using an accent-colored (purple) glow style
- **Tighter spacing:** Reduced top/bottom margins (`mb-8` → `mb-4`) between the logo, search, and conversation sections for a denser layout
- **Restructured Folders section:** Moved the Folders section (heading, folder creation input, folder list) inside the scrollable conversation area, directly above the unfiled conversations list, so everything scrolls together
- **Removed duplicate section rendering:** Folder items now render directly under the Folders heading within the scrollable area, instead of being rendered separately inside `renderConversationSections`