### PR TITLE
feat(docker): optimize image size from 4.25GB to 2.64GB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,23 +31,23 @@ ENV AGENT_BROWSER_SOCKET_DIR=/app/data/runtime/agent-browser
 # Install uv for uvx (Python-based MCP servers)
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 
-# Install chromium and agent-browser
 RUN apt-get update && apt-get install -y --no-install-recommends chromium \
-    && rm -rf /var/lib/apt/lists/*
-RUN npm install -g agent-browser \
+    && rm -rf /var/lib/apt/lists/* \
+    && npm install -g agent-browser \
     && mv /usr/local/bin/agent-browser /usr/local/bin/agent-browser-core \
     && printf '#!/bin/sh\nexec agent-browser-core --executable-path /usr/bin/chromium "$@"\n' > /usr/local/bin/agent-browser \
-    && chmod +x /usr/local/bin/agent-browser
+    && chmod +x /usr/local/bin/agent-browser \
+    && npm cache clean --force
 
 RUN groupadd --system eidon && useradd --system --gid eidon eidon
-COPY --from=builder /app/.next/standalone ./
-COPY --from=builder /app/.next/static ./.next/static
-COPY --from=builder /app/public ./public
-COPY --from=builder /app/server.cjs ./server.cjs
-COPY --from=builder /app/ws-handler-compiled.cjs ./ws-handler-compiled.cjs
-COPY --from=prod-deps /app/node_modules ./node_modules
-RUN install -d -m 700 /app/data /app/data/home /app/data/tmp /app/data/runtime /app/data/runtime/agent-browser \
-    && chown -R eidon:eidon /app
+COPY --from=builder --chown=eidon:eidon /app/.next/standalone ./
+COPY --from=builder --chown=eidon:eidon /app/.next/static ./.next/static
+COPY --from=builder --chown=eidon:eidon /app/public ./public
+COPY --from=builder --chown=eidon:eidon /app/server.cjs ./server.cjs
+COPY --from=builder --chown=eidon:eidon /app/ws-handler-compiled.cjs ./ws-handler-compiled.cjs
+COPY --from=prod-deps --chown=eidon:eidon /app/node_modules ./node_modules
+RUN rm -rf ./node_modules/onnxruntime-web/dist \
+    && install -d -m 700 -o eidon -g eidon /app/data /app/data/home /app/data/tmp /app/data/runtime /app/data/runtime/agent-browser
 USER eidon
 EXPOSE 3000
 VOLUME ["/app/data"]

--- a/tests/e2e/features.spec.ts
+++ b/tests/e2e/features.spec.ts
@@ -5,11 +5,13 @@ import path from "node:path";
 
 import { expect, test } from "@playwright/test";
 
+const EIDON_TEST_PASSWORD = process.env.EIDON_TEST_PASSWORD ?? "changeme123";
+
 async function signIn(page: import("@playwright/test").Page) {
   const response = await page.request.post("/api/auth/login", {
     data: {
       username: "admin",
-      password: "changeme123"
+      password: EIDON_TEST_PASSWORD
     }
   });
 

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -1,11 +1,13 @@
 import { expect, test } from "@playwright/test";
 
+const EIDON_TEST_PASSWORD = process.env.EIDON_TEST_PASSWORD ?? "changeme123";
+
 test("redirects to login, signs in, opens settings, and creates a chat", async ({ page }) => {
   await page.goto("/");
   await expect(page).toHaveURL(/\/login$/);
 
   await page.getByPlaceholder("Username").fill("admin");
-  await page.getByPlaceholder("Password").fill("changeme123");
+  await page.getByPlaceholder("Password").fill(EIDON_TEST_PASSWORD);
   await page.getByRole("button", { name: "Proceed" }).click();
   await page.waitForURL("http://localhost:3117/", { timeout: 15000 });
 

--- a/tests/unit/dockerfile.test.ts
+++ b/tests/unit/dockerfile.test.ts
@@ -12,8 +12,8 @@ describe("Dockerfile", () => {
     expect(dockerfile).toContain("ENV XDG_RUNTIME_DIR=/app/data/runtime");
     expect(dockerfile).toContain("ENV AGENT_BROWSER_SOCKET_DIR=/app/data/runtime/agent-browser");
     expect(dockerfile).toContain(
-      "install -d -m 700 /app/data /app/data/home /app/data/tmp /app/data/runtime /app/data/runtime/agent-browser"
+      "install -d -m 700 -o eidon -g eidon /app/data /app/data/home /app/data/tmp /app/data/runtime /app/data/runtime/agent-browser"
     );
-    expect(dockerfile).toContain("chown -R eidon:eidon /app");
+    expect(dockerfile).toContain("--chown=eidon:eidon");
   });
 });


### PR DESCRIPTION
## Summary

Reduce Docker image size by **38%** (1.6GB saved) through layer optimization and ownership handling.

### Changes

- **`--chown=eidon:eidon` on all COPY commands** — eliminates a 1.5GB duplicate layer caused by `chown -R` copying the entire filesystem
- **Combined RUN layers** — merged chromium install, agent-browser setup, and npm cache clean into a single layer to reduce intermediate layer overhead
- **Pruned `onnxruntime-web/dist`** — removed 125MB of unused WASM runtime files (server only uses `onnxruntime-node`)
- **Fixed directory ownership** — `install -d -m 700 -o eidon -g eidon` creates data directories with correct ownership upfront
- **Updated E2E tests** — `EIDON_TEST_PASSWORD` env var support for testing against production-mode containers
- **Updated unit tests** — assertions match new Dockerfile structure

### Verification

- ✅ 1153 unit tests pass
- ✅ Docker image builds successfully
- ✅ Full E2E flow verified: login → chat → settings → new chat
- ✅ All container functionality working (WebSocket, auth, navigation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)