### PR TITLE
feat(chat): preserve line breaks in user message bubbles

### DIFF
--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -988,7 +988,7 @@ export function MessageBubble({
                 />
               ) : content ? (
                 <div ref={contentRef} className="markdown-body">
-                  <Streamdown mode="static" plugins={STREAMDOWN_PLUGINS}>{content}</Streamdown>
+                  <Streamdown mode="static" plugins={STREAMDOWN_PLUGINS}>{content.replace(/\n/g, "  \n")}</Streamdown>
                 </div>
               ) : null}
               {message.attachments?.length ? (


### PR DESCRIPTION
## Summary

- User messages containing line breaks now display with those line breaks preserved in the chat bubble
- Converts single `\n` characters to markdown hard breaks (`  \n` — two trailing spaces + newline) before passing user message content to the Streamdown markdown renderer
- Scoped exclusively to the user message rendering path — assistant messages are unaffected
- The original `content` variable is not mutated, so copy, edit, and comparison logic continue to work with raw text

## Testing

- All 5 existing `message-bubble` unit tests pass
- Visually validated multi-line messages render correctly on desktop and mobile viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)