### PR TITLE
feat: show context gauge on initial load for conversations with messages

### DIFF
--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -497,7 +497,11 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
   const [streamTimeline, setStreamTimeline] = useState<MessageTimelineItem[]>([]);
   const [hasReceivedFirstToken, setHasReceivedFirstToken] = useState(false);
   const [compactionInProgress, setCompactionInProgress] = useState(false);
-  const [usedTokens, setUsedTokens] = useState<number | null>(null);
+  const [usedTokens, setUsedTokens] = useState<number | null>(() => {
+    const sanitized = sanitizeMessages(payload.messages);
+    if (sanitized.length === 0) return null;
+    return sanitized.reduce((sum, m) => sum + m.estimatedTokens, 0);
+  });
   const [isConversationActive, setIsConversationActive] = useState(payload.conversation.isActive);
   const hasInitializedTokensRef = useRef(false);
 

--- a/components/context-gauge.tsx
+++ b/components/context-gauge.tsx
@@ -107,12 +107,13 @@ export function ContextGauge({ usedTokens, usableLimit, maxLimit }: ContextGauge
 
       {showTooltip && (
         <div
-          className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-2.5 py-1.5 rounded-lg bg-[#27272a] border border-white/10 shadow-lg whitespace-nowrap z-50"
+          className="absolute bottom-full right-0 mb-2 px-2.5 py-1.5 rounded-lg bg-[#27272a] border border-white/10 shadow-lg z-50"
           onMouseEnter={handleMouseEnter}
           onMouseLeave={handleMouseLeave}
         >
-          <div className="text-[11px] text-white/60 whitespace-nowrap">
-            {usedFormatted} used / {usableFormatted} usable ({thresholdPercent}% of {maxFormatted})
+          <div className="text-[11px] text-white/60 text-center">
+            <div className="whitespace-nowrap">{usedFormatted} used / {usableFormatted} usable</div>
+            <div className="whitespace-nowrap">({thresholdPercent}% of {maxFormatted})</div>
           </div>
         </div>
       )}

--- a/tests/unit/chat-view.test.ts
+++ b/tests/unit/chat-view.test.ts
@@ -3992,6 +3992,35 @@ describe("chat view", () => {
     expect(composerRow).not.toHaveClass("items-end");
   });
 
+  it("shows the context gauge immediately when loading a conversation with existing messages", async () => {
+    const payload = createPayload({
+      messages: [
+        createMessage({ id: "msg_user_1", role: "user", content: "Hello", estimatedTokens: 10 }),
+        createMessage({ id: "msg_assistant_1", role: "assistant", content: "Hi there", estimatedTokens: 20 })
+      ]
+    });
+    renderWithProvider(React.createElement(ChatView, { payload }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Test conversation")).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole("progressbar")).toBeInTheDocument();
+    expect(screen.getByText("Context")).toBeInTheDocument();
+  });
+
+  it("hides the context gauge for a new conversation with no messages", async () => {
+    const payload = createPayload({ messages: [] });
+    renderWithProvider(React.createElement(ChatView, { payload }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Test conversation")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByRole("progressbar")).toBeNull();
+    expect(screen.queryByText("Context")).toBeNull();
+  });
+
   it("updates token usage gauge when usage event arrives", async () => {
     renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
 


### PR DESCRIPTION
## Summary

- **Initialize `usedTokens` state from existing messages** instead of `null`, so the context gauge renders immediately when loading a conversation that already has messages (previously it only appeared after the first streaming response).
- **Fix context gauge tooltip positioning** — anchor to the right instead of centering, preventing overflow off-screen.
- **Improve tooltip layout** — split usage info into two lines for better readability.
- **Add tests** for both cases: gauge visible on load with messages, and gauge hidden for empty conversations.

## Files changed

| File | Change |
|------|--------|
| `components/chat-view.tsx` | Initialize `usedTokens` from sanitized messages with lazy state initializer |
| `components/context-gauge.tsx` | Fix tooltip positioning and line wrapping |
| `tests/unit/chat-view.test.ts` | Add 2 tests for initial gauge visibility |