### PR TITLE
Remove assistant chat bubble chrome from message content

### DIFF
--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -199,12 +199,9 @@ function CollapsibleActionRow({
   );
 }
 
-const ASSISTANT_MAX_WIDTH = "max-w-full md:max-w-[95%]";
-const ASSISTANT_BUBBLE_BASE =
-  "w-fit max-w-full rounded-2xl border border-white/8 bg-white/[0.03] px-2.5 py-2 md:px-4 md:py-3 text-[var(--text)]";
-const ASSISTANT_BUBBLE = `${ASSISTANT_BUBBLE_BASE} shadow-[0_2px_10px_rgba(0,0,0,0.22)]`;
-const ASSISTANT_BUBBLE_STREAMING =
-  "w-fit max-w-full rounded-2xl border border-white/8 bg-white/[0.03] px-2.5 pt-2 pb-8 md:px-4 md:pt-3 md:pb-9 text-[var(--text)]";
+const ASSISTANT_CONTENT =
+  "w-full max-w-full text-[var(--text)]";
+const ASSISTANT_ERROR_MAX_WIDTH = "max-w-full md:max-w-[95%]";
 const ASSISTANT_LOADING_SHELL =
   "mt-[6px] inline-flex items-center overflow-hidden rounded-lg border border-white/5 bg-white/[0.015] px-2 py-1";
 
@@ -678,13 +675,8 @@ function MessageBubbleImpl({
 
   return (
     <Message from="assistant" data-message-id={message.id}>
-      <div className="flex flex-col gap-1 md:flex-row md:gap-3.5">
-        <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-white/[0.06] border border-white/6 text-[10px] font-bold text-white/60 overflow-hidden md:mt-1">
-          {/* eslint-disable-next-line @next/next/no-img-element -- Static assistant avatar is deliberately tiny and unoptimized. */}
-          <img src="/agent-icon.png" alt="" width={28} height={28} className="h-full w-full object-cover" />
-        </div>
-
-        <div className="min-w-0 flex-1 text-[14.5px] text-[var(--text)] md:pt-0.5">
+      <div className="flex w-full flex-col gap-1">
+        <div className="min-w-0 w-full text-[14.5px] text-[var(--text)]">
           <div className="flex flex-col items-start gap-3">
             {showThinkingShell ? (
               <div
@@ -748,7 +740,7 @@ function MessageBubbleImpl({
               )
             ) : message.status === "error" ? (
               <div className="group flex w-full min-w-0 flex-col items-start">
-                <MessageContent className={`w-full ${ASSISTANT_MAX_WIDTH} flex-col gap-3`}>
+                <MessageContent className={`w-full ${ASSISTANT_ERROR_MAX_WIDTH} flex-col gap-3`}>
                   {assistantBlocks
                     .filter(
                       (item): item is Extract<MessageTimelineItem, { timelineKind: "action" }> =>
@@ -781,7 +773,7 @@ function MessageBubbleImpl({
               </div>
             ) : assistantBlocks.length || content || assistantImageAttachments.length || assistantFileAttachments.length ? (
               <div className="group flex w-full min-w-0 flex-col items-start">
-                <MessageContent className={`w-full ${ASSISTANT_MAX_WIDTH}`}>
+                <MessageContent className="w-full">
                   <div ref={contentRef} className="flex flex-col gap-3">
                     {assistantBlocks.map((item) => {
                       if (item.timelineKind === "action") {
@@ -796,8 +788,8 @@ function MessageBubbleImpl({
                       return (
                         <div
                           key={item.id}
-                          className={isAssistantStreaming ? ASSISTANT_BUBBLE_STREAMING : ASSISTANT_BUBBLE}
-                          data-testid="assistant-message-bubble"
+                          className={ASSISTANT_CONTENT}
+                          data-testid="assistant-message-content"
                         >
                           <div className="markdown-body">
                             <AssistantMarkdown content={renderedContent} />
@@ -815,8 +807,8 @@ function MessageBubbleImpl({
                     })}
                     {showStandaloneAssistantImageBubble ? (
                       <div
-                        className={ASSISTANT_BUBBLE}
-                        data-testid="assistant-message-bubble"
+                        className={ASSISTANT_CONTENT}
+                        data-testid="assistant-message-content"
                       >
                         <AssistantInlineImageAttachments
                           attachments={assistantImageAttachments}

--- a/tests/e2e/features.spec.ts
+++ b/tests/e2e/features.spec.ts
@@ -1417,17 +1417,17 @@ test.describe("Feature: Chat attachments", () => {
       await expect(sendMessageButton).toBeEnabled({ timeout: 10000 });
       await sendMessageButton.click();
 
-      const assistantBubble = page.locator('[data-testid="assistant-message-bubble"]').last();
-      await expect(assistantBubble.getByText("Here is the generated image.")).toBeVisible({
+      const assistantContent = page.locator('[data-testid="assistant-message-content"]').last();
+      await expect(assistantContent.getByText("Here is the generated image.")).toBeVisible({
         timeout: 10000
       });
       await expect(
-        assistantBubble.getByText("The real attachment preview should render below.")
+        assistantContent.getByText("The real attachment preview should render below.")
       ).toBeVisible({ timeout: 10000 });
-      await expect(assistantBubble.getByText(/data:image\/png;base64/i)).toHaveCount(0);
+      await expect(assistantContent.getByText(/data:image\/png;base64/i)).toHaveCount(0);
       await expect(page.getByText(/data:image\/png;base64/i)).toHaveCount(0);
 
-      const inlinePreviewButton = assistantBubble.getByRole("button", {
+      const inlinePreviewButton = assistantContent.getByRole("button", {
         name: /^Preview .+\.png$/
       });
       await expect(inlinePreviewButton).toHaveCount(1);

--- a/tests/unit/chat-view.test.ts
+++ b/tests/unit/chat-view.test.ts
@@ -3699,8 +3699,8 @@ describe("chat view", () => {
     });
   });
 
-  it("keeps a late-joined streaming answer in a single bubble until a new boundary appears", async () => {
-    const { container } = renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
+  it("keeps a late-joined streaming answer in a single prose container until a new boundary appears", async () => {
+    renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
 
     act(() => {
       wsMock.onMessage!({
@@ -3752,9 +3752,9 @@ describe("chat view", () => {
     });
 
     await waitFor(() => {
-      const bubbles = container.querySelectorAll('[data-testid="assistant-message-bubble"]');
-      expect(bubbles).toHaveLength(1);
-      expect(bubbles[0]?.textContent).toContain("Already streamed and still typing");
+      const proseContainers = screen.getAllByTestId("assistant-message-content");
+      expect(proseContainers).toHaveLength(1);
+      expect(proseContainers[0]).toHaveTextContent("Already streamed and still typing");
     });
   });
 

--- a/tests/unit/message-bubble.test.ts
+++ b/tests/unit/message-bubble.test.ts
@@ -141,6 +141,27 @@ afterEach(() => {
 });
 
 describe("message bubble", () => {
+  it("renders assistant prose without an avatar or chat bubble frame", () => {
+    const { container } = render(
+      React.createElement(MessageBubble, {
+        message: createAssistantMessage()
+      })
+    );
+
+    const assistantContent = screen.getByTestId("assistant-message-content");
+
+    expect(container.querySelector('img[src="/agent-icon.png"]')).toBeNull();
+    expect(container.querySelector('img[src="/chat-icon.png"]')).toBeNull();
+    expect(container.querySelector('[data-testid="assistant-message-bubble"]')).toBeNull();
+    expect(assistantContent).toHaveTextContent("Final answer");
+    expect(assistantContent.className).toContain("w-full");
+    expect(assistantContent.className).not.toContain("w-fit");
+    expect(assistantContent.className).not.toContain("rounded-2xl");
+    expect(assistantContent.className).not.toContain("border");
+    expect(assistantContent.className).not.toContain("bg-white");
+    expect(assistantContent.className).not.toContain("shadow");
+  });
+
   it("renders persisted completed actions with their summaries", () => {
     render(
       React.createElement(MessageBubble, {
@@ -474,7 +495,7 @@ describe("message bubble", () => {
       })
     );
 
-    const blocks = Array.from(container.querySelectorAll('[data-testid="assistant-message-bubble"], [data-testid="assistant-actions-shell"]'));
+    const blocks = Array.from(container.querySelectorAll('[data-testid="assistant-message-content"], [data-testid="assistant-actions-shell"]'));
 
     expect(blocks).toHaveLength(3);
     expect(blocks[0]?.textContent).toContain("First segment");
@@ -482,7 +503,7 @@ describe("message bubble", () => {
     expect(blocks[2]?.textContent).toContain("Second segment");
   });
 
-  it("collapses adjacent assistant text segments into a single bubble", () => {
+  it("collapses adjacent assistant text segments into a single prose container", () => {
     const { container } = render(
       React.createElement(MessageBubble, {
         message: {
@@ -508,13 +529,13 @@ describe("message bubble", () => {
       })
     );
 
-    const bubbles = container.querySelectorAll('[data-testid="assistant-message-bubble"]');
+    const proseContainers = container.querySelectorAll('[data-testid="assistant-message-content"]');
 
-    expect(bubbles).toHaveLength(1);
-    expect(bubbles[0]?.textContent).toContain("Hello there");
+    expect(proseContainers).toHaveLength(1);
+    expect(proseContainers[0]?.textContent).toContain("Hello there");
   });
 
-  it("does not append a second assistant bubble when normalized timeline text already covers escaped message content", () => {
+  it("does not append a second assistant prose container when normalized timeline text already covers escaped message content", () => {
     const escapedContent = [
       "Here is the table:",
       "",
@@ -541,12 +562,12 @@ describe("message bubble", () => {
       })
     );
 
-    const bubbles = container.querySelectorAll('[data-testid="assistant-message-bubble"]');
+    const proseContainers = container.querySelectorAll('[data-testid="assistant-message-content"]');
 
-    expect(bubbles).toHaveLength(1);
+    expect(proseContainers).toHaveLength(1);
     expect(screen.getByRole("table")).toBeInTheDocument();
-    expect(bubbles[0]?.textContent).toContain("Elena Varga");
-    expect(bubbles[0]?.textContent).not.toContain("\\n");
+    expect(proseContainers[0]?.textContent).toContain("Elena Varga");
+    expect(proseContainers[0]?.textContent).not.toContain("\\n");
   });
 
   it("does not splice a divergent message.content tail onto the timeline segments", () => {
@@ -568,10 +589,10 @@ describe("message bubble", () => {
       })
     );
 
-    const bubbles = container.querySelectorAll('[data-testid="assistant-message-bubble"]');
+    const proseContainers = container.querySelectorAll('[data-testid="assistant-message-content"]');
 
-    expect(bubbles).toHaveLength(1);
-    expect(bubbles[0]?.textContent).toContain("Streamed answer.");
+    expect(proseContainers).toHaveLength(1);
+    expect(proseContainers[0]?.textContent).toContain("Streamed answer.");
     expect(container.textContent).not.toContain("finalized answer");
   });
 
@@ -627,17 +648,17 @@ describe("message bubble", () => {
 
     const blocks = Array.from(
       container.querySelectorAll(
-        '[data-testid="assistant-message-bubble"], [data-testid="assistant-actions-shell"]'
+        '[data-testid="assistant-message-content"], [data-testid="assistant-actions-shell"]'
       )
     );
-    const bubbles = container.querySelectorAll('[data-testid="assistant-message-bubble"]');
+    const proseContainers = container.querySelectorAll('[data-testid="assistant-message-content"]');
 
-    expect(bubbles).toHaveLength(1);
-    expect(bubbles[0]?.textContent).toContain(
+    expect(proseContainers).toHaveLength(1);
+    expect(proseContainers[0]?.textContent).toContain(
       "Got it, Charles. I'll remember that you prefer Celsius over Fahrenheit."
     );
     expect(blocks).toHaveLength(2);
-    expect(blocks[0]?.getAttribute("data-testid")).toBe("assistant-message-bubble");
+    expect(blocks[0]?.getAttribute("data-testid")).toBe("assistant-message-content");
     expect(blocks[1]?.getAttribute("data-testid")).toBe("assistant-actions-shell");
     expect(blocks[1]?.textContent).toContain("Save memory");
   });
@@ -706,7 +727,7 @@ describe("message bubble", () => {
 
     const thinkingMarkdown = container.querySelector(".thinking-markdown-body");
     const assistantMarkdown = container.querySelector(
-      '[data-testid="assistant-message-bubble"] .markdown-body'
+      '[data-testid="assistant-message-content"] .markdown-body'
     );
 
     expect(thinkingMarkdown).not.toBeNull();
@@ -762,7 +783,7 @@ describe("message bubble", () => {
 
     const thinkingMarkdown = container.querySelector(".thinking-markdown-body");
     const answerMarkdown = container.querySelector(
-      '[data-testid="assistant-message-bubble"] .markdown-body'
+      '[data-testid="assistant-message-content"] .markdown-body'
     );
 
     expect(thinkingMarkdown?.textContent).toContain("Thought one");
@@ -777,7 +798,7 @@ describe("message bubble", () => {
     expect(answerMarkdown?.textContent).not.toContain("\\\\n");
   });
 
-  it("renders markdown elements inside a compact assistant bubble", () => {
+  it("renders markdown elements inside an unframed assistant prose container", () => {
     const { container } = render(
       React.createElement(MessageBubble, {
         message: {
@@ -820,7 +841,15 @@ describe("message bubble", () => {
       })
     );
 
-    expect(screen.getByTestId("assistant-message-bubble").className).toContain("w-fit");
+    const assistantContent = screen.getByTestId("assistant-message-content");
+
+    expect(assistantContent.className).toContain("w-full");
+    expect(assistantContent.className).toContain("max-w-full");
+    expect(assistantContent.className).not.toContain("w-fit");
+    expect(assistantContent.className).not.toContain("rounded-2xl");
+    expect(assistantContent.className).not.toContain("border");
+    expect(assistantContent.className).not.toContain("bg-white");
+    expect(assistantContent.className).not.toContain("shadow");
     expect(screen.getByRole("heading", { level: 1, name: "Markdown Test Report" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { level: 2, name: "Lists" })).toBeInTheDocument();
     expect(screen.getAllByRole("list").length).toBeGreaterThanOrEqual(3);
@@ -880,7 +909,7 @@ describe("message bubble", () => {
     expect(screen.getByRole("button", { name: "Copy Code" })).toBeInTheDocument();
   });
 
-  it("caps assistant bubbles at the container width so fenced code blocks can scroll internally on narrow screens", () => {
+  it("keeps assistant prose full width so fenced code blocks can scroll internally on narrow screens", () => {
     render(
       React.createElement(MessageBubble, {
         message: {
@@ -890,9 +919,12 @@ describe("message bubble", () => {
       })
     );
 
-    expect(screen.getByTestId("assistant-message-bubble").className).toContain("max-w-full");
-    expect(screen.getByTestId("assistant-message-bubble").parentElement?.parentElement?.className).toContain("w-full");
-    expect(screen.getByTestId("assistant-message-bubble").parentElement?.parentElement?.className).toContain("min-w-0");
+    const assistantContent = screen.getByTestId("assistant-message-content");
+
+    expect(assistantContent.className).toContain("w-full");
+    expect(assistantContent.className).toContain("max-w-full");
+    expect(assistantContent.parentElement?.parentElement?.className).toContain("w-full");
+    expect(assistantContent.parentElement?.parentElement?.className).toContain("min-w-0");
   });
 
 
@@ -1067,7 +1099,7 @@ describe("message bubble", () => {
     expect(screen.getByRole("button", { name: "Copy Code" })).toBeInTheDocument();
   });
 
-  it("keeps untagged assistant code blocks on the code block path without changing the thinking bubble", async () => {
+  it("keeps untagged assistant code blocks on the code block path without changing the thinking shell", async () => {
     const { container } = render(
       React.createElement(MessageBubble, {
         message: {
@@ -1173,7 +1205,7 @@ describe("message bubble", () => {
     );
 
     expect(container.querySelector('[data-streamdown="code-block"]')).not.toBeNull();
-    expect(container.querySelector('[data-testid="assistant-message-bubble"] p code')).toBeNull();
+    expect(container.querySelector('[data-testid="assistant-message-content"] p code')).toBeNull();
   });
 
 
@@ -1190,7 +1222,7 @@ describe("message bubble", () => {
 
     expect(screen.getByText("token")).toBeInTheDocument();
     expect(container.querySelector('[data-streamdown="code-block"]')).toBeNull();
-    expect(container.querySelector('[data-testid="assistant-message-bubble"] p code')).not.toBeNull();
+    expect(container.querySelector('[data-testid="assistant-message-content"] p code')).not.toBeNull();
   });
 
   it("copies only the fenced code payload from the block action", async () => {
@@ -1464,18 +1496,18 @@ describe("message bubble", () => {
       })
     );
 
-    const bubble = screen.getByTestId("assistant-message-bubble");
+    const assistantContent = screen.getByTestId("assistant-message-content");
 
-    expect(within(bubble).getByText("I've attached the generated image and notes below.")).toBeInTheDocument();
-    expect(within(bubble).getByRole("button", { name: "Preview photo.png" })).toBeInTheDocument();
-    expect(within(bubble).queryByRole("img", { name: "photo.png" })).toBeNull();
+    expect(within(assistantContent).getByText("I've attached the generated image and notes below.")).toBeInTheDocument();
+    expect(within(assistantContent).getByRole("button", { name: "Preview photo.png" })).toBeInTheDocument();
+    expect(within(assistantContent).queryByRole("img", { name: "photo.png" })).toBeNull();
     expect(screen.getByText("notes.txt")).toBeInTheDocument();
 
-    const imagePreviewButtonsOutsideBubble = Array.from(
+    const imagePreviewButtonsOutsideAssistantContent = Array.from(
       container.querySelectorAll('button[aria-label="Preview photo.png"]')
-    ).filter((button) => !bubble.contains(button));
+    ).filter((button) => !assistantContent.contains(button));
 
-    expect(imagePreviewButtonsOutsideBubble).toHaveLength(0);
+    expect(imagePreviewButtonsOutsideAssistantContent).toHaveLength(0);
   });
 
   it("opens the existing attachment preview modal when clicking an inline assistant image", async () => {
@@ -1506,7 +1538,7 @@ describe("message bubble", () => {
     );
 
     fireEvent.click(
-      within(screen.getByTestId("assistant-message-bubble")).getByRole("button", {
+      within(screen.getByTestId("assistant-message-content")).getByRole("button", {
         name: "Preview photo.png"
       })
     );

--- a/tests/unit/message-bubble.test.tsx
+++ b/tests/unit/message-bubble.test.tsx
@@ -39,15 +39,22 @@ function createUserMessage(): Message {
 }
 
 describe("message bubble avatar", () => {
-  it("renders the assistant avatar from agent-icon.png", () => {
+  it("renders assistant prose without an avatar or chat bubble frame", () => {
     const { container } = render(
       React.createElement(MessageBubble, {
         message: createAssistantMessage()
       })
     );
 
-    expect(container.querySelector('img[src="/agent-icon.png"]')).not.toBeNull();
+    const assistantContent = screen.getByTestId("assistant-message-content");
+
+    expect(container.querySelector('img[src="/agent-icon.png"]')).toBeNull();
     expect(container.querySelector('img[src="/chat-icon.png"]')).toBeNull();
+    expect(container.querySelector('[data-testid="assistant-message-bubble"]')).toBeNull();
+    expect(assistantContent).toHaveTextContent("Final answer");
+    expect(assistantContent.className).toContain("w-full");
+    expect(assistantContent.className).not.toContain("rounded-2xl");
+    expect(assistantContent.className).not.toContain("bg-white");
   });
 
   it("shows the edit action for user messages only", () => {

--- a/tests/unit/shared-conversation-view.test.tsx
+++ b/tests/unit/shared-conversation-view.test.tsx
@@ -200,7 +200,8 @@ describe("SharedConversationView", () => {
     expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
     expect(screen.queryByText("New Chat")).not.toBeInTheDocument();
     expect(screen.queryByText("Search")).not.toBeInTheDocument();
-    expect(container.querySelector('img[src="/agent-icon.png"]')).not.toBeNull();
+    expect(container.querySelector('img[src="/agent-icon.png"]')).toBeNull();
+    expect(screen.getByTestId("assistant-message-content")).toHaveTextContent("I inspected it.");
     expect(screen.getByTestId("assistant-thinking-shell")).toBeInTheDocument();
     expect(screen.getByTestId("assistant-actions-shell")).toHaveTextContent("Web browser");
 


### PR DESCRIPTION
## Summary
- Simplify assistant message rendering by dropping the avatar and framed bubble styling around prose content
- Rename the assistant content test id and update message-bubble, chat-view, and shared conversation tests to match
- Keep error states and attachment rendering covered under the new content-centric structure

## Testing
- Updated unit and e2e assertions for assistant prose, attachment previews, and streaming behavior
- Not run (not requested)