### PR TITLE
Fix mobile WebSocket reconnects

### DIFF
--- a/lib/conversation-manager.ts
+++ b/lib/conversation-manager.ts
@@ -6,6 +6,14 @@ import { sanitizeMobilePayload } from "@/lib/mobile-api";
 
 export const MAX_WS_CONNECTIONS = 500;
 
+function mobileServerMessage(event: ServerMessage) {
+  const sanitized = sanitizeMobilePayload(event) as ServerMessage;
+  if (sanitized.type === "error" && !sanitized.code) {
+    return { ...sanitized, code: "request_failed" };
+  }
+  return sanitized;
+}
+
 export function createConversationManager() {
   const rooms = new Map<string, Set<WebSocket>>();
   const clientRooms = new Map<WebSocket, Set<string>>();
@@ -41,7 +49,7 @@ export function createConversationManager() {
     if (!room) return;
     for (const ws of room) {
       const payload = connectionKinds.get(ws) === "mobile"
-        ? sanitizeMobilePayload(event) as ServerMessage
+        ? mobileServerMessage(event)
         : event;
       sendWebSocketData(ws, serializeServerMessage(payload));
     }
@@ -112,7 +120,7 @@ export function createConversationManager() {
       }
 
       const payload = connectionKinds.get(ws) === "mobile"
-        ? sanitizeMobilePayload(event) as ServerMessage
+        ? mobileServerMessage(event)
         : event;
       sendWebSocketData(ws, serializeServerMessage(payload));
     }

--- a/lib/ws-handler.ts
+++ b/lib/ws-handler.ts
@@ -29,6 +29,7 @@ import { bootstrapRuntimeState } from "@/lib/runtime-bootstrap";
 import { truncateText } from "@/lib/bounded-text";
 import { sanitizeMobilePayload } from "@/lib/mobile-api";
 import {
+  claimWebSocketUpgradeRouting,
   resolveWebSocketAuthMode,
   routeWebSocketUpgrade
 } from "@/lib/ws-upgrade-router";
@@ -41,6 +42,7 @@ export {
   getDb,
   initTitleModel,
   initializeMcpServers,
+  claimWebSocketUpgradeRouting,
   resolveWebSocketAuthMode,
   routeWebSocketUpgrade,
   shutdownAllProcesses

--- a/lib/ws-upgrade-router.ts
+++ b/lib/ws-upgrade-router.ts
@@ -9,6 +9,14 @@ type UpgradeFallback = (
   head: Buffer
 ) => void;
 
+type NextUpgradeOwner = {
+  setupWebSocketHandler: () => void;
+};
+
+export function claimWebSocketUpgradeRouting(app: NextUpgradeOwner) {
+  app.setupWebSocketHandler();
+}
+
 export function resolveWebSocketAuthMode(request: IncomingMessage) {
   const pathname = new URL(request.url ?? "/", "http://localhost").pathname;
   return pathname === "/api/v1/ws" ? "mobile" as const : "browser" as const;

--- a/server.cjs
+++ b/server.cjs
@@ -102,6 +102,7 @@ app.prepare().then(async () => {
   });
   const {
     bootstrapRuntimeState,
+    claimWebSocketUpgradeRouting,
     createAutomationScheduler,
     resolveWebSocketAuthMode,
     routeWebSocketUpgrade,
@@ -109,6 +110,7 @@ app.prepare().then(async () => {
   } = require("./ws-handler-compiled.cjs");
   bootstrapRuntimeState();
   setupWebSocketHandler(wss, { authModeForRequest: resolveWebSocketAuthMode });
+  claimWebSocketUpgradeRouting(app);
   const upgradeHandler = app.getUpgradeHandler();
   server.on("upgrade", (request, socket, head) => {
     routeWebSocketUpgrade(

--- a/tests/fixtures/native-fake-provider.mjs
+++ b/tests/fixtures/native-fake-provider.mjs
@@ -1,6 +1,8 @@
 import http from "node:http";
 
 const port = Number(process.env.PORT || 4010);
+const failOnceAttempts = new Map();
+const failedStreamRequestsBeforeRecovery = 9;
 
 function json(response, status, body) {
   response.writeHead(status, { "content-type": "application/json" });
@@ -24,6 +26,14 @@ function promptText(body) {
   return JSON.stringify(body.messages ?? body.input ?? "");
 }
 
+function failureKey(body, prompt) {
+  if (!Array.isArray(body.messages)) return prompt;
+  const message = body.messages.findLast((item) =>
+    item?.role === "user" && JSON.stringify(item.content).includes("[fail-once]")
+  );
+  return message ? JSON.stringify(message.content) : prompt;
+}
+
 const server = http.createServer(async (request, response) => {
   if (request.method === "GET" && request.url === "/v1/models") {
     return json(response, 200, {
@@ -38,8 +48,22 @@ const server = http.createServer(async (request, response) => {
 
   try {
     const body = JSON.parse(await readBody(request));
-    if (promptText(body).includes("[fail]")) {
+    const prompt = promptText(body);
+    const failureAttemptKey = failureKey(body, prompt);
+    const promptFailureAttempts = failOnceAttempts.get(failureAttemptKey) ?? 0;
+    if (
+      body.stream
+      && prompt.includes("[fail-once]")
+      && promptFailureAttempts < failedStreamRequestsBeforeRecovery
+    ) {
+      failOnceAttempts.set(failureAttemptKey, promptFailureAttempts + 1);
       return json(response, 503, { error: { message: "Deterministic provider failure" } });
+    }
+    if (prompt.includes("[fail]")) {
+      return json(response, 503, { error: { message: "Deterministic provider failure" } });
+    }
+    if (body.stream && prompt.includes("[slow]")) {
+      await new Promise((resolve) => setTimeout(resolve, 1500));
     }
 
     const content = "Deterministic native-client integration response.";

--- a/tests/unit/conversation-manager.test.ts
+++ b/tests/unit/conversation-manager.test.ts
@@ -144,6 +144,26 @@ describe("conversation-manager", () => {
     expect(JSON.stringify(mobileSent)).not.toContain("extractedText");
   });
 
+  it("adds a stable code to legacy errors sent to mobile connections", async () => {
+    const { createConversationManager } = await import("@/lib/conversation-manager");
+    const manager = createConversationManager();
+    const { ws: browserSocket, sent: browserSent } = createMockWs();
+    const { ws: mobileSocket, sent: mobileSent } = createMockWs();
+
+    manager.addConnection(browserSocket, "shared-user", "browser");
+    manager.addConnection(mobileSocket, "shared-user", "mobile");
+    manager.subscribe("conv-1", browserSocket);
+    manager.subscribe("conv-1", mobileSocket);
+    manager.broadcast("conv-1", { type: "error", message: "Unable to complete the turn" });
+
+    expect(browserSent[0]).toEqual({ type: "error", message: "Unable to complete the turn" });
+    expect(mobileSent[0]).toEqual({
+      type: "error",
+      code: "request_failed",
+      message: "Unable to complete the turn"
+    });
+  });
+
   it("closes slow consumers instead of growing their send buffer", async () => {
     const { createConversationManager } = await import("@/lib/conversation-manager");
     const { MAX_WS_BUFFERED_BYTES } = await import("@/lib/ws-send");

--- a/tests/unit/ws-upgrade-router.test.ts
+++ b/tests/unit/ws-upgrade-router.test.ts
@@ -6,6 +6,7 @@ import type WebSocket from "ws";
 import type { WebSocketServer } from "ws";
 
 import {
+  claimWebSocketUpgradeRouting,
   resolveWebSocketAuthMode,
   routeWebSocketUpgrade
 } from "@/lib/ws-upgrade-router";
@@ -33,6 +34,15 @@ function target() {
 }
 
 describe("WebSocket upgrade routing", () => {
+  it("claims upgrade routing before the Next request handler adds a duplicate listener", () => {
+    const setupWebSocketHandler = vi.fn();
+
+    claimWebSocketUpgradeRouting({ setupWebSocketHandler });
+
+    expect(setupWebSocketHandler).toHaveBeenCalledOnce();
+    expect(setupWebSocketHandler).toHaveBeenCalledWith();
+  });
+
   it.each([
     ["/ws?client=browser", "browser"],
     ["/api/v1/ws?client=native", "mobile"],


### PR DESCRIPTION
## Summary

- make the custom server the sole owner of WebSocket upgrade routing before Next.js can attach a competing listener
- provide stable error codes on mobile WebSocket broadcasts while preserving the existing browser payload shape
- extend deterministic provider and routing coverage for native-client recovery behavior

## Root cause

Next.js could attach its own upgrade listener after the first HTTP request even though the custom server already routed `/ws` and `/api/v1/ws`. Mobile clients could complete the initial handshake, then lose the socket when subscribing to a conversation or requesting its snapshot. Legacy broadcast errors without a `code` also violated the Mobile API v1 client contract.

## Impact

The native iOS client can subscribe to conversations created on another device, receive the snapshot, and remain connected instead of repeatedly showing a reconnecting banner. Mobile errors now retain a stable contract without changing browser WebSocket behavior.

## Validation

- `npm test`: 137/137 files and 1,484/1,484 tests passed
- coverage: 90.52% statements, 85.45% branches, 94.23% functions, 90.52% lines
- local native cross-device flow: a conversation created through a second mobile session appeared live and opened without reconnecting
- seeded native HTTPS integration: 3/3 passed
- iPhone suite: 114 passed, 0 failed; app-owned coverage 86.75%
- iPad UI suite: 17 passed, 0 failed
- unsigned iOS Release archive passed
