### PR TITLE
feat(composer): single-line textarea with dynamic expansion

### DIFF
--- a/components/chat-composer.tsx
+++ b/components/chat-composer.tsx
@@ -272,7 +272,7 @@ export function ChatComposer({
     ref: textareaRef as React.RefObject<HTMLTextAreaElement | null>,
     value: input
   });
-  const isExpanded = textareaHeight > 60;
+  const isExpanded = textareaHeight > 52;
   const { showToolbar, inputFocusProps, onControlOpenChange } = useCollapsibleToolbar({
     enabled: collapsibleToolbarOnMobile
   });
@@ -428,15 +428,19 @@ export function ChatComposer({
         ) : null}
       </AnimatePresence>
 
-      <div className={cn("flex w-full gap-2 pb-1 pr-1.5", isExpanded ? "items-end" : "items-center")}>
+      <div className={cn("flex w-full gap-2 pr-1.5", isExpanded ? "items-end" : "items-start")}>
         <div className="flex-1 min-w-0">
           <Textarea
             ref={textareaRef}
             value={input}
             {...inputFocusProps}
             onChange={(event) => onInputChange(event.target.value)}
-            placeholder="Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
-            className="max-h-[60vh] min-h-[52px] w-full resize-none border-0 bg-transparent px-4 py-3.5 text-[15px] text-[var(--text)] focus-visible:ring-0 focus:outline-none scrollbar-thin placeholder:text-white/20 caret-[var(--accent)] overflow-y-auto"
+            placeholder=""
+            rows={1}
+            className={cn(
+              "block max-h-[60vh] min-h-[40px] w-full resize-none border border-white/[0.06] rounded-2xl bg-white/[0.03] px-4 py-2 text-[15px] text-[var(--text)] focus-visible:ring-0 focus:outline-none focus:border-[var(--accent)]/30 focus:bg-white/[0.05] placeholder:text-white/20 caret-[var(--accent)]",
+              isExpanded ? "overflow-y-auto scrollbar-thin" : "overflow-hidden"
+            )}
             style={{ height: `${textareaHeight}px`, transition: "height 150ms ease" }}
             onKeyDown={(event) => {
               if (event.key === "Enter" && !event.shiftKey) {
@@ -587,7 +591,7 @@ export function ChatComposer({
             onAnimationStart={() => setToolbarOverflow("hidden")}
             onAnimationComplete={() => setToolbarOverflow("visible")}
           >
-            <div className="flex items-center justify-between px-1.5 pb-1 pt-1.5 border-t border-white/5">
+            <div className="flex items-center justify-between px-1.5 pb-1 pt-1.5 mt-1.5 sm:mt-2 border-t border-white/5">
               <div className="flex items-center gap-0.5">
                 <button
                   className="p-2 text-white/30 hover:text-white/60 transition-all duration-200 rounded-xl hover:bg-white/5 shrink-0"

--- a/lib/use-auto-resize.ts
+++ b/lib/use-auto-resize.ts
@@ -8,7 +8,7 @@ type UseAutoResizeOptions = {
   minHeight?: number;
 };
 
-export function useAutoResize({ ref, value, minHeight = 52 }: UseAutoResizeOptions) {
+export function useAutoResize({ ref, value, minHeight = 40 }: UseAutoResizeOptions) {
   const [height, setHeight] = useState<number>(minHeight);
 
   const adjustHeight = useCallback(() => {

--- a/tests/e2e/features.spec.ts
+++ b/tests/e2e/features.spec.ts
@@ -781,9 +781,7 @@ test.describe("Feature: Create and delete conversations", () => {
         hasMediaDevices: "function"
       });
 
-    const composer = page.getByPlaceholder(
-      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
-    );
+    const composer = page.getByRole("textbox");
     const startVoiceInputButton = page.getByRole("button", { name: "Start voice input" });
 
     await expect(composer).toBeVisible({ timeout: 5000 });
@@ -1172,7 +1170,7 @@ test.describe("Feature: Automations workspace", () => {
     });
     await page.getByRole("link", { name: /Open transcript/ }).first().click();
     await expect(page).toHaveURL(/\/automations\/[^/]+\/runs\/[^/]+$/, { timeout: 10000 });
-    await expect(page.getByPlaceholder(/Ask, create, or start a task/i)).toBeVisible({
+    await expect(page.getByRole("textbox")).toBeVisible({
       timeout: 10000
     });
   });
@@ -1210,7 +1208,7 @@ test.describe("Feature: Chat attachments", () => {
     await expect(page.getByRole("button", { name: "Remove photo.png" })).toBeVisible({
       timeout: 5000
     });
-    await page.getByPlaceholder(/Ask, create, or start a task/i).fill("Please inspect this");
+    await page.getByRole("textbox").fill("Please inspect this");
     await expect(page.getByAltText("photo.png")).toBeVisible({ timeout: 5000 });
     await expect(page.getByRole("button", { name: "Send message" })).toBeEnabled({
       timeout: 5000
@@ -1285,7 +1283,7 @@ test.describe("Feature: Chat attachments", () => {
     ]);
     await uploadResponsePromise;
 
-    await page.getByPlaceholder(/Ask, create, or start a task/i).fill("hello");
+    await page.getByRole("textbox").fill("hello");
     await page.getByRole("button", { name: "Send message" }).click();
 
     await expect(page.getByText("hello", { exact: true })).toHaveCount(1, {
@@ -1319,7 +1317,7 @@ test.describe("Feature: Chat attachments", () => {
     await chooser.setFiles({ name: "photo.png", mimeType: "image/png", buffer: TINY_PNG });
     await uploadResponsePromise;
 
-    await page.getByPlaceholder(/Ask, create, or start a task/i).fill("Keep this image");
+    await page.getByRole("textbox").fill("Keep this image");
     await page.getByRole("button", { name: "Send message" }).click();
     await expect(page.getByRole("button", { name: "Preview photo.png" }).last()).toBeVisible({
       timeout: 1000
@@ -1361,7 +1359,7 @@ test.describe("Feature: Chat attachments", () => {
     await chooser.setFiles({ name: "notes.txt", mimeType: "text/plain", buffer: Buffer.from("hello") });
     await uploadResponsePromise;
 
-    await page.getByPlaceholder(/Ask, create, or start a task/i).fill("Keep these notes");
+    await page.getByRole("textbox").fill("Keep these notes");
     await page.getByRole("button", { name: "Send message" }).click();
     await expect(page.getByRole("button", { name: "Preview notes.txt" }).last()).toBeVisible({
       timeout: 1000
@@ -1406,7 +1404,7 @@ test.describe("Feature: Chat attachments", () => {
       await createNewChat(page);
       await expect(page).toHaveURL(/\/chat\//, { timeout: 10000 });
 
-      const composer = page.getByPlaceholder(/Ask, create, or start a task/i);
+      const composer = page.getByRole("textbox");
       const sendMessageButtons = page.getByRole("button", { name: "Send message" });
       const startVoiceInputButton = page.getByRole("button", { name: "Start voice input" });
 
@@ -1488,7 +1486,7 @@ test.describe("Feature: Chat attachments", () => {
       await createNewChat(page);
       await expect(page).toHaveURL(/\/chat\//, { timeout: 10000 });
 
-      const composer = page.getByPlaceholder(/Ask, create, or start a task/i);
+      const composer = page.getByRole("textbox");
       const sendMessageButton = page.getByRole("button", { name: "Send message" });
       const startVoiceInputButton = page.getByRole("button", { name: "Start voice input" });
       await expect(composer).toBeEditable({ timeout: 10000 });
@@ -1570,7 +1568,7 @@ test.describe("Feature: Queued chat follow-ups", () => {
         .listChatRequests()
         .filter((request) => request.stream && !request.isTitleRequest).length;
 
-      const composer = page.getByPlaceholder(/Ask, create, or start a task/i);
+      const composer = page.getByRole("textbox");
       const sendMessageButton = page.getByRole("button", { name: "Send message" });
       const startVoiceInputButton = page.getByRole("button", { name: "Start voice input" });
 
@@ -1617,7 +1615,7 @@ test.describe("Feature: Queued chat follow-ups", () => {
       const reconnectedPage = await page.context().newPage();
       await reconnectedPage.goto(page.url(), { waitUntil: "domcontentloaded" });
 
-      const reconnectedComposer = reconnectedPage.getByPlaceholder(/Ask, create, or start a task/i);
+      const reconnectedComposer = reconnectedPage.getByRole("textbox");
       const reconnectedQueueHeader = reconnectedPage.getByText("3 queued follow-ups");
 
       await expect(reconnectedComposer).toBeEditable({ timeout: 10000 });
@@ -1652,7 +1650,7 @@ test.describe("Feature: Queued chat follow-ups", () => {
         .listChatRequests()
         .filter((request) => request.stream && !request.isTitleRequest).length;
 
-      const composer = page.getByPlaceholder(/Ask, create, or start a task/i);
+      const composer = page.getByRole("textbox");
       const sendMessageButton = page.getByRole("button", { name: "Send message" });
       const startVoiceInputButton = page.getByRole("button", { name: "Start voice input" });
 

--- a/tests/unit/chat-view.test.ts
+++ b/tests/unit/chat-view.test.ts
@@ -634,9 +634,7 @@ describe("chat view", () => {
   it("focuses the composer textarea when the conversation loads", async () => {
     renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
 
-    const textarea = screen.getByPlaceholderText(
-      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
-    );
+    const textarea = screen.getByRole("textbox");
 
     await waitFor(() => {
       expect(textarea).toHaveFocus();
@@ -652,9 +650,7 @@ describe("chat view", () => {
     renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
 
     expect(
-      screen.getByPlaceholderText(
-        "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
-      )
+      screen.getByRole("textbox")
     ).not.toHaveFocus();
   });
 
@@ -989,9 +985,7 @@ describe("chat view", () => {
   it("sends a message via WebSocket when the user submits", async () => {
     renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
 
-    const textarea = screen.getByPlaceholderText(
-      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
-    );
+    const textarea = screen.getByRole("textbox");
 
     fireEvent.change(textarea, { target: { value: "Hello world" } });
     fireEvent.keyDown(textarea, { key: "Enter" });
@@ -1018,9 +1012,7 @@ describe("chat view", () => {
       })
     );
 
-    const textarea = screen.getByPlaceholderText(
-      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
-    );
+    const textarea = screen.getByRole("textbox");
 
     fireEvent.change(textarea, { target: { value: "Queued follow-up" } });
     fireEvent.keyDown(textarea, { key: "Enter" });
@@ -1048,9 +1040,7 @@ describe("chat view", () => {
 
     renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
 
-    const textarea = screen.getByPlaceholderText(
-      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
-    );
+    const textarea = screen.getByRole("textbox");
 
     act(() => {
       textarea.focus();
@@ -1089,9 +1079,7 @@ describe("chat view", () => {
       })
     );
 
-    const textarea = screen.getByPlaceholderText(
-      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
-    );
+    const textarea = screen.getByRole("textbox");
 
     act(() => {
       textarea.focus();
@@ -1115,9 +1103,7 @@ describe("chat view", () => {
   it("keeps the composer focused after sending on non-touch devices", async () => {
     renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
 
-    const textarea = screen.getByPlaceholderText(
-      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
-    );
+    const textarea = screen.getByRole("textbox");
 
     await waitFor(() => {
       expect(textarea).toHaveFocus();
@@ -1144,9 +1130,7 @@ describe("chat view", () => {
 
     const { container } = renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
 
-    const textarea = screen.getByPlaceholderText(
-      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
-    );
+    const textarea = screen.getByRole("textbox");
 
     fireEvent.change(textarea, { target: { value: "Hello world" } });
     fireEvent.keyDown(textarea, { key: "Enter" });
@@ -1165,9 +1149,7 @@ describe("chat view", () => {
   it("appends dictated text into the draft without sending a message", async () => {
     renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
 
-    const textarea = screen.getByPlaceholderText(
-      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
-    );
+    const textarea = screen.getByRole("textbox");
     expect(screen.queryByRole("combobox", { name: "Speech language" })).toBeNull();
 
     fireEvent.change(textarea, { target: { value: "Existing draft   " } });
@@ -1189,9 +1171,7 @@ describe("chat view", () => {
   it("does not submit when Enter is pressed during active voice input", async () => {
     renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
 
-    const textarea = screen.getByPlaceholderText(
-      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
-    );
+    const textarea = screen.getByRole("textbox");
 
     fireEvent.change(textarea, { target: { value: "Keep this draft" } });
     fireEvent.click(screen.getByRole("button", { name: "Start voice input" }));
@@ -1611,9 +1591,7 @@ describe("chat view", () => {
   it("shows a provisional generate image row immediately after message_start for image requests", async () => {
     renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
 
-    const textarea = screen.getByPlaceholderText(
-      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
-    );
+    const textarea = screen.getByRole("textbox");
 
     fireEvent.change(textarea, { target: { value: "Generate an image of a yellow star" } });
     fireEvent.keyDown(textarea, { key: "Enter" });
@@ -1978,9 +1956,7 @@ describe("chat view", () => {
   it("ignores stale empty snapshots after a local send has started", async () => {
     renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
 
-    const textarea = screen.getByPlaceholderText(
-      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
-    );
+    const textarea = screen.getByRole("textbox");
 
     fireEvent.change(textarea, { target: { value: "hello" } });
     fireEvent.keyDown(textarea, { key: "Enter" });
@@ -2025,9 +2001,7 @@ describe("chat view", () => {
   it("keeps an optimistic user message visible when an unrelated server user message arrives first", async () => {
     renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
 
-    const textarea = screen.getByPlaceholderText(
-      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
-    );
+    const textarea = screen.getByRole("textbox");
 
     fireEvent.change(textarea, { target: { value: "keep this attachment" } });
     fireEvent.keyDown(textarea, { key: "Enter" });
@@ -2083,9 +2057,7 @@ describe("chat view", () => {
 
     const { container } = renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
     const input = container.querySelector('input[type="file"]') as HTMLInputElement;
-    const textarea = screen.getByPlaceholderText(
-      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
-    );
+    const textarea = screen.getByRole("textbox");
 
     fireEvent.change(input, {
       target: {
@@ -2177,9 +2149,7 @@ describe("chat view", () => {
 
     const { container } = renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
     const input = container.querySelector('input[type="file"]') as HTMLInputElement;
-    const textarea = screen.getByPlaceholderText(
-      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
-    );
+    const textarea = screen.getByRole("textbox");
 
     fireEvent.change(input, {
       target: {
@@ -2335,9 +2305,7 @@ describe("chat view", () => {
 
     const { container } = renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
     const input = container.querySelector('input[type="file"]') as HTMLInputElement;
-    const textarea = screen.getByPlaceholderText(
-      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
-    );
+    const textarea = screen.getByRole("textbox");
 
     fireEvent.change(input, {
       target: {
@@ -2468,9 +2436,7 @@ describe("chat view", () => {
       React.createElement(ChatView, { payload: createPayload() })
     );
     const input = container.querySelector('input[type="file"]') as HTMLInputElement;
-    const textarea = screen.getByPlaceholderText(
-      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
-    );
+    const textarea = screen.getByRole("textbox");
 
     fireEvent.change(input, {
       target: {
@@ -2535,9 +2501,7 @@ describe("chat view", () => {
 
     const { container } = renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
     const input = container.querySelector('input[type="file"]') as HTMLInputElement;
-    const textarea = screen.getByPlaceholderText(
-      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
-    );
+    const textarea = screen.getByRole("textbox");
 
     fireEvent.change(input, {
       target: {
@@ -2687,9 +2651,7 @@ describe("chat view", () => {
       React.createElement(ChatView, { payload: createPayload() })
     );
     const input = container.querySelector('input[type="file"]') as HTMLInputElement;
-    const textarea = screen.getByPlaceholderText(
-      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
-    );
+    const textarea = screen.getByRole("textbox");
 
     fireEvent.change(input, {
       target: {
@@ -2870,9 +2832,7 @@ describe("chat view", () => {
         })
       })
     );
-    const textarea = screen.getByPlaceholderText(
-      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
-    );
+    const textarea = screen.getByRole("textbox");
 
     act(() => {
       wsMock.onMessage!({
@@ -2932,9 +2892,7 @@ describe("chat view", () => {
 
   it("hides the scroll-to-newest pill when the user sends from a scrolled-up conversation", async () => {
     renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
-    const textarea = screen.getByPlaceholderText(
-      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
-    );
+    const textarea = screen.getByRole("textbox");
 
     await flushAnimationFrame();
 
@@ -2979,9 +2937,7 @@ describe("chat view", () => {
 
   it("follows streaming overflow after sending", async () => {
     renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
-    const textarea = screen.getByPlaceholderText(
-      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
-    );
+    const textarea = screen.getByRole("textbox");
 
     fireEvent.change(textarea, { target: { value: "Track the next reply" } });
     fireEvent.keyDown(textarea, { key: "Enter" });
@@ -3038,9 +2994,7 @@ describe("chat view", () => {
       } as Response);
 
     renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
-    const textarea = screen.getByPlaceholderText(
-      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
-    );
+    const textarea = screen.getByRole("textbox");
 
     fireEvent.change(textarea, { target: { value: "Server-backed prompt" } });
     fireEvent.keyDown(textarea, { key: "Enter" });
@@ -3060,9 +3014,7 @@ describe("chat view", () => {
 
   it("scrolls to anchor the user message near the top after sending", async () => {
     renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
-    const textarea = screen.getByPlaceholderText(
-      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
-    );
+    const textarea = screen.getByRole("textbox");
 
     const scrollIntoViewSpy2 = vi.spyOn(Element.prototype, 'scrollIntoView').mockImplementation(() => {});
 
@@ -3093,9 +3045,7 @@ describe("chat view", () => {
         })
       })
     );
-    const textarea = screen.getByPlaceholderText(
-      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
-    );
+    const textarea = screen.getByRole("textbox");
 
     act(() => {
       wsMock.onMessage!({
@@ -3127,9 +3077,7 @@ describe("chat view", () => {
 
   it("cancels streaming follow immediately when the user wheels away", async () => {
     renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
-    const textarea = screen.getByPlaceholderText(
-      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
-    );
+    const textarea = screen.getByRole("textbox");
 
     fireEvent.change(textarea, { target: { value: "Track then interrupt" } });
     fireEvent.keyDown(textarea, { key: "Enter" });
@@ -3476,9 +3424,7 @@ describe("chat view", () => {
 
     renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
 
-    const textarea = screen.getByPlaceholderText(
-      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
-    );
+    const textarea = screen.getByRole("textbox");
 
     fireEvent.change(textarea, { target: { value: "hello" } });
     fireEvent.keyDown(textarea, { key: "Enter" });
@@ -4096,9 +4042,7 @@ describe("chat view", () => {
       });
     });
 
-    const textarea = screen.getByPlaceholderText(
-      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
-    );
+    const textarea = screen.getByRole("textbox");
 
     fireEvent.change(textarea, { target: { value: "Queued while streaming" } });
 
@@ -4107,17 +4051,15 @@ describe("chat view", () => {
     expect(screen.getByText("Agent working - send still queues")).toBeInTheDocument();
   });
 
-  it("centers the composer controls against the textarea body", async () => {
+  it("aligns the composer controls with the top of the textarea", async () => {
     await act(async () => {
       renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
     });
 
-    const textarea = screen.getByPlaceholderText(
-      "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
-    );
+    const textarea = screen.getByRole("textbox");
     const composerRow = textarea.parentElement?.parentElement;
 
-    expect(composerRow).toHaveClass("items-center");
+    expect(composerRow).toHaveClass("items-start");
     expect(composerRow).not.toHaveClass("items-end");
   });
 

--- a/tests/unit/home-view.test.tsx
+++ b/tests/unit/home-view.test.tsx
@@ -238,9 +238,7 @@ describe("home view", () => {
     );
 
     fireEvent.change(
-      screen.getByPlaceholderText(
-        "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
-      ),
+      screen.getByRole("textbox"),
       {
         target: {
           value: "Start this thread"
@@ -290,9 +288,7 @@ describe("home view", () => {
     );
 
     expect(
-      screen.getByPlaceholderText(
-        "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
-      )
+      screen.getByRole("textbox")
     ).not.toHaveFocus();
   });
 
@@ -320,9 +316,7 @@ describe("home view", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByPlaceholderText(
-          "Ask, create, or start a task. Press ⌘ ⏎ to insert a line break..."
-        )
+        screen.getByRole("textbox")
       ).toHaveValue("home transcript");
     });
 

--- a/tests/unit/shared-conversation-view.test.tsx
+++ b/tests/unit/shared-conversation-view.test.tsx
@@ -197,7 +197,7 @@ describe("SharedConversationView", () => {
       "linear-gradient(to bottom, #FFFFFF 0%, #D4C8FF 40%, #8b5cf6 100%)"
     );
     expect(screen.getByText("Shared UI thread")).toBeInTheDocument();
-    expect(screen.queryByPlaceholderText(/Ask, create, or start a task/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
     expect(screen.queryByText("New Chat")).not.toBeInTheDocument();
     expect(screen.queryByText("Search")).not.toBeInTheDocument();
     expect(container.querySelector('img[src="/agent-icon.png"]')).not.toBeNull();

--- a/tests/unit/use-auto-resize.test.ts
+++ b/tests/unit/use-auto-resize.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { act, renderHook } from "@testing-library/react";
+import { renderHook } from "@testing-library/react";
 
 import { useAutoResize } from "@/lib/use-auto-resize";
 
@@ -32,11 +32,11 @@ describe("useAutoResize", () => {
     const ref = { current: textarea };
 
     const { result } = renderHook(() =>
-      useAutoResize({ ref, value: "hi", minHeight: 52 })
+      useAutoResize({ ref, value: "hi", minHeight: 40 })
     );
 
-    expect(result.current.height).toBe(52);
-    expect(textarea.style.height).toBe("52px");
+    expect(result.current.height).toBe(40);
+    expect(textarea.style.height).toBe("40px");
   });
 
   it("adjusts height when value changes", () => {
@@ -74,7 +74,7 @@ describe("useAutoResize", () => {
     expect(result.current.height).toBe(80);
   });
 
-  it("uses default minHeight of 52", () => {
+  it("uses default minHeight of 40", () => {
     const textarea = createTextarea(30);
     const ref = { current: textarea };
 
@@ -82,7 +82,7 @@ describe("useAutoResize", () => {
       useAutoResize({ ref, value: "" })
     );
 
-    expect(result.current.height).toBe(52);
+    expect(result.current.height).toBe(40);
   });
 
   it("does nothing when ref.current is null", () => {
@@ -92,6 +92,6 @@ describe("useAutoResize", () => {
       useAutoResize({ ref, value: "hello" })
     );
 
-    expect(result.current.height).toBe(52);
+    expect(result.current.height).toBe(40);
   });
 });


### PR DESCRIPTION
## Summary

Reworks the chat composer textarea to start as a compact single-line input and dynamically expand as content grows.

- **Single-line start**: Reduced `minHeight` from 52px to 40px, added `rows={1}` to prevent HTML's default 2-row height, and tightened padding from `py-3.5` to `py-2`
- **Visual distinction**: Added subtle background fill (`bg-white/[0.03]`) and faint border (`border-white/[0.06]`) at rest, with accent border on focus, so the input is distinguishable from the composer shell
- **Pixel-perfect alignment**: Used `items-start` and `display: block` on the textarea to eliminate inline-block baseline whitespace and align the send/mic buttons with the textarea center
- **Conditional scrollbar**: `overflow-hidden` when single-line, `overflow-y-auto scrollbar-thin` when expanded — no scrollbar artifact when content fits
- **Equalized spacing**: Adjusted row padding and toolbar margin so top/bottom spacing around the textarea is visually balanced in both toolbar-visible and toolbar-hidden states
- **Removed placeholder**: Cleared the long placeholder text for a cleaner compact appearance
- **Tests updated**: All `use-auto-resize` test assertions updated for new default `minHeight` of 40

🤖 Generated with [Claude Code](https://claude.com/claude-code)