### PR TITLE
fix(chat): restore desktop conversation input bar width on home page

### DIFF
--- a/components/home-view.tsx
+++ b/components/home-view.tsx
@@ -343,7 +343,7 @@ export function HomeView({
         </div>
       </div>
 
-      <div className="absolute inset-x-0 bottom-0 z-50 px-3 pb-composer-safe pointer-events-none sm:relative sm:inset-auto sm:z-auto sm:px-0 sm:pb-0 sm:pointer-events-auto">
+      <div className="absolute inset-x-0 bottom-0 z-50 px-3 pb-composer-safe pointer-events-none sm:relative sm:inset-auto sm:z-auto sm:w-full sm:px-0 sm:pb-0 sm:pointer-events-auto">
         <div className="mx-auto w-full max-w-[980px] px-3 sm:px-4 md:px-8 pt-1 pointer-events-auto">
           <ChatComposer
             input={input}


### PR DESCRIPTION
## Summary

- Restores proper width of the conversation input bar on the desktop home page (when not inside a conversation)
- Adds `sm:w-full` to the ChatComposer wrapper div so it stretches to full width on desktop inside a `flex flex-col items-center` parent
- The mobile cursor alignment fix (PR #198) restructured the layout so the wrapper uses `absolute inset-x-0` on mobile (forcing full width) but `sm:relative` on desktop — without an explicit width, `items-center` caused it to shrink to content width

## Test plan

- [x] Verified desktop (1280px): composer is ~968px wide, constrained by `max-w-[980px]`, centered
- [x] Verified mobile (375px): composer is ~351px wide, spanning nearly full viewport — unchanged
- [x] All tests pass, coverage at 89.8%

🤖 Generated with [Claude Code](https://claude.com/claude-code)