### PR TITLE
fix: handle deleted provider profiles gracefully

### DIFF
--- a/app/chat/[conversationId]/page.tsx
+++ b/app/chat/[conversationId]/page.tsx
@@ -53,6 +53,19 @@ export default async function ConversationPage({
     redirect(`/automations/${conversation.automationId}/runs/${conversation.automationRunId}`);
   }
 
+  const validProviderIds = new Set(settings.providerProfiles.map((p) => p.id));
+  const resolvedProviderProfileId =
+    conversation.providerProfileId && validProviderIds.has(conversation.providerProfileId)
+      ? conversation.providerProfileId
+      : settings.defaultProviderProfileId && validProviderIds.has(settings.defaultProviderProfileId)
+        ? settings.defaultProviderProfileId
+        : settings.providerProfiles[0]?.id ?? null;
+
+  const validatedConversation =
+    resolvedProviderProfileId !== conversation.providerProfileId
+      ? { ...conversation, providerProfileId: resolvedProviderProfileId }
+      : conversation;
+
   return (
     <Shell
       currentUser={user}
@@ -62,8 +75,9 @@ export default async function ConversationPage({
       currentConversation={conversation}
     >
       <ChatView
+        key={conversation.id}
         payload={{
-          conversation,
+          conversation: validatedConversation,
           messages: listVisibleMessages(conversation.id),
           queuedMessages: listQueuedMessages(conversation.id),
           settings: {

--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -527,11 +527,27 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
   const compactionInProgressRef = useRef(false);
   const thinkingStartTimeRef = useRef<number | null>(null);
   const [thinkingDuration, setThinkingDuration] = useState<number | undefined>(undefined);
+  function resolveProviderProfileId(
+    conversationProviderId: string | null,
+    profiles: ProviderProfileSummary[],
+    defaultId: string | null
+  ) {
+    const profileIds = new Set(profiles.map((p) => p.id));
+    if (conversationProviderId && profileIds.has(conversationProviderId)) {
+      return conversationProviderId;
+    }
+    if (defaultId && profileIds.has(defaultId)) {
+      return defaultId;
+    }
+    return profiles[0]?.id ?? "";
+  }
+
   const [providerProfileId, setProviderProfileId] = useState(
-    payload.conversation.providerProfileId ??
-      payload.defaultProviderProfileId ??
-      payload.providerProfiles[0]?.id ??
-      ""
+    () => resolveProviderProfileId(
+      payload.conversation.providerProfileId,
+      payload.providerProfiles,
+      payload.defaultProviderProfileId
+    )
   );
   const [pendingAttachments, setPendingAttachments] = useState<MessageAttachment[]>([]);
   const [isUploadingAttachments, setIsUploadingAttachments] = useState(false);
@@ -751,10 +767,11 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
 
   useEffect(() => {
     setProviderProfileId(
-      payload.conversation.providerProfileId ??
-        payload.defaultProviderProfileId ??
-        payload.providerProfiles[0]?.id ??
-        ""
+      resolveProviderProfileId(
+        payload.conversation.providerProfileId,
+        payload.providerProfiles,
+        payload.defaultProviderProfileId
+      )
     );
   }, [payload.conversation.providerProfileId, payload.defaultProviderProfileId, payload.providerProfiles]);
 

--- a/components/settings/sections/providers-section.tsx
+++ b/components/settings/sections/providers-section.tsx
@@ -271,12 +271,44 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
     }
   }
 
-  function handleDeleteConfirm() {
-    if (pendingDeleteId) {
-      removeProviderProfile(pendingDeleteId);
+  async function handleDeleteConfirm() {
+    if (!pendingDeleteId) {
+      setDeleteConfirmOpen(false);
+      return;
     }
+
+    const profileId = pendingDeleteId;
     setDeleteConfirmOpen(false);
     setPendingDeleteId(null);
+
+    if (providerProfiles.length === 1) return;
+
+    const nextProfiles = providerProfiles.filter((p) => p.id !== profileId);
+    const nextDefault = defaultProviderProfileId === profileId
+      ? (nextProfiles.find((p) => p.id === defaultProviderProfileId)?.id ?? nextProfiles[0]?.id ?? "")
+      : defaultProviderProfileId;
+
+    const response = await fetch("/api/settings/providers", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(await buildSettingsPayload(nextDefault, nextProfiles))
+    });
+
+    if (response.ok) {
+      setProviderProfiles(nextProfiles);
+      setSelectedProviderProfileId(
+        selectedProviderProfileId === profileId
+          ? (nextProfiles.find((p) => p.id === nextDefault)?.id ?? nextProfiles[0]?.id ?? "")
+          : selectedProviderProfileId
+      );
+      if (defaultProviderProfileId === profileId) {
+        setDefaultProviderProfileId(nextDefault);
+      }
+      toast.showToast("success", "Provider deleted.");
+    } else {
+      const result = (await response.json().catch(() => ({}))) as { error?: string };
+      toast.showToast("error", result.error ?? "Unable to delete provider");
+    }
   }
 
   async function handleDuplicateProviderProfile() {
@@ -322,14 +354,15 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
     }
   }
 
-  async function buildSettingsPayload(defaultProviderProfileIdOverride?: string) {
+  async function buildSettingsPayload(defaultProviderProfileIdOverride?: string, profilesOverride?: ProviderProfileDraft[]) {
     const nextDefaultProviderProfileId = defaultProviderProfileIdOverride ?? defaultProviderProfileId;
+    const profilesToSave = profilesOverride ?? providerProfiles;
 
     return {
       ...settings,
       defaultProviderProfileId: nextDefaultProviderProfileId,
       skillsEnabled,
-      providerProfiles: providerProfiles.map((profile) => ({
+      providerProfiles: profilesToSave.map((profile) => ({
         id: profile.id,
         name: profile.name,
         providerKind: profile.providerKind ?? "openai_compatible",
@@ -366,11 +399,11 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
     return saveSettingsWithDefault(defaultProviderProfileId);
   }
 
-  async function saveSettingsWithDefault(nextDefaultProviderProfileId: string) {
+  async function saveSettingsWithDefault(nextDefaultProviderProfileId: string, profilesOverride?: ProviderProfileDraft[]) {
     const response = await fetch("/api/settings/providers", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(await buildSettingsPayload(nextDefaultProviderProfileId))
+      body: JSON.stringify(await buildSettingsPayload(nextDefaultProviderProfileId, profilesOverride))
     });
 
     const result = (await response.json()) as { error?: string };


### PR DESCRIPTION
## Summary

- **Server-side validation** (`app/chat/[conversationId]/page.tsx`): Resolves the conversation's `providerProfileId` against currently valid providers before rendering, falling back to the default or first available profile. Adds a `key` prop to force re-render when the provider changes.
- **Client-side validation** (`components/chat-view.tsx`): Extracts a `resolveProviderProfileId` helper used in both the initial state and the sync effect, so stale/deleted provider IDs never reach the chat UI.
- **Safe provider deletion** (`components/settings/sections/providers-section.tsx`): Provider deletion now sends the updated profile list and default directly via API (`PUT /api/settings/providers`) instead of relying on the generic `removeProviderProfile` flow. Handles default reassignment and selection state cleanup.