### PR TITLE
Fix iOS PWA keyboard resize handling

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -89,6 +89,11 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+html.ios-pwa,
+html.ios-pwa body {
+  overflow: hidden;
+}
+
 html.ios-pwa .app-shell {
   height: var(--ios-app-height, 100dvh);
 }

--- a/tests/unit/chat-view.test.ts
+++ b/tests/unit/chat-view.test.ts
@@ -652,6 +652,12 @@ describe("chat view", () => {
     });
   });
 
+  it("does not mark the floating composer as an iOS keyboard lift target", () => {
+    renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
+
+    expect(screen.getByRole("textbox").closest(".ios-keyboard-lift")).toBeNull();
+  });
+
   it("does not autofocus the composer on touch devices", () => {
     Object.defineProperty(navigator, "maxTouchPoints", {
       configurable: true,

--- a/tests/unit/home-view.test.tsx
+++ b/tests/unit/home-view.test.tsx
@@ -291,6 +291,21 @@ describe("home view", () => {
     ).not.toHaveFocus();
   });
 
+  it("does not mark the floating composer as an iOS keyboard lift target", () => {
+    render(
+      React.createElement(HomeView, {
+        providerProfiles: [createProviderProfile()],
+        defaultProviderProfileId: "profile_default",
+        settings: {
+          sttEngine: "browser",
+          sttLanguage: "en"
+        }
+      })
+    );
+
+    expect(screen.getByRole("textbox").closest(".ios-keyboard-lift")).toBeNull();
+  });
+
   it("dictates into the home composer draft without auto-sending", async () => {
     render(
       React.createElement(HomeView, {

--- a/tests/unit/pwa-shell-css.test.ts
+++ b/tests/unit/pwa-shell-css.test.ts
@@ -1,0 +1,29 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const globalsCss = fs.readFileSync(path.join(process.cwd(), "app/globals.css"), "utf8");
+
+function findRule(selector: string) {
+  return globalsCss
+    .match(/[^{}]+{[^{}]+}/g)
+    ?.find((rule) =>
+      rule
+        .slice(0, rule.indexOf("{"))
+        .split(",")
+        .map((item) => item.trim())
+        .includes(selector)
+    );
+}
+
+function expectRuleDeclaration(selector: string, declaration: string) {
+  expect(findRule(selector)).toEqual(expect.stringContaining(declaration));
+}
+
+describe("PWA shell CSS", () => {
+  it("locks the iOS PWA document while preserving scroll containment rules", () => {
+    expectRuleDeclaration("html.ios-pwa", "overflow: hidden;");
+    expectRuleDeclaration("html.ios-pwa body", "overflow: hidden;");
+    expectRuleDeclaration("body", "overscroll-behavior: none;");
+    expectRuleDeclaration(".conversation-scroller", "scrollbar-gutter: auto !important;");
+  });
+});

--- a/tests/unit/use-ios-pwa.test.ts
+++ b/tests/unit/use-ios-pwa.test.ts
@@ -314,6 +314,80 @@ describe("useIosPwa", () => {
     });
   });
 
+  it("keeps --ios-app-height tied to window.innerHeight when the visual viewport shrinks", () => {
+    setNavigatorStandalone(true);
+    setInnerHeight(812);
+
+    let capturedListener: EventListener | null = null;
+    const fakeVisualViewport = {
+      height: 812,
+      offsetTop: 0,
+      addEventListener: vi.fn((_type: string, listener: EventListener) => {
+        capturedListener = listener;
+      }),
+      removeEventListener: vi.fn(),
+    };
+
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: fakeVisualViewport,
+    });
+
+    renderHook(() => useIosPwa());
+    expect(appHeightVar()).toBe("812px");
+    expect(capturedListener).not.toBeNull();
+
+    fakeVisualViewport.height = 500;
+    act(() => {
+      capturedListener!(new Event("resize"));
+      flushRaf();
+    });
+
+    expect(appHeightVar()).toBe("812px");
+
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: undefined,
+    });
+  });
+
+  it("updates --ios-app-height from window.innerHeight when innerHeight shrinks with the keyboard", () => {
+    setNavigatorStandalone(true);
+    setInnerHeight(812);
+
+    let capturedListener: EventListener | null = null;
+    const fakeVisualViewport = {
+      height: 812,
+      offsetTop: 0,
+      addEventListener: vi.fn((_type: string, listener: EventListener) => {
+        capturedListener = listener;
+      }),
+      removeEventListener: vi.fn(),
+    };
+
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: fakeVisualViewport,
+    });
+
+    renderHook(() => useIosPwa());
+    expect(appHeightVar()).toBe("812px");
+
+    setInnerHeight(500);
+    fakeVisualViewport.height = 500;
+    act(() => {
+      capturedListener!(new Event("resize"));
+      flushRaf();
+    });
+
+    expect(appHeightVar()).toBe("500px");
+
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: undefined,
+    });
+  });
+
   it("does not add listeners and does not set class when not standalone", () => {
     setNavigatorStandalone(false);
     setInnerHeight(812);


### PR DESCRIPTION
## Summary
- Lock the iOS PWA document to prevent page scroll bleed during keyboard interaction.
- Keep floating composers out of the iOS keyboard lift target so they stay anchored correctly.
- Add regression coverage for iOS PWA shell CSS, composer placement, and app-height updates when the keyboard changes viewport size.

## Testing
- Added unit tests for the iOS PWA shell CSS and composer behavior.
- Added hook tests covering `--ios-app-height` updates under visual viewport and keyboard resize scenarios.