### PR TITLE
fix: only spin sidebar icon when title generation is running

### DIFF
--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -350,7 +350,7 @@ function ConversationItem({
             : "text-white/70 hover:bg-white/[0.03] hover:text-white/90"
         }`}
       >
-        {(conversation.isActive || conversation.titleGenerationStatus === "pending") ? (
+        {(conversation.isActive || conversation.titleGenerationStatus === "running") ? (
           <LoaderCircle className="h-3.5 w-3.5 shrink-0 animate-spin text-[var(--accent)]" />
         ) : (
           <MessageSquare className={`h-4 w-4 shrink-0 transition-opacity duration-300 ${active ? "opacity-100 text-[var(--accent)]" : "opacity-60"}`} />

--- a/tests/unit/sidebar.test.tsx
+++ b/tests/unit/sidebar.test.tsx
@@ -4,7 +4,7 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { highlightMatch, Sidebar } from "@/components/sidebar";
-import type { ConversationListPage } from "@/lib/types";
+import type { Conversation, ConversationListPage } from "@/lib/types";
 
 vi.mock("next/navigation", () => ({
   usePathname: () => "/chat/conversation-1",
@@ -47,6 +47,115 @@ describe("highlightMatch", () => {
     expect(result).toContain('<mark class="bg-[var(--accent)]/30 text-white rounded px-0.5">silver moon</mark>');
     expect(result).not.toContain("<img");
     expect(result).not.toContain('onerror="alert(1)"');
+  });
+});
+
+function buildConversation(overrides: Partial<Conversation> = {}): Conversation {
+  return {
+    id: "conversation-1",
+    title: "Mobile drawer layout",
+    titleGenerationStatus: "completed",
+    folderId: null,
+    providerProfileId: null,
+    automationId: null,
+    automationRunId: null,
+    conversationOrigin: "manual",
+    sortOrder: 0,
+    createdAt: "2026-05-07T12:00:00.000Z",
+    updatedAt: "2026-05-07T12:00:00.000Z",
+    isActive: false,
+    shareEnabled: false,
+    shareToken: null,
+    sharedAt: null,
+    isTemporary: false,
+    ...overrides
+  };
+}
+
+function getIconForConversation(title: string) {
+  const link = screen.getByText(title).closest("a");
+  return link?.querySelector("svg");
+}
+
+describe("Sidebar conversation row spinner", () => {
+  it("does not show a spinner for a freshly-created conversation with pending title generation", () => {
+    const page: ConversationListPage = {
+      conversations: [
+        buildConversation({
+          id: "conv-pending",
+          title: "Conversation",
+          titleGenerationStatus: "pending",
+          isActive: false
+        })
+      ],
+      hasMore: false,
+      nextCursor: null
+    };
+
+    render(<Sidebar conversationPage={page} folders={[]} />);
+
+    const icon = getIconForConversation("Conversation");
+    expect(icon).not.toHaveClass("animate-spin");
+  });
+
+  it("shows a spinner when title generation is running", () => {
+    const page: ConversationListPage = {
+      conversations: [
+        buildConversation({
+          id: "conv-running",
+          title: "Conversation",
+          titleGenerationStatus: "running",
+          isActive: false
+        })
+      ],
+      hasMore: false,
+      nextCursor: null
+    };
+
+    render(<Sidebar conversationPage={page} folders={[]} />);
+
+    const icon = getIconForConversation("Conversation");
+    expect(icon).toHaveClass("animate-spin");
+  });
+
+  it("shows a spinner when the conversation is active (agent working)", () => {
+    const page: ConversationListPage = {
+      conversations: [
+        buildConversation({
+          id: "conv-active",
+          title: "Working conversation",
+          titleGenerationStatus: "completed",
+          isActive: true
+        })
+      ],
+      hasMore: false,
+      nextCursor: null
+    };
+
+    render(<Sidebar conversationPage={page} folders={[]} />);
+
+    const icon = getIconForConversation("Working conversation");
+    expect(icon).toHaveClass("animate-spin");
+  });
+
+  it("does not show a spinner for an idle completed conversation", () => {
+    const page: ConversationListPage = {
+      conversations: [
+        buildConversation({
+          id: "conv-idle",
+          title: "Mobile drawer layout",
+          titleGenerationStatus: "completed",
+          isActive: false
+        })
+      ],
+      hasMore: false,
+      nextCursor: null
+    };
+
+    render(<Sidebar conversationPage={page} folders={[]} />);
+
+    const icon = getIconForConversation("Mobile drawer layout");
+    expect(icon).not.toHaveClass("animate-spin");
   });
 });
 


### PR DESCRIPTION
## Summary

- Fixed sidebar showing a spinner next to newly-created conversations even though no work was happening. Root cause: the spinner condition checked for `titleGenerationStatus === \"pending\"`, but `\"pending\"` is the initial state set at conversation creation (queued, not started). Title generation only transitions to `\"running\"` after the first user message.
- Changed the condition in `components/sidebar.tsx` to `\"running\"` so the spinner shows only when title generation is actually in progress or the agent is active (`isActive`).
- Added unit tests covering all four states (pending, running, active, idle) to lock in the behavior.

## Test plan

- [x] Unit tests pass (1098/1098)
- [x] Browser-verified: creating a new conversation now shows the static MessageSquare icon in the sidebar instead of a spinner