### PR TITLE
feat(chat): switch code block theme to Dracula for better readability

### DIFF
--- a/components/ai-elements/message.tsx
+++ b/components/ai-elements/message.tsx
@@ -13,7 +13,7 @@ import {
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { cjk } from "@streamdown/cjk";
-import { code } from "@streamdown/code";
+import { createCodePlugin } from "@streamdown/code";
 import { math } from "@streamdown/math";
 import { mermaid } from "@streamdown/mermaid";
 import type { UIMessage } from "ai";
@@ -316,6 +316,7 @@ export const MessageBranchPage = ({
 
 export type MessageResponseProps = ComponentProps<typeof Streamdown>;
 
+const code = createCodePlugin({ themes: ["dracula", "dracula"] });
 const streamdownPlugins = { cjk, code, math, mermaid };
 
 export const MessageResponse = memo(

--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -3,7 +3,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import { Brain, Check, ChevronDown, ChevronRight, Copy, GitFork, LoaderCircle, Pencil, RefreshCw, Square, X } from "lucide-react";
 import { Streamdown } from "streamdown";
-import { code } from "@streamdown/code";
+import { createCodePlugin } from "@streamdown/code";
 import { mermaid } from "@streamdown/mermaid";
 import { MarkdownErrorBoundary } from "@/components/markdown-error-boundary";
 import {
@@ -39,6 +39,7 @@ import {
   MessageAction
 } from "@/components/ai-elements/message";
 
+const code = createCodePlugin({ themes: ["dracula", "dracula"] });
 const STREAMDOWN_PLUGINS = { code, mermaid };
 const COPY_RESET_DELAY_MS = 1600;
 


### PR DESCRIPTION
## Summary

- Switched Streamdown code block syntax highlighting theme from the default (`github-light`/`github-dark`) to **Dracula** for significantly better contrast and readability on dark UIs
- Replaced the pre-configured `code` export from `@streamdown/code` with `createCodePlugin({ themes: ["dracula", "dracula"] })` so the plugin itself tokenizes with Dracula colors
- Updated both `components/message-bubble.tsx` and `components/ai-elements/message.tsx` to use the new Dracula-themed code plugin
- Removed `shikiTheme` prop approach (which was overridden by the plugin's internal themes) in favor of configuring the plugin directly

## Why

The default `github-dark` theme had poor contrast against the app's dark background, making code highlighting nearly invisible. Dracula provides vibrant, high-contrast token colors that are much more readable in dark environments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)