### PR TITLE
fix: strip provider namespace from model name before capability matching

### DIFF
--- a/lib/model-capabilities.ts
+++ b/lib/model-capabilities.ts
@@ -30,11 +30,12 @@ export function resolveCapabilities(
   userOverrides?: Partial<ResolvedCapabilities>
 ): ResolvedCapabilities {
   const normalized = model.trim().toLowerCase();
+  const bareModel = normalized.includes("/") ? normalized.slice(normalized.lastIndexOf("/") + 1) : normalized;
 
   const resolved = { ...DEFAULT_CAPABILITIES };
 
   const entry: Partial<ModelCapabilityOverride> | undefined =
-    MODEL_REGISTRY.find((e) => normalized.startsWith(e.prefix));
+    MODEL_REGISTRY.find((e) => bareModel.startsWith(e.prefix));
 
   if (entry) {
     const { prefix: _, ...overrides } = entry;

--- a/tests/unit/model-capabilities.test.ts
+++ b/tests/unit/model-capabilities.test.ts
@@ -94,6 +94,23 @@ describe("supportsVisibleReasoning", () => {
     expect(supportsVisibleReasoning("claude-haiku-4-5", "chat_completions")).toBe(true);
     expect(supportsImageInput("claude-haiku-4-5", "chat_completions")).toBe(true);
   });
+
+  it("strips openrouter-style provider namespace before prefix matching", () => {
+    expect(supportsVisibleReasoning("xiaomi/mimo-v2.5", "chat_completions")).toBe(true);
+    expect(supportsImageInput("xiaomi/mimo-v2.5", "chat_completions")).toBe(true);
+    expect(supportsVisibleReasoning("anthropic/claude-sonnet-4-6", "chat_completions")).toBe(true);
+    expect(supportsImageInput("anthropic/claude-sonnet-4-6", "chat_completions")).toBe(true);
+    expect(supportsImageInput("openai/gpt-4o", "chat_completions")).toBe(true);
+    expect(supportsImageInput("google/gemini-3-flash", "chat_completions")).toBe(true);
+    expect(supportsVisibleReasoning("deepseek/deepseek-r1", "chat_completions")).toBe(true);
+  });
+
+  it("strips provider namespace while preserving apiMode constraints", () => {
+    expect(resolveCapabilities("openai/gpt-oss-mini", "responses").vision).toBe(true);
+    expect(resolveCapabilities("openai/gpt-oss-mini", "chat_completions").vision).toBe(false);
+    expect(resolveCapabilities("deepseek/deepseek-r1", "chat_completions").reasoning).toBe(true);
+    expect(resolveCapabilities("deepseek/deepseek-r1", "responses").reasoning).toBe(false);
+  });
 });
 
 describe("supportsImageInput", () => {


### PR DESCRIPTION
## Summary

- **Root cause:** OpenRouter models use namespaced names (e.g. `xiaomi/mimo-v2.5`), but the model capability registry in `model-capabilities.ts` used `startsWith(prefix)` on the raw model name. Since `"xiaomi/mimo-v2.5"` does not start with `"mimo-"`, no registry entry matched, causing `vision`, `reasoning`, and other capabilities to silently default to `false`.
- **Fix:** Strip the provider namespace (everything before the last `/`) from the model name before prefix matching. This makes `xiaomi/mimo-v2.5` resolve identically to `mimo-v2.5`, while being a no-op for bare model names.
- **Impact:** Fixes vision not working for OpenRouter with models like `xiaomi/mimo-v2.5`. Also fixes reasoning detection, thinking replay, and extra body settings for all namespaced OpenRouter models (e.g. `anthropic/claude-sonnet-4`, `openai/gpt-4o`, `deepseek/deepseek-r1`).
- **Tests:** Added 2 test cases covering namespace stripping and apiMode constraint preservation across namespaced model names. All 1164 tests pass.