### PR TITLE
fix: parse text-embedded tool calls instead of rendering them as chat bubbles

### DIFF
--- a/lib/provider.ts
+++ b/lib/provider.ts
@@ -16,6 +16,7 @@ import {
   getResponseOutputItemMessageText,
   mergeRecoveredStreamText
 } from "./provider-response-parsing";
+import { createTextToolCallInterceptor } from "./tool-call-text-parsing";
 
 export {
   withDateContextSystemMessage,
@@ -678,6 +679,7 @@ export async function* streamProviderResponse(input: {
     { signal }
   ) as unknown as AsyncIterable<any>;
 
+  const answerInterceptor = createTextToolCallInterceptor();
   const toolCallChunks = new Map<string, { name: string; arguments: string }>();
 
   try {
@@ -700,8 +702,10 @@ export async function* streamProviderResponse(input: {
       }
 
       if (delta) {
-        answer += delta;
-        yield { type: "answer_delta", text: delta };
+        const emitted = answerInterceptor.feed(delta);
+        if (emitted) {
+          yield { type: "answer_delta", text: emitted };
+        }
       }
 
       if (rawDelta.tool_calls) {
@@ -737,6 +741,12 @@ export async function* streamProviderResponse(input: {
     }
   }
 
+  const answerTail = answerInterceptor.flush();
+  if (answerTail) {
+    yield { type: "answer_delta", text: answerTail };
+  }
+  answer = answerInterceptor.answer;
+
   yield {
     type: "usage",
     inputTokens: usage.inputTokens,
@@ -746,6 +756,9 @@ export async function* streamProviderResponse(input: {
   const toolCalls: ProviderToolCall[] = [];
   for (const [, call] of toolCallChunks) {
     toolCalls.push({ id: `call_${toolCalls.length}`, name: call.name, arguments: call.arguments });
+  }
+  for (const textToolCall of answerInterceptor.toolCalls) {
+    toolCalls.push(textToolCall);
   }
 
   return { answer, thinking, toolCalls: toolCalls.length ? toolCalls : undefined, usage };

--- a/lib/tool-call-text-parsing.ts
+++ b/lib/tool-call-text-parsing.ts
@@ -1,0 +1,228 @@
+import type { ProviderToolCall } from "@/lib/types";
+
+const OPEN_TAG = "<tool_call";
+const CLOSE_TAG = "</tool_call>";
+
+function longestSuffixPrefix(text: string, marker: string): number {
+  const max = Math.min(text.length, marker.length - 1);
+  for (let len = max; len > 0; len -= 1) {
+    if (marker.startsWith(text.slice(text.length - len))) {
+      return len;
+    }
+  }
+  return 0;
+}
+
+function coerceToolCallValue(raw: string): unknown {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return "";
+  }
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return trimmed;
+  }
+}
+
+export function parseToolCallTextBlock(body: string): { name: string; arguments: string } | null {
+  if (!body || !body.trim()) {
+    return null;
+  }
+
+  const funcMatch = body.match(/<function\s*=\s*([^>]*?)\s*>/i);
+  if (funcMatch) {
+    const name = funcMatch[1].trim();
+    if (!name) {
+      return null;
+    }
+
+    const paramRegex = /<parameter\s*=\s*([^>]*?)\s*>/gi;
+    const markers: Array<{ name: string; start: number; valueStart: number }> = [];
+    let match: RegExpExecArray | null;
+    while ((match = paramRegex.exec(body)) !== null) {
+      const paramName = match[1].trim();
+      if (!paramName) {
+        continue;
+      }
+      markers.push({
+        name: paramName,
+        start: match.index,
+        valueStart: match.index + match[0].length
+      });
+    }
+
+    const args: Record<string, unknown> = {};
+    for (let index = 0; index < markers.length; index += 1) {
+      const marker = markers[index];
+      const valueEnd = index + 1 < markers.length ? markers[index + 1].start : body.length;
+      args[marker.name] = coerceToolCallValue(body.slice(marker.valueStart, valueEnd));
+    }
+
+    return { name, arguments: JSON.stringify(args) };
+  }
+
+  const jsonStart = body.search(/[{[]/);
+  if (jsonStart !== -1) {
+    try {
+      const parsed = JSON.parse(body.slice(jsonStart).trim());
+      if (
+        parsed &&
+        typeof parsed === "object" &&
+        typeof parsed.name === "string" &&
+        parsed.name.trim()
+      ) {
+        const rawArguments = parsed.arguments ?? parsed.parameters ?? {};
+        return {
+          name: String(parsed.name).trim(),
+          arguments: JSON.stringify(rawArguments)
+        };
+      }
+    } catch {
+      // not a JSON tool call; fall through
+    }
+  }
+
+  return null;
+}
+
+export interface TextToolCallInterceptor {
+  feed(text: string): string;
+  flush(): string;
+  readonly answer: string;
+  readonly toolCalls: ProviderToolCall[];
+}
+
+export function createTextToolCallInterceptor(): TextToolCallInterceptor {
+  let answer = "";
+  let pending = "";
+  let toolBody = "";
+  let restoreBuffer = "";
+  let inside = false;
+  let needOpenClose = false;
+  const toolCalls: ProviderToolCall[] = [];
+
+  function commitToolBody() {
+    const parsed = parseToolCallTextBlock(toolBody);
+    if (parsed) {
+      toolCalls.push({
+        id: `text_call_${toolCalls.length}`,
+        name: parsed.name,
+        arguments: parsed.arguments
+      });
+    } else {
+      restoreBuffer += `<tool_call>${toolBody}</tool_call>`;
+    }
+    toolBody = "";
+  }
+
+  function feed(text: string): string {
+    pending += text;
+    let emitted = "";
+
+    let guard = 0;
+    while (pending && guard++ < 10000) {
+      if (needOpenClose) {
+        const gt = pending.indexOf(">");
+        if (gt === -1) {
+          break;
+        }
+        pending = pending.slice(gt + 1);
+        needOpenClose = false;
+        inside = true;
+        toolBody = "";
+        continue;
+      }
+
+      if (inside) {
+        const closeIdx = pending.indexOf(CLOSE_TAG);
+        if (closeIdx === -1) {
+          const hold = longestSuffixPrefix(pending, CLOSE_TAG);
+          const safeLen = pending.length - hold;
+          if (safeLen > 0) {
+            toolBody += pending.slice(0, safeLen);
+          }
+          pending = hold ? pending.slice(safeLen) : "";
+          break;
+        }
+        toolBody += pending.slice(0, closeIdx);
+        pending = pending.slice(closeIdx + CLOSE_TAG.length);
+        inside = false;
+        commitToolBody();
+        if (restoreBuffer) {
+          emitted += restoreBuffer;
+          restoreBuffer = "";
+        }
+        continue;
+      }
+
+      const openIdx = pending.indexOf(OPEN_TAG);
+      if (openIdx === -1) {
+        const hold = longestSuffixPrefix(pending, OPEN_TAG);
+        const safeLen = pending.length - hold;
+        if (safeLen > 0) {
+          emitted += pending.slice(0, safeLen);
+          pending = hold ? pending.slice(safeLen) : "";
+        }
+        break;
+      }
+
+      if (openIdx > 0) {
+        emitted += pending.slice(0, openIdx);
+      }
+      pending = pending.slice(openIdx + OPEN_TAG.length);
+      const gt = pending.indexOf(">");
+      if (gt === -1) {
+        needOpenClose = true;
+        break;
+      }
+      pending = pending.slice(gt + 1);
+      inside = true;
+      toolBody = "";
+    }
+
+    answer += emitted;
+    return emitted;
+  }
+
+  function flush(): string {
+    let emitted = "";
+
+    if (inside) {
+      const parsed = parseToolCallTextBlock(toolBody);
+      if (parsed) {
+        toolCalls.push({
+          id: `text_call_${toolCalls.length}`,
+          name: parsed.name,
+          arguments: parsed.arguments
+        });
+      } else {
+        emitted += `<tool_call>${toolBody}`;
+      }
+      toolBody = "";
+      pending = "";
+      inside = false;
+    } else if (needOpenClose) {
+      emitted += `<tool_call${pending}`;
+      pending = "";
+      needOpenClose = false;
+    } else if (pending) {
+      emitted += pending;
+      pending = "";
+    }
+
+    answer += emitted;
+    return emitted;
+  }
+
+  return {
+    feed,
+    flush,
+    get answer() {
+      return answer;
+    },
+    get toolCalls() {
+      return toolCalls;
+    }
+  };
+}

--- a/tests/unit/provider.test.ts
+++ b/tests/unit/provider.test.ts
@@ -579,6 +579,59 @@ describe("provider integration", () => {
     });
   });
 
+  it("extracts a tool call emitted as raw <tool_call> text in chat_completions mode", async () => {
+    chatCreate.mockResolvedValue(
+      createAsyncStream([
+        { choices: [{ delta: { content: "Let me take a screenshot.\n" } }] },
+        { choices: [{ delta: { content: "<tool_call> <function=execute_" } }] },
+        { choices: [{ delta: { content: "shell_command> <parameter=command>agent-browser screenshot /tmp/ia-quote2.png --full </tool_call>" } }] }
+      ])
+    );
+
+    const { streamProviderResponse } = await import("@/lib/provider");
+    const stream = streamProviderResponse({
+      settings: createSettings({
+        apiMode: "chat_completions",
+        apiBaseUrl: "https://api.xiaomimimo.com/v1",
+        model: "mimo-v2.5",
+        reasoningEffort: "medium",
+        reasoningSummaryEnabled: true
+      }),
+      promptMessages: [{ role: "user", content: "Screenshot the page" }]
+    });
+
+    const events: ChatStreamEvent[] = [];
+    let result: Awaited<ReturnType<typeof stream.next>>["value"] | undefined;
+
+    while (true) {
+      const next = await stream.next();
+      if (next.done) {
+        result = next.value;
+        break;
+      }
+      events.push(next.value);
+    }
+
+    expect(result?.answer).toBe("Let me take a screenshot.\n");
+    expect(result?.toolCalls).toEqual([
+      {
+        id: "text_call_0",
+        name: "execute_shell_command",
+        arguments: JSON.stringify({
+          command: "agent-browser screenshot /tmp/ia-quote2.png --full"
+        })
+      }
+    ]);
+
+    const answerText = events
+      .filter((event) => event.type === "answer_delta")
+      .map((event) => (event as { text: string }).text)
+      .join("");
+    expect(answerText).toBe("Let me take a screenshot.\n");
+    expect(answerText).not.toContain("<tool_call>");
+    expect(answerText).not.toContain("execute_shell_command");
+  });
+
   it("updates streamed chat tool call names and arguments across chunks", async () => {
     chatCreate.mockResolvedValue(
       createAsyncStream([

--- a/tests/unit/tool-call-text-parsing.test.ts
+++ b/tests/unit/tool-call-text-parsing.test.ts
@@ -1,0 +1,182 @@
+import {
+  createTextToolCallInterceptor,
+  parseToolCallTextBlock
+} from "@/lib/tool-call-text-parsing";
+
+describe("parseToolCallTextBlock", () => {
+  it("parses the <function=>/<parameter=> tool call format", () => {
+    const body =
+      " <function=execute_shell_command> <parameter=command>agent-browser screenshot /tmp/ia-quote2.png --full ";
+
+    expect(parseToolCallTextBlock(body)).toEqual({
+      name: "execute_shell_command",
+      arguments: JSON.stringify({
+        command: "agent-browser screenshot /tmp/ia-quote2.png --full"
+      })
+    });
+  });
+
+  it("parses multiple parameters in order", () => {
+    const body =
+      "<function=create_memory> <parameter=name>favorite-color <parameter=content>blue and green ";
+
+    expect(parseToolCallTextBlock(body)).toEqual({
+      name: "create_memory",
+      arguments: JSON.stringify({
+        name: "favorite-color",
+        content: "blue and green"
+      })
+    });
+  });
+
+  it("coerces JSON-looking values and leaves plain text as strings", () => {
+    const body =
+      "<function=update> <parameter=count>3 <parameter=enabled>true <parameter=label>hello world";
+
+    expect(parseToolCallTextBlock(body)).toEqual({
+      name: "update",
+      arguments: JSON.stringify({ count: 3, enabled: true, label: "hello world" })
+    });
+  });
+
+  it("returns empty arguments object when there are no parameters", () => {
+    expect(parseToolCallTextBlock("<function=ping> ")).toEqual({
+      name: "ping",
+      arguments: "{}"
+    });
+  });
+
+  it("parses the JSON (hermes) tool call form", () => {
+    expect(
+      parseToolCallTextBlock('{"name":"search","arguments":{"query":"MCP"}}')
+    ).toEqual({
+      name: "search",
+      arguments: JSON.stringify({ query: "MCP" })
+    });
+  });
+
+  it("returns null for plain prose without a function or json body", () => {
+    expect(parseToolCallTextBlock("nothing to see here")).toBeNull();
+    expect(parseToolCallTextBlock("")).toBeNull();
+    expect(parseToolCallTextBlock("   ")).toBeNull();
+  });
+});
+
+describe("createTextToolCallInterceptor", () => {
+  it("extracts a tool call streamed in a single chunk and strips it from the answer", () => {
+    const interceptor = createTextToolCallInterceptor();
+    const emitted = interceptor.feed(
+      "<tool_call> <function=execute_shell_command> <parameter=command>echo hi </tool_call>"
+    );
+
+    expect(emitted).toBe("");
+    interceptor.flush();
+
+    expect(interceptor.answer).toBe("");
+    expect(interceptor.toolCalls).toEqual([
+      {
+        id: "text_call_0",
+        name: "execute_shell_command",
+        arguments: JSON.stringify({ command: "echo hi" })
+      }
+    ]);
+  });
+
+  it("extracts a tool call streamed token-by-token across many chunks", () => {
+    const interceptor = createTextToolCallInterceptor();
+    const tokens = [
+      "Let me run this.\n",
+      "<tool_",
+      "call>",
+      " <function=execute_shell_",
+      "command> <parameter=comm",
+      "and>agent-browser screenshot /tmp/x.png --full ",
+      "</tool_",
+      "call>"
+    ];
+
+    let emitted = "";
+    for (const token of tokens) {
+      emitted += interceptor.feed(token);
+    }
+    emitted += interceptor.flush();
+
+    expect(emitted).toBe("Let me run this.\n");
+    expect(interceptor.answer).toBe("Let me run this.\n");
+    expect(interceptor.toolCalls).toEqual([
+      {
+        id: "text_call_0",
+        name: "execute_shell_command",
+        arguments: JSON.stringify({
+          command: "agent-browser screenshot /tmp/x.png --full"
+        })
+      }
+    ]);
+  });
+
+  it("keeps leading and trailing answer text around an extracted tool call", () => {
+    const interceptor = createTextToolCallInterceptor();
+    interceptor.feed("before <tool_call> <function=noop> </tool_call> after");
+    interceptor.flush();
+
+    expect(interceptor.answer).toBe("before  after");
+    expect(interceptor.toolCalls).toHaveLength(1);
+  });
+
+  it("passes ordinary answer text through unchanged", () => {
+    const interceptor = createTextToolCallInterceptor();
+
+    expect(interceptor.feed("Hello ")).toBe("Hello ");
+    expect(interceptor.feed("world")).toBe("world");
+    interceptor.flush();
+
+    expect(interceptor.answer).toBe("Hello world");
+    expect(interceptor.toolCalls).toEqual([]);
+  });
+
+  it("holds back a partial open tag until it resolves", () => {
+    const interceptor = createTextToolCallInterceptor();
+
+    expect(interceptor.feed("see <")).toBe("see ");
+    expect(interceptor.feed("tool_")).toBe("");
+    expect(interceptor.feed("call>")).toBe("");
+    interceptor.feed(" <function=go> </tool_call>");
+    interceptor.flush();
+
+    expect(interceptor.toolCalls).toHaveLength(1);
+    expect(interceptor.toolCalls[0].name).toBe("go");
+  });
+
+  it("restores an unparseable tool call block as answer text", () => {
+    const interceptor = createTextToolCallInterceptor();
+    interceptor.feed("<tool_call>not a real tool call</tool_call>");
+    interceptor.flush();
+
+    expect(interceptor.answer).toBe("<tool_call>not a real tool call</tool_call>");
+    expect(interceptor.toolCalls).toEqual([]);
+  });
+
+  it("flushes a trailing bare open bracket as answer text", () => {
+    const interceptor = createTextToolCallInterceptor();
+    interceptor.feed("if a <");
+    const tail = interceptor.flush();
+
+    expect(tail).toBe("<");
+    expect(interceptor.answer).toBe("if a <");
+  });
+
+  it("parses an unterminated tool call block on flush", () => {
+    const interceptor = createTextToolCallInterceptor();
+    interceptor.feed("<tool_call> <function=execute_shell_command> <parameter=command>pwd");
+    interceptor.flush();
+
+    expect(interceptor.toolCalls).toEqual([
+      {
+        id: "text_call_0",
+        name: "execute_shell_command",
+        arguments: JSON.stringify({ command: "pwd" })
+      }
+    ]);
+    expect(interceptor.answer).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary

Some OpenAI-compatible models (notably **mimo-v2.5**) intermittently emit a tool call as raw text instead of via the structured `delta.tool_calls` field:

\`\`\`
<tool_call> <function=execute_shell_command> <parameter=command>agent-browser screenshot /tmp/x.png --full </tool_call>
\`\`\`

That text streamed into the assistant answer, was persisted as a message segment, and rendered verbatim as a chat bubble — the tool never executed, and the conversation stalled.

- **Add a streaming interceptor** (`lib/tool-call-text-parsing.ts`) that sits in front of `answer_delta` emission in the chat-completions path. It detects `<tool_call>…</tool_call>` blocks token-by-token across arbitrary chunk boundaries (holding back partial tag prefixes so nothing flashes), buffers them without emitting as answer text, and parses `<function=NAME>` + `<parameter=NAME>VALUE` pairs into structured `ProviderToolCall`s. A JSON/Hermes form fallback is also supported.
- **Merge parsed calls** with any structured `delta.tool_calls` so both code paths coexist; parsed calls get `text_call_*` ids to avoid collisions.
- **Suppress during streaming, not just at the end** — the content-persistence layer treats streamed segments as authoritative, so the raw text must never be emitted as an `answer_delta` in the first place.
- Unparseable blocks (e.g. prose containing a stray `<tool_call>`) are restored as ordinary answer text rather than silently dropped; unknown tool names degrade to a benign "Unknown tool" result fed back to the model.

## Test plan

- New unit tests for the interceptor/parser (`tests/unit/tool-call-text-parsing.test.ts`, 14 tests): single-chunk and token-by-token extraction, leading/trailing text, partial-tag holdback, unparseable restore, and unterminated-block flush.
- New integration test in `tests/unit/provider.test.ts` reproducing the exact bug (mimo-v2.5 streaming a `<tool_call>` as content) — asserts the answer contains no raw `<tool_call>`/tool-name text and the call is parsed as `execute_shell_command`.
- Full suite: 1212/1212 passing; global coverage above the 85% threshold (Stmts 89.96, Branch 85.31, Funcs 92.54, Lines 89.96).

🤖 Generated with [Claude Code](https://claude.com/claude-code)