### PR TITLE
feat: increase sidebar icon and text visibility

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -93,11 +93,6 @@ body {
   color: white;
 }
 
-a {
-  color: inherit;
-  text-decoration: none;
-}
-
 button,
 input,
 textarea,
@@ -609,6 +604,10 @@ select {
 @layer base {
   * {
     @apply border-border outline-ring/50;
+  }
+  a {
+    color: inherit;
+    text-decoration: none;
   }
   body {
     @apply bg-background text-foreground;

--- a/components/sidebar-footer-nav.tsx
+++ b/components/sidebar-footer-nav.tsx
@@ -5,7 +5,7 @@ import type { MouseEvent as ReactMouseEvent } from "react";
 import { Clock3, Settings } from "lucide-react";
 
 const baseLinkClassName =
-  "flex w-full items-center gap-3 rounded-2xl px-4 py-3 text-sm text-white/30 transition-all duration-300 hover:bg-white/[0.03] hover:text-white/60";
+  "flex w-full items-center gap-3 rounded-2xl px-4 py-3 text-sm text-white/70 transition-all duration-300 hover:bg-white/[0.03] hover:text-white/90";
 
 type SidebarFooterNavProps = {
   onNavigateAction: (href: string) => void | Promise<void>;
@@ -40,7 +40,7 @@ export function SidebarFooterNav({ onNavigateAction }: SidebarFooterNavProps) {
         className={baseLinkClassName}
         onClick={(event) => interceptNavigation(event, "/settings", onNavigateAction)}
       >
-        <Settings className="h-4.5 w-4.5 opacity-50" />
+        <Settings className="h-4.5 w-4.5 opacity-60" />
         <span className="font-medium">Settings</span>
       </Link>
 
@@ -50,7 +50,7 @@ export function SidebarFooterNav({ onNavigateAction }: SidebarFooterNavProps) {
         className={baseLinkClassName}
         onClick={(event) => interceptNavigation(event, "/automations", onNavigateAction)}
       >
-        <Clock3 className="h-4.5 w-4.5 opacity-50" />
+        <Clock3 className="h-4.5 w-4.5 opacity-60" />
         <span className="font-medium">Automations</span>
       </Link>
     </div>

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -347,13 +347,13 @@ function ConversationItem({
         className={`group relative flex items-center gap-3 rounded-2xl px-3 py-2 text-sm transition-all duration-300 ${
           active
             ? "bg-white/[0.05] text-white font-semibold"
-            : "text-white/30 hover:bg-white/[0.03] hover:text-white/60"
+            : "text-white/70 hover:bg-white/[0.03] hover:text-white/90"
         }`}
       >
         {(conversation.isActive || conversation.titleGenerationStatus === "pending") ? (
           <LoaderCircle className="h-3.5 w-3.5 shrink-0 animate-spin text-[var(--accent)]" />
         ) : (
-          <MessageSquare className={`h-4 w-4 shrink-0 transition-opacity duration-300 ${active ? "opacity-100 text-[var(--accent)]" : "opacity-40"}`} />
+          <MessageSquare className={`h-4 w-4 shrink-0 transition-opacity duration-300 ${active ? "opacity-100 text-[var(--accent)]" : "opacity-60"}`} />
         )}
 
         <div className="relative min-w-0 flex-1 overflow-hidden">
@@ -580,7 +580,7 @@ function FolderItem({
     <div ref={setNodeRef} style={style} {...(dragEnabled ? attributes : {})}>
       <div
         ref={dragEnabled ? setFolderDropRef : undefined}
-        className={`group flex items-center gap-3 rounded-2xl pl-1 pr-3 py-2 text-sm text-white/30 hover:bg-white/[0.03] transition-all duration-300 cursor-pointer ${
+        className={`group flex items-center gap-3 rounded-2xl pl-1 pr-3 py-2 text-sm text-white/70 hover:bg-white/[0.03] transition-all duration-300 cursor-pointer ${
           dragEnabled && isOverFolderDrop
             ? "bg-white/[0.05] border border-white/10 shadow-2xl"
             : "border border-transparent"
@@ -591,7 +591,7 @@ function FolderItem({
         {...(dragEnabled ? listeners : {})}
       >
         {collapsed ? (
-          <FolderIcon className="h-4 w-4 opacity-30" />
+          <FolderIcon className="h-4 w-4 opacity-60" />
         ) : (
           <FolderOpen className="h-4 w-4 text-[var(--accent)] opacity-60" />
         )}


### PR DESCRIPTION
## Summary

- Increased folder icon opacity from `0.30` to `0.60` for better visibility
- Increased conversation icon opacity from `0.40` to `0.60`
- Increased inactive sidebar item text contrast from `text-white/30` to `text-white/70`
- Increased hover state text contrast from `text-white/60` to `text-white/90`
- Increased footer nav icon opacity from `0.50` to `0.60`
- Moved anchor (`<a>`) reset styles into `@layer base` in `globals.css` for proper cascade ordering