### PR TITLE
fix: keep mobile Enter as newline, improve composer hint spacing

### DIFF
--- a/components/chat-composer.tsx
+++ b/components/chat-composer.tsx
@@ -25,6 +25,7 @@ import type { SpeechPhase } from "@/lib/speech/types";
 import { cn } from "@/lib/utils";
 import { useAutoResize } from "@/lib/use-auto-resize";
 import { useCollapsibleToolbar } from "@/lib/use-collapsible-toolbar";
+import { useIsMobile } from "@/lib/use-is-mobile";
 import type {
   MessageAttachment,
   ProviderProfileSummary
@@ -276,6 +277,7 @@ export function ChatComposer({
   const { showToolbar, inputFocusProps, onControlOpenChange } = useCollapsibleToolbar({
     enabled: collapsibleToolbarOnMobile
   });
+  const isMobile = useIsMobile();
   const [toolbarOverflow, setToolbarOverflow] = useState<"hidden" | "visible">("visible");
 
   useEffect(() => {
@@ -442,7 +444,7 @@ export function ChatComposer({
             )}
             style={{ height: `${textareaHeight}px`, transition: "height 150ms ease" }}
             onKeyDown={(event) => {
-              if (event.key === "Enter" && !event.shiftKey) {
+              if (event.key === "Enter" && !event.shiftKey && !isMobile) {
                 event.preventDefault();
                 if (isSpeechActive) {
                   return;
@@ -558,7 +560,7 @@ export function ChatComposer({
         <motion.div
           initial={{ opacity: 0, y: 4 }}
           animate={{ opacity: 1, y: 0 }}
-          className="px-4 pb-2 text-[11px] font-medium text-white/45"
+          className="px-4 pt-2 pb-2 text-[11px] font-medium text-white/45"
         >
           Agent working - send still queues
         </motion.div>

--- a/lib/use-collapsible-toolbar.ts
+++ b/lib/use-collapsible-toolbar.ts
@@ -2,40 +2,19 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 
-const MOBILE_QUERY = "(max-width: 767px)";
+import { useIsMobile } from "@/lib/use-is-mobile";
+
 const COLLAPSE_DELAY_MS = 150;
-
-function matchMediaSupported(): boolean {
-  return typeof window !== "undefined" && typeof window.matchMedia === "function";
-}
-
-function getInitialMobile(): boolean {
-  if (!matchMediaSupported()) {
-    return false;
-  }
-  return window.matchMedia(MOBILE_QUERY).matches;
-}
 
 type UseCollapsibleToolbarOptions = { enabled: boolean };
 
 export function useCollapsibleToolbar({ enabled }: UseCollapsibleToolbarOptions) {
-  const [isMobile, setIsMobile] = useState<boolean>(getInitialMobile);
+  const isMobile = useIsMobile();
   const [expanded, setExpanded] = useState(false);
 
   const isInputFocusedRef = useRef(false);
   const openControlCountRef = useRef(0);
   const collapseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  useEffect(() => {
-    if (!matchMediaSupported()) {
-      return;
-    }
-    const mql = window.matchMedia(MOBILE_QUERY);
-    const update = () => setIsMobile(mql.matches);
-    update();
-    mql.addEventListener("change", update);
-    return () => mql.removeEventListener("change", update);
-  }, []);
 
   const cancelScheduledCollapse = useCallback(() => {
     if (collapseTimerRef.current !== null) {

--- a/lib/use-is-mobile.ts
+++ b/lib/use-is-mobile.ts
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const MOBILE_QUERY = "(max-width: 767px)";
+
+function matchMediaSupported(): boolean {
+  return typeof window !== "undefined" && typeof window.matchMedia === "function";
+}
+
+function getInitialMobile(): boolean {
+  if (!matchMediaSupported()) {
+    return false;
+  }
+  return window.matchMedia(MOBILE_QUERY).matches;
+}
+
+export function useIsMobile(): boolean {
+  const [isMobile, setIsMobile] = useState<boolean>(getInitialMobile);
+
+  useEffect(() => {
+    if (!matchMediaSupported()) {
+      return;
+    }
+    const mql = window.matchMedia(MOBILE_QUERY);
+    const update = () => setIsMobile(mql.matches);
+    update();
+    mql.addEventListener("change", update);
+    return () => mql.removeEventListener("change", update);
+  }, []);
+
+  return isMobile;
+}

--- a/tests/unit/chat-composer.test.tsx
+++ b/tests/unit/chat-composer.test.tsx
@@ -231,3 +231,27 @@ describe("ChatComposer clipboard image paste", () => {
     expect(clipboardEvent.defaultPrevented).toBe(true);
   });
 });
+
+describe("ChatComposer Enter key submission", () => {
+  it("submits on Enter on a desktop viewport", () => {
+    installMatchMedia(false);
+    const onSubmit = vi.fn();
+    renderComposer({ input: "hello", onSubmit });
+
+    const textarea = screen.getByRole("textbox");
+    fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+
+    expect(onSubmit).toHaveBeenCalledOnce();
+  });
+
+  it("does not submit on Enter on a mobile viewport (line break instead)", () => {
+    installMatchMedia(true);
+    const onSubmit = vi.fn();
+    renderComposer({ input: "hello", onSubmit });
+
+    const textarea = screen.getByRole("textbox");
+    fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Two focused composer UX fixes, plus a small dedup refactor.

- **Mobile Enter no longer submits.** On viewports ≤767px, pressing `Enter` now inserts a line break instead of sending; the dedicated send button is the only way to submit. Desktop behavior is unchanged (`Enter` = submit, `Shift+Enter` = newline). This matches how mobile on-screen keyboards conventionally behave and prevents accidental sends.
- **"Agent working - send still queues" hint spacing.** The hint sat flush against the input bar (it had bottom padding but no top spacing). Added `pt-2` so it has a little breathing room above it.
- **Deduplicated mobile detection.** Extracted a shared `useIsMobile()` hook (`lib/use-is-mobile.ts`, using the codebase's existing `(max-width: 767px)` definition) and pointed `lib/use-collapsible-toolbar.ts` at it, removing the duplicated `matchMedia` logic. The media-query-based definition keeps the existing `maxTouchPoints`-keyed touch-device tests passing.

## Test plan
- `npm test` — 117 files / 1197 tests passing; global coverage 90% stmts / 85.36% branch.
- `npm run typecheck` — clean.
- `npm run lint` — 0 errors.
- New unit tests: desktop `Enter` submits, mobile `Enter` does not.
- Browser-validated: mobile (375×812) `Enter` inserts a newline without submitting; desktop (1280×800) `Enter` submits, `Shift+Enter` newline; hint shows 8px top padding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)