### PR TITLE
Preserve thinking phases around streaming actions

### DIFF
--- a/components/chat-snapshot-helpers.ts
+++ b/components/chat-snapshot-helpers.ts
@@ -181,6 +181,64 @@ export function updateStreamingAction(
   return [...timeline, { ...action, timelineKind: "action" }];
 }
 
+export function ensureStreamingThinkingPhase(
+  timeline: MessageTimelineItem[],
+  messageId: string,
+  startOffset: number,
+  startedAt: string
+): MessageTimelineItem[] {
+  const lastItem = timeline.at(-1);
+
+  if (lastItem?.timelineKind === "thinking" && lastItem.status === "running") {
+    return timeline;
+  }
+
+  const phaseIndex = timeline.filter((item) => item.timelineKind === "thinking").length;
+
+  return [
+    ...timeline,
+    {
+      id: `stream_thinking_${messageId}_${phaseIndex}`,
+      messageId,
+      timelineKind: "thinking",
+      status: "running",
+      sortOrder: timeline.length,
+      startOffset,
+      endOffset: null,
+      startedAt,
+      completedAt: null
+    }
+  ];
+}
+
+export function completeStreamingThinkingPhase(
+  timeline: MessageTimelineItem[],
+  endOffset: number,
+  status: "completed" | "error" | "stopped",
+  completedAt: string
+): MessageTimelineItem[] {
+  for (let index = timeline.length - 1; index >= 0; index -= 1) {
+    const item = timeline[index];
+
+    if (item.timelineKind !== "thinking" || item.status !== "running") {
+      continue;
+    }
+
+    return timeline.map((candidate, candidateIndex) =>
+      candidateIndex === index
+        ? {
+            ...item,
+            status,
+            endOffset,
+            completedAt
+          }
+        : candidate
+    );
+  }
+
+  return timeline;
+}
+
 export function isLegacyCompactionNotice(message: Pick<Message, "role" | "systemKind">) {
   return message.role === "system" && message.systemKind === "compaction_notice";
 }
@@ -364,11 +422,15 @@ export function adoptStreamingSnapshotState(timeline: MessageTimelineItem[] | un
     }
 
     flushBufferedText();
-    consolidated.push({
-      ...item,
-      timelineKind: "action",
-      sortOrder: consolidated.length
-    });
+    consolidated.push(
+      item.timelineKind === "thinking"
+        ? { ...item, sortOrder: consolidated.length }
+        : {
+            ...item,
+            timelineKind: "action",
+            sortOrder: consolidated.length
+          }
+    );
   }
 
   flushBufferedText();

--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -21,6 +21,8 @@ import {
   type PendingLocalSubmission,
   adoptStreamingSnapshotState,
   appendStreamingAction,
+  completeStreamingThinkingPhase,
+  ensureStreamingThinkingPhase,
   getAttachmentIdSignature,
   isQueuedMessageOperationError,
   matchesPendingLocalSubmission,
@@ -320,12 +322,21 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
       streamTimelineRef.current,
       adoptedStream.timeline
     );
+    const nextTimeline =
+      mergedTimeline.at(-1)?.timelineKind === "action"
+        ? completeStreamingThinkingPhase(
+            mergedTimeline,
+            nextThinking.length,
+            "completed",
+            new Date().toISOString()
+          )
+        : mergedTimeline;
 
     streamBuffer.setAnswer(nextAnswer, { immediate: adopt });
     streamBuffer.setThinking(nextThinking, { immediate: adopt });
     setStreamMessageId(snapshotMessage.id);
-    updateStreamTimeline(mergedTimeline);
-    setHasReceivedFirstToken(Boolean(nextAnswer || nextThinking || mergedTimeline.length));
+    updateStreamTimeline(nextTimeline);
+    setHasReceivedFirstToken(Boolean(nextAnswer || nextThinking || nextTimeline.length));
     setIsSending(true);
     setIsConversationActive(true);
   }, [streamBuffer, updateStreamTimeline]);
@@ -530,6 +541,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
     if (event.type === "stream_retry") {
       finalizePendingRef.current = false;
       streamBuffer.reset();
+      updateStreamTimeline([]);
       return;
     }
 
@@ -604,6 +616,16 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
     if (event.type === "thinking_delta") {
       clearCompactionIndicator();
       setHasReceivedFirstToken(true);
+      const thinkingSnapshot = streamBuffer.getSnapshot();
+      const startedAt = new Date().toISOString();
+      updateStreamTimeline((previous) =>
+        ensureStreamingThinkingPhase(
+          previous,
+          streamMessageIdRef.current ?? "streaming",
+          thinkingSnapshot.thinkingTarget.length,
+          startedAt
+        )
+      );
       streamBuffer.appendThinking(event.text);
       if (!thinkingStartTimeRef.current) {
         thinkingStartTimeRef.current = Date.now();
@@ -613,6 +635,14 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
     if (event.type === "answer_delta") {
       clearCompactionIndicator();
       setHasReceivedFirstToken(true);
+      updateStreamTimeline((previous) =>
+        completeStreamingThinkingPhase(
+          previous,
+          streamBuffer.getSnapshot().thinkingTarget.length,
+          "completed",
+          new Date().toISOString()
+        )
+      );
       streamBuffer.appendAnswer(event.text);
       if (thinkingStartTimeRef.current) {
         const duration = (Date.now() - thinkingStartTimeRef.current) / 1000;
@@ -641,23 +671,31 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
     if (event.type === "action_start") {
       clearCompactionIndicator();
       updateStreamTimeline((prev) => {
-        const isExisting = prev.some((item) => item.timelineKind === "action" && item.id === event.action.id);
+        const timelineWithCompletedThinking = completeStreamingThinkingPhase(
+          prev,
+          streamBuffer.getSnapshot().thinkingTarget.length,
+          "completed",
+          new Date().toISOString()
+        );
+        const isExisting = timelineWithCompletedThinking.some(
+          (item) => item.timelineKind === "action" && item.id === event.action.id
+        );
         if (isExisting) {
-          return appendStreamingAction(prev, event.action);
+          return appendStreamingAction(timelineWithCompletedThinking, event.action);
         }
 
-        const previousTextLen = prev
+        const previousTextLen = timelineWithCompletedThinking
           .filter((item): item is Extract<MessageTimelineItem, { timelineKind: "text" }> => item.timelineKind === "text")
           .reduce((sum, item) => sum + item.content.length, 0);
 
         const newText = streamBuffer.getSnapshot().answerTarget.slice(previousTextLen);
-        const nextTimeline = [...prev];
+        const nextTimeline = [...timelineWithCompletedThinking];
 
         if (newText.length > 0) {
           nextTimeline.push({
             id: `stream_text_${Date.now()}_${prev.length}`,
             timelineKind: "text",
-            sortOrder: prev.length,
+            sortOrder: nextTimeline.length,
             createdAt: new Date().toISOString(),
             content: newText
           });
@@ -669,13 +707,32 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
 
     if (event.type === "action_complete" || event.type === "action_error") {
       clearCompactionIndicator();
-      updateStreamTimeline((prev) => updateStreamingAction(prev, event.action));
+      updateStreamTimeline((previous) =>
+        updateStreamingAction(
+          completeStreamingThinkingPhase(
+            previous,
+            streamBuffer.getSnapshot().thinkingTarget.length,
+            "completed",
+            new Date().toISOString()
+          ),
+          event.action
+        )
+      );
     }
 
     if (event.type === "done") {
       clearCompactionIndicator();
       const wasStopped = isStopPending;
       setIsStopPending(false);
+
+      updateStreamTimeline((previous) =>
+        completeStreamingThinkingPhase(
+          previous,
+          streamBuffer.getSnapshot().thinkingTarget.length,
+          wasStopped ? "stopped" : "completed",
+          new Date().toISOString()
+        )
+      );
 
       const isForActiveStream = event.messageId === streamMessageIdRef.current;
 
@@ -687,11 +744,22 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
         });
       }
 
-      if (event.message) {
+      const streamedTimeline = streamTimelineRef.current;
+      const finalTimeline = event.message?.timeline
+        ? mergeStreamingSnapshotTimeline(streamedTimeline, event.message.timeline)
+        : streamedTimeline;
+
+      const completedMessage = event.message;
+
+      if (completedMessage) {
         setMessages((current) =>
           current.map((m) =>
             m.id === event.messageId
-              ? { ...event.message, status: wasStopped ? ("stopped" as const) : ("completed" as const) } as Message
+              ? {
+                  ...completedMessage,
+                  status: wasStopped ? ("stopped" as const) : ("completed" as const),
+                  timeline: finalTimeline.length > 0 ? finalTimeline : completedMessage.timeline
+                } as Message
               : m
           )
         );
@@ -699,8 +767,6 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
         const bufferSnapshot = streamBuffer.getSnapshot();
         const finalAnswer = bufferSnapshot.answerTarget;
         const finalThinking = bufferSnapshot.thinkingTarget;
-        const finalTimeline = streamTimelineRef.current;
-
         setMessages((current) =>
           current.map((m) =>
             m.id === event.messageId
@@ -745,6 +811,14 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
     if (event.type === "error") {
       clearCompactionIndicator();
       setIsStopPending(false);
+      updateStreamTimeline((previous) =>
+        completeStreamingThinkingPhase(
+          previous,
+          streamBuffer.getSnapshot().thinkingTarget.length,
+          "error",
+          new Date().toISOString()
+        )
+      );
       const activeStreamMessageId = streamMessageIdRef.current;
 
       if (activeStreamMessageId) {
@@ -891,6 +965,14 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
             isActive: false
           });
           const activeStreamMessageId = streamMessageIdRef.current;
+          updateStreamTimeline((previous) =>
+            completeStreamingThinkingPhase(
+              previous,
+              streamBuffer.getSnapshot().thinkingTarget.length,
+              "error",
+              new Date().toISOString()
+            )
+          );
           const finalTimeline = streamTimelineRef.current;
           setMessages((current) => {
             if (activeStreamMessageId) {

--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -231,6 +231,13 @@ const ASSISTANT_ERROR_MAX_WIDTH = "max-w-full md:max-w-[95%]";
 const ASSISTANT_LOADING_SHELL =
   "mt-[6px] inline-flex items-center overflow-hidden rounded-lg border border-white/5 bg-white/[0.015] px-2 py-1";
 
+type ThinkingTimelineItem = Extract<MessageTimelineItem, { timelineKind: "thinking" }>;
+type RenderedThinkingTimelineItem = ThinkingTimelineItem & { content: string };
+type AssistantBlock =
+  | Extract<MessageTimelineItem, { timelineKind: "text" }>
+  | Extract<MessageTimelineItem, { timelineKind: "action" }>
+  | RenderedThinkingTimelineItem;
+
 function getActionSignature(action: Pick<MessageActionType, "kind" | "label" | "detail" | "toolName">) {
   return [action.kind, action.label, action.detail, action.toolName ?? ""].join("\u0000");
 }
@@ -331,7 +338,7 @@ function MessageBubbleImpl({
   onPreviewAttachment?: (attachment: MessageAttachment) => void;
   readOnly?: boolean;
 }) {
-  const [thinkingOpen, setThinkingOpen] = useState(false);
+  const [thinkingOpenItems, setThinkingOpenItems] = useState<Record<string, boolean>>({});
   const [toolOpenItems, setToolOpenItems] = useState<Record<string, boolean>>({});
   const [copyState, setCopyState] = useState<"idle" | "copied" | "error">("idle");
   const [isEditing, setIsEditing] = useState(false);
@@ -379,7 +386,7 @@ function MessageBubbleImpl({
       ...action,
       timelineKind: "action" as const
     }));
-    const assistantBlocks: MessageTimelineItem[] = [];
+    const assistantBlocks: AssistantBlock[] = [];
     const deferredMemoryProposalBlocks: Extract<MessageTimelineItem, { timelineKind: "action" }>[] = [];
     let bufferedText = "";
 
@@ -403,6 +410,19 @@ function MessageBubbleImpl({
     }
 
     timeline.forEach((item) => {
+      if (item.timelineKind === "thinking") {
+        appendBufferedText();
+        const visibleEnd = Math.min(
+          item.endOffset ?? rawThinking.length,
+          rawThinking.length
+        );
+        assistantBlocks.push({
+          ...item,
+          content: rawThinking.slice(item.startOffset, visibleEnd)
+        });
+        return;
+      }
+
       if (item.timelineKind === "action") {
         if (isMemoryProposalAction(item)) {
           deferredMemoryProposalBlocks.push(item);
@@ -514,6 +534,82 @@ function MessageBubbleImpl({
     setToolOpenItems((prev) => ({ ...prev, [id]: !prev[id] }));
   }
 
+  function toggleThinkingItem(id: string) {
+    setThinkingOpenItems((previous) => ({
+      ...previous,
+      [id]: !previous[id]
+    }));
+  }
+
+  function renderThinkingShell({
+    id,
+    content: thinkingShellContent,
+    status,
+    duration
+  }: {
+    id: string;
+    content: string;
+    status: "running" | "completed" | "error" | "stopped";
+    duration?: number;
+  }) {
+    const isOpen = thinkingOpenItems[id] ?? false;
+    const isRunning = status === "running";
+    const statusIcon = isRunning
+      ? <LoaderCircle className="h-3 w-3 animate-spin text-white/45" />
+      : status === "completed"
+        ? <Check className="h-3 w-3 text-emerald-400/80" />
+        : status === "stopped"
+          ? <Square className="h-3 w-3 fill-current text-red-400" />
+          : <X className="h-3 w-3 text-red-400" />;
+
+    return (
+      <div
+        key={id}
+        data-testid="assistant-thinking-shell"
+        data-thinking-status={status}
+        className="w-fit rounded-lg border border-white/5 bg-white/[0.015] px-2 py-1 transition-all duration-300"
+      >
+        <button
+          type="button"
+          onClick={() => toggleThinkingItem(id)}
+          className="flex w-full items-center gap-1.5 text-left transition hover:opacity-80"
+        >
+          <span className="flex h-3.5 w-3.5 shrink-0 items-center justify-center">
+            {statusIcon}
+          </span>
+          <span className="flex items-center gap-1 text-[11px] text-white/50">
+            <span className="font-medium">{isRunning ? "Thinking" : "Thought"}</span>
+            {isRunning ? (
+              <span className="text-white/30">...</span>
+            ) : duration ? (
+              <span className="text-white/30">({duration.toFixed(1)}s)</span>
+            ) : null}
+          </span>
+          <span className="ml-auto flex items-center">
+            {isOpen ? (
+              <ChevronDown className="h-3.5 w-3.5 text-white/30" />
+            ) : (
+              <ChevronRight className="h-3.5 w-3.5 text-white/30" />
+            )}
+          </span>
+        </button>
+
+        {isOpen && thinkingShellContent ? (
+          <div
+            className="markdown-body thinking-markdown-body mt-1.5"
+            onClick={() => {
+              if (!window.getSelection()?.toString()) {
+                toggleThinkingItem(id);
+              }
+            }}
+          >
+            <Streamdown>{thinkingShellContent}</Streamdown>
+          </div>
+        ) : null}
+      </div>
+    );
+  }
+
   function renderAssistantActionItem(item: Extract<MessageTimelineItem, { timelineKind: "action" }>) {
     return (
       <div key={item.id} data-testid="assistant-actions-shell">
@@ -542,7 +638,11 @@ function MessageBubbleImpl({
     message.role === "assistant" &&
     assistantImageAttachments.length > 0 &&
     lastRenderableAssistantTextId === null;
-  const showThinkingShell = !awaitingFirstToken && (thinkingInProgress || hasThinking || Boolean(thinkingContent));
+  const hasTimelineThinking = assistantBlocks.some((item) => item.timelineKind === "thinking");
+  const showThinkingShell =
+    !hasTimelineThinking &&
+    !awaitingFirstToken &&
+    (thinkingInProgress || hasThinking || Boolean(thinkingContent));
   const showUserBubbleActions = Boolean(content) && !awaitingFirstToken;
   const isAssistantStreaming =
     message.role === "assistant" &&
@@ -556,6 +656,14 @@ function MessageBubbleImpl({
     Boolean(renderedAssistantText) &&
     !awaitingFirstToken &&
     !isAssistantStreaming;
+  const thinkingShell = showThinkingShell
+    ? renderThinkingShell({
+        id: `thinking_${message.id}`,
+        content: thinkingContent,
+        status: thinkingInProgress ? "running" : "completed",
+        duration: thinkingDuration
+      })
+    : null;
 
   function setCopyFeedback(nextState: "copied" | "error") {
     setCopyState(nextState);
@@ -739,54 +847,7 @@ function MessageBubbleImpl({
       <div className="flex w-full flex-col gap-1">
         <div className="min-w-0 w-full text-[14.5px] text-[var(--text)]">
           <div className="flex flex-col items-start gap-3">
-            {showThinkingShell ? (
-              <div
-                data-testid="assistant-thinking-shell"
-                className={`w-fit rounded-lg border border-white/5 bg-white/[0.015] px-2 py-1 transition-all duration-300`}
-              >
-                <button
-                  type="button"
-                  onClick={() => setThinkingOpen((current) => !current)}
-                  className="flex w-full items-center gap-1.5 text-left transition hover:opacity-80"
-                >
-                  <span className="flex h-3.5 w-3.5 shrink-0 items-center justify-center">
-                    {thinkingInProgress ? (
-                      <LoaderCircle className="h-3 w-3 animate-spin text-white/45" />
-                    ) : (
-                      <Check className="h-3 w-3 text-emerald-400/80" />
-                    )}
-                  </span>
-                  <span className="flex items-center gap-1 text-[11px] text-white/50">
-                    <span className="font-medium">{thinkingInProgress ? "Thinking" : "Thought"}</span>
-                    {thinkingInProgress ? (
-                      <span className="text-white/30">...</span>
-                    ) : thinkingDuration ? (
-                      <span className="text-white/30">({thinkingDuration.toFixed(1)}s)</span>
-                    ) : null}
-                  </span>
-                  <span className="ml-auto flex items-center">
-                    {thinkingOpen ? (
-                      <ChevronDown className="h-3.5 w-3.5 text-white/30" />
-                    ) : (
-                      <ChevronRight className="h-3.5 w-3.5 text-white/30" />
-                    )}
-                  </span>
-                </button>
-
-                {thinkingOpen && thinkingContent ? (
-                  <div
-                    className="markdown-body thinking-markdown-body mt-1.5"
-                    onClick={() => {
-                      if (!window.getSelection()?.toString()) {
-                        setThinkingOpen(false);
-                      }
-                    }}
-                  >
-                    <Streamdown>{thinkingContent}</Streamdown>
-                  </div>
-                ) : null}
-              </div>
-            ) : null}
+            {thinkingShell}
 
             {awaitingFirstToken ? (
               compactionInProgress ? (
@@ -803,11 +864,19 @@ function MessageBubbleImpl({
               <div className="group flex w-full min-w-0 flex-col items-start">
                 <MessageContent className={`w-full ${ASSISTANT_ERROR_MAX_WIDTH} flex-col gap-3`}>
                   {assistantBlocks
-                    .filter(
-                      (item): item is Extract<MessageTimelineItem, { timelineKind: "action" }> =>
-                        item.timelineKind === "action"
-                    )
-                    .map((item) => renderAssistantActionItem(item))}
+                    .filter((item) => item.timelineKind !== "text")
+                    .map((item) =>
+                      item.timelineKind === "thinking"
+                        ? renderThinkingShell({
+                            id: item.id,
+                            content: item.content,
+                            status: item.status,
+                            duration: item.completedAt
+                              ? (Date.parse(item.completedAt) - Date.parse(item.startedAt)) / 1000
+                              : undefined
+                          })
+                        : renderAssistantActionItem(item)
+                    )}
                   <div
                     className="w-fit max-w-full rounded-2xl border border-red-400/10 bg-red-500/5 px-2.5 py-2 text-red-300/85 shadow-[0_2px_10px_rgba(0,0,0,0.22)] md:px-4 md:py-3"
                     data-testid="assistant-error-bubble"
@@ -837,6 +906,17 @@ function MessageBubbleImpl({
                 <MessageContent className="w-full">
                   <div ref={contentRef} className="flex flex-col gap-3">
                     {assistantBlocks.map((item) => {
+                      if (item.timelineKind === "thinking") {
+                        return renderThinkingShell({
+                          id: item.id,
+                          content: item.content,
+                          status: item.status,
+                          duration: item.completedAt
+                            ? (Date.parse(item.completedAt) - Date.parse(item.startedAt)) / 1000
+                            : undefined
+                        });
+                      }
+
                       if (item.timelineKind === "action") {
                         return renderAssistantActionItem(item);
                       }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -61,6 +61,8 @@ export type MessageActionKind = "skill_load" | "mcp_tool_call" | "shell_command"
 
 export type MessageActionStatus = "running" | "pending" | "completed" | "error" | "stopped";
 
+export type MessageThinkingStatus = "running" | "completed" | "error" | "stopped";
+
 export type AttachmentKind = "image" | "text";
 
 export type MemoryNodeType = "leaf_summary" | "merged_summary";
@@ -412,6 +414,17 @@ export type MessageTimelineItem =
       sortOrder: number;
       createdAt: string;
       content: string;
+    }
+  | {
+      id: string;
+      messageId: string;
+      timelineKind: "thinking";
+      status: MessageThinkingStatus;
+      sortOrder: number;
+      startOffset: number;
+      endOffset: number | null;
+      startedAt: string;
+      completedAt: string | null;
     }
   | ({
       timelineKind: "action";

--- a/tests/unit/chat-snapshot-helpers.test.ts
+++ b/tests/unit/chat-snapshot-helpers.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { reconcileSnapshotMessages } from "@/components/chat-snapshot-helpers";
-import type { Message, MessageAction } from "@/lib/types";
+import {
+  completeStreamingThinkingPhase,
+  ensureStreamingThinkingPhase,
+  reconcileSnapshotMessages
+} from "@/components/chat-snapshot-helpers";
+import type { Message, MessageAction, MessageTimelineItem } from "@/lib/types";
 
 function makeMessage(overrides: Partial<Message> & { id: string }): Message {
   return {
@@ -87,5 +91,75 @@ describe("reconcileSnapshotMessages identity preservation", () => {
     ]);
     expect(result.anchorMessageIdRemap.get("local_1")).toBe("srv_1");
     expect(result.messages.map((m) => m.id)).toEqual(["srv_1"]);
+  });
+});
+
+describe("streaming thinking phases", () => {
+  it("completes a phase in place and appends resumed thinking after the tool", () => {
+    const firstPhase = ensureStreamingThinkingPhase(
+      [],
+      "msg_assistant",
+      0,
+      "2026-07-27T12:00:00.000Z"
+    );
+    const repeatedDelta = ensureStreamingThinkingPhase(
+      firstPhase,
+      "msg_assistant",
+      8,
+      "2026-07-27T12:00:00.500Z"
+    );
+    const completedPhase = completeStreamingThinkingPhase(
+      repeatedDelta,
+      16,
+      "completed",
+      "2026-07-27T12:00:01.000Z"
+    );
+    const toolAction: MessageTimelineItem = {
+      id: "act_search",
+      messageId: "msg_assistant",
+      timelineKind: "action",
+      kind: "mcp_tool_call",
+      status: "completed",
+      serverId: "exa",
+      skillId: null,
+      toolName: "web_search_exa",
+      label: "Web search",
+      detail: "query=Eidon",
+      arguments: { query: "Eidon" },
+      resultSummary: "Found results",
+      sortOrder: 1,
+      startedAt: "2026-07-27T12:00:01.000Z",
+      completedAt: "2026-07-27T12:00:02.000Z",
+      proposalState: null,
+      proposalPayload: null,
+      proposalUpdatedAt: null
+    };
+    const resumedPhase = ensureStreamingThinkingPhase(
+      [...completedPhase, toolAction],
+      "msg_assistant",
+      16,
+      "2026-07-27T12:00:02.000Z"
+    );
+
+    expect(repeatedDelta).toBe(firstPhase);
+    expect(resumedPhase.map((item) => item.timelineKind)).toEqual([
+      "thinking",
+      "action",
+      "thinking"
+    ]);
+    expect(resumedPhase[0]).toEqual(
+      expect.objectContaining({
+        id: "stream_thinking_msg_assistant_0",
+        status: "completed",
+        endOffset: 16
+      })
+    );
+    expect(resumedPhase[2]).toEqual(
+      expect.objectContaining({
+        id: "stream_thinking_msg_assistant_1",
+        status: "running",
+        startOffset: 16
+      })
+    );
   });
 });

--- a/tests/unit/chat-view.test.ts
+++ b/tests/unit/chat-view.test.ts
@@ -1630,7 +1630,7 @@ describe("chat view", () => {
       expect(screen.getByText("Generate image")).toBeInTheDocument();
     });
 
-    expect(screen.getByRole("button", { name: "Thought" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^Thought/ })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Thinking ..." })).toBeNull();
   });
 
@@ -3700,6 +3700,32 @@ describe("chat view", () => {
         type: "delta",
         conversationId: "conv_1",
         event: {
+          type: "action_start",
+          action: {
+            id: "act_live",
+            messageId: "msg_assistant",
+            kind: "mcp_tool_call",
+            status: "running",
+            serverId: "exa",
+            skillId: null,
+            toolName: "web_search_exa",
+            label: "web_search_exa",
+            detail: "query=booking",
+            arguments: { query: "booking" },
+            resultSummary: "",
+            sortOrder: 1,
+            startedAt: new Date().toISOString(),
+            completedAt: null,
+            proposalState: null,
+            proposalPayload: null,
+            proposalUpdatedAt: null
+          }
+        }
+      });
+      wsMock.onMessage!({
+        type: "delta",
+        conversationId: "conv_1",
+        event: {
           type: "action_complete",
           action: {
             id: "act_live",
@@ -3721,6 +3747,11 @@ describe("chat view", () => {
             proposalUpdatedAt: null
           }
         }
+      });
+      wsMock.onMessage!({
+        type: "delta",
+        conversationId: "conv_1",
+        event: { type: "thinking_delta", text: " Reviewing the results" }
       });
 
       resolveFetch?.({
@@ -3772,7 +3803,36 @@ describe("chat view", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByTestId("assistant-thinking-shell")).toBeInTheDocument();
+      expect(screen.getAllByTestId("assistant-thinking-shell")).toHaveLength(2);
+    });
+
+    const completedAction = screen.getByTestId("assistant-actions-shell");
+    const thinkingPhases = screen.getAllByTestId("assistant-thinking-shell");
+
+    expect(thinkingPhases).toHaveLength(2);
+    expect(thinkingPhases[0]).toHaveAttribute("data-thinking-status", "completed");
+    expect(thinkingPhases[1]).toHaveAttribute("data-thinking-status", "running");
+    expect(thinkingPhases[0].compareDocumentPosition(completedAction)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING
+    );
+    expect(completedAction.compareDocumentPosition(thinkingPhases[1])).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING
+    );
+
+    act(() => {
+      wsMock.onMessage!({
+        type: "delta",
+        conversationId: "conv_1",
+        event: { type: "done", messageId: "msg_assistant" }
+      });
+    });
+
+    await waitFor(() => {
+      const completedThinkingPhases = screen.getAllByTestId("assistant-thinking-shell");
+      expect(completedThinkingPhases[0]).toBe(thinkingPhases[0]);
+      expect(completedThinkingPhases[1]).toBe(thinkingPhases[1]);
+      expect(completedThinkingPhases[0]).toHaveAttribute("data-thinking-status", "completed");
+      expect(completedThinkingPhases[1]).toHaveAttribute("data-thinking-status", "completed");
     });
   });
 

--- a/tests/unit/message-bubble.test.ts
+++ b/tests/unit/message-bubble.test.ts
@@ -102,6 +102,23 @@ function createToolAction(
   };
 }
 
+function createThinkingItem(
+  overrides: Partial<Extract<MessageTimelineItem, { timelineKind: "thinking" }>> = {}
+): Extract<MessageTimelineItem, { timelineKind: "thinking" }> {
+  return {
+    id: "thinking_0",
+    messageId: "msg_assistant",
+    timelineKind: "thinking",
+    status: "completed",
+    sortOrder: 0,
+    startOffset: 0,
+    endOffset: 16,
+    startedAt: "2026-07-27T12:00:00.000Z",
+    completedAt: "2026-07-27T12:00:01.000Z",
+    ...overrides
+  };
+}
+
 function createMemoryProposalMessage(
   overrides: Partial<Message> = {},
   actionOverrides: Partial<Extract<MessageTimelineItem, { timelineKind: "action" }>> = {}
@@ -427,7 +444,7 @@ describe("message bubble", () => {
     expect(screen.queryByRole("button", { name: "Create memory proposal" })).toBeNull();
   });
 
-  it("keeps the thought shell above action rows", () => {
+  it("keeps the completed thought shell above action rows", () => {
     render(
       React.createElement(MessageBubble, {
         message: {
@@ -454,6 +471,123 @@ describe("message bubble", () => {
     expect(thinkingShell.compareDocumentPosition(actionsShell)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING
     );
+  });
+
+  it("keeps distinct thinking phases in chronological timeline order", () => {
+    const { container } = render(
+      React.createElement(MessageBubble, {
+        message: {
+          ...createAssistantMessage(),
+          status: "streaming",
+          content: "",
+          thinkingContent: "Before the searchAfter the search",
+          timeline: [
+            createThinkingItem({
+              id: "thinking_before",
+              startOffset: 0,
+              endOffset: 17,
+              sortOrder: 0
+            }),
+            {
+              ...createToolAction({
+                id: "act_done",
+                messageId: "msg_assistant",
+                serverId: "mcp_docs",
+                toolName: "search_docs",
+                label: "Search docs",
+                detail: "query=MCP",
+                resultSummary: "Found MCP documentation",
+                sortOrder: 1
+              }),
+              timelineKind: "action"
+            },
+            createThinkingItem({
+              id: "thinking_after",
+              status: "running",
+              startOffset: 17,
+              endOffset: null,
+              sortOrder: 2,
+              completedAt: null
+            })
+          ]
+        },
+        streamingThinking: "Before the searchAfter the search",
+        streamingTimeline: [
+          createThinkingItem({
+            id: "thinking_before",
+            startOffset: 0,
+            endOffset: 17,
+            sortOrder: 0
+          }),
+          {
+            ...createToolAction({
+              id: "act_done",
+              messageId: "msg_assistant",
+              serverId: "mcp_docs",
+              toolName: "search_docs",
+              label: "Search docs",
+              detail: "query=MCP",
+              resultSummary: "Found MCP documentation",
+              sortOrder: 1
+            }),
+            timelineKind: "action"
+          },
+          createThinkingItem({
+            id: "thinking_after",
+            status: "running",
+            startOffset: 17,
+            endOffset: null,
+            sortOrder: 2,
+            completedAt: null
+          })
+        ],
+        hasThinking: true
+      })
+    );
+
+    const blocks = Array.from(
+      container.querySelectorAll(
+        '[data-testid="assistant-thinking-shell"], [data-testid="assistant-actions-shell"]'
+      )
+    );
+
+    expect(blocks).toHaveLength(3);
+    expect(blocks[0]).toHaveAttribute("data-thinking-status", "completed");
+    expect(blocks[1]).toHaveTextContent("Search docs");
+    expect(blocks[2]).toHaveAttribute("data-thinking-status", "running");
+  });
+
+  it("keeps action rows in chronological order while their statuses change", () => {
+    render(
+      React.createElement(MessageBubble, {
+        message: {
+          ...createAssistantMessage(),
+          actions: [
+            createToolAction({
+              id: "act_running",
+              messageId: "msg_assistant",
+              label: "Searching the web",
+              detail: "query=Eidon",
+              resultSummary: "",
+              status: "running",
+              completedAt: null
+            }),
+            createToolAction({
+              id: "act_done",
+              messageId: "msg_assistant",
+              label: "Read documentation",
+              detail: "url=https://example.com/docs",
+              resultSummary: "Documentation loaded"
+            })
+          ]
+        }
+      })
+    );
+
+    const actionShells = screen.getAllByTestId("assistant-actions-shell");
+
+    expect(actionShells[0]).toHaveTextContent("Searching the web");
+    expect(actionShells[1]).toHaveTextContent("Read documentation");
   });
 
   it("renders assistant text and tool actions in timeline order", () => {


### PR DESCRIPTION
## Summary

- Track distinct thinking phases before and after streaming actions.
- Render each phase in timeline order with independent status, duration, and expansion state.
- Preserve thinking phases when adopting snapshots and finalize them across completion, retry, stop, and error paths.
- Add unit and chat-view coverage for resumed thinking phases.

## Testing

- Not run (not requested).