### PR TITLE
fix(pwa): stop iOS keyboard from hiding focused inputs and the composer

### DIFF
--- a/lib/use-ios-pwa.ts
+++ b/lib/use-ios-pwa.ts
@@ -3,6 +3,7 @@
 import { useEffect } from "react";
 
 const IOS_PWA_CLASS = "ios-pwa";
+const FOCUS_SETTLE_DELAY_MS = 300;
 
 function isIosStandalone(): boolean {
   if (typeof navigator === "undefined") {
@@ -10,6 +11,18 @@ function isIosStandalone(): boolean {
   }
 
   return (navigator as { standalone?: boolean }).standalone === true;
+}
+
+function isEditableElement(element: Element | null): element is HTMLElement {
+  if (!(element instanceof HTMLElement)) {
+    return false;
+  }
+
+  return (
+    element instanceof HTMLInputElement ||
+    element instanceof HTMLTextAreaElement ||
+    element.isContentEditable
+  );
 }
 
 export function useIosPwa() {
@@ -22,11 +35,37 @@ export function useIosPwa() {
     root.classList.add(IOS_PWA_CLASS);
 
     let frameHandle: number | null = null;
+    let focusTimeout: number | null = null;
     let lastHeight = -1;
+
+    const correctScroll = () => {
+      if (window.scrollX !== 0 || window.scrollY !== 0) {
+        window.scrollTo(0, 0);
+      }
+      const scroller = document.scrollingElement;
+      if (scroller) {
+        if (scroller.scrollTop !== 0) {
+          scroller.scrollTop = 0;
+        }
+        if (scroller.scrollLeft !== 0) {
+          scroller.scrollLeft = 0;
+        }
+      }
+      const active = document.activeElement;
+      if (isEditableElement(active)) {
+        active.scrollIntoView({ block: "nearest" });
+      }
+    };
 
     const applyHeight = () => {
       frameHandle = null;
-      const height = Math.round(window.innerHeight);
+      correctScroll();
+      const vv = window.visualViewport;
+      const scale = vv?.scale ?? 1;
+      const height =
+        vv && scale === 1
+          ? Math.min(Math.round(window.innerHeight), Math.round(vv.height))
+          : Math.round(window.innerHeight);
       if (height === lastHeight) {
         return;
       }
@@ -41,20 +80,38 @@ export function useIosPwa() {
       frameHandle = window.requestAnimationFrame(applyHeight);
     };
 
+    const handleFocusIn = () => {
+      scheduleApply();
+      if (focusTimeout !== null) {
+        window.clearTimeout(focusTimeout);
+      }
+      focusTimeout = window.setTimeout(() => {
+        focusTimeout = null;
+        correctScroll();
+      }, FOCUS_SETTLE_DELAY_MS);
+    };
+
     applyHeight();
     window.addEventListener("resize", scheduleApply);
     window.addEventListener("orientationchange", scheduleApply);
     window.visualViewport?.addEventListener("resize", scheduleApply);
+    window.visualViewport?.addEventListener("scroll", scheduleApply);
+    document.addEventListener("focusin", handleFocusIn);
 
     return () => {
       if (frameHandle !== null) {
         window.cancelAnimationFrame(frameHandle);
+      }
+      if (focusTimeout !== null) {
+        window.clearTimeout(focusTimeout);
       }
       root.classList.remove(IOS_PWA_CLASS);
       root.style.removeProperty("--ios-app-height");
       window.removeEventListener("resize", scheduleApply);
       window.removeEventListener("orientationchange", scheduleApply);
       window.visualViewport?.removeEventListener("resize", scheduleApply);
+      window.visualViewport?.removeEventListener("scroll", scheduleApply);
+      document.removeEventListener("focusin", handleFocusIn);
     };
   }, []);
 }

--- a/tests/unit/use-ios-pwa.test.ts
+++ b/tests/unit/use-ios-pwa.test.ts
@@ -28,6 +28,34 @@ function appHeightVar() {
   return document.documentElement.style.getPropertyValue("--ios-app-height");
 }
 
+function setWindowScrollTo(value: typeof window.scrollTo) {
+  Object.defineProperty(window, "scrollTo", { configurable: true, writable: true, value });
+}
+
+function setWindowScroll(x: number, y: number) {
+  Object.defineProperty(window, "scrollX", { configurable: true, writable: true, value: x });
+  Object.defineProperty(window, "scrollY", { configurable: true, writable: true, value: y });
+}
+
+function setElementScroll(element: Element, top: number, left: number) {
+  let topValue = top;
+  let leftValue = left;
+  Object.defineProperty(element, "scrollTop", {
+    configurable: true,
+    get: () => topValue,
+    set: (value: number) => {
+      topValue = value;
+    },
+  });
+  Object.defineProperty(element, "scrollLeft", {
+    configurable: true,
+    get: () => leftValue,
+    set: (value: number) => {
+      leftValue = value;
+    },
+  });
+}
+
 describe("useIosPwa", () => {
   let rafCallbacks: Map<number, FrameRequestCallback>;
   let rafCounter: number;
@@ -63,6 +91,28 @@ describe("useIosPwa", () => {
     setNavigatorStandalone(undefined);
     document.documentElement.classList.remove("ios-pwa");
     document.documentElement.style.removeProperty("--ios-app-height");
+  });
+
+  let originalScrollTo: typeof window.scrollTo;
+  let originalScrollIntoView: Element["scrollIntoView"] | undefined;
+
+  beforeEach(() => {
+    originalScrollTo = window.scrollTo;
+    originalScrollIntoView = Element.prototype.scrollIntoView;
+  });
+
+  afterEach(() => {
+    setWindowScrollTo(originalScrollTo);
+    if (originalScrollIntoView) {
+      Element.prototype.scrollIntoView = originalScrollIntoView;
+    } else {
+      Reflect.deleteProperty(Element.prototype, "scrollIntoView");
+    }
+    setWindowScroll(0, 0);
+    Reflect.deleteProperty(document, "scrollingElement");
+    Reflect.deleteProperty(document.documentElement, "scrollTop");
+    Reflect.deleteProperty(document.documentElement, "scrollLeft");
+    vi.useRealTimers();
   });
 
   it("does not mark the document outside an iOS home-screen app", () => {
@@ -250,6 +300,8 @@ describe("useIosPwa", () => {
 
     const listeners = new Map<string, EventListenerOrEventListenerObject[]>();
     const fakeVisualViewport = {
+      height: 812,
+      scale: 1,
       addEventListener: vi.fn((type: string, listener: EventListenerOrEventListenerObject) => {
         const existing = listeners.get(type) ?? [];
         listeners.set(type, [...existing, listener]);
@@ -285,6 +337,8 @@ describe("useIosPwa", () => {
 
     let capturedListener: EventListener | null = null;
     const fakeVisualViewport = {
+      height: 812,
+      scale: 1,
       addEventListener: vi.fn((_type: string, listener: EventListener) => {
         capturedListener = listener;
       }),
@@ -301,6 +355,7 @@ describe("useIosPwa", () => {
     expect(capturedListener).not.toBeNull();
 
     setInnerHeight(500);
+    fakeVisualViewport.height = 500;
     act(() => {
       capturedListener!(new Event("resize"));
       flushRaf();
@@ -314,7 +369,7 @@ describe("useIosPwa", () => {
     });
   });
 
-  it("keeps --ios-app-height tied to window.innerHeight when the visual viewport shrinks", () => {
+  it("follows the visual viewport when the keyboard shrinks it while innerHeight stays fixed", () => {
     setNavigatorStandalone(true);
     setInnerHeight(812);
 
@@ -322,6 +377,7 @@ describe("useIosPwa", () => {
     const fakeVisualViewport = {
       height: 812,
       offsetTop: 0,
+      scale: 1,
       addEventListener: vi.fn((_type: string, listener: EventListener) => {
         capturedListener = listener;
       }),
@@ -343,7 +399,7 @@ describe("useIosPwa", () => {
       flushRaf();
     });
 
-    expect(appHeightVar()).toBe("812px");
+    expect(appHeightVar()).toBe("500px");
 
     Object.defineProperty(window, "visualViewport", {
       configurable: true,
@@ -359,6 +415,7 @@ describe("useIosPwa", () => {
     const fakeVisualViewport = {
       height: 812,
       offsetTop: 0,
+      scale: 1,
       addEventListener: vi.fn((_type: string, listener: EventListener) => {
         capturedListener = listener;
       }),
@@ -381,6 +438,87 @@ describe("useIosPwa", () => {
     });
 
     expect(appHeightVar()).toBe("500px");
+
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: undefined,
+    });
+  });
+
+  it("ignores the visual viewport while pinch-zoomed so the shell keeps the layout height", () => {
+    setNavigatorStandalone(true);
+    setInnerHeight(812);
+
+    let capturedListener: EventListener | null = null;
+    const fakeVisualViewport = {
+      height: 400,
+      offsetTop: 0,
+      scale: 2,
+      addEventListener: vi.fn((_type: string, listener: EventListener) => {
+        capturedListener = listener;
+      }),
+      removeEventListener: vi.fn(),
+    };
+
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: fakeVisualViewport,
+    });
+
+    renderHook(() => useIosPwa());
+    expect(appHeightVar()).toBe("812px");
+    expect(capturedListener).not.toBeNull();
+
+    act(() => {
+      capturedListener!(new Event("resize"));
+      flushRaf();
+    });
+
+    expect(appHeightVar()).toBe("812px");
+
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: undefined,
+    });
+  });
+
+  it("restores the full shell height when the keyboard closes and the visual viewport grows back", () => {
+    setNavigatorStandalone(true);
+    setInnerHeight(812);
+
+    let capturedListener: EventListener | null = null;
+    const fakeVisualViewport = {
+      height: 812,
+      offsetTop: 0,
+      scale: 1,
+      addEventListener: vi.fn((_type: string, listener: EventListener) => {
+        capturedListener = listener;
+      }),
+      removeEventListener: vi.fn(),
+    };
+
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: fakeVisualViewport,
+    });
+
+    renderHook(() => useIosPwa());
+    expect(appHeightVar()).toBe("812px");
+    expect(capturedListener).not.toBeNull();
+
+    fakeVisualViewport.height = 500;
+    act(() => {
+      capturedListener!(new Event("resize"));
+      flushRaf();
+    });
+    expect(appHeightVar()).toBe("500px");
+
+    fakeVisualViewport.height = 812;
+    act(() => {
+      capturedListener!(new Event("resize"));
+      flushRaf();
+    });
+    expect(appHeightVar()).toBe("812px");
 
     Object.defineProperty(window, "visualViewport", {
       configurable: true,
@@ -402,5 +540,259 @@ describe("useIosPwa", () => {
     expect(addSpy).not.toHaveBeenCalledWith("orientationchange", expect.any(Function));
 
     addSpy.mockRestore();
+  });
+
+  it("resets the document pan when the visual viewport resizes while the document is panned", () => {
+    setNavigatorStandalone(true);
+    setInnerHeight(812);
+
+    let capturedResize: EventListener | null = null;
+    const fakeVisualViewport = {
+      height: 812,
+      scale: 1,
+      addEventListener: vi.fn((type: string, listener: EventListener) => {
+        if (type === "resize") {
+          capturedResize = listener;
+        }
+      }),
+      removeEventListener: vi.fn(),
+    };
+
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: fakeVisualViewport,
+    });
+
+    const scrollToMock = vi.fn();
+    setWindowScrollTo(scrollToMock as unknown as typeof window.scrollTo);
+
+    renderHook(() => useIosPwa());
+    expect(capturedResize).not.toBeNull();
+    scrollToMock.mockClear();
+
+    setWindowScroll(0, 350);
+    const scroller = document.documentElement;
+    Object.defineProperty(document, "scrollingElement", { configurable: true, value: scroller });
+    setElementScroll(scroller, 120, 15);
+
+    setInnerHeight(500);
+    fakeVisualViewport.height = 500;
+    act(() => {
+      capturedResize!(new Event("resize"));
+      flushRaf();
+    });
+
+    expect(scrollToMock).toHaveBeenCalledWith(0, 0);
+    expect(scroller.scrollTop).toBe(0);
+    expect(scroller.scrollLeft).toBe(0);
+    expect(appHeightVar()).toBe("500px");
+
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: undefined,
+    });
+  });
+
+  it("corrects the document pan when the visual viewport scrolls without resizing", () => {
+    setNavigatorStandalone(true);
+    setInnerHeight(812);
+
+    let capturedScroll: EventListener | null = null;
+    const fakeVisualViewport = {
+      height: 812,
+      scale: 1,
+      addEventListener: vi.fn((type: string, listener: EventListener) => {
+        if (type === "scroll") {
+          capturedScroll = listener;
+        }
+      }),
+      removeEventListener: vi.fn(),
+    };
+
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: fakeVisualViewport,
+    });
+
+    const scrollToMock = vi.fn();
+    setWindowScrollTo(scrollToMock as unknown as typeof window.scrollTo);
+
+    renderHook(() => useIosPwa());
+    expect(capturedScroll).not.toBeNull();
+    scrollToMock.mockClear();
+
+    setWindowScroll(0, 200);
+    act(() => {
+      capturedScroll!(new Event("scroll"));
+      flushRaf();
+    });
+
+    expect(scrollToMock).toHaveBeenCalledWith(0, 0);
+
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: undefined,
+    });
+  });
+
+  it("reveals the focused editable element after focusin", () => {
+    setNavigatorStandalone(true);
+    setInnerHeight(812);
+
+    const scrollIntoViewMock = vi.fn();
+    Element.prototype.scrollIntoView = scrollIntoViewMock;
+    setWindowScrollTo(vi.fn() as unknown as typeof window.scrollTo);
+
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+
+    renderHook(() => useIosPwa());
+
+    act(() => {
+      input.focus();
+      flushRaf();
+    });
+
+    expect(scrollIntoViewMock).toHaveBeenCalledWith({ block: "nearest" });
+
+    input.remove();
+  });
+
+  it("runs a trailing correction after focusin once WebKit's late pan can land", () => {
+    vi.useFakeTimers();
+    setNavigatorStandalone(true);
+    setInnerHeight(812);
+
+    const scrollIntoViewMock = vi.fn();
+    Element.prototype.scrollIntoView = scrollIntoViewMock;
+    setWindowScrollTo(vi.fn() as unknown as typeof window.scrollTo);
+
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+
+    renderHook(() => useIosPwa());
+
+    act(() => {
+      input.focus();
+      flushRaf();
+    });
+    scrollIntoViewMock.mockClear();
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(scrollIntoViewMock).toHaveBeenCalledWith({ block: "nearest" });
+
+    input.remove();
+  });
+
+  it("clears the trailing focus correction on unmount", () => {
+    vi.useFakeTimers();
+    setNavigatorStandalone(true);
+    setInnerHeight(812);
+
+    const scrollIntoViewMock = vi.fn();
+    Element.prototype.scrollIntoView = scrollIntoViewMock;
+    setWindowScrollTo(vi.fn() as unknown as typeof window.scrollTo);
+
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+
+    const { unmount } = renderHook(() => useIosPwa());
+
+    act(() => {
+      input.focus();
+      flushRaf();
+    });
+    scrollIntoViewMock.mockClear();
+
+    unmount();
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(scrollIntoViewMock).not.toHaveBeenCalled();
+
+    input.remove();
+  });
+
+  it("does not scroll a non-editable focused element into view", () => {
+    setNavigatorStandalone(true);
+    setInnerHeight(812);
+
+    const scrollIntoViewMock = vi.fn();
+    Element.prototype.scrollIntoView = scrollIntoViewMock;
+    setWindowScrollTo(vi.fn() as unknown as typeof window.scrollTo);
+
+    const button = document.createElement("button");
+    document.body.appendChild(button);
+
+    renderHook(() => useIosPwa());
+
+    act(() => {
+      button.focus();
+      flushRaf();
+    });
+
+    expect(scrollIntoViewMock).not.toHaveBeenCalled();
+
+    button.remove();
+  });
+
+  it("does not listen for focusin and never corrects scroll when not standalone", () => {
+    setNavigatorStandalone(false);
+    setInnerHeight(812);
+
+    const docAddSpy = vi.spyOn(document, "addEventListener");
+    const scrollToMock = vi.fn();
+    setWindowScrollTo(scrollToMock as unknown as typeof window.scrollTo);
+    setWindowScroll(0, 350);
+
+    renderHook(() => useIosPwa());
+
+    expect(docAddSpy).not.toHaveBeenCalledWith("focusin", expect.any(Function));
+    expect(scrollToMock).not.toHaveBeenCalled();
+
+    docAddSpy.mockRestore();
+  });
+
+  it("removes the visualViewport scroll and document focusin listeners on unmount", () => {
+    setNavigatorStandalone(true);
+    setInnerHeight(812);
+
+    const fakeVisualViewport = {
+      height: 812,
+      scale: 1,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    };
+
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: fakeVisualViewport,
+    });
+
+    const docAddSpy = vi.spyOn(document, "addEventListener");
+    const docRemoveSpy = vi.spyOn(document, "removeEventListener");
+
+    const { unmount } = renderHook(() => useIosPwa());
+
+    expect(fakeVisualViewport.addEventListener).toHaveBeenCalledWith("scroll", expect.any(Function));
+    expect(docAddSpy).toHaveBeenCalledWith("focusin", expect.any(Function));
+
+    unmount();
+
+    expect(fakeVisualViewport.removeEventListener).toHaveBeenCalledWith("scroll", expect.any(Function));
+    expect(docRemoveSpy).toHaveBeenCalledWith("focusin", expect.any(Function));
+
+    docAddSpy.mockRestore();
+    docRemoveSpy.mockRestore();
+
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: undefined,
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Reset the stale WebKit keyboard pan (document scroll) in `useIosPwa` and reveal the focused editable field inside its scroll container, eliminating the black void that appeared when focusing settings fields in the iOS standalone PWA.
- Size the app shell from `min(innerHeight, visualViewport.height)` when the keyboard shrinks the visual viewport (with a pinch-zoom guard), so the chat composer stays flush above the keyboard instead of disappearing behind it.
- Add a `focusin` listener with a trailing correction to catch WebKit's late pan during the keyboard animation, plus a `visualViewport` scroll listener.
- Extend `use-ios-pwa` unit tests to 28 cases covering pan reset, focus reveal, pinch zoom, keyboard close restore, and listener cleanup; full suite passes 1276/1276 with 90.33% global coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)