### PR TITLE
fix: resolve multi-PDF upload truncation and binary preview gibberish

### DIFF
--- a/app/api/attachments/route.ts
+++ b/app/api/attachments/route.ts
@@ -9,102 +9,9 @@ const formSchema = z.object({
   conversationId: z.string().min(1)
 });
 
-function getMultipartBoundary(contentType: string | null) {
-  if (!contentType) {
-    return null;
-  }
-
-  const match = contentType.match(/boundary=(?:"([^"]+)"|([^;]+))/i);
-  return match?.[1] ?? match?.[2] ?? null;
-}
-
-function parseContentDisposition(value: string) {
-  const nameMatch = value.match(/name="([^"]+)"/i);
-  const filenameMatch = value.match(/filename="([^"]*)"/i);
-
-  return {
-    name: nameMatch?.[1] ?? null,
-    filename: filenameMatch?.[1] ?? null
-  };
-}
-
-async function parseMultipartRequest(request: Request) {
-  const boundary = getMultipartBoundary(request.headers.get("content-type"));
-
-  if (!boundary) {
-    throw new Error("Invalid attachment upload");
-  }
-
-  const body = Buffer.from(await request.arrayBuffer());
-  const boundaryBuffer = Buffer.from(`--${boundary}`);
-  const headerSeparator = Buffer.from("\r\n\r\n");
-  const fields = new Map<string, string>();
-  const files: Array<{ filename: string; mimeType: string; bytes: Buffer }> = [];
-
-  let cursor = body.indexOf(boundaryBuffer);
-
-  while (cursor !== -1) {
-    let partStart = cursor + boundaryBuffer.length;
-
-    if (body[partStart] === 45 && body[partStart + 1] === 45) {
-      break;
-    }
-
-    if (body[partStart] === 13 && body[partStart + 1] === 10) {
-      partStart += 2;
-    }
-
-    const nextBoundary = body.indexOf(boundaryBuffer, partStart);
-
-    if (nextBoundary === -1) {
-      break;
-    }
-
-    let partEnd = nextBoundary;
-
-    if (body[partEnd - 2] === 13 && body[partEnd - 1] === 10) {
-      partEnd -= 2;
-    }
-
-    const part = body.slice(partStart, partEnd);
-    const headerEnd = part.indexOf(headerSeparator);
-
-    if (headerEnd === -1) {
-      cursor = nextBoundary;
-      continue;
-    }
-
-    const headersText = part.slice(0, headerEnd).toString("utf8");
-    const content = part.slice(headerEnd + headerSeparator.length);
-    const headers = new Map(
-      headersText
-        .split("\r\n")
-        .map((line) => {
-          const separatorIndex = line.indexOf(":");
-          const key = separatorIndex >= 0 ? line.slice(0, separatorIndex).trim().toLowerCase() : "";
-          const value = separatorIndex >= 0 ? line.slice(separatorIndex + 1).trim() : "";
-          return [key, value] as const;
-        })
-        .filter(([key]) => key)
-    );
-    const disposition = parseContentDisposition(headers.get("content-disposition") ?? "");
-
-    if (disposition.name) {
-      if (disposition.filename !== null) {
-        files.push({
-          filename: disposition.filename,
-          mimeType: headers.get("content-type") ?? "application/octet-stream",
-          bytes: content
-        });
-      } else {
-        fields.set(disposition.name, content.toString("utf8"));
-      }
-    }
-
-    cursor = nextBoundary;
-  }
-
-  return { fields, files };
+async function parseFormData(request: Request): Promise<FormData> {
+  const body = await request.arrayBuffer();
+  return new Response(body, { headers: request.headers }).formData();
 }
 
 export async function POST(request: Request) {
@@ -114,15 +21,16 @@ export async function POST(request: Request) {
     return badRequest("Authentication required", 401);
   }
 
-  let multipart: Awaited<ReturnType<typeof parseMultipartRequest>>;
+  let formData: FormData;
 
   try {
-    multipart = await parseMultipartRequest(request);
+    formData = await parseFormData(request);
   } catch {
     return badRequest("Invalid attachment upload");
   }
+
   const parsed = formSchema.safeParse({
-    conversationId: multipart.fields.get("conversationId")
+    conversationId: formData.get("conversationId")
   });
 
   if (!parsed.success) {
@@ -133,11 +41,21 @@ export async function POST(request: Request) {
     return badRequest("Conversation not found", 404);
   }
 
-  const files = multipart.files;
+  const fileEntries = formData
+    .getAll("files")
+    .filter((entry): entry is File => entry instanceof File);
 
-  if (!files.length) {
+  if (!fileEntries.length) {
     return badRequest("No files were uploaded");
   }
+
+  const files = await Promise.all(
+    fileEntries.map(async (file) => ({
+      filename: file.name,
+      mimeType: file.type || "application/octet-stream",
+      bytes: Buffer.from(await file.arrayBuffer())
+    }))
+  );
 
   try {
     const attachments = await createAttachments(

--- a/lib/attachments.ts
+++ b/lib/attachments.ts
@@ -1,8 +1,6 @@
 import { createHash } from "node:crypto";
 import fs from "node:fs";
-import { createRequire } from "node:module";
 import path from "node:path";
-import { pathToFileURL } from "node:url";
 
 import { MAX_ATTACHMENT_BYTES } from "@/lib/constants";
 import { getDb } from "@/lib/db";
@@ -162,11 +160,6 @@ async function extractText(bytes: Buffer, filename: string) {
   if (extension === ".pdf") {
     try {
       const pdfjsLib = await import("pdfjs-dist/legacy/build/pdf.mjs");
-      if (!pdfjsLib.GlobalWorkerOptions.workerSrc) {
-        const require = createRequire(import.meta.url);
-        const workerPath = require.resolve("pdfjs-dist/legacy/build/pdf.worker.mjs");
-        pdfjsLib.GlobalWorkerOptions.workerSrc = pathToFileURL(workerPath).href;
-      }
       const doc = await pdfjsLib.getDocument({ data: new Uint8Array(bytes), useSystemFonts: true }).promise;
       const pages: string[] = [];
       for (let i = 1; i <= doc.numPages; i++) {
@@ -618,6 +611,14 @@ export function readAttachmentText(
 ) {
   if (!isInlineTextPreviewableAttachment(attachment)) {
     throw new AttachmentTextPreviewUnsupportedError();
+  }
+
+  if (attachment.extractedText.length > 0) {
+    return attachment.extractedText;
+  }
+
+  if (!attachment.mimeType.startsWith("text/")) {
+    return attachment.extractedText;
   }
 
   try {

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,9 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   output: "standalone",
   serverExternalPackages: ["onnxruntime-node", "@huggingface/transformers", "pdfjs-dist"],
+  experimental: {
+    middlewareClientMaxBodySize: "100mb"
+  }
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary

Three related fixes for the attachment upload and preview pipeline:

### Root Cause
Next.js 15 has a **default 10MB body size limit** (`middlewareClientMaxBodySize`) for routes passing through middleware. When 3 PDFs exceeded this limit, the request body was silently truncated — cutting off the last file. The custom hand-written multipart parser then couldn't find the closing boundary and silently dropped the truncated file.

### Changes

- **`next.config.ts`** — Raise `experimental.middlewareClientMaxBodySize` from 10MB to 100MB to accommodate multiple large file uploads
- **`app/api/attachments/route.ts`** — Replace the 108-line custom multipart parser (which silently dropped files on truncated bodies and was vulnerable to binary data interference) with the standard Web API `Response(body).formData()` parser
- **`lib/attachments.ts`** — Fix `readAttachmentText` returning raw PDF binary as UTF-8 gibberish in the preview modal; now returns pre-extracted text for non-`text/*` MIME types. Also removed the `require.resolve("pdfjs-dist/...")` worker config that conflicted with `serverExternalPackages` ESM resolution.

### Testing
- All 1167 existing tests pass
- Global test coverage: 89.79%

🤖 Generated with [Claude Code](https://claude.com/claude-code)