### PR TITLE
fix(settings): reset dirty state after provider deletion

### DIFF
--- a/components/settings/sections/providers-section.tsx
+++ b/components/settings/sections/providers-section.tsx
@@ -368,15 +368,24 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
     });
 
     if (response.ok) {
+      const newSelectedId = selectedProviderProfileId === profileId
+        ? (nextProfiles.find((p) => p.id === nextDefault)?.id ?? nextProfiles[0]?.id ?? "")
+        : selectedProviderProfileId;
+      const newActiveProfile = nextProfiles.find((p) => p.id === newSelectedId) ?? nextProfiles[0];
+
       setProviderProfiles(nextProfiles);
-      setSelectedProviderProfileId(
-        selectedProviderProfileId === profileId
-          ? (nextProfiles.find((p) => p.id === nextDefault)?.id ?? nextProfiles[0]?.id ?? "")
-          : selectedProviderProfileId
-      );
+      setSelectedProviderProfileId(newSelectedId);
       if (defaultProviderProfileId === profileId) {
         setDefaultProviderProfileId(nextDefault);
       }
+
+      if (newActiveProfile) {
+        resetDirty({
+          ...buildDirtySnapshot(newActiveProfile),
+          defaultProviderProfileId: defaultProviderProfileId === profileId ? nextDefault : defaultProviderProfileId,
+        });
+      }
+
       toast.showToast("success", "Provider deleted.");
     } else {
       const result = (await response.json().catch(() => ({}))) as { error?: string };


### PR DESCRIPTION
## Summary

- **Fixed false "unsaved changes" prompt after deleting a provider.** When a provider was deleted, the UI correctly switched to the fallback provider, but the dirty-state snapshot still held the deleted provider's field values — causing `isDirty` to evaluate `true` against the new provider's data and triggering the unsaved changes modal.
- The `handleDeleteConfirm()` handler now calls `resetDirty()` with a correctly-computed snapshot of the new active profile after deletion.
- The snapshot includes the updated `defaultProviderProfileId` for the case where the deleted provider was the default.
- This aligns with the existing pattern used by every other provider-switching path (`addProviderProfile`, profile card click), which all call `resetDirty(buildDirtySnapshot(profile))`.

## Root Cause

`useDirtyState` tracks changes by comparing the current field values against a JSON snapshot. After deleting provider A and switching to provider B, the snapshot still contained A's serialized fields while `current` reflected B's fields — different data, so `isDirty` was always `true`.

## Testing

- ✅ Delete a non-default provider — clean switch, no dirty state, no modal
- ✅ Delete the DEFAULT provider — new default assigned correctly, no dirty state, no modal
- ✅ Navigate away after deletion — no unsaved changes prompt