### PR TITLE
feat(provider): add DeepSeek preset + replace maxOutputTokens hard cap with relative cap

### DIFF
--- a/lib/provider-presets.ts
+++ b/lib/provider-presets.ts
@@ -11,6 +11,8 @@ type ProviderPresetValues = {
   reasoningEffort: ReasoningEffort;
   reasoningSummaryEnabled: boolean;
   modelContextLimit: number;
+  temperature?: number;
+  maxOutputTokens?: number;
 };
 
 type ProviderPresetDefinition = {
@@ -29,6 +31,8 @@ type PresetCompatibleProfile = {
   reasoningEffort: ReasoningEffort;
   reasoningSummaryEnabled: boolean;
   modelContextLimit: number;
+  temperature?: number;
+  maxOutputTokens?: number;
 };
 
 export const PROVIDER_PRESETS: ProviderPresetDefinition[] = [
@@ -86,6 +90,22 @@ export const PROVIDER_PRESETS: ProviderPresetDefinition[] = [
       reasoningEffort: "medium",
       reasoningSummaryEnabled: true,
       modelContextLimit: 200000
+    }
+  },
+  {
+    id: "deepseek",
+    label: "DeepSeek",
+    providerKind: "openai_compatible",
+    values: {
+      name: "DeepSeek",
+      apiBaseUrl: "https://api.deepseek.com",
+      model: "deepseek-v4-flash",
+      apiMode: "chat_completions",
+      reasoningEffort: "medium",
+      reasoningSummaryEnabled: true,
+      modelContextLimit: 1_000_000,
+      temperature: 1.3,
+      maxOutputTokens: 8192
     }
   },
   {
@@ -175,15 +195,33 @@ export function getMatchingProviderPresetId(
     }
 
     const { values } = entry;
+    const required: Array<keyof typeof values> = [
+      "apiBaseUrl",
+      "model",
+      "apiMode",
+      "reasoningEffort",
+      "reasoningSummaryEnabled",
+      "modelContextLimit"
+    ];
 
-    return (
-      values.apiBaseUrl === profile.apiBaseUrl &&
-      values.model === profile.model &&
-      values.apiMode === profile.apiMode &&
-      values.reasoningEffort === profile.reasoningEffort &&
-      values.reasoningSummaryEnabled === profile.reasoningSummaryEnabled &&
-      values.modelContextLimit === profile.modelContextLimit
-    );
+    for (const key of required) {
+      if (values[key] !== profile[key]) {
+        return false;
+      }
+    }
+
+    if (values.temperature !== undefined && values.temperature !== profile.temperature) {
+      return false;
+    }
+
+    if (
+      values.maxOutputTokens !== undefined &&
+      values.maxOutputTokens !== profile.maxOutputTokens
+    ) {
+      return false;
+    }
+
+    return true;
   });
 
   return preset?.id ?? null;

--- a/lib/settings.ts
+++ b/lib/settings.ts
@@ -38,7 +38,7 @@ const runtimeSettingsSchema = z.object({
   mergedMinNodeCount: z.coerce.number().int().min(2).max(20).default(4),
   mergedTargetTokens: z.coerce.number().int().min(128).max(16000).default(1600),
   visionMode: z.enum(["none", "native", "mcp"]).default("native"),
-  providerPresetId: z.enum(["ollama_cloud", "glm_coding_plan", "openrouter", "opencode_go", "custom_openai_compatible", "anthropic_official", "opencode_go_anthropic"]).nullable().default(null),
+  providerPresetId: z.enum(["ollama_cloud", "glm_coding_plan", "openrouter", "opencode_go", "deepseek", "custom_openai_compatible", "anthropic_official", "opencode_go_anthropic"]).nullable().default(null),
   githubUserAccessTokenEncrypted: z.string().default(""),
   githubRefreshTokenEncrypted: z.string().default(""),
   githubAccountLogin: z.string().nullable().default(null),

--- a/lib/settings.ts
+++ b/lib/settings.ts
@@ -25,7 +25,7 @@ const runtimeSettingsSchema = z.object({
   apiMode: z.enum(["responses", "chat_completions"]),
   systemPrompt: z.string().min(0),
   temperature: z.coerce.number().min(0).max(2),
-  maxOutputTokens: z.coerce.number().int().min(128).max(32768),
+  maxOutputTokens: z.coerce.number().int().min(128),
   reasoningEffort: z.enum(["none", "low", "medium", "high", "xhigh"]),
   reasoningSummaryEnabled: z.coerce.boolean(),
   modelContextLimit: z.coerce.number().int().min(4096).max(2_000_000),
@@ -73,6 +73,14 @@ const providerProfileInputSchema = runtimeSettingsSchema.extend({
         path: ["systemPrompt"]
       });
     }
+  }
+
+  if (value.maxOutputTokens + value.safetyMarginTokens >= value.modelContextLimit) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `maxOutputTokens (${value.maxOutputTokens}) plus safetyMarginTokens (${value.safetyMarginTokens}) must be less than modelContextLimit (${value.modelContextLimit})`,
+      path: ["maxOutputTokens"]
+    });
   }
 });
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -72,6 +72,7 @@ export type ProviderPresetId =
   | "glm_coding_plan"
   | "openrouter"
   | "opencode_go"
+  | "deepseek"
   | "custom_openai_compatible"
   | "anthropic_official"
   | "opencode_go_anthropic";

--- a/tests/unit/provider-presets.test.ts
+++ b/tests/unit/provider-presets.test.ts
@@ -108,15 +108,26 @@ describe("provider presets", () => {
     expect(getMatchingProviderPresetId(profile)).toBe("ollama_cloud");
   });
 
-  it("preserves non-provider tuning and secrets when applying a preset", () => {
+  it("preserves profile secrets and non-preset tuning when applying a preset", () => {
     const original = createProfile();
     const profile = applyProviderPreset(original, "glm_coding_plan");
 
     expect(profile.apiKey).toBe(original.apiKey);
     expect(profile.hasApiKey).toBe(original.hasApiKey);
     expect(profile.systemPrompt).toBe(original.systemPrompt);
+    expect(profile.compactionThreshold).toBe(original.compactionThreshold);
+    expect(profile.freshTailCount).toBe(original.freshTailCount);
     expect(profile.temperature).toBe(original.temperature);
     expect(profile.maxOutputTokens).toBe(original.maxOutputTokens);
+  });
+
+  it("overwrites temperature and maxOutputTokens when the preset defines them", () => {
+    const original = createProfile();
+    const profile = applyProviderPreset(original, "deepseek");
+
+    expect(profile.temperature).toBe(1.3);
+    expect(profile.maxOutputTokens).toBe(8192);
+    expect(profile.systemPrompt).toBe(original.systemPrompt);
     expect(profile.compactionThreshold).toBe(original.compactionThreshold);
     expect(profile.freshTailCount).toBe(original.freshTailCount);
   });
@@ -199,5 +210,39 @@ describe("provider presets", () => {
     };
 
     expect(getMatchingProviderPresetId(profile)).toBeNull();
+  });
+
+  it("applies the DeepSeek preset values without overwriting the name", () => {
+    const profile = applyProviderPreset(createProfile(), "deepseek");
+
+    expect(profile.name).toBe("Original profile");
+    expect(profile.apiBaseUrl).toBe("https://api.deepseek.com");
+    expect(profile.model).toBe("deepseek-v4-flash");
+    expect(profile.apiMode).toBe("chat_completions");
+    expect(profile.reasoningEffort).toBe("medium");
+    expect(profile.reasoningSummaryEnabled).toBe(true);
+    expect(profile.modelContextLimit).toBe(1_000_000);
+    expect(profile.temperature).toBe(1.3);
+    expect(profile.maxOutputTokens).toBe(8192);
+  });
+
+  it("matches a profile back to the DeepSeek preset when the provider fields align", () => {
+    const profile = {
+      ...createProfile(),
+      ...getProviderPreset("deepseek").values
+    };
+
+    expect(getMatchingProviderPresetId(profile)).toBe("deepseek");
+  });
+
+  it("matches an OpenRouter profile even when temperature and maxOutputTokens differ from defaults", () => {
+    const profile = {
+      ...createProfile(),
+      ...getProviderPreset("openrouter").values,
+      temperature: 0.9,
+      maxOutputTokens: 4096
+    };
+
+    expect(getMatchingProviderPresetId(profile)).toBe("openrouter");
   });
 });

--- a/tests/unit/settings.test.ts
+++ b/tests/unit/settings.test.ts
@@ -36,12 +36,13 @@ function buildProfile(
     systemPrompt: string;
     temperature: number;
     maxOutputTokens: number;
-    reasoningEffort: "low" | "medium" | "high" | "xhigh";
+    reasoningEffort: "none" | "low" | "medium" | "high" | "xhigh";
     reasoningSummaryEnabled: boolean;
     modelContextLimit: number;
     compactionThreshold: number;
     freshTailCount: number;
-    providerPresetId: "ollama_cloud" | "glm_coding_plan" | "openrouter" | "opencode_go" | "custom_openai_compatible" | null;
+    safetyMarginTokens: number;
+    providerPresetId: "ollama_cloud" | "glm_coding_plan" | "openrouter" | "opencode_go" | "deepseek" | "custom_openai_compatible" | "anthropic_official" | "opencode_go_anthropic" | null;
   }> = {}
 ) {
   return {
@@ -59,6 +60,7 @@ function buildProfile(
     modelContextLimit: overrides.modelContextLimit ?? 16384,
     compactionThreshold: overrides.compactionThreshold ?? 0.8,
     freshTailCount: overrides.freshTailCount ?? 12,
+    safetyMarginTokens: overrides.safetyMarginTokens ?? 1200,
     providerPresetId: overrides.providerPresetId ?? null
   };
 }
@@ -1310,5 +1312,41 @@ describe("settings storage", () => {
     expect(saved?.providerKind).toBe("anthropic");
     expect(saved?.providerPresetId).toBe("anthropic_official");
     expect(getProviderProfileWithApiKey("profile_anthropic")?.apiKey).toBe("sk-ant-test");
+  });
+
+  it("rejects maxOutputTokens that, combined with safetyMarginTokens, reaches modelContextLimit", () => {
+    const profile = buildProfile({
+      id: "profile_invalid_output",
+      name: "Invalid Output",
+      modelContextLimit: 10_000,
+      safetyMarginTokens: 1200,
+      maxOutputTokens: 9000
+    });
+
+    expect(() =>
+      updateSettings({
+        defaultProviderProfileId: profile.id,
+        skillsEnabled: true,
+        providerProfiles: [profile]
+      })
+    ).toThrow(/must be less than modelContextLimit/);
+  });
+
+  it("accepts maxOutputTokens above the previous 32768 hard cap when modelContextLimit allows it", () => {
+    const profile = buildProfile({
+      id: "profile_large_output",
+      name: "Large Output",
+      modelContextLimit: 1_000_000,
+      safetyMarginTokens: 1200,
+      maxOutputTokens: 384_000
+    });
+
+    expect(() =>
+      updateSettings({
+        defaultProviderProfileId: profile.id,
+        skillsEnabled: true,
+        providerProfiles: [profile]
+      })
+    ).not.toThrow();
   });
 });


### PR DESCRIPTION
## Summary

- Add **DeepSeek** as a first-class OpenAI-compatible provider preset, configured against the official `api-docs.deepseek.com` reference:
  - Base URL: `https://api.deepseek.com`
  - Default model: `deepseek-v4-flash`
  - Context limit: **1M tokens**
  - Temperature: **1.3** (general conversation)
  - Max output tokens: **8192** (sensible starter below the 384K ceiling)
  - API mode: `chat_completions`, reasoning effort `medium`, reasoning summary enabled
- Extend `ProviderPresetValues` with optional `temperature` and `maxOutputTokens`. Presets that define them stamp the profile on apply; presets that omit them preserve the existing profile values (unchanged behavior for the 6 existing presets).
- Rewrite `getMatchingProviderPresetId` to compare only the fields a preset actually defines, so profiles with custom temperature/maxOutput still match presets like OpenRouter that don't set those fields.
- Replace the hard `maxOutputTokens: .max(32768)` cap with a relative validator: `maxOutputTokens + safetyMarginTokens < modelContextLimit`. This allows providers like DeepSeek (max output 384K) to be configured correctly while enforcing that output always fits inside the context window.

## Test coverage

- New DeepSeek apply + match tests in `tests/unit/provider-presets.test.ts`.
- New OpenRouter match-with-custom-temperature test verifying the matcher rewrite.
- Updated preservation-contract tests reflecting that `temperature`/`maxOutputTokens` are now preset-tunable.
- New `tests/unit/settings.test.ts` cases asserting the relative cap rejects oversized values and that `384_000` is accepted with a 1M context.
- Full suite: 1153/1153 tests pass. `tsc --noEmit` clean. `eslint` 0 errors.

## Files

- `lib/types.ts` — extend `ProviderPresetId` union
- `lib/provider-presets.ts` — optional preset fields, DeepSeek entry, matcher rewrite
- `lib/settings.ts` — extend enum, drop hard cap, add `superRefine` relative-cap rule
- `tests/unit/provider-presets.test.ts`, `tests/unit/settings.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)