### PR TITLE
fix(chat): restore live streaming after message edit-resend and fix edit keyboard shortcuts

### DIFF
--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -211,6 +211,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
   const streamThinkingTargetRef = useRef("");
   const streamMessageIdRef = useRef<string | null>(null);
   const streamTimelineRef = useRef<MessageTimelineItem[]>([]);
+  const isSendingRef = useRef(false);
   const [updatingMessageId, setUpdatingMessageId] = useState<string | null>(null);
   const [forkingMessageId, setForkingMessageId] = useState<string | null>(null);
   const [retryingMessageId, setRetryingMessageId] = useState<string | null>(null);
@@ -312,9 +313,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
 
     setStreamMessageId(snapshotMessage.id);
     setStreamAnswerTarget(nextAnswer);
-    setStreamAnswerDisplay(nextAnswer);
     setStreamThinkingTarget(nextThinking);
-    setStreamThinkingDisplay(nextThinking);
     updateStreamTimeline(mergedTimeline);
     setHasReceivedFirstToken(Boolean(nextAnswer || nextThinking || mergedTimeline.length));
     setIsSending(true);
@@ -344,6 +343,10 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
   useEffect(() => {
     streamMessageIdRef.current = streamMessageId;
   }, [streamMessageId]);
+
+  useEffect(() => {
+    isSendingRef.current = isSending;
+  }, [isSending]);
 
   useEffect(() => {
     streamTimelineRef.current = streamTimeline;
@@ -647,13 +650,18 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
     if (event.type === "done") {
       clearCompactionIndicator();
       clearIdleTimer();
-      setIsConversationActive(false);
       const wasStopped = isStopPending;
       setIsStopPending(false);
-      dispatchConversationActivityUpdated({
-        conversationId: payload.conversation.id,
-        isActive: false
-      });
+
+      const isForActiveStream = event.messageId === streamMessageIdRef.current;
+
+      if (isForActiveStream) {
+        setIsConversationActive(false);
+        dispatchConversationActivityUpdated({
+          conversationId: payload.conversation.id,
+          isActive: false
+        });
+      }
 
       if (event.message) {
         setMessages((current) =>
@@ -663,7 +671,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
               : m
           )
         );
-      } else {
+      } else if (isForActiveStream) {
         const finalAnswer = streamAnswerTargetRef.current;
         const finalThinking = streamThinkingTargetRef.current;
         const finalTimeline = streamTimelineRef.current;
@@ -682,36 +690,42 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
           )
         );
       }
-      setStreamMessageId(null);
-      updateStreamTimeline([]);
-      setStreamAnswerTarget("");
-      setStreamAnswerDisplay("");
-      setStreamThinkingTarget("");
-      setStreamThinkingDisplay("");
-      streamAnswerTargetRef.current = "";
-      streamThinkingTargetRef.current = "";
-      setIsSending(false);
+
+      if (isForActiveStream) {
+        setStreamMessageId(null);
+        updateStreamTimeline([]);
+        setStreamAnswerTarget("");
+        setStreamAnswerDisplay("");
+        setStreamThinkingTarget("");
+        setStreamThinkingDisplay("");
+        streamAnswerTargetRef.current = "";
+        streamThinkingTargetRef.current = "";
+        setIsSending(false);
+      }
     }
 
     if (event.type === "error") {
       clearCompactionIndicator();
       clearIdleTimer();
-      setIsConversationActive(false);
       setIsStopPending(false);
       const activeStreamMessageId = streamMessageIdRef.current;
-      dispatchConversationActivityUpdated({
-        conversationId: payload.conversation.id,
-        isActive: false
-      });
-      setMessages((current) =>
-        current.map((m) =>
-          m.id === activeStreamMessageId ? { ...m, status: "error" as const, content: event.message } : m
-        )
-      );
+
+      if (activeStreamMessageId) {
+        setIsConversationActive(false);
+        dispatchConversationActivityUpdated({
+          conversationId: payload.conversation.id,
+          isActive: false
+        });
+        setMessages((current) =>
+          current.map((m) =>
+            m.id === activeStreamMessageId ? { ...m, status: "error" as const, content: event.message } : m
+          )
+        );
+        setStreamMessageId(null);
+        updateStreamTimeline([]);
+        setIsSending(false);
+      }
       setError("");
-      setStreamMessageId(null);
-      updateStreamTimeline([]);
-      setIsSending(false);
     }
   }
 
@@ -1120,6 +1134,13 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
 
         if (activeMessage?.status === "streaming") {
           syncActiveStreamingMessageFromSnapshot(activeMessage);
+        } else if (!activeStreamMessageId) {
+          const streamingMsg = result.messages.find(
+            (message) => message.role === "assistant" && message.status === "streaming"
+          );
+          if (streamingMsg) {
+            syncActiveStreamingMessageFromSnapshot(streamingMsg);
+          }
         }
 
         const shouldIgnoreInactiveResult =
@@ -1134,7 +1155,8 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
           return;
         }
 
-        if (!result.conversation.isActive || (activeMessage && activeMessage.status !== "streaming")) {
+        const awaitingTurnStart = isSendingRef.current && !activeStreamMessageId;
+        if (!awaitingTurnStart && (!result.conversation.isActive || (activeMessage && activeMessage.status !== "streaming"))) {
           setStreamMessageId(null);
           updateStreamTimeline([]);
           setStreamAnswerTarget("");
@@ -1165,7 +1187,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
       cancelled = true;
       stopMessageSyncPolling();
     };
-  }, [needsMessageSync, payload.conversation.id, streamMessageId, syncActiveStreamingMessageFromSnapshot, updateStreamTimeline]);
+  }, [needsMessageSync, payload.conversation.id, syncActiveStreamingMessageFromSnapshot, updateStreamTimeline]);
 
   useEffect(() => {
     if (streamThinkingDisplay === streamThinkingTarget) {
@@ -1340,6 +1362,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
       }
 
       setIsSending(true);
+      setIsConversationActive(true);
     } catch (caughtError) {
       setError(caughtError instanceof Error ? caughtError.message : "Unable to update message");
       throw caughtError;
@@ -1438,6 +1461,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
       }
 
       setIsSending(true);
+      setIsConversationActive(true);
     } catch (caughtError) {
       setError(
         caughtError instanceof Error ? caughtError.message : "Message retry failed"

--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -543,7 +543,7 @@ export function MessageBubble({
                   onChange={(event) => setDraft(event.target.value)}
                   className="min-h-[88px] border-0 bg-transparent px-0 py-0 text-[14.5px] leading-7 text-[var(--text)] focus-visible:ring-0"
                   onKeyDown={(event) => {
-                    if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
+                    if (event.key === "Enter" && !event.shiftKey) {
                       event.preventDefault();
                       void handleSaveEdit();
                     }


### PR DESCRIPTION
## Summary

Two bugs fixed in the message edit-resend flow:

### 1. Live streaming not visible after editing and resending a message

After editing a sent message and clicking the checkmark to resend, the UI showed no streaming indicators (thinking bubble, typing spinner, Streamdown caret). Text appeared in blocks every couple of seconds via polling fallback instead of smooth live streaming.

**Root causes & fixes in `chat-view.tsx`:**
- **Stale cross-turn events** — `done` and `error` handlers unconditionally cleared streaming state regardless of which turn the event belonged to. A previous turn's `done` could wipe out the new turn's streaming mid-flight. Now guarded with `event.messageId === streamMessageIdRef.current`.
- **Missing streaming state adoption in polling** — When WebSocket `message_start` was missed (e.g., timing race with HTTP response), the polling handler had no fallback to adopt the streaming state from the snapshot. Added the same adoption logic that the WebSocket `snapshot` handler already had.
- **Missing `setIsConversationActive(true)`** — `updateUserMessage` and `retryAssistantMessage` didn't set this (unlike `submit()`), causing premature polling cleanup.
- **Premature polling cleanup** — When `isSending` was true but no stream message existed yet (server hasn't started the turn), polling gave up on seeing `isActive: false`. Now keeps polling while awaiting turn start.
- **Display jump in snapshot sync** — `syncActiveStreamingMessageFromSnapshot` was setting `streamAnswerDisplay` directly to the full accumulated text, bypassing the throttled character-by-character reveal. Removed the display setters so the smooth Streamdown reveal is preserved.

### 2. Edit textarea keyboard shortcuts

The edit textarea required `Cmd/Ctrl+Enter` to save. Now matches the main chat composer: **Enter sends**, **Shift+Enter adds a newline**, **Escape cancels**.

## Files changed
- `components/chat-view.tsx` — Streaming state guards, polling adoption, cleanup resilience
- `components/message-bubble.tsx` — Edit textarea keyboard handler

🤖 Generated with [Claude Code](https://claude.com/claude-code)