### PR TITLE
feat: collapse composer toolbar on mobile + fix iOS-PWA shell height

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -89,7 +89,7 @@ body {
 }
 
 html.ios-pwa .app-shell {
-  height: calc(100dvh + env(safe-area-inset-top, 0px));
+  height: var(--ios-app-height, 100dvh);
 }
 
 ::selection {

--- a/components/chat-composer.tsx
+++ b/components/chat-composer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useRef, useEffect } from "react";
+import React, { useState, useRef, useEffect, useCallback } from "react";
 import {
   AlertCircle,
   ArrowUp,
@@ -24,6 +24,7 @@ import { Textarea } from "@/components/ui/textarea";
 import type { SpeechPhase } from "@/lib/speech/types";
 import { cn } from "@/lib/utils";
 import { useAutoResize } from "@/lib/use-auto-resize";
+import { useCollapsibleToolbar } from "@/lib/use-collapsible-toolbar";
 import type {
   MessageAttachment,
   ProviderProfileSummary
@@ -65,6 +66,7 @@ type ChatComposerProps = {
   onTemporaryChange?: (value: boolean) => void;
   isAtBottom?: boolean;
   onJumpToBottom?: () => void;
+  collapsibleToolbarOnMobile?: boolean;
 };
 
 function CustomDropdown<T extends { id: string; name: string }>({
@@ -76,7 +78,8 @@ function CustomDropdown<T extends { id: string; name: string }>({
   disabled,
   accentColor = "cyan",
   mutedWhenEmpty = false,
-  allowDeselect = false
+  allowDeselect = false,
+  onOpenChange
 }: {
   items: T[];
   selectedId: string | null;
@@ -87,20 +90,32 @@ function CustomDropdown<T extends { id: string; name: string }>({
   accentColor?: "cyan" | "violet";
   mutedWhenEmpty?: boolean;
   allowDeselect?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }) {
   const [isOpen, setIsOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const selectedItem = items.find((item) => item.id === selectedId);
 
+  const updateOpen = useCallback(
+    (next: boolean) => {
+      setIsOpen(next);
+      onOpenChange?.(next);
+    },
+    [onOpenChange]
+  );
+
   useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
     const handleClickOutside = (event: MouseEvent) => {
       if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
-        setIsOpen(false);
+        updateOpen(false);
       }
     };
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, []);
+  }, [isOpen, updateOpen]);
 
   const noItems = mutedWhenEmpty && items.length === 0;
   const isDisabled = disabled || noItems;
@@ -120,7 +135,7 @@ function CustomDropdown<T extends { id: string; name: string }>({
       <button
         type="button"
         disabled={isDisabled}
-        onClick={() => { if (!isDisabled) setIsOpen(!isOpen); }}
+        onClick={() => { if (!isDisabled) updateOpen(!isOpen); }}
         className={cn(
           "flex items-center gap-2 rounded-xl px-2.5 py-1.5 transition-all duration-200",
           !isDisabled && "hover:bg-white/5",
@@ -160,7 +175,7 @@ function CustomDropdown<T extends { id: string; name: string }>({
                   type="button"
                   onClick={() => {
                     onSelect(null);
-                    setIsOpen(false);
+                    updateOpen(false);
                   }}
                   className={cn(
                     "w-full rounded-xl px-3 py-2 text-left text-xs transition-colors hover:bg-white/5",
@@ -180,7 +195,7 @@ function CustomDropdown<T extends { id: string; name: string }>({
                     } else {
                       onSelect(item.id);
                     }
-                    setIsOpen(false);
+                    updateOpen(false);
                   }}
                   className={cn(
                     "w-full rounded-xl px-3 py-2.5 text-left transition-colors hover:bg-white/5",
@@ -249,6 +264,7 @@ export function ChatComposer({
   onTemporaryChange,
   isAtBottom = true,
   onJumpToBottom,
+  collapsibleToolbarOnMobile = false,
 }: ChatComposerProps) {
   const fileInputRef = React.useRef<HTMLInputElement | null>(null);
   const [mounted, setMounted] = useState(false);
@@ -257,6 +273,10 @@ export function ChatComposer({
     value: input
   });
   const isExpanded = textareaHeight > 60;
+  const { showToolbar, inputFocusProps, onControlOpenChange } = useCollapsibleToolbar({
+    enabled: collapsibleToolbarOnMobile
+  });
+  const [toolbarOverflow, setToolbarOverflow] = useState<"hidden" | "visible">("visible");
 
   useEffect(() => {
     setMounted(true);
@@ -413,6 +433,7 @@ export function ChatComposer({
           <Textarea
             ref={textareaRef}
             value={input}
+            {...inputFocusProps}
             onChange={(event) => onInputChange(event.target.value)}
             placeholder="Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
             className="max-h-[60vh] min-h-[52px] w-full resize-none border-0 bg-transparent px-4 py-3.5 text-[15px] text-[var(--text)] focus-visible:ring-0 focus:outline-none scrollbar-thin placeholder:text-white/20 caret-[var(--accent)] overflow-y-auto"
@@ -554,55 +575,72 @@ export function ChatComposer({
         </motion.div>
       ) : null}
 
-      <div className="flex items-center justify-between px-1.5 pb-1 pt-1.5 border-t border-white/5">
-        <div className="flex items-center gap-0.5">
-          <button
-            className="p-2 text-white/30 hover:text-white/60 transition-all duration-200 rounded-xl hover:bg-white/5 shrink-0"
-            aria-label="Attach files"
-            type="button"
-            disabled={!mounted}
-            onClick={() => fileInputRef.current?.click()}
+      <AnimatePresence initial={false}>
+        {showToolbar && (
+          <motion.div
+            key="composer-toolbar"
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: "auto", opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.22, ease: [0.22, 1, 0.36, 1] }}
+            style={{ overflow: toolbarOverflow }}
+            onAnimationStart={() => setToolbarOverflow("hidden")}
+            onAnimationComplete={() => setToolbarOverflow("visible")}
           >
-            <Paperclip className="h-4.5 w-4.5" />
-          </button>
+            <div className="flex items-center justify-between px-1.5 pb-1 pt-1.5 border-t border-white/5">
+              <div className="flex items-center gap-0.5">
+                <button
+                  className="p-2 text-white/30 hover:text-white/60 transition-all duration-200 rounded-xl hover:bg-white/5 shrink-0"
+                  aria-label="Attach files"
+                  type="button"
+                  disabled={!mounted}
+                  onClick={() => fileInputRef.current?.click()}
+                >
+                  <Paperclip className="h-4.5 w-4.5" />
+                </button>
 
-          <div className="h-4 w-px bg-white/5 mx-1" />
+                <div className="h-4 w-px bg-white/5 mx-1" />
 
-          <CustomDropdown
-            items={displayModels}
-            selectedId={providerProfileId}
-            onSelect={(id) => id && void onProviderProfileChange(id)}
-            icon={Bot}
-            placeholder=""
-            accentColor="cyan"
-            disabled={!mounted || isSending}
-          />
+                <CustomDropdown
+                  items={displayModels}
+                  selectedId={providerProfileId}
+                  onSelect={(id) => id && void onProviderProfileChange(id)}
+                  icon={Bot}
+                  placeholder=""
+                  accentColor="cyan"
+                  disabled={!mounted || isSending}
+                  onOpenChange={onControlOpenChange}
+                />
 
-          <CustomDropdown
-            items={personas}
-            selectedId={personaId}
-            onSelect={(id) => void onPersonaChange(id)}
-            icon={Users}
-            accentColor="violet"
-            disabled={!mounted || isSending}
-            mutedWhenEmpty
-            allowDeselect
-          />
-        </div>
+                <CustomDropdown
+                  items={personas}
+                  selectedId={personaId}
+                  onSelect={(id) => void onPersonaChange(id)}
+                  icon={Users}
+                  accentColor="violet"
+                  disabled={!mounted || isSending}
+                  mutedWhenEmpty
+                  allowDeselect
+                  onOpenChange={onControlOpenChange}
+                />
+              </div>
 
-        <div className="flex items-center gap-2 sm:gap-3">
-          {showContextUsage && (
-            <div className="flex items-center gap-2 px-1">
-              <span className="text-[10px] text-white/20 font-medium tracking-wider uppercase hidden md:inline-block">Context</span>
-              <ContextGauge
-                usedTokens={usedTokens}
-                usableLimit={compactionLimit}
-                maxLimit={modelContextLimit}
-              />
+              <div className="flex items-center gap-2 sm:gap-3">
+                {showContextUsage && (
+                  <div className="flex items-center gap-2 px-1">
+                    <span className="text-[10px] text-white/20 font-medium tracking-wider uppercase hidden md:inline-block">Context</span>
+                    <ContextGauge
+                      usedTokens={usedTokens}
+                      usableLimit={compactionLimit}
+                      maxLimit={modelContextLimit}
+                    />
+                  </div>
+                )}
+              </div>
             </div>
-          )}
-        </div>
-      </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </div>
     </div>
   );

--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -2369,6 +2369,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
             }}
             isAtBottom={isAtBottom}
             onJumpToBottom={jumpToBottom}
+            collapsibleToolbarOnMobile
             onStartSpeech={() => {
               setError("");
               void startSpeech();

--- a/lib/use-collapsible-toolbar.ts
+++ b/lib/use-collapsible-toolbar.ts
@@ -1,0 +1,91 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const MOBILE_QUERY = "(max-width: 767px)";
+const COLLAPSE_DELAY_MS = 150;
+
+function matchMediaSupported(): boolean {
+  return typeof window !== "undefined" && typeof window.matchMedia === "function";
+}
+
+function getInitialMobile(): boolean {
+  if (!matchMediaSupported()) {
+    return false;
+  }
+  return window.matchMedia(MOBILE_QUERY).matches;
+}
+
+type UseCollapsibleToolbarOptions = { enabled: boolean };
+
+export function useCollapsibleToolbar({ enabled }: UseCollapsibleToolbarOptions) {
+  const [isMobile, setIsMobile] = useState<boolean>(getInitialMobile);
+  const [expanded, setExpanded] = useState(false);
+
+  const isInputFocusedRef = useRef(false);
+  const openControlCountRef = useRef(0);
+  const collapseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (!matchMediaSupported()) {
+      return;
+    }
+    const mql = window.matchMedia(MOBILE_QUERY);
+    const update = () => setIsMobile(mql.matches);
+    update();
+    mql.addEventListener("change", update);
+    return () => mql.removeEventListener("change", update);
+  }, []);
+
+  const cancelScheduledCollapse = useCallback(() => {
+    if (collapseTimerRef.current !== null) {
+      clearTimeout(collapseTimerRef.current);
+      collapseTimerRef.current = null;
+    }
+  }, []);
+
+  const scheduleCollapse = useCallback(() => {
+    cancelScheduledCollapse();
+    collapseTimerRef.current = setTimeout(() => {
+      collapseTimerRef.current = null;
+      if (!isInputFocusedRef.current && openControlCountRef.current === 0) {
+        setExpanded(false);
+      }
+    }, COLLAPSE_DELAY_MS);
+  }, [cancelScheduledCollapse]);
+
+  const onFocus = useCallback(() => {
+    isInputFocusedRef.current = true;
+    cancelScheduledCollapse();
+    setExpanded(true);
+  }, [cancelScheduledCollapse]);
+
+  const onBlur = useCallback(() => {
+    isInputFocusedRef.current = false;
+    scheduleCollapse();
+  }, [scheduleCollapse]);
+
+  const onControlOpenChange = useCallback(
+    (open: boolean) => {
+      if (open) {
+        openControlCountRef.current += 1;
+        cancelScheduledCollapse();
+        setExpanded(true);
+      } else {
+        openControlCountRef.current = Math.max(0, openControlCountRef.current - 1);
+        scheduleCollapse();
+      }
+    },
+    [cancelScheduledCollapse, scheduleCollapse]
+  );
+
+  useEffect(() => () => cancelScheduledCollapse(), [cancelScheduledCollapse]);
+
+  const showToolbar = !enabled || !isMobile || expanded;
+
+  return {
+    showToolbar,
+    inputFocusProps: { onFocus, onBlur },
+    onControlOpenChange
+  };
+}

--- a/lib/use-ios-pwa.ts
+++ b/lib/use-ios-pwa.ts
@@ -21,8 +21,19 @@ export function useIosPwa() {
     const root = document.documentElement;
     root.classList.add(IOS_PWA_CLASS);
 
+    const applyHeight = () => {
+      root.style.setProperty("--ios-app-height", `${window.innerHeight}px`);
+    };
+
+    applyHeight();
+    window.addEventListener("resize", applyHeight);
+    window.addEventListener("orientationchange", applyHeight);
+
     return () => {
       root.classList.remove(IOS_PWA_CLASS);
+      root.style.removeProperty("--ios-app-height");
+      window.removeEventListener("resize", applyHeight);
+      window.removeEventListener("orientationchange", applyHeight);
     };
   }, []);
 }

--- a/tests/unit/chat-composer.test.tsx
+++ b/tests/unit/chat-composer.test.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+
+import { ChatComposer } from "@/components/chat-composer";
+import type { SpeechPhase } from "@/lib/speech/types";
+
+const originalMatchMedia = window.matchMedia;
+
+function installMatchMedia(matches: boolean) {
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: query === "(max-width: 767px)" ? matches : false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn()
+    }))
+  });
+}
+
+afterEach(() => {
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: originalMatchMedia
+  });
+});
+
+function renderComposer(overrides: Partial<React.ComponentProps<typeof ChatComposer>> = {}) {
+  const textareaRef = React.createRef<HTMLTextAreaElement>();
+  const props: React.ComponentProps<typeof ChatComposer> = {
+    input: "",
+    onInputChange: vi.fn(),
+    onSubmit: vi.fn(),
+    isSending: false,
+    pendingAttachments: [],
+    isUploadingAttachments: false,
+    onUploadFiles: vi.fn(),
+    onRemovePendingAttachment: vi.fn(),
+    showVisionWarning: false,
+    providerProfiles: [],
+    providerProfileId: "",
+    onProviderProfileChange: vi.fn(),
+    personas: [],
+    personaId: null,
+    onPersonaChange: vi.fn(),
+    textareaRef,
+    usedTokens: null,
+    modelContextLimit: 128000,
+    compactionLimit: 100000,
+    hasMessages: false,
+    canStop: false,
+    isStopPending: false,
+    onStop: vi.fn(),
+    speechPhase: "idle" as SpeechPhase,
+    speechLevel: 0,
+    speechError: null,
+    onStartSpeech: vi.fn(),
+    onStopSpeech: vi.fn(),
+    ...overrides
+  };
+  render(<ChatComposer {...props} />);
+  return { textareaRef };
+}
+
+describe("ChatComposer collapsible toolbar", () => {
+  it("shows the toolbar when the feature is disabled (home view), even on mobile", () => {
+    installMatchMedia(true);
+    renderComposer({ collapsibleToolbarOnMobile: false });
+    expect(screen.getByLabelText("Attach files")).toBeInTheDocument();
+  });
+
+  it("shows the toolbar on desktop when the feature is enabled", () => {
+    installMatchMedia(false);
+    renderComposer({ collapsibleToolbarOnMobile: true });
+    expect(screen.getByLabelText("Attach files")).toBeInTheDocument();
+  });
+
+  it("hides the toolbar at rest on mobile and reveals it on input focus", async () => {
+    installMatchMedia(true);
+    const { textareaRef } = renderComposer({ collapsibleToolbarOnMobile: true });
+
+    expect(screen.queryByLabelText("Attach files")).toBeNull();
+
+    act(() => {
+      textareaRef.current?.focus();
+      if (textareaRef.current) fireEvent.focus(textareaRef.current);
+    });
+
+    expect(await screen.findByLabelText("Attach files")).toBeInTheDocument();
+  });
+});

--- a/tests/unit/chat-view.test.ts
+++ b/tests/unit/chat-view.test.ts
@@ -658,6 +658,35 @@ describe("chat view", () => {
     ).not.toHaveFocus();
   });
 
+  it("collapses the composer toolbar at rest on mobile (collapsibleToolbarOnMobile wired)", () => {
+    const originalMatchMedia = window.matchMedia;
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: query === "(max-width: 767px)",
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn()
+      }))
+    });
+
+    try {
+      renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
+      expect(screen.queryByLabelText("Attach files")).toBeNull();
+    } finally {
+      Object.defineProperty(window, "matchMedia", {
+        configurable: true,
+        writable: true,
+        value: originalMatchMedia
+      });
+    }
+  });
+
   it("shows a drop overlay and uploads dropped files", async () => {
     const attachment = createAttachment({
       id: "att_2",

--- a/tests/unit/use-collapsible-toolbar.test.tsx
+++ b/tests/unit/use-collapsible-toolbar.test.tsx
@@ -1,0 +1,159 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+
+import { useCollapsibleToolbar } from "@/lib/use-collapsible-toolbar";
+
+type FakeMql = {
+  matches: boolean;
+  media: string;
+  onchange: null;
+  addEventListener: (type: string, cb: () => void) => void;
+  removeEventListener: (type: string, cb: () => void) => void;
+  addListener: () => void;
+  removeListener: () => void;
+  dispatchEvent: () => boolean;
+};
+
+let currentMql: FakeMql | null = null;
+let changeHandler: (() => void) | null = null;
+const originalMatchMedia = window.matchMedia;
+
+function installMatchMedia(matches: boolean) {
+  changeHandler = null;
+  currentMql = {
+    matches,
+    media: "(max-width: 767px)",
+    onchange: null,
+    addEventListener: (_type: string, cb: () => void) => {
+      changeHandler = cb;
+    },
+    removeEventListener: () => {
+      changeHandler = null;
+    },
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false
+  };
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: vi.fn(() => currentMql)
+  });
+}
+
+function removeMatchMedia() {
+  delete (window as { matchMedia?: unknown }).matchMedia;
+}
+
+afterEach(() => {
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: originalMatchMedia
+  });
+  currentMql = null;
+  changeHandler = null;
+  vi.useRealTimers();
+});
+
+describe("useCollapsibleToolbar", () => {
+  it("always shows the toolbar when the feature is disabled, even on mobile", () => {
+    installMatchMedia(true);
+    const { result } = renderHook(() => useCollapsibleToolbar({ enabled: false }));
+    expect(result.current.showToolbar).toBe(true);
+  });
+
+  it("always shows the toolbar when matchMedia is unavailable (treated as not mobile)", () => {
+    removeMatchMedia();
+    const { result } = renderHook(() => useCollapsibleToolbar({ enabled: true }));
+    expect(result.current.showToolbar).toBe(true);
+  });
+
+  it("always shows the toolbar on a non-mobile viewport", () => {
+    installMatchMedia(false);
+    const { result } = renderHook(() => useCollapsibleToolbar({ enabled: true }));
+    expect(result.current.showToolbar).toBe(true);
+  });
+
+  it("starts collapsed on mobile and expands on input focus", () => {
+    installMatchMedia(true);
+    const { result } = renderHook(() => useCollapsibleToolbar({ enabled: true }));
+    expect(result.current.showToolbar).toBe(false);
+
+    act(() => result.current.inputFocusProps.onFocus());
+    expect(result.current.showToolbar).toBe(true);
+  });
+
+  it("collapses after blur once the delay elapses", () => {
+    vi.useFakeTimers();
+    installMatchMedia(true);
+    const { result } = renderHook(() => useCollapsibleToolbar({ enabled: true }));
+
+    act(() => result.current.inputFocusProps.onFocus());
+    act(() => result.current.inputFocusProps.onBlur());
+    expect(result.current.showToolbar).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(149);
+    });
+    expect(result.current.showToolbar).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(51);
+    });
+    expect(result.current.showToolbar).toBe(false);
+  });
+
+  it("does not collapse on blur while a control (dropdown) is open", () => {
+    vi.useFakeTimers();
+    installMatchMedia(true);
+    const { result } = renderHook(() => useCollapsibleToolbar({ enabled: true }));
+
+    act(() => result.current.inputFocusProps.onFocus());
+    act(() => result.current.onControlOpenChange(true));
+    act(() => result.current.inputFocusProps.onBlur());
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(result.current.showToolbar).toBe(true);
+
+    act(() => result.current.onControlOpenChange(false));
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(result.current.showToolbar).toBe(false);
+  });
+
+  it("reacts to viewport changes via the media query listener", () => {
+    installMatchMedia(false);
+    const { result } = renderHook(() => useCollapsibleToolbar({ enabled: true }));
+    expect(result.current.showToolbar).toBe(true);
+
+    act(() => {
+      if (currentMql) currentMql.matches = true;
+      changeHandler?.();
+    });
+    expect(result.current.showToolbar).toBe(false);
+  });
+
+  it("clears the pending collapse timer on unmount", () => {
+    vi.useFakeTimers();
+    installMatchMedia(true);
+    const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
+    const { result, unmount } = renderHook(() => useCollapsibleToolbar({ enabled: true }));
+
+    act(() => result.current.inputFocusProps.onFocus());
+    act(() => result.current.inputFocusProps.onBlur());
+
+    clearTimeoutSpy.mockClear();
+    unmount();
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+
+    expect(() => {
+      vi.advanceTimersByTime(200);
+    }).not.toThrow();
+
+    clearTimeoutSpy.mockRestore();
+  });
+});

--- a/tests/unit/use-ios-pwa.test.ts
+++ b/tests/unit/use-ios-pwa.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { renderHook } from "@testing-library/react";
+import { act, renderHook } from "@testing-library/react";
 
 import { useIosPwa } from "@/lib/use-ios-pwa";
 
@@ -20,6 +20,7 @@ describe("useIosPwa", () => {
   afterEach(() => {
     setNavigatorStandalone(undefined);
     document.documentElement.classList.remove("ios-pwa");
+    document.documentElement.style.removeProperty("--ios-app-height");
   });
 
   it("does not mark the document outside an iOS home-screen app", () => {
@@ -54,5 +55,76 @@ describe("useIosPwa", () => {
 
     unmount();
     expect(hasIosPwaClass()).toBe(false);
+  });
+
+  function setInnerHeight(value: number) {
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      writable: true,
+      value
+    });
+  }
+
+  function appHeightVar() {
+    return document.documentElement.style.getPropertyValue("--ios-app-height");
+  }
+
+  it("publishes the measured window height as --ios-app-height in an iOS standalone PWA", () => {
+    setNavigatorStandalone(true);
+    setInnerHeight(812);
+
+    renderHook(() => useIosPwa());
+
+    expect(appHeightVar()).toBe("812px");
+  });
+
+  it("updates --ios-app-height on window resize", () => {
+    setNavigatorStandalone(true);
+    setInnerHeight(812);
+
+    renderHook(() => useIosPwa());
+    expect(appHeightVar()).toBe("812px");
+
+    setInnerHeight(640);
+    act(() => {
+      window.dispatchEvent(new Event("resize"));
+    });
+
+    expect(appHeightVar()).toBe("640px");
+  });
+
+  it("updates --ios-app-height on orientationchange", () => {
+    setNavigatorStandalone(true);
+    setInnerHeight(812);
+
+    renderHook(() => useIosPwa());
+    expect(appHeightVar()).toBe("812px");
+
+    setInnerHeight(375);
+    act(() => {
+      window.dispatchEvent(new Event("orientationchange"));
+    });
+
+    expect(appHeightVar()).toBe("375px");
+  });
+
+  it("removes --ios-app-height on unmount", () => {
+    setNavigatorStandalone(true);
+    setInnerHeight(812);
+
+    const { unmount } = renderHook(() => useIosPwa());
+    expect(appHeightVar()).toBe("812px");
+
+    unmount();
+    expect(appHeightVar()).toBe("");
+  });
+
+  it("does not set --ios-app-height outside an iOS standalone PWA", () => {
+    setNavigatorStandalone(false);
+    setInnerHeight(812);
+
+    renderHook(() => useIosPwa());
+
+    expect(appHeightVar()).toBe("");
   });
 });


### PR DESCRIPTION
## Summary
- On mobile (<768px), the chat composer's bottom toolbar (attach, model, persona, context gauge) now collapses while the input is unfocused and expands when it's focused — giving the conversation more reading height; opening the model/persona dropdown keeps it expanded, and desktop/home-view behavior is unchanged.
- Fixes the iOS standalone PWA where the composer could sit below the visible fold: the app-shell height is now driven by a JS-measured `--ios-app-height` (`window.innerHeight`, updated on resize/orientationchange) instead of the version-fragile `100dvh + safe-area-inset-top`, while preserving the keyboard-lift behavior.
- Adds a reusable `useCollapsibleToolbar` hook and extends `useIosPwa`, with unit tests across the hook, composer, chat-view, and ios-pwa (global coverage ≥85%).

## Test Plan
- [x] `npm run typecheck`, `npm run lint` (0 errors), `npm run test` — 129/129 files, coverage 90.32%/85.13%/92.99%/90.32%.
- [x] Browser-validated: desktop always-on; mobile collapse-at-rest, focus-expand, blur-collapse, dropdown-open guard, un-clipped upward menu.
- [ ] On-device check: confirm the composer is fully visible at rest in the iOS standalone PWA and still lifts above the keyboard on focus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)