### PR TITLE
fix(settings): use destructive Button variant for sign-out

### DIFF
--- a/components/settings/settings-nav.tsx
+++ b/components/settings/settings-nav.tsx
@@ -182,15 +182,16 @@ export function SettingsNav({
             <p className="text-sm font-medium text-[var(--text)]">
               {currentUser.username}
             </p>
-            <button
+            <Button
               type="button"
+              variant="destructive"
               onClick={() => void handleLogout()}
               disabled={isSigningOut}
-              className="mt-1.5 inline-flex items-center gap-1.5 text-xs text-red-400/80 transition-colors hover:text-red-300 disabled:cursor-not-allowed disabled:opacity-50"
+              className="mt-3 px-4 py-2 text-xs"
             >
               <LogOut className="h-3 w-3" />
               Sign out
-            </button>
+            </Button>
             <p className="mt-2.5 text-[10px] font-medium text-white/30 tracking-[0.04em] tabular-nums">
               {appVersion}
             </p>


### PR DESCRIPTION
## Summary

- Replace the plain `<button>` element with the `<Button>` component using the `destructive` variant for the sign-out action in the settings nav
- Provides consistent styling with the project's design system and better visual affordance for a destructive action
- Adjusts spacing (`mt-3`, `px-4 py-2`) for proper button sizing