### PR TITLE
feat(chat): support pasting images from clipboard into chat input

### DIFF
--- a/components/chat-composer.tsx
+++ b/components/chat-composer.tsx
@@ -450,6 +450,15 @@ export function ChatComposer({
                 void onSubmit();
               }
             }}
+            onPaste={(event) => {
+              const files = Array.from(event.clipboardData.files);
+              const imageFiles = files.filter((file) => file.type.startsWith("image/"));
+
+              if (imageFiles.length > 0) {
+                event.preventDefault();
+                void onUploadFiles(imageFiles);
+              }
+            }}
           />
         </div>
 

--- a/docs/superpowers/plans/2026-06-04-clipboard-image-paste.md
+++ b/docs/superpowers/plans/2026-06-04-clipboard-image-paste.md
@@ -1,0 +1,181 @@
+# Clipboard Image Paste Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow users to paste images from clipboard into the chat input bar, treating them identically to file-upload attachments.
+
+**Architecture:** Add an `onPaste` handler to the `<Textarea>` in `ChatComposer` that extracts image `File` objects from `clipboardData.files` and passes them to the existing `onUploadFiles` prop. No new state, props, components, or backend changes.
+
+**Tech Stack:** React, TypeScript, Vitest, @testing-library/react
+
+---
+
+### Task 1: Add failing test for clipboard image paste
+
+**Files:**
+- Test: `tests/unit/chat-composer.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Add the following test to `tests/unit/chat-composer.test.tsx` inside a new `describe` block, after the existing `describe("ChatComposer collapsible toolbar", ...)` block:
+
+```tsx
+describe("ChatComposer clipboard image paste", () => {
+  it("calls onUploadFiles when an image is pasted from clipboard", () => {
+    const onUploadFiles = vi.fn();
+    renderComposer({ onUploadFiles });
+
+    const textarea = screen.getByRole("textbox");
+
+    const imageFile = new File(["fake-image-bytes"], "screenshot.png", { type: "image/png" });
+    const clipboardEvent = new ClipboardEvent("paste", {
+      bubbles: true,
+      cancelable: true,
+      clipboardData: new DataTransfer()
+    });
+    clipboardEvent.clipboardData!.items.add(imageFile);
+
+    fireEvent(textarea, clipboardEvent);
+
+    expect(onUploadFiles).toHaveBeenCalledOnce();
+    expect(onUploadFiles).toHaveBeenCalledWith([imageFile]);
+  });
+
+  it("does not call onUploadFiles when text is pasted", () => {
+    const onUploadFiles = vi.fn();
+    renderComposer({ onUploadFiles });
+
+    const textarea = screen.getByRole("textbox");
+
+    const clipboardEvent = new ClipboardEvent("paste", {
+      bubbles: true,
+      cancelable: true,
+      clipboardData: new DataTransfer()
+    });
+    clipboardEvent.clipboardData!.setData("text/plain", "hello");
+
+    fireEvent(textarea, clipboardEvent);
+
+    expect(onUploadFiles).not.toHaveBeenCalled();
+  });
+
+  it("does not call onUploadFiles when non-image files are pasted", () => {
+    const onUploadFiles = vi.fn();
+    renderComposer({ onUploadFiles });
+
+    const textarea = screen.getByRole("textbox");
+
+    const textFile = new File(["hello"], "notes.txt", { type: "text/plain" });
+    const clipboardEvent = new ClipboardEvent("paste", {
+      bubbles: true,
+      cancelable: true,
+      clipboardData: new DataTransfer()
+    });
+    clipboardEvent.clipboardData!.items.add(textFile);
+
+    fireEvent(textarea, clipboardEvent);
+
+    expect(onUploadFiles).not.toHaveBeenCalled();
+  });
+
+  it("filters to only image files when mixed content is pasted", () => {
+    const onUploadFiles = vi.fn();
+    renderComposer({ onUploadFiles });
+
+    const textarea = screen.getByRole("textbox");
+
+    const imageFile = new File(["fake-image-bytes"], "photo.jpg", { type: "image/jpeg" });
+    const textFile = new File(["hello"], "notes.txt", { type: "text/plain" });
+    const clipboardEvent = new ClipboardEvent("paste", {
+      bubbles: true,
+      cancelable: true,
+      clipboardData: new DataTransfer()
+    });
+    clipboardEvent.clipboardData!.items.add(imageFile);
+    clipboardEvent.clipboardData!.items.add(textFile);
+
+    fireEvent(textarea, clipboardEvent);
+
+    expect(onUploadFiles).toHaveBeenCalledOnce();
+    expect(onUploadFiles).toHaveBeenCalledWith([imageFile]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run tests/unit/chat-composer.test.tsx`
+Expected: The new "calls onUploadFiles when an image is pasted from clipboard" test FAILS because the textarea has no `onPaste` handler — `onUploadFiles` is never called.
+
+---
+
+### Task 2: Implement the onPaste handler
+
+**Files:**
+- Modify: `components/chat-composer.tsx:432-453` (the `<Textarea>` element)
+
+- [ ] **Step 1: Add the onPaste handler to the Textarea**
+
+In `components/chat-composer.tsx`, add an `onPaste` prop to the `<Textarea>` component (around line 432). The handler goes right after the existing `onKeyDown` prop. Add this to the `<Textarea>` element:
+
+```tsx
+onPaste={(event) => {
+  const files = Array.from(event.clipboardData.files);
+  const imageFiles = files.filter((file) => file.type.startsWith("image/"));
+
+  if (imageFiles.length > 0) {
+    void onUploadFiles(imageFiles);
+  }
+}}
+```
+
+The full `<Textarea>` element should now look like:
+
+```tsx
+<Textarea
+  ref={textareaRef}
+  value={input}
+  {...inputFocusProps}
+  onChange={(event) => onInputChange(event.target.value)}
+  placeholder=""
+  rows={1}
+  className={cn(
+    "block max-h-[60vh] min-h-[40px] w-full resize-none border border-white/[0.06] rounded-2xl bg-white/[0.03] px-3 sm:px-4 py-2 text-[15px] text-[var(--text)] leading-relaxed focus-visible:ring-0 focus:outline-none focus:border-[var(--accent)]/30 focus:bg-white/[0.05] placeholder:text-white/20 caret-[var(--accent)]",
+    isExpanded ? "overflow-y-auto scrollbar-thin" : "overflow-hidden"
+  )}
+  style={{ height: `${textareaHeight}px`, transition: "height 150ms ease" }}
+  onKeyDown={(event) => {
+    if (event.key === "Enter" && !event.shiftKey) {
+      event.preventDefault();
+      if (isSpeechActive) {
+        return;
+      }
+      void onSubmit();
+    }
+  }}
+  onPaste={(event) => {
+    const files = Array.from(event.clipboardData.files);
+    const imageFiles = files.filter((file) => file.type.startsWith("image/"));
+
+    if (imageFiles.length > 0) {
+      void onUploadFiles(imageFiles);
+    }
+  }}
+/>
+```
+
+- [ ] **Step 2: Run the tests to verify they pass**
+
+Run: `npx vitest run tests/unit/chat-composer.test.tsx`
+Expected: All tests PASS, including the 4 new clipboard paste tests.
+
+---
+
+### Task 3: Commit
+
+- [ ] **Step 1: Commit the changes**
+
+```bash
+git add components/chat-composer.tsx tests/unit/chat-composer.test.tsx
+git commit -m "feat(chat): support pasting images from clipboard into chat input"
+```

--- a/docs/superpowers/specs/2026-06-04-clipboard-image-paste-design.md
+++ b/docs/superpowers/specs/2026-06-04-clipboard-image-paste-design.md
@@ -1,0 +1,52 @@
+# Clipboard Image Paste in Chat Input
+
+## Summary
+
+Allow users to paste images from their clipboard (Cmd/Ctrl+V) directly into the chat text input bar. Pasted images are treated identically to files uploaded via the attachment button — uploaded to the server, shown in the pending attachment preview bar, and sent with the message on submit.
+
+## Scope
+
+- Direct clipboard image files only (screenshots, copied image files)
+- No HTML clipboard parsing (no extracting base64 images from rich content)
+
+## Architecture
+
+### Approach
+
+Add an `onPaste` handler to the `<textarea>` in `ChatComposer`. No new components, props, state, or backend changes.
+
+### Data Flow
+
+```
+User presses Cmd/Ctrl+V with image in clipboard
+  → Browser fires paste event on <textarea>
+  → onPaste handler checks e.clipboardData.files
+  → Filters for image/* MIME types
+  → Calls existing onUploadFiles(imageFiles) prop
+  → Existing flow: uploadFiles() → POST /api/attachments → pendingAttachments state
+  → Image appears in preview bar, sent with message on submit
+```
+
+### Component Change
+
+**File:** `components/chat-composer.tsx`
+
+Add `onPaste` handler to the `<textarea>` that:
+1. Reads `e.clipboardData.files` from the `ClipboardEvent`
+2. Filters to only image files (`file.type.startsWith("image/")`)
+3. If no image files found, returns early (default text paste behavior)
+4. Calls `onUploadFiles(filteredFiles)` — the existing prop already wired to `ChatView.uploadFiles()`
+
+## Edge Cases
+
+| Case | Behavior |
+|------|----------|
+| Text paste | No image files → default browser text insertion |
+| Multiple images | All passed to `uploadFiles()`, same as multi-file picker |
+| Mixed text + image | Only image files extracted; text paste proceeds normally |
+| Non-image files | Filtered out by `image/*` MIME type check |
+| Upload failure | Handled by existing error handling in `uploadFiles()` |
+
+## Files Modified
+
+- `components/chat-composer.tsx` — add `onPaste` handler to textarea

--- a/tests/unit/chat-composer.test.tsx
+++ b/tests/unit/chat-composer.test.tsx
@@ -6,6 +6,55 @@ import { act, fireEvent, render, screen } from "@testing-library/react";
 import { ChatComposer } from "@/components/chat-composer";
 import type { SpeechPhase } from "@/lib/speech/types";
 
+function createMockClipboardData(initialFiles: File[] = []) {
+  const storedFiles: File[] = [...initialFiles];
+  const dataMap = new Map<string, string>();
+
+  return {
+    get files(): FileList {
+      const list = Object.create(FileList.prototype) as Record<number, File>;
+      for (let i = 0; i < storedFiles.length; i++) list[i] = storedFiles[i];
+      Object.defineProperty(list, "length", { value: storedFiles.length });
+      return list as unknown as FileList;
+    },
+    items: {
+      add(file: File | string) {
+        if (file instanceof File) storedFiles.push(file);
+      },
+      length: storedFiles.length,
+      clear() {},
+      remove() {}
+    },
+    setData(format: string, value: string) {
+      dataMap.set(format, value);
+    },
+    getData(format: string) {
+      return dataMap.get(format) ?? "";
+    }
+  } as unknown as DataTransfer;
+}
+
+class MockClipboardEvent extends Event {
+  clipboardData: DataTransfer;
+
+  constructor(type: string, init?: EventInit & { clipboardData?: DataTransfer }) {
+    super(type, init);
+    this.clipboardData = init?.clipboardData ?? createMockClipboardData();
+  }
+}
+
+Object.defineProperty(window, "ClipboardEvent", {
+  configurable: true,
+  writable: true,
+  value: MockClipboardEvent
+});
+
+Object.defineProperty(window, "DataTransfer", {
+  configurable: true,
+  writable: true,
+  value: createMockClipboardData
+});
+
 const originalMatchMedia = window.matchMedia;
 
 function installMatchMedia(matches: boolean) {
@@ -95,5 +144,90 @@ describe("ChatComposer collapsible toolbar", () => {
     });
 
     expect(await screen.findByLabelText("Attach files")).toBeInTheDocument();
+  });
+});
+
+describe("ChatComposer clipboard image paste", () => {
+  it("calls onUploadFiles when an image is pasted from clipboard", () => {
+    const onUploadFiles = vi.fn();
+    renderComposer({ onUploadFiles });
+
+    const textarea = screen.getByRole("textbox");
+
+    const imageFile = new File(["fake-image-bytes"], "screenshot.png", { type: "image/png" });
+    const clipboardEvent = new ClipboardEvent("paste", {
+      bubbles: true,
+      cancelable: true,
+      clipboardData: new DataTransfer()
+    });
+    clipboardEvent.clipboardData!.items.add(imageFile);
+
+    fireEvent(textarea, clipboardEvent);
+
+    expect(onUploadFiles).toHaveBeenCalledOnce();
+    expect(onUploadFiles).toHaveBeenCalledWith([imageFile]);
+    expect(clipboardEvent.defaultPrevented).toBe(true);
+  });
+
+  it("does not call onUploadFiles when text is pasted", () => {
+    const onUploadFiles = vi.fn();
+    renderComposer({ onUploadFiles });
+
+    const textarea = screen.getByRole("textbox");
+
+    const clipboardEvent = new ClipboardEvent("paste", {
+      bubbles: true,
+      cancelable: true,
+      clipboardData: new DataTransfer()
+    });
+    clipboardEvent.clipboardData!.setData("text/plain", "hello");
+
+    fireEvent(textarea, clipboardEvent);
+
+    expect(onUploadFiles).not.toHaveBeenCalled();
+    expect(clipboardEvent.defaultPrevented).toBe(false);
+  });
+
+  it("does not call onUploadFiles when non-image files are pasted", () => {
+    const onUploadFiles = vi.fn();
+    renderComposer({ onUploadFiles });
+
+    const textarea = screen.getByRole("textbox");
+
+    const textFile = new File(["hello"], "notes.txt", { type: "text/plain" });
+    const clipboardEvent = new ClipboardEvent("paste", {
+      bubbles: true,
+      cancelable: true,
+      clipboardData: new DataTransfer()
+    });
+    clipboardEvent.clipboardData!.items.add(textFile);
+
+    fireEvent(textarea, clipboardEvent);
+
+    expect(onUploadFiles).not.toHaveBeenCalled();
+    expect(clipboardEvent.defaultPrevented).toBe(false);
+  });
+
+  it("filters to only image files when mixed content is pasted", () => {
+    const onUploadFiles = vi.fn();
+    renderComposer({ onUploadFiles });
+
+    const textarea = screen.getByRole("textbox");
+
+    const imageFile = new File(["fake-image-bytes"], "photo.jpg", { type: "image/jpeg" });
+    const textFile = new File(["hello"], "notes.txt", { type: "text/plain" });
+    const clipboardEvent = new ClipboardEvent("paste", {
+      bubbles: true,
+      cancelable: true,
+      clipboardData: new DataTransfer()
+    });
+    clipboardEvent.clipboardData!.items.add(imageFile);
+    clipboardEvent.clipboardData!.items.add(textFile);
+
+    fireEvent(textarea, clipboardEvent);
+
+    expect(onUploadFiles).toHaveBeenCalledOnce();
+    expect(onUploadFiles).toHaveBeenCalledWith([imageFile]);
+    expect(clipboardEvent.defaultPrevented).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- Add `onPaste` handler to the chat input textarea that detects image files from clipboard data and uploads them using the existing attachment pipeline
- When a user pastes an image (Cmd/Ctrl+V), it is treated identically to uploading via the attachment button — uploaded to server, shown in pending attachment preview, and sent with the message
- Filters to only `image/*` MIME types, calls `event.preventDefault()` to suppress base64 garbage in the textarea, and passes image files to the existing `onUploadFiles` prop
- 4 new unit tests covering: image paste triggers upload, text paste is ignored, non-image paste is ignored, mixed content filters to images only, plus `preventDefault` assertions

## Files Changed

- `components/chat-composer.tsx` — added `onPaste` handler to `<Textarea>` (5 lines of logic)
- `tests/unit/chat-composer.test.tsx` — 4 test cases + jsdom ClipboardEvent/DataTransfer polyfills
- Design spec and implementation plan docs

## Test Results

All 1156 tests pass across 113 test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)