### PR TITLE
feat(readme-demo): add web search, visuals, code, mermaid, and memories fixtures

### DIFF
--- a/lib/readme-demo.ts
+++ b/lib/readme-demo.ts
@@ -243,12 +243,63 @@ Lead with product value, keep claims accurate, and make install steps feel easy.
   primaryConversationTitle: "April launch control room",
   secondaryConversationTitle: "Provider fallback matrix",
   automationConversationTitle: "Nightly launch scan · Apr 14",
+  webSearchConversationTitle: "Self-hosting an LLM stack",
+  visualsConversationTitle: "Designing a deploy pipeline",
+  visualsCodeConversationTitle: "Rate limiter helper",
+  visualsMermaidConversationTitle: "Request lifecycle diagram",
+  memoriesConversationTitle: "Onboarding preferences · saved",
   automation: {
     name: "Nightly launch watch",
     prompt:
       "Review launch docs, provider health, and screenshot coverage. Summarize only the blockers and missing proof.",
     timeOfDay: "23:15"
-  }
+  },
+  extraAutomations: [
+    {
+      name: "Morning brief · blockers",
+      prompt:
+        "Scan open issues, PRs, and deploy logs. Send a short morning brief naming the top 3 blockers and their owners.",
+      scheduleKind: "calendar" as const,
+      calendarFrequency: "daily" as const,
+      timeOfDay: "08:30",
+      enabled: true
+    },
+    {
+      name: "Weekly README drift check",
+      prompt:
+        "Compare the live README against the current product. Flag anything stale, missing, or contradicted by recent releases.",
+      scheduleKind: "calendar" as const,
+      calendarFrequency: "weekly" as const,
+      timeOfDay: "09:00",
+      daysOfWeek: [1],
+      enabled: true
+    },
+    {
+      name: "Provider health poll",
+      prompt:
+        "Ping every configured provider and report latency + error rate. Alert if any provider exceeds 5% errors.",
+      scheduleKind: "interval" as const,
+      intervalMinutes: 30,
+      enabled: true
+    },
+    {
+      name: "Screenshot coverage audit",
+      prompt:
+        "List every product feature and check whether a current screenshot exists. Report missing or outdated captures.",
+      scheduleKind: "calendar" as const,
+      calendarFrequency: "daily" as const,
+      timeOfDay: "18:45",
+      enabled: false
+    },
+    {
+      name: "Memory tidy-up",
+      prompt:
+        "Review stored memories, dedupe overlapping entries, and archive anything older than 60 days that is no longer referenced.",
+      scheduleKind: "interval" as const,
+      intervalMinutes: 360,
+      enabled: false
+    }
+  ]
 };
 
 export type ReadmeDemoSeedResult = {
@@ -260,6 +311,11 @@ export type ReadmeDemoSeedResult = {
   automationConversationId: string;
   automationId: string;
   automationRunId: string;
+  webSearchConversationId: string;
+  visualsConversationId: string;
+  visualsCodeConversationId: string;
+  visualsMermaidConversationId: string;
+  memoriesConversationId: string;
 };
 
 async function deleteDemoUsers() {
@@ -578,6 +634,304 @@ export async function seedReadmeDemoData(): Promise<ReadmeDemoSeedResult> {
     finishedAt: "2026-04-14T09:16:42.000Z"
   });
 
+  for (const fixture of README_DEMO_FIXTURES.extraAutomations) {
+    const extra = createAutomation(
+      {
+        name: fixture.name,
+        prompt: fixture.prompt,
+        providerProfileId: README_DEMO_FIXTURES.providerProfiles[1].id,
+        personaId: personas[0]?.id ?? null,
+        scheduleKind: fixture.scheduleKind,
+        intervalMinutes: fixture.scheduleKind === "interval" ? fixture.intervalMinutes : null,
+        calendarFrequency: fixture.scheduleKind === "calendar" ? fixture.calendarFrequency : null,
+        timeOfDay: fixture.scheduleKind === "calendar" ? fixture.timeOfDay : null,
+        daysOfWeek: fixture.daysOfWeek ?? [],
+        enabled: fixture.enabled
+      },
+      envSuperAdmin.id
+    );
+
+    const shouldSeedRun = fixture.name === "Morning brief · blockers" || fixture.name === "Weekly README drift check" || fixture.name === "Provider health poll";
+
+    if (!shouldSeedRun) {
+      continue;
+    }
+
+    const runScheduledFor =
+      fixture.scheduleKind === "interval" ? "2026-04-15T08:00:00.000Z" : "2026-04-15T08:30:00.000Z";
+    const run = createAutomationRun({
+      automationId: extra.id,
+      scheduledFor: runScheduledFor,
+      triggerSource: "schedule"
+    });
+
+    updateAutomationRunStatus(run.id, {
+      status: "running",
+      startedAt: "2026-04-15T08:30:12.000Z"
+    });
+
+    const runConversation = createConversation(
+      `${fixture.name} · Apr 15`,
+      launchOpsFolder.id,
+      {
+        providerProfileId: README_DEMO_FIXTURES.providerProfiles[1].id,
+        origin: "automation",
+        automationId: extra.id,
+        automationRunId: run.id
+      },
+      envSuperAdmin.id
+    );
+    attachConversationToRun(run.id, runConversation.id);
+
+    createMessage({
+      conversationId: runConversation.id,
+      role: "user",
+      content: fixture.prompt
+    });
+    createMessage({
+      conversationId: runConversation.id,
+      role: "assistant",
+      content: "Run complete. No new blockers, all providers healthy, and coverage is current."
+    });
+
+    updateAutomationRunStatus(run.id, {
+      status: "completed",
+      startedAt: "2026-04-15T08:30:12.000Z",
+      finishedAt: "2026-04-15T08:31:48.000Z"
+    });
+  }
+
+  const webSearchConversation = createConversation(
+    README_DEMO_FIXTURES.webSearchConversationTitle,
+    playbooksFolder.id,
+    {
+      providerProfileId: README_DEMO_FIXTURES.providerProfiles[1].id
+    },
+    envSuperAdmin.id
+  );
+
+  createMessage({
+    conversationId: webSearchConversation.id,
+    role: "user",
+    content:
+      "What's the most reliable way to self-host an LLM stack in 2026? I want model routing, memory, and a usable admin UI."
+  });
+
+  const webSearchReply = createMessage({
+    conversationId: webSearchConversation.id,
+    role: "assistant",
+    content: ""
+  });
+
+  createMessageTextSegment({
+    messageId: webSearchReply.id,
+    sortOrder: 0,
+    content:
+      "Self-hosting an LLM stack in 2026 comes down to three layers: a model gateway that routes across providers, a memory layer that keeps context cheap, and an admin UI that non-engineers can actually drive. Let me pull the current landscape."
+  });
+
+  const webSearchAction = createMessageAction({
+    messageId: webSearchReply.id,
+    kind: "mcp_tool_call",
+    status: "completed",
+    toolName: "web_search",
+    label: "Web search",
+    detail: "Searched the web for self-hosted LLM stack, model gateways, and open-source memory layers.",
+    arguments: {
+      query: "self-host LLM stack 2026 model routing memory admin UI",
+      limit: 5
+    },
+    resultSummary: "5 sources reviewed",
+    sortOrder: 1
+  });
+  markCompletedAction(webSearchAction.id);
+
+  const agentBrowserAction = createMessageAction({
+    messageId: webSearchReply.id,
+    kind: "skill_load",
+    status: "completed",
+    skillId: "builtin-agent-browser",
+    label: "Agent Browser",
+    detail: "Browsed 3 pages to verify the sources: the OpenRouter routing docs, the Mem0 README, and the Open WebUI features page.",
+    resultSummary: "3 pages read",
+    sortOrder: 2
+  });
+  markCompletedAction(agentBrowserAction.id);
+
+  createMessageTextSegment({
+    messageId: webSearchReply.id,
+    sortOrder: 3,
+    content: `The mature pattern in 2026 is a **gateway-first architecture**: keep a local fallback model (Ollama, vLLM) and route to hosted models (OpenAI, Anthropic via OpenRouter) for heavy reasoning [1][3]. Memory is usually a small vector store plus a structured key-value layer so long-running agents stay cheap [2]. For the admin layer, self-hostable web UIs like Eidon and Open WebUI now cover multi-user auth, provider profiles, and per-team policies out of the box [4][5].
+
+**Key takeaways:**
+- Route by task, not just model size — keep coding and vision on specialist models.
+- Store memories per-user, not globally, to avoid context bleed across teammates.
+- Pick an admin UI that lets you swap providers without redeploying.
+
+**Sources:**
+1. OpenRouter — Model routing and fallback docs — https://openrouter.ai/docs
+2. Mem0 — Open-source memory layer for LLMs — https://github.com/mem0ai/mem0
+3. Ollama — Run large language models locally — https://ollama.com
+4. Open WebUI — Self-hosted LLM interface — https://github.com/open-webui/open-webui
+5. LiteLLM — Proxy for 100+ LLM providers — https://github.com/BerriAI/litellm`
+  });
+
+  const visualsConversation = createConversation(
+    README_DEMO_FIXTURES.visualsConversationTitle,
+    launchOpsFolder.id,
+    {
+      providerProfileId: README_DEMO_FIXTURES.providerProfiles[1].id
+    },
+    envSuperAdmin.id
+  );
+
+  createMessage({
+    conversationId: visualsConversation.id,
+    role: "user",
+    content:
+      "Sketch out a deploy pipeline for Eidon with a pre-deploy check, a build step, and a gated rollout."
+  });
+
+  const visualsReply = createMessage({
+    conversationId: visualsConversation.id,
+    role: "assistant",
+    content: ""
+  });
+
+  createMessageTextSegment({
+    messageId: visualsReply.id,
+    sortOrder: 0,
+    content:
+      "Here's the pipeline as code — a single guard function gates every deploy on the readiness checks:\n\n```ts\nexport async function deployEidon(opts: DeployOptions) {\n  const checks = await runPreDeployChecks(opts);\n  if (!checks.ok) {\n    throw new Error(\"Blocked: \" + checks.reason);\n  }\n  const artifact = await buildArtifact(opts.version);\n  await stageRollout(artifact, { strategy: \"canary\", windows: [5, 25, 100] });\n  return { version: opts.version, status: \"live\" };\n}\n```\n\nAnd the flow as a diagram — note the gate that blocks rollout until checks pass:\n\n```mermaid\nflowchart TD\n    A[Push to main] --> B{Pre-deploy checks}\n    B -- pass --> C[Build artifact]\n    B -- fail --> Z[Block deploy]\n    C --> D[Stage canary 5%]\n    D --> E{Metrics healthy?}\n    E -- yes --> F[Ramp to 100%]\n    E -- no --> G[Auto-rollback]\n    F --> H[Live]\n```"
+  });
+
+  const visualsCodeConversation = createConversation(
+    README_DEMO_FIXTURES.visualsCodeConversationTitle,
+    playbooksFolder.id,
+    {
+      providerProfileId: README_DEMO_FIXTURES.providerProfiles[1].id
+    },
+    envSuperAdmin.id
+  );
+
+  createMessage({
+    conversationId: visualsCodeConversation.id,
+    role: "user",
+    content:
+      "Write me a small TypeScript token-bucket rate limiter I can drop into the API gateway."
+  });
+
+  const visualsCodeReply = createMessage({
+    conversationId: visualsCodeConversation.id,
+    role: "assistant",
+    content: ""
+  });
+
+  createMessageTextSegment({
+    messageId: visualsCodeReply.id,
+    sortOrder: 0,
+    content:
+      "Here's a compact token-bucket limiter — one bucket per key, refilled lazily, and thread-safe enough for a single Node process:\n\n```ts\ntype Bucket = { tokens: number; updated: number };\n\nexport class RateLimiter {\n  private buckets = new Map<string, Bucket>();\n  constructor(private capacity: number, private refillPerSec: number) {}\n\n  private refill(b: Bucket, now: number) {\n    const elapsed = (now - b.updated) / 1000;\n    b.tokens = Math.min(this.capacity, b.tokens + elapsed * this.refillPerSec);\n    b.updated = now;\n  }\n\n  tryConsume(key: string, now = Date.now()): boolean {\n    let b = this.buckets.get(key);\n    if (!b) {\n      b = { tokens: this.capacity, updated: now };\n      this.buckets.set(key, b);\n    }\n    this.refill(b, now);\n    if (b.tokens < 1) return false;\n    b.tokens -= 1;\n    return true;\n  }\n}\n```\n\nCall `tryConsume(userId)` on every request; returning `false` means you should respond `429 Too Many Requests`."
+  });
+
+  const visualsMermaidConversation = createConversation(
+    README_DEMO_FIXTURES.visualsMermaidConversationTitle,
+    playbooksFolder.id,
+    {
+      providerProfileId: README_DEMO_FIXTURES.providerProfiles[1].id
+    },
+    envSuperAdmin.id
+  );
+
+  createMessage({
+    conversationId: visualsMermaidConversation.id,
+    role: "user",
+    content:
+      "Map out how a chat request flows through Eidon from the browser to the model response."
+  });
+
+  const visualsMermaidReply = createMessage({
+    conversationId: visualsMermaidConversation.id,
+    role: "assistant",
+    content: ""
+  });
+
+  createMessageTextSegment({
+    messageId: visualsMermaidReply.id,
+    sortOrder: 0,
+    content:
+      "Here's the full request lifecycle — from the browser, through the API and provider router, down to the model, and back as a streamed response:\n\n```mermaid\nsequenceDiagram\n    participant U as Browser\n    participant A as Eidon API\n    participant R as Provider Router\n    participant M as LLM Provider\n    U->>A: POST /api/chat (messages, history)\n    A->>A: Load skills + memories\n    A->>R: Resolve provider profile\n    R->>M: Forward request (stream)\n    M-->>R: Stream tokens\n    R-->>A: Relay tokens\n    A-->>U: SSE token stream\n    A->>A: Persist message + segments\n    M-->>A: Stream complete\n    A-->>U: Final message + actions\n```"
+  });
+
+  const memoriesConversation = createConversation(
+    README_DEMO_FIXTURES.memoriesConversationTitle,
+    playbooksFolder.id,
+    {
+      providerProfileId: README_DEMO_FIXTURES.providerProfiles[1].id
+    },
+    envSuperAdmin.id
+  );
+
+  createMessage({
+    conversationId: memoriesConversation.id,
+    role: "user",
+    content:
+      "Let's get you set up. I self-host everything, I route through OpenRouter by default, and my team works Toronto mornings / Abuja afternoons. Keep responses short with explicit owners."
+  });
+
+  const memoriesReply = createMessage({
+    conversationId: memoriesConversation.id,
+    role: "assistant",
+    content: ""
+  });
+
+  createMessageTextSegment({
+    messageId: memoriesReply.id,
+    sortOrder: 0,
+    content:
+      "Got it — I've captured your setup so I can default to it going forward."
+  });
+
+  const memoryActionOne = createMessageAction({
+    messageId: memoriesReply.id,
+    kind: "create_memory",
+    status: "completed",
+    label: "Saved memory",
+    detail: "Stored the preference for self-hosted deployments and OpenRouter (anthropic/claude-sonnet-4) as the default provider.",
+    resultSummary: "Preference · self-hosted + OpenRouter default",
+    sortOrder: 1
+  });
+  markCompletedAction(memoryActionOne.id);
+
+  const memoryActionTwo = createMessageAction({
+    messageId: memoriesReply.id,
+    kind: "create_memory",
+    status: "completed",
+    label: "Saved memory",
+    detail: "Stored the working-hours overlap as Toronto mornings and Abuja afternoons, so scheduling suggestions respect the team's overlap window.",
+    resultSummary: "Location · Toronto mornings / Abuja afternoons",
+    sortOrder: 2
+  });
+  markCompletedAction(memoryActionTwo.id);
+
+  const memoryActionThree = createMessageAction({
+    messageId: memoriesReply.id,
+    kind: "create_memory",
+    status: "completed",
+    label: "Saved memory",
+    detail: "Stored the communication preference: short summaries with explicit owners, dates, and rollback notes.",
+    resultSummary: "Preference · concise summaries with owners",
+    sortOrder: 3
+  });
+  markCompletedAction(memoryActionThree.id);
+
+  createMessageTextSegment({
+    messageId: memoriesReply.id,
+    sortOrder: 4,
+    content:
+      "Three memories saved. I'll lean on these for routing, scheduling, and how I format answers."
+  });
+
   return {
     envSuperAdminId: envSuperAdmin.id,
     localAdminId: localAdmin.id,
@@ -586,6 +940,11 @@ export async function seedReadmeDemoData(): Promise<ReadmeDemoSeedResult> {
     secondaryConversationId: secondaryConversation.id,
     automationConversationId: automationConversation.id,
     automationId: automation.id,
-    automationRunId: completedRun.id
+    automationRunId: completedRun.id,
+    webSearchConversationId: webSearchConversation.id,
+    visualsConversationId: visualsConversation.id,
+    visualsCodeConversationId: visualsCodeConversation.id,
+    visualsMermaidConversationId: visualsMermaidConversation.id,
+    memoriesConversationId: memoriesConversation.id
   };
 }

--- a/tests/unit/readme-demo.test.ts
+++ b/tests/unit/readme-demo.test.ts
@@ -48,9 +48,15 @@ describe("readme demo seed", () => {
       README_DEMO_FIXTURES.memories.length
     );
 
-    expect(listAutomations(seeded.envSuperAdminId).map((automation) => automation.name)).toEqual(
-      [README_DEMO_FIXTURES.automation.name]
+    const expectedAutomationNames = [
+      README_DEMO_FIXTURES.automation.name,
+      ...README_DEMO_FIXTURES.extraAutomations.map((automation) => automation.name)
+    ];
+    const automations = listAutomations(seeded.envSuperAdminId);
+    expect(automations.map((automation) => automation.name)).toEqual(
+      expect.arrayContaining(expectedAutomationNames)
     );
+    expect(automations).toHaveLength(expectedAutomationNames.length);
 
     const automationRuns = listAutomationRuns(seeded.automationId, seeded.envSuperAdminId);
     expect(automationRuns).toEqual([
@@ -59,6 +65,39 @@ describe("readme demo seed", () => {
         status: "completed"
       })
     ]);
+
+    expect(
+      listConversations(seeded.envSuperAdminId).map((conversation) => conversation.title)
+    ).toEqual(
+      expect.arrayContaining([
+        README_DEMO_FIXTURES.webSearchConversationTitle,
+        README_DEMO_FIXTURES.visualsConversationTitle,
+        README_DEMO_FIXTURES.visualsCodeConversationTitle,
+        README_DEMO_FIXTURES.visualsMermaidConversationTitle,
+        README_DEMO_FIXTURES.memoriesConversationTitle
+      ])
+    );
+
+    const webSearchSnapshot = getConversationSnapshot(
+      seeded.webSearchConversationId,
+      seeded.envSuperAdminId
+    );
+    expect(webSearchSnapshot?.messages.some((message) => message.role === "assistant")).toBe(true);
+    expect(webSearchSnapshot?.messages.some((message) => message.actions?.some((action) => action.kind === "mcp_tool_call"))).toBe(true);
+
+    const visualsCodeSnapshot = getConversationSnapshot(
+      seeded.visualsCodeConversationId,
+      seeded.envSuperAdminId
+    );
+    expect(visualsCodeSnapshot?.conversation.title).toBe(
+      README_DEMO_FIXTURES.visualsCodeConversationTitle
+    );
+
+    const memoriesSnapshot = getConversationSnapshot(
+      seeded.memoriesConversationId,
+      seeded.envSuperAdminId
+    );
+    expect(memoriesSnapshot?.messages.some((message) => message.actions?.some((action) => action.kind === "create_memory"))).toBe(true);
 
     const snapshot = getConversationSnapshot(
       seeded.primaryConversationId,


### PR DESCRIPTION
## Summary

The README demo seeder (`lib/readme-demo.ts`, run via `npm run seed:readme-demo`) powers the screenshot-ready demo workspace used in the README. It had a local, uncommitted change that enriched the dataset with more product surface area, but the accompanying unit test was not updated, leaving `npm test` red on this change.

This PR finishes that work and gets it onto a branch.

### Changes
- **`lib/readme-demo.ts`** — adds new fixture fields and seeding logic:
  - 5 new conversations: **web search** (with `mcp_tool_call` + `skill_load` actions), **deploy-pipeline visuals** (markdown + mermaid), **code** (token-bucket rate limiter), **mermaid sequence diagram**, and **memories** (multiple `create_memory` actions).
  - 5 **extra automations** (morning brief, weekly README drift check, provider health poll, screenshot coverage audit, memory tidy-up), three of which get seeded runs + conversations.
  - Extends `ReadmeDemoSeedResult` with the new conversation IDs and returns them.
- **`tests/unit/readme-demo.test.ts`** — updates the automations assertion (now expects all 6, order-independent) and adds assertions that the new conversations exist and contain the expected assistant actions (`mcp_tool_call`, `create_memory`).

### Verification
- `npm run typecheck` — passes.
- `npx vitest run tests/unit/readme-demo.test.ts` — 2/2 pass.
- `npm test` — **1239/1239 tests pass** across 119 files.
- Global coverage **90.27%** lines / 85.64% branches (above the 85% threshold).