### PR TITLE
feat(streaming): fluid token streaming with stable composer layout

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -564,6 +564,12 @@ select {
   .animate-fade-in {
     animation-duration: 0.01ms !important;
   }
+
+  [data-sd-animate] {
+    animation: none;
+    opacity: 1;
+    filter: none;
+  }
 }
 
 @theme inline {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import { Inter, Instrument_Serif, Orbitron, Geist } from "next/font/google";
 import { APP_NAME } from "@/lib/constants";
 import { ServiceWorkerRegistration } from "@/components/service-worker-registration";
 
+import "streamdown/styles.css";
 import "@/app/globals.css";
 import { cn } from "@/lib/utils";
 

--- a/components/ai-elements/conversation.tsx
+++ b/components/ai-elements/conversation.tsx
@@ -94,8 +94,9 @@ export const ConversationScrollButton = ({
   return (
     !isAtBottom && (
       <Button
+        aria-label="Scroll to latest messages"
         className={cn(
-          "absolute bottom-4 left-[50%] translate-x-[-50%] flex h-8 items-center gap-1 rounded-full border border-white/10 bg-white/[0.06] text-[10px] font-bold uppercase tracking-wider text-white/60 shadow-lg backdrop-blur-md transition-all hover:bg-white/[0.1] hover:text-white/80",
+          "absolute bottom-[calc(var(--composer-height,160px)_+_12px)] left-[50%] z-10 translate-x-[-50%] flex h-8 items-center gap-1 rounded-full border border-white/10 bg-zinc-900/85 px-3.5 text-[10px] font-bold uppercase tracking-wider text-white/60 shadow-[0_2px_8px_rgba(0,0,0,0.35)] backdrop-blur-md transition-colors duration-200 animate-fade-in hover:border-white/15 hover:bg-zinc-800/85 hover:text-white/90",
           className
         )}
         onClick={handleScrollToBottom}

--- a/components/ai-elements/conversation.tsx
+++ b/components/ai-elements/conversation.tsx
@@ -81,6 +81,11 @@ export const ConversationEmptyState = ({
 
 export type ConversationScrollButtonProps = ComponentProps<typeof Button>;
 
+const SCROLL_TO_LATEST_OPTIONS = {
+  animation: { damping: 0.75, stiffness: 0.1, mass: 1 },
+  ignoreEscapes: true
+} as const;
+
 export const ConversationScrollButton = ({
   className,
   ...props
@@ -88,7 +93,7 @@ export const ConversationScrollButton = ({
   const { isAtBottom, scrollToBottom } = useStickToBottomContext();
 
   const handleScrollToBottom = useCallback(() => {
-    scrollToBottom();
+    void scrollToBottom(SCROLL_TO_LATEST_OPTIONS);
   }, [scrollToBottom]);
 
   return (
@@ -96,7 +101,7 @@ export const ConversationScrollButton = ({
       <Button
         aria-label="Scroll to latest messages"
         className={cn(
-          "absolute bottom-[calc(var(--composer-height,160px)_+_12px)] left-[50%] z-10 translate-x-[-50%] flex h-8 items-center gap-1 rounded-full border border-white/10 bg-zinc-900/85 px-3.5 text-[10px] font-bold uppercase tracking-wider text-white/60 shadow-[0_2px_8px_rgba(0,0,0,0.35)] backdrop-blur-md transition-colors duration-200 animate-fade-in hover:border-white/15 hover:bg-zinc-800/85 hover:text-white/90",
+          "absolute bottom-[calc(var(--composer-height,160px)_+_6px)] left-[50%] z-10 translate-x-[-50%] flex h-8 items-center gap-1 rounded-full border border-[var(--accent)] bg-[var(--accent)] px-3.5 text-[10px] font-bold uppercase tracking-wider text-white shadow-[0_0_16px_var(--accent-glow)] transition-all duration-200 animate-fade-in hover:bg-[var(--accent)] hover:text-white hover:opacity-90 active:scale-[0.96]",
           className
         )}
         onClick={handleScrollToBottom}

--- a/components/ai-elements/conversation.tsx
+++ b/components/ai-elements/conversation.tsx
@@ -101,7 +101,7 @@ export const ConversationScrollButton = ({
       <Button
         aria-label="Scroll to latest messages"
         className={cn(
-          "absolute bottom-[calc(var(--composer-height,160px)_+_6px)] left-[50%] z-10 translate-x-[-50%] flex h-8 items-center gap-1 rounded-full border border-[var(--accent)] bg-[var(--accent)] px-3.5 text-[10px] font-bold uppercase tracking-wider text-white shadow-[0_0_16px_var(--accent-glow)] transition-all duration-200 animate-fade-in hover:bg-[var(--accent)] hover:text-white hover:opacity-90 active:scale-[0.96]",
+          "absolute bottom-[var(--composer-height,160px)] left-[50%] z-10 translate-x-[-50%] flex h-8 items-center gap-1 rounded-full border border-[var(--accent)] bg-[var(--accent)] px-3.5 text-[10px] font-bold uppercase tracking-wider text-white shadow-[0_0_16px_var(--accent-glow)] transition-all duration-200 animate-fade-in hover:bg-[var(--accent)] hover:text-white hover:opacity-90 active:scale-[0.96]",
           className
         )}
         onClick={handleScrollToBottom}

--- a/components/chat-composer.tsx
+++ b/components/chat-composer.tsx
@@ -65,8 +65,6 @@ type ChatComposerProps = {
   isTemporary?: boolean;
   showTemporaryToggle?: boolean;
   onTemporaryChange?: (value: boolean) => void;
-  isAtBottom?: boolean;
-  onJumpToBottom?: () => void;
   collapsibleToolbarOnMobile?: boolean;
 };
 
@@ -263,8 +261,6 @@ export function ChatComposer({
   isTemporary = false,
   showTemporaryToggle = false,
   onTemporaryChange,
-  isAtBottom = true,
-  onJumpToBottom,
   collapsibleToolbarOnMobile = false,
 }: ChatComposerProps) {
   const fileInputRef = React.useRef<HTMLInputElement | null>(null);
@@ -311,20 +307,6 @@ export function ChatComposer({
 
   return (
     <div className="relative">
-      {!isAtBottom && (
-        <div className="absolute -top-[19px] left-4 z-0 flex items-start h-[24px]">
-          <button
-            type="button"
-            onClick={onJumpToBottom}
-            style={{ fontSize: '10px' }}
-            className="relative flex h-full items-center gap-0.5 rounded-t-md border border-b-0 border-[var(--accent)] bg-[var(--accent)] px-2.5 font-bold uppercase tracking-wider text-white shadow-[0_0_16px_var(--accent-glow)] transition-all duration-150 hover:opacity-90 active:scale-[0.96]"
-            aria-label="Scroll to latest messages"
-            title="Scroll to latest"
-          >
-            ↓ Latest
-          </button>
-        </div>
-      )}
       {isTemporary && !showTemporaryToggle && (
         <div className="absolute -top-[19px] right-4 z-10 flex items-center h-[19px]">
           <div className="relative flex h-full items-center rounded-t-md border border-b-0 border-violet-500/50 border-dashed bg-zinc-900/85 backdrop-blur-md px-2.5 text-[10px] font-bold uppercase tracking-wider text-violet-300">

--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import {
   Conversation as ConversationContainer,
   ConversationContent,
@@ -80,17 +80,11 @@ const VISIBLE_MESSAGE_INCREMENT = 100;
 const EMPTY_TIMELINE: MessageTimelineItem[] = [];
 
 function StickToBottomBridge({
-  onAtBottomChange,
   scrollToBottomRef
 }: {
-  onAtBottomChange: (atBottom: boolean) => void;
   scrollToBottomRef: React.RefObject<(() => void) | null>;
 }) {
-  const { isAtBottom, scrollToBottom } = useStickToBottomContext();
-
-  useEffect(() => {
-    onAtBottomChange(isAtBottom);
-  }, [isAtBottom, onAtBottomChange]);
+  const { scrollToBottom } = useStickToBottomContext();
 
   useEffect(() => {
     scrollToBottomRef.current = scrollToBottom;
@@ -182,9 +176,6 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
   const [personas, setPersonas] = useState<Array<{ id: string; name: string }>>([]);
   const [personaId, setPersonaId] = useState<string | null>(null);
   const scrollToBottomRef = useRef<(() => void) | null>(null);
-  const [isAtBottom, setIsAtBottom] = useState(true);
-  const queueBannerRef = useRef<HTMLDivElement>(null);
-  const viewportHeightRef = useRef(800);
   const anchorSpacerRef = useRef<HTMLDivElement>(null);
   const composerAreaRef = useRef<HTMLDivElement>(null);
   const [composerAreaHeight, setComposerAreaHeight] = useState(160);
@@ -458,20 +449,18 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
 
   useEffect(() => {
     scrollToBottomRef.current?.();
-    setIsAtBottom(true);
   }, [payload.conversation.id]);
 
-  const jumpToBottom = useCallback(() => {
-    scrollToBottomRef.current?.();
-  }, []);
-
-  useEffect(() => {
+  useLayoutEffect(() => {
     const el = composerAreaRef.current;
-    if (!el || typeof ResizeObserver === "undefined") return;
-    const observer = new ResizeObserver(() => {
+    if (!el) return;
+    const measure = () => {
       const next = el.offsetHeight;
       setComposerAreaHeight((current) => (current === next ? current : next));
-    });
+    };
+    measure();
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(measure);
     observer.observe(el);
     return () => observer.disconnect();
   }, []);
@@ -485,7 +474,9 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
     pendingAnchorMessageIdRef.current = null;
     requestAnimationFrame(() => {
       if (anchorSpacerRef.current) {
-        anchorSpacerRef.current.style.height = `${viewportHeightRef.current}px`;
+        const scrollerHeight =
+          anchorSpacerRef.current.closest(".conversation-scroller")?.clientHeight ?? 800;
+        anchorSpacerRef.current.style.height = `${scrollerHeight}px`;
       }
       const targetEl = document.querySelector(`[data-message-id="${messageId}"]`);
       targetEl?.scrollIntoView({ block: "start", behavior: "auto" });
@@ -1901,12 +1892,12 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
         </div>
       </div>
 
-      <div className="relative flex min-h-0 flex-1 flex-col">
+      <div
+        className="relative flex min-h-0 flex-1 flex-col"
+        style={{ ["--composer-height" as string]: `${composerAreaHeight}px` }}
+      >
       <ConversationContainer>
-        <StickToBottomBridge
-          onAtBottomChange={setIsAtBottom}
-          scrollToBottomRef={scrollToBottomRef}
-        />
+        <StickToBottomBridge scrollToBottomRef={scrollToBottomRef} />
         <ConversationContent
           className="gap-2.5 px-2 pt-4 md:gap-4 md:px-8"
         >
@@ -1973,14 +1964,19 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
               {error}
             </div>
           ) : null}
-          <div ref={anchorSpacerRef} style={{ height: streamMessageId ? Math.max(80, composerAreaHeight + 40) : Math.max(24, composerAreaHeight) }} />
+          <div ref={anchorSpacerRef} />
+          <div aria-hidden style={{ height: "calc(var(--composer-height, 160px) + 24px)" }} />
         </ConversationContent>
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-x-0 bottom-[var(--composer-height,160px)] h-10 bg-gradient-to-t from-[var(--background)] via-[var(--background)]/65 to-transparent"
+        />
         <ConversationScrollButton />
       </ConversationContainer>
 
         <div ref={composerAreaRef} className="absolute inset-x-0 bottom-0 z-50 pointer-events-none">
          <div className="mx-auto w-full max-w-[980px] px-3 sm:px-4 md:px-8 pt-1 pb-composer-safe pointer-events-auto">
-          <div ref={queueBannerRef}>
+          <div>
             <QueuedMessageBanner
               items={queuedMessages}
               onEdit={updateQueuedMessage}
@@ -2027,8 +2023,6 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
                 body: JSON.stringify({ isTemporary: value })
               }).catch(() => {});
             }}
-            isAtBottom={isAtBottom}
-            onJumpToBottom={jumpToBottom}
             collapsibleToolbarOnMobile
             onStartSpeech={() => {
               setError("");

--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -1967,10 +1967,6 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
           <div ref={anchorSpacerRef} />
           <div aria-hidden style={{ height: "calc(var(--composer-height, 160px) + 24px)" }} />
         </ConversationContent>
-        <div
-          aria-hidden
-          className="pointer-events-none absolute inset-x-0 bottom-[var(--composer-height,160px)] h-10 bg-gradient-to-t from-[var(--background)] via-[var(--background)]/65 to-transparent"
-        />
         <ConversationScrollButton />
       </ConversationContainer>
 

--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -16,7 +16,6 @@ import {
 } from "@/components/attachment-preview-modal";
 import { ChatComposer } from "@/components/chat-composer";
 import { QueuedMessageBanner } from "@/components/queued-message-banner";
-import { TypingIndicator } from "@/components/message-bubble";
 import { useShareConversation } from "@/components/share-conversation-context";
 import {
   type PendingLocalSubmission,
@@ -120,7 +119,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
   const [isStopPending, setIsStopPending] = useState(false);
   const [isTemporaryToggled, setIsTemporaryToggled] = useState(payload.conversation.isTemporary);
   const streamBufferRef = useRef<ReturnType<typeof createStreamBuffer> | null>(null);
-  streamBufferRef.current ??= createStreamBuffer({ answerCharsPerSecond: 180, thinkingCharsPerSecond: 180 });
+  streamBufferRef.current ??= createStreamBuffer();
   const streamBuffer = streamBufferRef.current;
   const [streamMessageId, setStreamMessageId] = useState<string | null>(null);
   const [streamTimeline, setStreamTimeline] = useState<MessageTimelineItem[]>([]);
@@ -189,9 +188,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
   const anchorSpacerRef = useRef<HTMLDivElement>(null);
   const composerAreaRef = useRef<HTMLDivElement>(null);
   const [composerAreaHeight, setComposerAreaHeight] = useState(160);
-  const [queueBannerHeight, setQueueBannerHeight] = useState(0);
-  const [isAgentIdle, setIsAgentIdle] = useState(false);
-  const idleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const finalizePendingRef = useRef(false);
 
   const {
     speechSnapshot,
@@ -312,7 +309,11 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
     setStreamTimeline(resolvedTimeline);
   }, []);
 
-  const syncActiveStreamingMessageFromSnapshot = useCallback((snapshotMessage: Message) => {
+  const syncActiveStreamingMessageFromSnapshot = useCallback((
+    snapshotMessage: Message,
+    options?: { adopt?: boolean }
+  ) => {
+    const adopt = options?.adopt ?? false;
     const adoptedStream = adoptStreamingSnapshotState(snapshotMessage.timeline);
     const bufferSnapshot = streamBuffer.getSnapshot();
     const nextAnswer =
@@ -329,8 +330,8 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
       adoptedStream.timeline
     );
 
-    streamBuffer.setAnswer(nextAnswer, { immediate: true });
-    streamBuffer.setThinking(nextThinking, { immediate: true });
+    streamBuffer.setAnswer(nextAnswer, { immediate: adopt });
+    streamBuffer.setThinking(nextThinking, { immediate: adopt });
     setStreamMessageId(snapshotMessage.id);
     updateStreamTimeline(mergedTimeline);
     setHasReceivedFirstToken(Boolean(nextAnswer || nextThinking || mergedTimeline.length));
@@ -414,6 +415,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
 
   function resetStreamingState() {
     clearCompactionIndicator();
+    finalizePendingRef.current = false;
     setStreamMessageId(null);
     updateStreamTimeline([]);
     streamBuffer.reset();
@@ -461,17 +463,6 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
 
   const jumpToBottom = useCallback(() => {
     scrollToBottomRef.current?.();
-  }, []);
-
-  useEffect(() => {
-    const el = queueBannerRef.current;
-    if (!el || typeof ResizeObserver === "undefined") return;
-    const observer = new ResizeObserver(() => {
-      const next = el.offsetHeight;
-      setQueueBannerHeight((current) => (current === next ? current : next));
-    });
-    observer.observe(el);
-    return () => observer.disconnect();
   }, []);
 
   useEffect(() => {
@@ -534,30 +525,20 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
     return () => window.cancelAnimationFrame(handle);
   }, [payload.conversation.id]);
 
-  useEffect(() => {
-    return () => {
-      if (idleTimerRef.current !== null) {
-        clearTimeout(idleTimerRef.current);
-      }
-    };
-  }, []);
-
   function handleDelta(event: ChatStreamEvent) {
     if (event.type === "compaction_start") {
       setCompactionInProgress(true);
-      resetIdleTimer();
       return;
     }
 
     if (event.type === "compaction_end") {
       setCompactionInProgress(false);
-      resetIdleTimer();
       return;
     }
 
     if (event.type === "stream_retry") {
+      finalizePendingRef.current = false;
       streamBuffer.reset();
-      resetIdleTimer();
       return;
     }
 
@@ -566,7 +547,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
       setStreamMessageId(event.messageId);
       streamMessageIdRef.current = event.messageId;
       setHasReceivedFirstToken(false);
-      resetIdleTimer();
+      finalizePendingRef.current = false;
       streamBuffer.reset();
       updateStreamTimeline(
         shouldShowProvisionalImageAction(messagesRef.current)
@@ -632,7 +613,6 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
     if (event.type === "thinking_delta") {
       clearCompactionIndicator();
       setHasReceivedFirstToken(true);
-      resetIdleTimer();
       streamBuffer.appendThinking(event.text);
       if (!thinkingStartTimeRef.current) {
         thinkingStartTimeRef.current = Date.now();
@@ -642,7 +622,6 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
     if (event.type === "answer_delta") {
       clearCompactionIndicator();
       setHasReceivedFirstToken(true);
-      resetIdleTimer();
       streamBuffer.appendAnswer(event.text);
       if (thinkingStartTimeRef.current) {
         const duration = (Date.now() - thinkingStartTimeRef.current) / 1000;
@@ -651,7 +630,6 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
     }
 
     if (event.type === "system_notice") {
-      resetIdleTimer();
       setMessages((current) => [
         ...current,
         {
@@ -671,7 +649,6 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
 
     if (event.type === "action_start") {
       clearCompactionIndicator();
-      resetIdleTimer();
       updateStreamTimeline((prev) => {
         const isExisting = prev.some((item) => item.timelineKind === "action" && item.id === event.action.id);
         if (isExisting) {
@@ -701,13 +678,11 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
 
     if (event.type === "action_complete" || event.type === "action_error") {
       clearCompactionIndicator();
-      resetIdleTimer();
       updateStreamTimeline((prev) => updateStreamingAction(prev, event.action));
     }
 
     if (event.type === "done") {
       clearCompactionIndicator();
-      clearIdleTimer();
       const wasStopped = isStopPending;
       setIsStopPending(false);
 
@@ -757,16 +732,27 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
       }
 
       if (isForActiveStream) {
-        setStreamMessageId(null);
-        updateStreamTimeline([]);
-        streamBuffer.reset();
         setIsSending(false);
+        if (wasStopped) {
+          finalizePendingRef.current = false;
+          setStreamMessageId(null);
+          updateStreamTimeline([]);
+          streamBuffer.reset();
+        } else {
+          finalizePendingRef.current = true;
+          streamBuffer.finalize();
+          streamBuffer.whenDrained(() => {
+            finalizePendingRef.current = false;
+            setStreamMessageId(null);
+            updateStreamTimeline([]);
+            streamBuffer.reset();
+          });
+        }
       }
     }
 
     if (event.type === "error") {
       clearCompactionIndicator();
-      clearIdleTimer();
       setIsStopPending(false);
       const activeStreamMessageId = streamMessageIdRef.current;
 
@@ -784,6 +770,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
               : m
           )
         );
+        finalizePendingRef.current = false;
         setStreamMessageId(null);
         updateStreamTimeline([]);
         streamBuffer.reset();
@@ -791,24 +778,6 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
       }
       setError("");
     }
-  }
-
-  function resetIdleTimer() {
-    if (idleTimerRef.current !== null) {
-      clearTimeout(idleTimerRef.current);
-    }
-    setIsAgentIdle(false);
-    idleTimerRef.current = setTimeout(() => {
-      setIsAgentIdle(true);
-    }, 1200);
-  }
-
-  function clearIdleTimer() {
-    if (idleTimerRef.current !== null) {
-      clearTimeout(idleTimerRef.current);
-      idleTimerRef.current = null;
-    }
-    setIsAgentIdle(false);
   }
 
   const {
@@ -849,13 +818,17 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
               (message) => message.id === streamMessageId
             );
 
-            if (activeSnapshotMessage && activeSnapshotMessage.status !== "streaming") {
+            if (
+              activeSnapshotMessage &&
+              activeSnapshotMessage.status !== "streaming" &&
+              !finalizePendingRef.current
+            ) {
               setStreamMessageId(null);
               updateStreamTimeline([]);
               streamBuffer.reset();
               setHasReceivedFirstToken(false);
               setIsSending(false);
-            } else if (activeSnapshotMessage) {
+            } else if (activeSnapshotMessage && activeSnapshotMessage.status === "streaming") {
               syncActiveStreamingMessageFromSnapshot(activeSnapshotMessage);
             }
           } else {
@@ -939,6 +912,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
             return current;
           });
           setError("");
+          finalizePendingRef.current = false;
           setStreamMessageId(null);
           updateStreamTimeline([]);
           streamBuffer.reset();
@@ -1204,7 +1178,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
             (message) => message.role === "assistant" && message.status === "streaming"
           );
           if (streamingMsg) {
-            syncActiveStreamingMessageFromSnapshot(streamingMsg);
+            syncActiveStreamingMessageFromSnapshot(streamingMsg, { adopt: !hasLocalStreamState });
           }
         }
 
@@ -1221,7 +1195,11 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
         }
 
         const awaitingTurnStart = isSendingRef.current && !activeStreamMessageId;
-        if (!awaitingTurnStart && (!result.conversation.isActive || (activeMessage && activeMessage.status !== "streaming"))) {
+        if (
+          !awaitingTurnStart &&
+          !finalizePendingRef.current &&
+          (!result.conversation.isActive || (activeMessage && activeMessage.status !== "streaming"))
+        ) {
           setStreamMessageId(null);
           updateStreamTimeline([]);
           streamBuffer.reset();
@@ -1666,7 +1644,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
     const effectivePersonaId = nextPersonaId ?? personaId;
     const hasActiveTurn =
       isConversationActive ||
-      Boolean(streamMessageIdRef.current) ||
+      Boolean(streamMessageIdRef.current && !finalizePendingRef.current) ||
       messagesRef.current.some(
         (message) => message.role === "assistant" && message.status === "streaming"
       );
@@ -1712,6 +1690,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
     setInput("");
     dismissComposerKeyboardOnTouch();
     setPendingAttachments([]);
+    finalizePendingRef.current = false;
     streamBuffer.reset();
     setStreamMessageId(null);
     updateStreamTimeline([]);
@@ -1986,12 +1965,6 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
                   isRetrying={retryingMessageId === message.id}
                   isRegenerating={regeneratingMessageId === message.id}
                 />
-
-                {isStreamingMessage && isAgentIdle && hasReceivedFirstToken && (
-                  <div className="animate-fade-in mt-[6px] inline-flex items-center overflow-hidden rounded-lg border border-white/5 bg-white/[0.015] px-2 py-1 md:ml-[42px]">
-                    <TypingIndicator compact />
-                  </div>
-                )}
               </div>
             );
           })}
@@ -2037,7 +2010,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
             compactionLimit={compactionLimit}
             modelContextLimit={selectedProfile?.modelContextLimit ?? 128000}
             hasMessages={messages.length > 0}
-            canStop={!!streamMessageId && !isStopPending}
+            canStop={!!streamMessageId && !isStopPending && isConversationActive}
             isStopPending={isStopPending}
             onStop={stopActiveTurn}
             speechPhase={speechSnapshot.phase}

--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -93,19 +93,45 @@ function AnsiText({
   );
 }
 
-const AssistantMarkdown = React.memo(function AssistantMarkdown({ content }: { content: string }) {
-  const plugins = useStreamdownPlugins(content);
-  const fallback = (
-    <pre className="whitespace-pre-wrap break-words text-sm">{content}</pre>
-  );
-  return (
-    <MarkdownErrorBoundary fallback={fallback} resetKey={content}>
-      <Streamdown plugins={plugins}>
-        {content}
-      </Streamdown>
-    </MarkdownErrorBoundary>
-  );
-});
+const ANIMATED_STREAM_OPTIONS = {
+  animation: "fadeIn",
+  duration: 200,
+  easing: "ease-out",
+  sep: "word"
+} as const;
+
+const AssistantMarkdown = React.memo(
+  function AssistantMarkdown({
+    content,
+    isAnimating = false,
+    showCaret = false
+  }: {
+    content: string;
+    isAnimating?: boolean;
+    showCaret?: boolean;
+  }) {
+    const plugins = useStreamdownPlugins(content);
+    const fallback = (
+      <pre className="whitespace-pre-wrap break-words text-sm">{content}</pre>
+    );
+    return (
+      <MarkdownErrorBoundary fallback={fallback} resetKey={content}>
+        <Streamdown
+          plugins={plugins}
+          animated={ANIMATED_STREAM_OPTIONS}
+          isAnimating={isAnimating}
+          caret={showCaret ? "block" : undefined}
+        >
+          {content}
+        </Streamdown>
+      </MarkdownErrorBoundary>
+    );
+  },
+  (previous, next) =>
+    previous.content === next.content &&
+    previous.isAnimating === next.isAnimating &&
+    previous.showCaret === next.showCaret
+);
 
 export function TypingIndicator({ compact = false }: { compact?: boolean }) {
   return (
@@ -820,6 +846,8 @@ function MessageBubbleImpl({
                       if (!renderedContent) {
                         return null;
                       }
+                      const isStreamingTailBlock =
+                        isAssistantStreaming && item.id === lastRenderableAssistantTextId;
                       return (
                         <div
                           key={item.id}
@@ -827,7 +855,11 @@ function MessageBubbleImpl({
                           data-testid="assistant-message-content"
                         >
                           <div className="markdown-body">
-                            <AssistantMarkdown content={renderedContent} />
+                            <AssistantMarkdown
+                              content={renderedContent}
+                              isAnimating={isStreamingTailBlock}
+                              showCaret={isStreamingTailBlock}
+                            />
                           </div>
                           {item.id === lastRenderableAssistantTextId && assistantImageAttachments.length ? (
                             <div className="mt-3">

--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -209,6 +209,38 @@ function getActionSignature(action: Pick<MessageActionType, "kind" | "label" | "
   return [action.kind, action.label, action.detail, action.toolName ?? ""].join("\u0000");
 }
 
+function clampStreamingTimeline(
+  timeline: MessageTimelineItem[],
+  display: string
+): MessageTimelineItem[] {
+  const clamped: MessageTimelineItem[] = [];
+  let offset = 0;
+
+  for (const item of timeline) {
+    if (item.timelineKind !== "text") {
+      clamped.push(item);
+      continue;
+    }
+
+    const visibleLength = Math.min(
+      Math.max(display.length - offset, 0),
+      item.content.length
+    );
+
+    if (visibleLength > 0) {
+      clamped.push(
+        visibleLength === item.content.length
+          ? item
+          : { ...item, content: item.content.slice(0, visibleLength) }
+      );
+    }
+
+    offset += item.content.length;
+  }
+
+  return clamped;
+}
+
 function escapeHtml(value: string) {
   return value
     .replaceAll("&", "&amp;")
@@ -312,7 +344,10 @@ function MessageBubbleImpl({
     const rawContent = streamingAnswer ?? message.content;
     const rawThinking = streamingThinking ?? message.thinkingContent;
     const actions = message.actions ?? [];
-    const liveTimeline = streamingTimeline ?? message.timeline;
+    const liveTimeline =
+      streamingTimeline !== undefined && streamingAnswer !== undefined
+        ? clampStreamingTimeline(streamingTimeline, streamingAnswer)
+        : streamingTimeline ?? message.timeline;
     const contentForComparison = normalizeLineBreaks(rawContent);
     const timeline = liveTimeline ?? actions.map((action) => ({
       ...action,

--- a/components/streaming-message.tsx
+++ b/components/streaming-message.tsx
@@ -14,7 +14,8 @@ const INACTIVE_SNAPSHOT: StreamBufferSnapshot = Object.freeze({
   answerTarget: "",
   answerDisplay: "",
   thinkingTarget: "",
-  thinkingDisplay: ""
+  thinkingDisplay: "",
+  isSettled: true
 });
 
 const noopSubscribe = () => () => {};

--- a/lib/stream-buffer.ts
+++ b/lib/stream-buffer.ts
@@ -3,14 +3,18 @@ export type StreamBufferSnapshot = {
   answerDisplay: string;
   thinkingTarget: string;
   thinkingDisplay: string;
+  isSettled: boolean;
 };
 
 export type StreamBufferOptions = {
   schedule?: (callback: () => void) => number;
   cancel?: (handle: number) => void;
   now?: () => number;
-  answerCharsPerSecond?: number;
-  thinkingCharsPerSecond?: number;
+  baseCharsPerSecond?: number;
+  drainWindowMs?: number;
+  finalizeDrainWindowMs?: number;
+  maxWordHoldChars?: number;
+  maxWordHoldMs?: number;
 };
 
 export type StreamBuffer = {
@@ -20,17 +24,28 @@ export type StreamBuffer = {
   appendThinking: (text: string) => void;
   setAnswer: (text: string, options?: { immediate?: boolean }) => void;
   setThinking: (text: string, options?: { immediate?: boolean }) => void;
+  finalize: () => void;
+  whenDrained: (callback: () => void) => () => void;
   reset: () => void;
 };
 
-const DEFAULT_ANSWER_CHARS_PER_SECOND = 400;
-const DEFAULT_THINKING_CHARS_PER_SECOND = 250;
+const DEFAULT_BASE_CHARS_PER_SECOND = 90;
+const DEFAULT_DRAIN_WINDOW_MS = 250;
+const DEFAULT_FINALIZE_DRAIN_WINDOW_MS = 175;
+const DEFAULT_MAX_WORD_HOLD_CHARS = 24;
+const DEFAULT_MAX_WORD_HOLD_MS = 350;
+const CARRY_CAP_FACTOR = 2;
+
 const EMPTY_SNAPSHOT: StreamBufferSnapshot = Object.freeze({
   answerTarget: "",
   answerDisplay: "",
   thinkingTarget: "",
-  thinkingDisplay: ""
+  thinkingDisplay: "",
+  isSettled: true
 });
+
+const BOUNDARY_CHAR_PATTERN =
+  /[\s⺀-鿿가-힯豈-﫿！-｠]/;
 
 function defaultSchedule(callback: () => void): number {
   if (typeof requestAnimationFrame === "function") {
@@ -47,15 +62,37 @@ function defaultCancel(handle: number) {
   clearTimeout(handle);
 }
 
+function isHighSurrogate(code: number) {
+  return code >= 0xd800 && code <= 0xdbff;
+}
+
+function graphemeSafeIndex(text: string, index: number) {
+  if (index > 0 && isHighSurrogate(text.charCodeAt(index - 1))) {
+    return index - 1;
+  }
+  return index;
+}
+
 export function createStreamBuffer(options: StreamBufferOptions = {}): StreamBuffer {
   const schedule = options.schedule ?? defaultSchedule;
   const cancel = options.cancel ?? defaultCancel;
   const now = options.now ?? (() => Date.now());
-  const answerRate = options.answerCharsPerSecond ?? DEFAULT_ANSWER_CHARS_PER_SECOND;
-  const thinkingRate = options.thinkingCharsPerSecond ?? DEFAULT_THINKING_CHARS_PER_SECOND;
+  const baseRate = options.baseCharsPerSecond ?? DEFAULT_BASE_CHARS_PER_SECOND;
+  const drainWindowMs = options.drainWindowMs ?? DEFAULT_DRAIN_WINDOW_MS;
+  const finalizeDrainWindowMs = options.finalizeDrainWindowMs ?? DEFAULT_FINALIZE_DRAIN_WINDOW_MS;
+  const maxWordHoldChars = options.maxWordHoldChars ?? DEFAULT_MAX_WORD_HOLD_CHARS;
+  const maxWordHoldMs = options.maxWordHoldMs ?? DEFAULT_MAX_WORD_HOLD_MS;
+  const carryCap = maxWordHoldChars * CARRY_CAP_FACTOR;
 
   let snapshot = EMPTY_SNAPSHOT;
+  let finalized = false;
+  const carries = { answer: 0, thinking: 0 };
+  const holdSince: { answer: number | null; thinking: number | null } = {
+    answer: null,
+    thinking: null
+  };
   const listeners = new Set<() => void>();
+  const drainCallbacks = new Set<() => void>();
   let frameHandle: number | null = null;
   let lastTick = 0;
 
@@ -65,19 +102,101 @@ export function createStreamBuffer(options: StreamBufferOptions = {}): StreamBuf
     }
   }
 
-  function isAnimating() {
+  function isBoundary(target: string, index: number) {
+    if (index === target.length && finalized) {
+      return true;
+    }
+    return BOUNDARY_CHAR_PATTERN.test(target.charAt(index - 1));
+  }
+
+  function findBoundary(target: string, fromExclusive: number, toInclusive: number) {
+    for (let index = toInclusive; index > fromExclusive; index -= 1) {
+      if (isBoundary(target, index)) {
+        return index;
+      }
+    }
+    return -1;
+  }
+
+  function advance(
+    field: "answer" | "thinking",
+    display: string,
+    target: string,
+    elapsedMs: number,
+    nowMs: number
+  ) {
+    const backlog = target.length - display.length;
+    if (backlog <= 0) {
+      carries[field] = 0;
+      holdSince[field] = null;
+      return display;
+    }
+
+    const windowMs = finalized ? finalizeDrainWindowMs : drainWindowMs;
+    const rate = Math.max(baseRate, (backlog * 1000) / windowMs);
+    const budget = carries[field] + (elapsedMs * rate) / 1000;
+    const candidate = Math.min(display.length + Math.floor(budget), target.length);
+
+    function hold() {
+      carries[field] = Math.min(budget, carryCap);
+      holdSince[field] ??= nowMs;
+      return display;
+    }
+
+    function reveal(index: number) {
+      carries[field] = Math.min(budget - (index - display.length), carryCap);
+      holdSince[field] = null;
+      return target.slice(0, index);
+    }
+
+    if (candidate <= display.length) {
+      return hold();
+    }
+
+    const boundary = findBoundary(target, display.length, candidate);
+
+    if (boundary !== -1) {
+      return reveal(boundary);
+    }
+
+    const holdExpired =
+      holdSince[field] !== null && nowMs - holdSince[field] >= maxWordHoldMs;
+
+    if (candidate - display.length >= maxWordHoldChars || holdExpired) {
+      const flushIndex = graphemeSafeIndex(target, candidate);
+      if (flushIndex > display.length) {
+        return reveal(flushIndex);
+      }
+    }
+
+    return hold();
+  }
+
+  function canProgress() {
     return (
       snapshot.answerDisplay.length < snapshot.answerTarget.length ||
       snapshot.thinkingDisplay.length < snapshot.thinkingTarget.length
     );
   }
 
-  function advance(display: string, target: string, rate: number, elapsedMs: number) {
-    if (display.length >= target.length) {
-      return display;
+  function commit(next: Omit<StreamBufferSnapshot, "isSettled">) {
+    snapshot = {
+      ...next,
+      isSettled:
+        next.answerDisplay.length >= next.answerTarget.length &&
+        next.thinkingDisplay.length >= next.thinkingTarget.length
+    };
+  }
+
+  function flushDrainCallbacksIfSettled() {
+    if (!snapshot.isSettled || drainCallbacks.size === 0) {
+      return;
     }
-    const step = Math.max(1, Math.round((elapsedMs / 1000) * rate));
-    return target.slice(0, display.length + step);
+    const callbacks = [...drainCallbacks];
+    drainCallbacks.clear();
+    for (const callback of callbacks) {
+      callback();
+    }
   }
 
   function tick() {
@@ -85,15 +204,16 @@ export function createStreamBuffer(options: StreamBufferOptions = {}): StreamBuf
     const current = now();
     const elapsed = Math.max(current - lastTick, 1);
     lastTick = current;
-    const nextAnswer = advance(snapshot.answerDisplay, snapshot.answerTarget, answerRate, elapsed);
-    const nextThinking = advance(snapshot.thinkingDisplay, snapshot.thinkingTarget, thinkingRate, elapsed);
+    const nextAnswer = advance("answer", snapshot.answerDisplay, snapshot.answerTarget, elapsed, current);
+    const nextThinking = advance("thinking", snapshot.thinkingDisplay, snapshot.thinkingTarget, elapsed, current);
 
     if (nextAnswer !== snapshot.answerDisplay || nextThinking !== snapshot.thinkingDisplay) {
-      snapshot = { ...snapshot, answerDisplay: nextAnswer, thinkingDisplay: nextThinking };
+      commit({ ...snapshot, answerDisplay: nextAnswer, thinkingDisplay: nextThinking });
       notify();
+      flushDrainCallbacksIfSettled();
     }
 
-    if (isAnimating()) {
+    if (canProgress()) {
       scheduleTick();
     }
   }
@@ -106,7 +226,7 @@ export function createStreamBuffer(options: StreamBufferOptions = {}): StreamBuf
   }
 
   function startAnimationIfNeeded() {
-    if (!isAnimating() || frameHandle !== null) {
+    if (!canProgress() || frameHandle !== null) {
       return;
     }
     lastTick = now();
@@ -116,30 +236,31 @@ export function createStreamBuffer(options: StreamBufferOptions = {}): StreamBuf
   function setText(field: "answer" | "thinking", text: string, immediate: boolean) {
     const targetKey = field === "answer" ? "answerTarget" : "thinkingTarget";
     const displayKey = field === "answer" ? "answerDisplay" : "thinkingDisplay";
+    const previousDisplay = snapshot[displayKey];
+    const previousSettled = snapshot.isSettled;
     const nextDisplay = immediate
       ? text
-      : text.startsWith(snapshot[displayKey])
-        ? snapshot[displayKey]
+      : text.startsWith(previousDisplay)
+        ? previousDisplay
         : text;
-    const changed = snapshot[targetKey] !== text || snapshot[displayKey] !== nextDisplay;
+    const changed = snapshot[targetKey] !== text || previousDisplay !== nextDisplay;
 
     if (!changed) {
       return;
     }
 
-    snapshot = { ...snapshot, [targetKey]: text, [displayKey]: nextDisplay };
+    commit({ ...snapshot, [targetKey]: text, [displayKey]: nextDisplay });
 
-    if (immediate) {
+    if (nextDisplay !== previousDisplay || snapshot.isSettled) {
+      carries[field] = 0;
+    }
+
+    if (nextDisplay !== previousDisplay || (snapshot.isSettled && !previousSettled)) {
       notify();
-      return;
     }
 
-    if (isAnimating()) {
-      startAnimationIfNeeded();
-      return;
-    }
-
-    notify();
+    flushDrainCallbacksIfSettled();
+    startAnimationIfNeeded();
   }
 
   return {
@@ -162,11 +283,34 @@ export function createStreamBuffer(options: StreamBufferOptions = {}): StreamBuf
     setThinking(text, opts) {
       setText("thinking", text, Boolean(opts?.immediate));
     },
+    finalize() {
+      if (finalized) {
+        return;
+      }
+      finalized = true;
+      startAnimationIfNeeded();
+    },
+    whenDrained(callback) {
+      if (snapshot.isSettled) {
+        callback();
+        return () => {};
+      }
+      drainCallbacks.add(callback);
+      return () => {
+        drainCallbacks.delete(callback);
+      };
+    },
     reset() {
       if (frameHandle !== null) {
         cancel(frameHandle);
         frameHandle = null;
       }
+      finalized = false;
+      carries.answer = 0;
+      carries.thinking = 0;
+      holdSince.answer = null;
+      holdSince.thinking = null;
+      drainCallbacks.clear();
       if (snapshot === EMPTY_SNAPSHOT) {
         return;
       }

--- a/tests/unit/chat-view.test.ts
+++ b/tests/unit/chat-view.test.ts
@@ -144,6 +144,7 @@ vi.mock("@/lib/speech/speech-controller", () => ({
 const stickToBottomMock = vi.hoisted(() => ({
   isAtBottomValue: true,
   scrollToBottom: vi.fn(),
+  listeners: new Set<() => void>(),
   _forceRender: null as (() => void) | null,
 }));
 
@@ -185,8 +186,27 @@ vi.mock("@/components/ai-elements/conversation", () => {
       }, [scrollerRef]);
       return React.createElement("div", { "data-testid": "conversation-content", ref: divRef }, children as React.ReactNode);
     },
-    ConversationScrollButton: () =>
-      React.createElement("button", { "data-testid": "conversation-scroll-button" }, "Scroll to bottom"),
+    ConversationScrollButton: () => {
+      const isAtBottom = React.useSyncExternalStore(
+        (onStoreChange: () => void) => {
+          stickToBottomMock.listeners.add(onStoreChange);
+          return () => stickToBottomMock.listeners.delete(onStoreChange);
+        },
+        () => stickToBottomMock.isAtBottomValue,
+        () => stickToBottomMock.isAtBottomValue
+      );
+      return isAtBottom
+        ? null
+        : React.createElement(
+            "button",
+            {
+              "data-testid": "conversation-scroll-button",
+              "aria-label": "Scroll to latest messages",
+              onClick: () => stickToBottomMock.scrollToBottom()
+            },
+            "Latest"
+          );
+    },
     ConversationEmptyState: ({ children, ...props }: Record<string, unknown>) =>
       React.createElement("div", { "data-testid": "conversation-empty-state", ...props }, children as React.ReactNode),
     ConversationDownload: ({ children, ...props }: Record<string, unknown>) =>
@@ -582,12 +602,21 @@ describe("chat view", () => {
       for (const callback of resizeObserverCallbacks) {
         callback([], {} as ResizeObserver);
       }
+      for (const listener of stickToBottomMock.listeners) {
+        listener();
+      }
     });
     if (stickToBottomMock._forceRender) {
       act(() => {
         stickToBottomMock._forceRender!();
       });
     }
+  }
+
+  function streamedText(expected: string) {
+    return (_content: string, node: Element | null) =>
+      node?.textContent === expected &&
+      Array.from(node.children).every((child) => child.textContent !== expected);
   }
 
   it("places the desktop share control in the conversation title header", () => {
@@ -3096,19 +3125,24 @@ describe("chat view", () => {
     });
   });
 
-  it("positions the Latest Messages pill to the right of the composer on desktop", async () => {
+  it("renders a single scroll-to-latest affordance that only appears when scrolled away from the bottom", async () => {
     renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
 
     await flushAnimationFrame();
 
+    expect(screen.queryByRole("button", { name: "Scroll to latest messages" })).toBeNull();
+
     simulateAtBottomState(false);
 
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Scroll to latest messages" })).toBeInTheDocument();
+      expect(screen.getAllByRole("button", { name: "Scroll to latest messages" })).toHaveLength(1);
     });
 
-    const pill = screen.getByRole("button", { name: "Scroll to latest messages" }).parentElement!;
-    expect(pill.className).toContain("left-4");
+    simulateAtBottomState(true);
+
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: "Scroll to latest messages" })).toBeNull();
+    });
   });
 
   it("follows streaming overflow after sending", async () => {
@@ -3142,7 +3176,7 @@ describe("chat view", () => {
     await flushAnimationFrame();
 
     await waitFor(() => {
-      expect(screen.getByText("A long response that overflows the viewport")).toBeInTheDocument();
+      expect(screen.getByText(streamedText("A long response that overflows the viewport"))).toBeInTheDocument();
     });
   });
 
@@ -3321,7 +3355,7 @@ describe("chat view", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText("A long response that starts following")).toBeInTheDocument();
+      expect(screen.getByText(streamedText("A long response that starts following"))).toBeInTheDocument();
     });
 
     simulateAtBottomState(false);
@@ -3624,7 +3658,7 @@ describe("chat view", () => {
     expect(screen.queryByRole("button", { name: /^Thinking$/i })).toBeNull();
 
     await waitFor(() => {
-      expect(screen.getByText("Working on it")).toBeInTheDocument();
+      expect(screen.getByText(streamedText("Working on it"))).toBeInTheDocument();
     });
   });
 
@@ -3842,7 +3876,7 @@ describe("chat view", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText("Already streamed")).toBeInTheDocument();
+      expect(screen.getByText(streamedText("Already streamed"))).toBeInTheDocument();
     });
 
     act(() => {

--- a/tests/unit/chat-view.test.ts
+++ b/tests/unit/chat-view.test.ts
@@ -2064,6 +2064,108 @@ describe("chat view", () => {
     expect(nodeBefore!.isConnected).toBe(true);
   });
 
+  it("drains the buffered tail smoothly after done instead of dumping it", async () => {
+    renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
+
+    const longAnswer = `${"lorem ipsum dolor sit amet ".repeat(20)}finis`;
+
+    act(() => {
+      wsMock.onMessage!({
+        type: "delta",
+        conversationId: "conv_1",
+        event: { type: "message_start", messageId: "msg_assistant" }
+      });
+    });
+    act(() => {
+      wsMock.onMessage!({
+        type: "delta",
+        conversationId: "conv_1",
+        event: { type: "answer_delta", text: longAnswer }
+      });
+    });
+    act(() => {
+      wsMock.onMessage!({
+        type: "delta",
+        conversationId: "conv_1",
+        event: { type: "done", messageId: "msg_assistant" }
+      });
+    });
+
+    expect(screen.queryByText(/finis/)).not.toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText(/finis/)).toBeInTheDocument();
+    });
+  });
+
+  it("accepts a new submission immediately after done while the tail is draining", async () => {
+    renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
+
+    act(() => {
+      wsMock.onMessage!({
+        type: "delta",
+        conversationId: "conv_1",
+        event: { type: "message_start", messageId: "msg_assistant" }
+      });
+    });
+    act(() => {
+      wsMock.onMessage!({
+        type: "delta",
+        conversationId: "conv_1",
+        event: { type: "answer_delta", text: `${"words keep flowing here ".repeat(20)}end` }
+      });
+    });
+    act(() => {
+      wsMock.onMessage!({
+        type: "delta",
+        conversationId: "conv_1",
+        event: { type: "done", messageId: "msg_assistant" }
+      });
+    });
+
+    wsMock.send.mockClear();
+    const textarea = screen.getByRole("textbox");
+    fireEvent.change(textarea, { target: { value: "follow-up" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(wsMock.send).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "message", content: "follow-up" })
+      );
+    });
+  });
+
+  it("hides the stop button as soon as the turn completes even while the tail is draining", async () => {
+    renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
+
+    act(() => {
+      wsMock.onMessage!({
+        type: "delta",
+        conversationId: "conv_1",
+        event: { type: "message_start", messageId: "msg_assistant" }
+      });
+    });
+    act(() => {
+      wsMock.onMessage!({
+        type: "delta",
+        conversationId: "conv_1",
+        event: { type: "answer_delta", text: `${"steady stream of words ".repeat(20)}done` }
+      });
+    });
+
+    expect(screen.getByRole("button", { name: "Stop response" })).toBeInTheDocument();
+
+    act(() => {
+      wsMock.onMessage!({
+        type: "delta",
+        conversationId: "conv_1",
+        event: { type: "done", messageId: "msg_assistant" }
+      });
+    });
+
+    expect(screen.queryByRole("button", { name: "Stop response" })).not.toBeInTheDocument();
+  });
+
   it("keeps an optimistic user message visible when an unrelated server user message arrives first", async () => {
     renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
 

--- a/tests/unit/conversation-scroll-button.test.tsx
+++ b/tests/unit/conversation-scroll-button.test.tsx
@@ -42,11 +42,11 @@ describe("ConversationScrollButton", () => {
     );
   });
 
-  it("floats 6px above the composer", () => {
+  it("sits flush against the composer area top", () => {
     stickContextMock.isAtBottom = false;
     render(React.createElement(ConversationScrollButton));
 
     const button = screen.getByRole("button", { name: "Scroll to latest messages" });
-    expect(button.className).toContain("bottom-[calc(var(--composer-height,160px)_+_6px)]");
+    expect(button.className).toContain("bottom-[var(--composer-height,160px)]");
   });
 });

--- a/tests/unit/conversation-scroll-button.test.tsx
+++ b/tests/unit/conversation-scroll-button.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const stickContextMock = vi.hoisted(() => ({
+  isAtBottom: false,
+  scrollToBottom: vi.fn()
+}));
+
+vi.mock("use-stick-to-bottom", () => ({
+  StickToBottom: Object.assign(
+    ({ children }: { children?: React.ReactNode }) => React.createElement("div", null, children),
+    { Content: ({ children }: { children?: React.ReactNode }) => React.createElement("div", null, children) }
+  ),
+  useStickToBottomContext: () => stickContextMock
+}));
+
+import { ConversationScrollButton } from "@/components/ai-elements/conversation";
+
+describe("ConversationScrollButton", () => {
+  it("renders nothing while pinned to the bottom", () => {
+    stickContextMock.isAtBottom = true;
+    render(React.createElement(ConversationScrollButton));
+    expect(screen.queryByRole("button", { name: "Scroll to latest messages" })).toBeNull();
+  });
+
+  it("scrolls decisively on click, overriding in-flight user scrolling", () => {
+    stickContextMock.isAtBottom = false;
+    stickContextMock.scrollToBottom.mockClear();
+    render(React.createElement(ConversationScrollButton));
+
+    fireEvent.click(screen.getByRole("button", { name: "Scroll to latest messages" }));
+
+    expect(stickContextMock.scrollToBottom).toHaveBeenCalledTimes(1);
+    expect(stickContextMock.scrollToBottom).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ignoreEscapes: true,
+        animation: expect.objectContaining({ stiffness: expect.any(Number) })
+      })
+    );
+  });
+
+  it("floats 6px above the composer", () => {
+    stickContextMock.isAtBottom = false;
+    render(React.createElement(ConversationScrollButton));
+
+    const button = screen.getByRole("button", { name: "Scroll to latest messages" });
+    expect(button.className).toContain("bottom-[calc(var(--composer-height,160px)_+_6px)]");
+  });
+});

--- a/tests/unit/stream-buffer.test.ts
+++ b/tests/unit/stream-buffer.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createStreamBuffer } from "@/lib/stream-buffer";
 
 function createManualScheduler() {
@@ -25,77 +25,225 @@ function createManualScheduler() {
   };
 }
 
+const PACING = {
+  baseCharsPerSecond: 100,
+  drainWindowMs: 250,
+  finalizeDrainWindowMs: 175,
+  maxWordHoldChars: 24,
+  maxWordHoldMs: 350
+};
+
 describe("createStreamBuffer", () => {
-  it("starts empty", () => {
+  it("starts empty and settled", () => {
     const buffer = createStreamBuffer();
     expect(buffer.getSnapshot()).toEqual({
       answerTarget: "",
       answerDisplay: "",
       thinkingTarget: "",
-      thinkingDisplay: ""
+      thinkingDisplay: "",
+      isSettled: true
     });
   });
 
-  it("appendAnswer updates target immediately and animates display via scheduler", () => {
+  it("reveals complete words and briefly holds the trailing partial word", () => {
     const scheduler = createManualScheduler();
-    const buffer = createStreamBuffer({ ...scheduler, answerCharsPerSecond: 1000 });
-    buffer.appendAnswer("hello world");
-    expect(buffer.getSnapshot().answerTarget).toBe("hello world");
+    const buffer = createStreamBuffer({ ...scheduler, ...PACING });
+    buffer.appendAnswer("hello world foo");
+
+    expect(buffer.getSnapshot().answerTarget).toBe("hello world foo");
     expect(buffer.getSnapshot().answerDisplay).toBe("");
-    scheduler.advance(5);
-    expect(buffer.getSnapshot().answerDisplay).toBe("hello");
-    scheduler.advance(100);
-    expect(buffer.getSnapshot().answerDisplay).toBe("hello world");
+    expect(buffer.getSnapshot().isSettled).toBe(false);
+
+    scheduler.advance(50);
+    scheduler.advance(50);
+    expect(buffer.getSnapshot().answerDisplay).toBe("hello ");
+
+    scheduler.advance(50);
+    expect(buffer.getSnapshot().answerDisplay).toBe("hello world ");
+
+    scheduler.advance(50);
+    scheduler.advance(50);
+    expect(buffer.getSnapshot().answerDisplay).toBe("hello world ");
+
+    buffer.finalize();
+    scheduler.advance(50);
+    expect(buffer.getSnapshot().answerDisplay).toBe("hello world foo");
+    expect(buffer.getSnapshot().isSettled).toBe(true);
     expect(scheduler.pendingCount()).toBe(0);
+  });
+
+  it("reveals a stalled trailing word once the hold deadline passes", () => {
+    const scheduler = createManualScheduler();
+    const buffer = createStreamBuffer({ ...scheduler, ...PACING });
+    buffer.appendAnswer("hello world");
+
+    scheduler.advance(100);
+    scheduler.advance(100);
+    expect(buffer.getSnapshot().answerDisplay).toBe("hello ");
+
+    for (let i = 0; i < 12; i += 1) scheduler.advance(16);
+    expect(buffer.getSnapshot().answerDisplay).toBe("hello ");
+
+    for (let i = 0; i < 15; i += 1) scheduler.advance(16);
+    expect(buffer.getSnapshot().answerDisplay).toBe("hello world");
+    expect(buffer.getSnapshot().isSettled).toBe(true);
+  });
+
+  it("reveals a held word once a new delta provides its boundary", () => {
+    const scheduler = createManualScheduler();
+    const buffer = createStreamBuffer({ ...scheduler, ...PACING });
+    buffer.appendAnswer("hello world");
+    scheduler.advance(100);
+    scheduler.advance(100);
+    expect(buffer.getSnapshot().answerDisplay).toBe("hello ");
+
+    buffer.appendAnswer(" again");
+    scheduler.advance(100);
+    scheduler.advance(100);
+    expect(buffer.getSnapshot().answerDisplay).toBe("hello world ");
+  });
+
+  it("adaptively drains a large backlog without ever dumping it in one frame", () => {
+    const scheduler = createManualScheduler();
+    const buffer = createStreamBuffer({ ...scheduler, ...PACING });
+    const text = "word ".repeat(600);
+    buffer.appendAnswer(text);
+    buffer.finalize();
+
+    let previousLength = 0;
+    let maxStep = 0;
+    for (let i = 0; i < 63; i += 1) {
+      scheduler.advance(16);
+      const length = buffer.getSnapshot().answerDisplay.length;
+      maxStep = Math.max(maxStep, length - previousLength);
+      previousLength = length;
+    }
+
+    const remaining = text.length - previousLength;
+    expect(remaining).toBeLessThan(text.length * 0.05);
+    expect(maxStep).toBeLessThan(text.length * 0.15);
+  });
+
+  it("accelerates with backlog so a fast stream never falls unboundedly behind", () => {
+    const scheduler = createManualScheduler();
+    const buffer = createStreamBuffer({ ...scheduler, ...PACING });
+
+    for (let i = 0; i < 100; i += 1) {
+      buffer.appendAnswer("chunk of streamed text ");
+      scheduler.advance(16);
+    }
+
+    const snapshot = buffer.getSnapshot();
+    const backlog = snapshot.answerTarget.length - snapshot.answerDisplay.length;
+    expect(backlog).toBeLessThan(600);
+  });
+
+  it("is frame-rate independent for the same elapsed time", () => {
+    const text = "word ".repeat(600);
+
+    const run = (stepMs: number, steps: number) => {
+      const scheduler = createManualScheduler();
+      const buffer = createStreamBuffer({ ...scheduler, ...PACING });
+      buffer.appendAnswer(text);
+      buffer.finalize();
+      for (let i = 0; i < steps; i += 1) scheduler.advance(stepMs);
+      return buffer.getSnapshot().answerDisplay.length;
+    };
+
+    const at60fps = run(16, 50);
+    const at30fps = run(33, 24);
+    expect(Math.abs(at60fps - at30fps)).toBeLessThan(text.length * 0.1);
+  });
+
+  it("force-flushes boundary-less runs in bounded steps instead of holding forever", () => {
+    const scheduler = createManualScheduler();
+    const buffer = createStreamBuffer({ ...scheduler, ...PACING });
+    buffer.appendAnswer("a".repeat(60));
+
+    for (let i = 0; i < 30; i += 1) scheduler.advance(16);
+
+    const revealed = buffer.getSnapshot().answerDisplay.length;
+    expect(revealed).toBeGreaterThanOrEqual(48);
+    expect(revealed).toBeLessThan(60);
+
+    for (let i = 0; i < 20; i += 1) scheduler.advance(16);
+    expect(buffer.getSnapshot().answerDisplay.length).toBe(60);
+  });
+
+  it("treats CJK characters as boundaries so they reveal without word holds", () => {
+    const scheduler = createManualScheduler();
+    const buffer = createStreamBuffer({ ...scheduler, ...PACING });
+    buffer.appendAnswer("你好世界");
+    scheduler.advance(50);
+    expect(buffer.getSnapshot().answerDisplay).toBe("你好世界");
+  });
+
+  it("never splits a surrogate pair when force-flushing", () => {
+    const scheduler = createManualScheduler();
+    const buffer = createStreamBuffer({ ...scheduler, ...PACING });
+    buffer.appendAnswer(`x${"👍".repeat(15)}`);
+    buffer.finalize();
+
+    for (let i = 0; i < 60; i += 1) {
+      scheduler.advance(16);
+      const display = buffer.getSnapshot().answerDisplay;
+      expect(/[\uD800-\uDBFF]$/.test(display)).toBe(false);
+    }
+    expect(buffer.getSnapshot().answerDisplay).toBe(`x${"👍".repeat(15)}`);
   });
 
   it("notifies subscribers once per animation frame, not per append", () => {
     const scheduler = createManualScheduler();
-    const buffer = createStreamBuffer({ ...scheduler, answerCharsPerSecond: 1000 });
+    const buffer = createStreamBuffer({ ...scheduler, ...PACING });
     let notifications = 0;
     buffer.subscribe(() => {
       notifications += 1;
     });
-    buffer.appendAnswer("a");
-    buffer.appendAnswer("b");
-    buffer.appendAnswer("c");
+    buffer.appendAnswer("aa ");
+    buffer.appendAnswer("bb ");
+    buffer.appendAnswer("cc ");
     expect(notifications).toBe(0);
-    scheduler.advance(50);
+    scheduler.advance(200);
     expect(notifications).toBe(1);
-    expect(buffer.getSnapshot().answerDisplay).toBe("abc");
+    expect(buffer.getSnapshot().answerDisplay).toBe("aa bb cc ");
   });
 
   it("keeps snapshot identity stable between changes", () => {
     const scheduler = createManualScheduler();
-    const buffer = createStreamBuffer({ ...scheduler });
+    const buffer = createStreamBuffer({ ...scheduler, ...PACING });
     const first = buffer.getSnapshot();
     expect(buffer.getSnapshot()).toBe(first);
-    buffer.appendAnswer("x");
-    scheduler.advance(50);
+    buffer.appendAnswer("xy ");
+    scheduler.advance(200);
     const second = buffer.getSnapshot();
     expect(second).not.toBe(first);
     expect(buffer.getSnapshot()).toBe(second);
   });
 
-  it("animates thinking at its own rate", () => {
+  it("animates the thinking channel with the same adaptive pacing", () => {
     const scheduler = createManualScheduler();
-    const buffer = createStreamBuffer({ ...scheduler, thinkingCharsPerSecond: 100 });
-    buffer.appendThinking("abcdefghij");
-    scheduler.advance(50);
-    expect(buffer.getSnapshot().thinkingDisplay).toBe("abcde");
+    const buffer = createStreamBuffer({ ...scheduler, ...PACING });
+    buffer.appendThinking("pondering deeply now");
+    scheduler.advance(100);
+    scheduler.advance(100);
+    expect(buffer.getSnapshot().thinkingDisplay).toBe("pondering deeply ");
+    buffer.finalize();
+    scheduler.advance(100);
+    expect(buffer.getSnapshot().thinkingDisplay).toBe("pondering deeply now");
   });
 
-  it("setAnswer immediate skips animation", () => {
+  it("setAnswer immediate skips animation and settles", () => {
     const scheduler = createManualScheduler();
-    const buffer = createStreamBuffer({ ...scheduler });
+    const buffer = createStreamBuffer({ ...scheduler, ...PACING });
     buffer.setAnswer("done", { immediate: true });
     expect(buffer.getSnapshot().answerDisplay).toBe("done");
+    expect(buffer.getSnapshot().isSettled).toBe(true);
     expect(scheduler.pendingCount()).toBe(0);
   });
 
   it("setAnswer clamps display when new target is shorter", () => {
     const scheduler = createManualScheduler();
-    const buffer = createStreamBuffer({ ...scheduler });
+    const buffer = createStreamBuffer({ ...scheduler, ...PACING });
     buffer.setAnswer("long text", { immediate: true });
     buffer.setAnswer("long");
     expect(buffer.getSnapshot().answerDisplay).toBe("long");
@@ -103,7 +251,7 @@ describe("createStreamBuffer", () => {
 
   it("setAnswer snaps display and notifies once when a same-length divergent target arrives", () => {
     const scheduler = createManualScheduler();
-    const buffer = createStreamBuffer({ ...scheduler });
+    const buffer = createStreamBuffer({ ...scheduler, ...PACING });
     buffer.setAnswer("abc", { immediate: true });
     let notifications = 0;
     buffer.subscribe(() => {
@@ -115,37 +263,126 @@ describe("createStreamBuffer", () => {
     expect(scheduler.pendingCount()).toBe(0);
   });
 
+  it("extends the target without resetting display when a longer snapshot arrives mid-stream", () => {
+    const scheduler = createManualScheduler();
+    const buffer = createStreamBuffer({ ...scheduler, ...PACING });
+    buffer.appendAnswer("hello world");
+    scheduler.advance(100);
+    scheduler.advance(100);
+    expect(buffer.getSnapshot().answerDisplay).toBe("hello ");
+
+    buffer.setAnswer("hello world and more trailing content");
+    expect(buffer.getSnapshot().answerDisplay).toBe("hello ");
+    expect(buffer.getSnapshot().answerTarget).toBe("hello world and more trailing content");
+  });
+
+  it("whenDrained fires immediately when already settled", () => {
+    const buffer = createStreamBuffer();
+    const callback = vi.fn();
+    buffer.whenDrained(callback);
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it("whenDrained waits for the drain to complete after finalize", () => {
+    const scheduler = createManualScheduler();
+    const buffer = createStreamBuffer({ ...scheduler, ...PACING });
+    const callback = vi.fn();
+    buffer.appendAnswer("almost done here");
+    buffer.finalize();
+    buffer.whenDrained(callback);
+    expect(callback).not.toHaveBeenCalled();
+
+    for (let i = 0; i < 20; i += 1) scheduler.advance(16);
+
+    expect(buffer.getSnapshot().answerDisplay).toBe("almost done here");
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it("whenDrained can be cancelled via the returned disposer", () => {
+    const scheduler = createManualScheduler();
+    const buffer = createStreamBuffer({ ...scheduler, ...PACING });
+    const callback = vi.fn();
+    buffer.appendAnswer("pending tail");
+    buffer.finalize();
+    const cancel = buffer.whenDrained(callback);
+    cancel();
+    for (let i = 0; i < 20; i += 1) scheduler.advance(16);
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it("reset cancels pending whenDrained callbacks", () => {
+    const scheduler = createManualScheduler();
+    const buffer = createStreamBuffer({ ...scheduler, ...PACING });
+    const callback = vi.fn();
+    buffer.appendAnswer("pending tail");
+    buffer.finalize();
+    buffer.whenDrained(callback);
+    buffer.reset();
+    for (let i = 0; i < 20; i += 1) scheduler.advance(16);
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it("finalize drains faster than the live-stream pacing", () => {
+    const text = "word ".repeat(200);
+
+    const run = (finalizeEarly: boolean) => {
+      const scheduler = createManualScheduler();
+      const buffer = createStreamBuffer({ ...scheduler, ...PACING });
+      buffer.appendAnswer(text);
+      if (finalizeEarly) buffer.finalize();
+      for (let i = 0; i < 10; i += 1) scheduler.advance(16);
+      return buffer.getSnapshot().answerDisplay.length;
+    };
+
+    expect(run(true)).toBeGreaterThan(run(false));
+  });
+
   it("reset clears everything, cancels animation and notifies", () => {
     const scheduler = createManualScheduler();
-    const buffer = createStreamBuffer({ ...scheduler });
+    const buffer = createStreamBuffer({ ...scheduler, ...PACING });
     let notifications = 0;
     buffer.subscribe(() => {
       notifications += 1;
     });
-    buffer.appendAnswer("text");
-    buffer.appendThinking("think");
+    buffer.appendAnswer("text ");
+    buffer.appendThinking("think ");
     buffer.reset();
     expect(notifications).toBe(1);
     expect(buffer.getSnapshot()).toEqual({
       answerTarget: "",
       answerDisplay: "",
       thinkingTarget: "",
-      thinkingDisplay: ""
+      thinkingDisplay: "",
+      isSettled: true
     });
     scheduler.advance(100);
     expect(buffer.getSnapshot().answerDisplay).toBe("");
   });
 
+  it("reset clears the finalized state so the buffer can animate a new turn", () => {
+    const scheduler = createManualScheduler();
+    const buffer = createStreamBuffer({ ...scheduler, ...PACING });
+    buffer.appendAnswer("first turn");
+    buffer.finalize();
+    scheduler.advance(200);
+    buffer.reset();
+
+    buffer.appendAnswer("second turn pending");
+    scheduler.advance(100);
+    scheduler.advance(100);
+    expect(buffer.getSnapshot().answerDisplay).toBe("second turn ");
+  });
+
   it("unsubscribe stops notifications", () => {
     const scheduler = createManualScheduler();
-    const buffer = createStreamBuffer({ ...scheduler });
+    const buffer = createStreamBuffer({ ...scheduler, ...PACING });
     let notifications = 0;
     const unsubscribe = buffer.subscribe(() => {
       notifications += 1;
     });
     unsubscribe();
-    buffer.appendAnswer("a");
-    scheduler.advance(50);
+    buffer.appendAnswer("aa ");
+    scheduler.advance(100);
     expect(notifications).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- Replace the fixed-rate typewriter with an adaptive stream buffer: reveal rate scales with backlog (~250ms bounded lag), word-boundary reveals with a 350ms hold deadline, CJK/grapheme-safe slicing, and a finalize/drain phase so completed turns animate out instead of dumping their backlog.
- Eliminate the remaining dump paths: snapshot syncs merge into the live stream without immediate flushes, and streaming timelines are clamped to the animated display so tool-call boundaries no longer flush hidden text.
- Add ChatGPT-style presentation via Streamdown's built-in per-word fadeIn + block caret on the streaming tail (styles.css was never imported), guarded by prefers-reduced-motion.
- Stabilize the composer region: constant clearance spacer driven by a --composer-height CSS variable (no more ±40px shifts at stream boundaries), removal of the mid-stream idle indicator and dead state, and one accent-purple scroll-to-latest pill that clicks through in-flight scrolling (ignoreEscapes) and snugs against the bar.
- Tests: 1266 passing across 121 files with new stream-buffer, drain-lifecycle, and scroll-button suites; coverage 90.3% statements / 85.7% branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)