### PR TITLE
fix: mobile composer keyboard dismissal and PWA viewport gaps

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -88,6 +88,10 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+html.ios-pwa .app-shell {
+  height: calc(100dvh + env(safe-area-inset-top, 0px));
+}
+
 ::selection {
   background: rgba(139, 92, 246, 0.35);
   color: white;
@@ -598,6 +602,14 @@ select {
   }
   .h-mobile-header {
     height: calc(3.5rem + env(safe-area-inset-top, 0px));
+  }
+  .pb-composer-safe {
+    padding-bottom: max(0.5rem, calc(env(safe-area-inset-bottom, 0px) - 1rem));
+  }
+  @media (min-width: 768px) {
+    .pb-composer-safe {
+      padding-bottom: 0.75rem;
+    }
   }
 }
 

--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -1975,6 +1975,13 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
     }
   }
 
+  function dismissComposerKeyboardOnTouch() {
+    if (shouldAutofocusTextInput()) {
+      return;
+    }
+    inputRef.current?.blur();
+  }
+
   async function submit(
     nextInput = input,
     nextPendingAttachments = pendingAttachments,
@@ -2013,6 +2020,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
       scrollToBottomRef.current?.();
       setError("");
       setInput("");
+      dismissComposerKeyboardOnTouch();
       wsSend({
         type: "queue_message",
         conversationId: payload.conversation.id,
@@ -2027,6 +2035,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
 
     setError("");
     setInput("");
+    dismissComposerKeyboardOnTouch();
     setPendingAttachments([]);
     setStreamThinkingTarget("");
     setStreamThinkingDisplay("");
@@ -2311,7 +2320,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
       </ConversationContainer>
 
         <div ref={composerAreaRef} className="absolute inset-x-0 bottom-0 z-50 pointer-events-none">
-         <div className="mx-auto w-full max-w-[980px] px-4 md:px-8 pt-1 pb-[max(0px,env(safe-area-inset-bottom))] md:pb-3 pointer-events-auto">
+         <div className="mx-auto w-full max-w-[980px] px-4 md:px-8 pt-1 pb-composer-safe pointer-events-auto">
           <div ref={queueBannerRef}>
             <QueuedMessageBanner
               items={queuedMessages}

--- a/components/shell.tsx
+++ b/components/shell.tsx
@@ -16,6 +16,7 @@ import type { AuthUser, Automation, Conversation, ConversationListPage, Folder }
 import { deleteConversationIfStillEmpty } from "@/lib/conversation-drafts";
 import { consumeHomeSubmitSidebarAutoHide } from "@/lib/chat-bootstrap";
 import { useGlobalWebSocket } from "@/lib/ws-client";
+import { useIosPwa } from "@/lib/use-ios-pwa";
 
 const COPY_RESET_DELAY_MS = 1600;
 const COPY_FADE_DURATION_MS = 200;
@@ -60,6 +61,7 @@ export function Shell({
   const pathname = usePathname();
   const router = useRouter();
   useGlobalWebSocket();
+  useIosPwa();
   const activeConversationId = pathname.startsWith("/chat/")
     ? pathname.split("/chat/")[1]
     : null;
@@ -282,7 +284,7 @@ export function Shell({
   }, [isSettingsPage, isAutomationsPage, pathname]);
 
   return (
-    <div className="flex h-[100dvh] w-full bg-[var(--background)] overflow-hidden">
+    <div className="app-shell flex h-[100dvh] w-full bg-[var(--background)] overflow-hidden">
       <AnimatePresence>
         {isSidebarOpen && (
           <motion.div

--- a/lib/use-ios-pwa.ts
+++ b/lib/use-ios-pwa.ts
@@ -1,0 +1,28 @@
+"use client";
+
+import { useEffect } from "react";
+
+const IOS_PWA_CLASS = "ios-pwa";
+
+function isIosStandalone(): boolean {
+  if (typeof navigator === "undefined") {
+    return false;
+  }
+
+  return (navigator as { standalone?: boolean }).standalone === true;
+}
+
+export function useIosPwa() {
+  useEffect(() => {
+    if (!isIosStandalone()) {
+      return;
+    }
+
+    const root = document.documentElement;
+    root.classList.add(IOS_PWA_CLASS);
+
+    return () => {
+      root.classList.remove(IOS_PWA_CLASS);
+    };
+  }, []);
+}

--- a/tests/unit/chat-view.test.ts
+++ b/tests/unit/chat-view.test.ts
@@ -1009,6 +1009,104 @@ describe("chat view", () => {
     );
   });
 
+  it("blurs the composer after sending on touch devices so the mobile keyboard dismisses", async () => {
+    Object.defineProperty(navigator, "maxTouchPoints", {
+      configurable: true,
+      value: 1
+    });
+
+    renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
+
+    const textarea = screen.getByPlaceholderText(
+      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
+    );
+
+    act(() => {
+      textarea.focus();
+    });
+    expect(textarea).toHaveFocus();
+
+    fireEvent.change(textarea, { target: { value: "Hello world" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(wsMock.send).toHaveBeenCalledWith({
+        type: "message",
+        conversationId: "conv_1",
+        content: "Hello world",
+        attachmentIds: []
+      });
+    });
+
+    expect(textarea).not.toHaveFocus();
+  });
+
+  it("blurs the composer after queuing a follow-up on touch devices", async () => {
+    Object.defineProperty(navigator, "maxTouchPoints", {
+      configurable: true,
+      value: 1
+    });
+
+    renderWithProvider(
+      React.createElement(ChatView, {
+        payload: createPayload({
+          conversation: {
+            ...createPayload().conversation,
+            isActive: true
+          }
+        })
+      })
+    );
+
+    const textarea = screen.getByPlaceholderText(
+      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
+    );
+
+    act(() => {
+      textarea.focus();
+    });
+    expect(textarea).toHaveFocus();
+
+    fireEvent.change(textarea, { target: { value: "Queued follow-up" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(wsMock.send).toHaveBeenCalledWith({
+        type: "queue_message",
+        conversationId: "conv_1",
+        content: "Queued follow-up"
+      });
+    });
+
+    expect(textarea).not.toHaveFocus();
+  });
+
+  it("keeps the composer focused after sending on non-touch devices", async () => {
+    renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
+
+    const textarea = screen.getByPlaceholderText(
+      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
+    );
+
+    await waitFor(() => {
+      expect(textarea).toHaveFocus();
+    });
+
+    fireEvent.change(textarea, { target: { value: "Hello world" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(wsMock.send).toHaveBeenCalledWith({
+        type: "message",
+        conversationId: "conv_1",
+        content: "Hello world",
+        attachmentIds: []
+      });
+    });
+
+    expect(textarea).toHaveFocus();
+  });
+
   it("shows an error instead of queuing a message when the websocket transport is unavailable", async () => {
     wsMock.connected = false;
     wsMock.failed = true;

--- a/tests/unit/use-ios-pwa.test.ts
+++ b/tests/unit/use-ios-pwa.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+
+import { renderHook } from "@testing-library/react";
+
+import { useIosPwa } from "@/lib/use-ios-pwa";
+
+function setNavigatorStandalone(value: boolean | undefined) {
+  if (value === undefined) {
+    delete (navigator as { standalone?: boolean }).standalone;
+    return;
+  }
+  Object.defineProperty(navigator, "standalone", { configurable: true, value });
+}
+
+function hasIosPwaClass() {
+  return document.documentElement.classList.contains("ios-pwa");
+}
+
+describe("useIosPwa", () => {
+  afterEach(() => {
+    setNavigatorStandalone(undefined);
+    document.documentElement.classList.remove("ios-pwa");
+  });
+
+  it("does not mark the document outside an iOS home-screen app", () => {
+    setNavigatorStandalone(false);
+
+    renderHook(() => useIosPwa());
+
+    expect(hasIosPwaClass()).toBe(false);
+  });
+
+  it("does not mark the document when navigator.standalone is absent (Android/desktop)", () => {
+    setNavigatorStandalone(undefined);
+
+    renderHook(() => useIosPwa());
+
+    expect(hasIosPwaClass()).toBe(false);
+  });
+
+  it("adds the ios-pwa class on the document element in an iOS standalone PWA", () => {
+    setNavigatorStandalone(true);
+
+    renderHook(() => useIosPwa());
+
+    expect(hasIosPwaClass()).toBe(true);
+  });
+
+  it("removes the ios-pwa class on unmount", () => {
+    setNavigatorStandalone(true);
+
+    const { unmount } = renderHook(() => useIosPwa());
+    expect(hasIosPwaClass()).toBe(true);
+
+    unmount();
+    expect(hasIosPwaClass()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- **Mobile keyboard on send:** blur the composer after sending on touch devices so the on-screen keyboard dismisses (reusing the existing `shouldAutofocusTextInput()` device check); desktop keeps focus so the user can keep typing. Covers both the send button and Enter.
- **Composer bottom clearance:** replaced the floating composer's full `env(safe-area-inset-bottom)` padding with a balanced `pb-composer-safe` utility, so it no longer leaves an oversized gap above the home indicator (and is never flush on no-notch phones).
- **iOS standalone PWA bottom gap:** with `apple-mobile-web-app-status-bar-style: black-translucent`, iOS reports `100dvh` short by the top safe-area inset, leaving an empty band at the bottom; the new `useIosPwa` hook marks iOS home-screen apps and CSS extends the shell by `env(safe-area-inset-top)` (scoped via `navigator.standalone`, so browsers/Android/desktop are untouched).
- **Tests:** +3 chat-view tests (touch blur, queue blur, desktop focus retained) and +4 hook tests; full suite passes (1108 tests) with coverage above 85%.
- Note: the iOS-standalone visual fix can only be fully confirmed on a physical installed PWA, since headless browsers don't reproduce iOS's short-`dvh` quirk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)