### PR TITLE
fix: parse <think> delimiters embedded in model content

### DIFF
--- a/lib/conversation-title-generator.ts
+++ b/lib/conversation-title-generator.ts
@@ -23,7 +23,7 @@ function trimToWordBoundary(value: string, maxLength: number) {
 }
 
 export function sanitizeGeneratedConversationTitle(rawTitle: string) {
-  const firstLine = rawTitle.split(/\r?\n/, 1)[0] ?? "";
+  const firstLine = rawTitle.trim().split(/\r?\n/, 1)[0] ?? "";
   const collapsed = firstLine
     .replace(/["'`""]+/g, "")
     .replace(/[.!?,;:\-–—]+/g, "")

--- a/lib/provider.ts
+++ b/lib/provider.ts
@@ -159,17 +159,19 @@ export async function callProviderText(input: {
   }
 
   if (profile.providerKind === "anthropic") {
-    const text = await callAnthropicText({
-      settings: profile,
-      messages: contextualPrompt,
-      abortSignal: input.abortSignal
-    });
+    const text = stripThinkingDelimiters(
+      await callAnthropicText({
+        settings: profile,
+        messages: contextualPrompt,
+        abortSignal: input.abortSignal
+      })
+    );
 
     if (!text.trim()) {
       throw new Error("Provider returned an empty response");
     }
 
-    return stripThinkingDelimiters(text);
+    return text;
   }
 
   const client = createClient(profile, profile.apiKey);
@@ -186,13 +188,13 @@ export async function callProviderText(input: {
       ? await client.responses.create(request, { signal: input.abortSignal })
       : await client.responses.create(request);
 
-    const text = normalizeLineBreaks(getResponseText(response));
+    const text = stripThinkingDelimiters(normalizeLineBreaks(getResponseText(response)));
 
     if (!text.trim()) {
       throw new Error("Provider returned an empty response");
     }
 
-    return stripThinkingDelimiters(text);
+    return text;
   }
 
   const request = {
@@ -206,17 +208,19 @@ export async function callProviderText(input: {
     ? await client.chat.completions.create(request, { signal: input.abortSignal })
     : await client.chat.completions.create(request);
 
-  const text = normalizeLineBreaks(
-    typeof response.choices[0]?.message?.content === "string"
-      ? response.choices[0]?.message?.content
-      : ""
+  const text = stripThinkingDelimiters(
+    normalizeLineBreaks(
+      typeof response.choices[0]?.message?.content === "string"
+        ? response.choices[0]?.message?.content
+        : ""
+    )
   );
 
   if (!text.trim()) {
     throw new Error("Provider returned an empty response");
   }
 
-  return stripThinkingDelimiters(text);
+  return text;
 }
 
 export async function* streamProviderResponse(input: {

--- a/lib/provider.ts
+++ b/lib/provider.ts
@@ -155,7 +155,13 @@ export async function callProviderText(input: {
       abortSignal: input.abortSignal
     });
 
-    return stripThinkingDelimiters(typeof result === "string" ? result : JSON.stringify(result));
+    const text = stripThinkingDelimiters(typeof result === "string" ? result : JSON.stringify(result));
+
+    if (!text.trim()) {
+      throw new Error("Provider returned an empty response");
+    }
+
+    return text;
   }
 
   if (profile.providerKind === "anthropic") {

--- a/lib/provider.ts
+++ b/lib/provider.ts
@@ -17,6 +17,7 @@ import {
   mergeRecoveredStreamText
 } from "./provider-response-parsing";
 import { createTextToolCallInterceptor } from "./tool-call-text-parsing";
+import { createThinkingDelimiterInterceptor, stripThinkingDelimiters } from "./thinking-delimiter-parsing";
 import { MAX_RUNTIME_TOOL_RESULT_CHARS, truncateText } from "@/lib/bounded-text";
 
 export {
@@ -154,7 +155,7 @@ export async function callProviderText(input: {
       abortSignal: input.abortSignal
     });
 
-    return typeof result === "string" ? result : JSON.stringify(result);
+    return stripThinkingDelimiters(typeof result === "string" ? result : JSON.stringify(result));
   }
 
   if (profile.providerKind === "anthropic") {
@@ -168,7 +169,7 @@ export async function callProviderText(input: {
       throw new Error("Provider returned an empty response");
     }
 
-    return text;
+    return stripThinkingDelimiters(text);
   }
 
   const client = createClient(profile, profile.apiKey);
@@ -191,7 +192,7 @@ export async function callProviderText(input: {
       throw new Error("Provider returned an empty response");
     }
 
-    return text;
+    return stripThinkingDelimiters(text);
   }
 
   const request = {
@@ -215,7 +216,7 @@ export async function callProviderText(input: {
     throw new Error("Provider returned an empty response");
   }
 
-  return text;
+  return stripThinkingDelimiters(text);
 }
 
 export async function* streamProviderResponse(input: {
@@ -693,6 +694,7 @@ export async function* streamProviderResponse(input: {
     { signal }
   ) as unknown as AsyncIterable<any>;
 
+  const thinkingInterceptor = createThinkingDelimiterInterceptor();
   const answerInterceptor = createTextToolCallInterceptor();
   const toolCallChunks = new Map<string, { name: string; arguments: string }>();
 
@@ -716,7 +718,12 @@ export async function* streamProviderResponse(input: {
       }
 
       if (delta) {
-        const emitted = answerInterceptor.feed(delta);
+        const { answer: answerText, thinking: thinkingText } = thinkingInterceptor.feed(delta);
+        if (thinkingText) {
+          thinking += thinkingText;
+          yield { type: "thinking_delta", text: thinkingText };
+        }
+        const emitted = answerInterceptor.feed(answerText);
         if (emitted) {
           yield { type: "answer_delta", text: emitted };
         }
@@ -755,6 +762,17 @@ export async function* streamProviderResponse(input: {
     }
   }
 
+  const thinkingTail = thinkingInterceptor.flush();
+  if (thinkingTail.thinking) {
+    thinking += thinkingTail.thinking;
+    yield { type: "thinking_delta", text: thinkingTail.thinking };
+  }
+  if (thinkingTail.answer) {
+    const tailEmitted = answerInterceptor.feed(thinkingTail.answer);
+    if (tailEmitted) {
+      yield { type: "answer_delta", text: tailEmitted };
+    }
+  }
   const answerTail = answerInterceptor.flush();
   if (answerTail) {
     yield { type: "answer_delta", text: answerTail };

--- a/lib/thinking-delimiter-parsing.ts
+++ b/lib/thinking-delimiter-parsing.ts
@@ -1,0 +1,121 @@
+const THINK_OPEN = "<think";
+const THINK_CLOSE = "</think>";
+
+function longestSuffixPrefix(text: string, marker: string): number {
+  const max = Math.min(text.length, marker.length - 1);
+  for (let len = max; len > 0; len -= 1) {
+    if (marker.startsWith(text.slice(text.length - len))) {
+      return len;
+    }
+  }
+  return 0;
+}
+
+export interface ThinkingDelimiterResult {
+  answer: string;
+  thinking: string;
+}
+
+export interface ThinkingDelimiterInterceptor {
+  feed(text: string): ThinkingDelimiterResult;
+  flush(): ThinkingDelimiterResult;
+}
+
+export function createThinkingDelimiterInterceptor(): ThinkingDelimiterInterceptor {
+  let pending = "";
+  let inside = false;
+  let needOpenClose = false;
+
+  function feed(text: string): ThinkingDelimiterResult {
+    pending += text;
+    let answer = "";
+    let thinking = "";
+
+    let guard = 0;
+    while (pending && guard++ < 10000) {
+      if (needOpenClose) {
+        const gt = pending.indexOf(">");
+        if (gt === -1) {
+          break;
+        }
+        pending = pending.slice(gt + 1);
+        needOpenClose = false;
+        inside = true;
+        continue;
+      }
+
+      if (inside) {
+        const closeIdx = pending.indexOf(THINK_CLOSE);
+        if (closeIdx === -1) {
+          const hold = longestSuffixPrefix(pending, THINK_CLOSE);
+          const safeLen = pending.length - hold;
+          if (safeLen > 0) {
+            thinking += pending.slice(0, safeLen);
+          }
+          pending = hold ? pending.slice(safeLen) : "";
+          break;
+        }
+        thinking += pending.slice(0, closeIdx);
+        pending = pending.slice(closeIdx + THINK_CLOSE.length);
+        inside = false;
+        continue;
+      }
+
+      const openIdx = pending.indexOf(THINK_OPEN);
+      if (openIdx === -1) {
+        const hold = longestSuffixPrefix(pending, THINK_OPEN);
+        const safeLen = pending.length - hold;
+        if (safeLen > 0) {
+          answer += pending.slice(0, safeLen);
+        }
+        pending = hold ? pending.slice(safeLen) : "";
+        break;
+      }
+
+      if (openIdx > 0) {
+        answer += pending.slice(0, openIdx);
+      }
+      pending = pending.slice(openIdx + THINK_OPEN.length);
+      const gt = pending.indexOf(">");
+      if (gt === -1) {
+        needOpenClose = true;
+        break;
+      }
+      pending = pending.slice(gt + 1);
+      inside = true;
+    }
+
+    return { answer, thinking };
+  }
+
+  function flush(): ThinkingDelimiterResult {
+    let answer = "";
+    let thinking = "";
+
+    if (inside) {
+      pending = "";
+      inside = false;
+    } else if (needOpenClose) {
+      answer = `${THINK_OPEN}${pending}`;
+      pending = "";
+      needOpenClose = false;
+    } else if (pending) {
+      answer = pending;
+      pending = "";
+    }
+
+    return { answer, thinking };
+  }
+
+  return { feed, flush };
+}
+
+export function stripThinkingDelimiters(text: string): string {
+  if (!text) {
+    return text;
+  }
+  const interceptor = createThinkingDelimiterInterceptor();
+  const { answer } = interceptor.feed(text);
+  const tail = interceptor.flush();
+  return `${answer}${tail.answer}`;
+}

--- a/lib/thinking-delimiter-parsing.ts
+++ b/lib/thinking-delimiter-parsing.ts
@@ -1,4 +1,4 @@
-const THINK_OPEN = "<think";
+const THINK_OPEN = "<think>";
 const THINK_CLOSE = "</think>";
 
 function longestSuffixPrefix(text: string, marker: string): number {
@@ -24,7 +24,6 @@ export interface ThinkingDelimiterInterceptor {
 export function createThinkingDelimiterInterceptor(): ThinkingDelimiterInterceptor {
   let pending = "";
   let inside = false;
-  let needOpenClose = false;
 
   function feed(text: string): ThinkingDelimiterResult {
     pending += text;
@@ -33,17 +32,6 @@ export function createThinkingDelimiterInterceptor(): ThinkingDelimiterIntercept
 
     let guard = 0;
     while (pending && guard++ < 10000) {
-      if (needOpenClose) {
-        const gt = pending.indexOf(">");
-        if (gt === -1) {
-          break;
-        }
-        pending = pending.slice(gt + 1);
-        needOpenClose = false;
-        inside = true;
-        continue;
-      }
-
       if (inside) {
         const closeIdx = pending.indexOf(THINK_CLOSE);
         if (closeIdx === -1) {
@@ -76,12 +64,6 @@ export function createThinkingDelimiterInterceptor(): ThinkingDelimiterIntercept
         answer += pending.slice(0, openIdx);
       }
       pending = pending.slice(openIdx + THINK_OPEN.length);
-      const gt = pending.indexOf(">");
-      if (gt === -1) {
-        needOpenClose = true;
-        break;
-      }
-      pending = pending.slice(gt + 1);
       inside = true;
     }
 
@@ -90,15 +72,11 @@ export function createThinkingDelimiterInterceptor(): ThinkingDelimiterIntercept
 
   function flush(): ThinkingDelimiterResult {
     let answer = "";
-    let thinking = "";
+    const thinking = "";
 
     if (inside) {
       pending = "";
       inside = false;
-    } else if (needOpenClose) {
-      answer = `${THINK_OPEN}${pending}`;
-      pending = "";
-      needOpenClose = false;
     } else if (pending) {
       answer = pending;
       pending = "";

--- a/tests/unit/compaction.test.ts
+++ b/tests/unit/compaction.test.ts
@@ -737,6 +737,49 @@ describe("lossless compaction", () => {
     expect(vi.mocked(callProviderText).mock.calls.at(-1)?.[0].abortSignal).toBe(controller.signal);
   });
 
+  it("does not commit a node or compact messages when stripping leaves no answer", async () => {
+    updateDefaultProfile({
+      modelContextLimit: 4096,
+      maxOutputTokens: 2000,
+      compactionThreshold: 0.6
+    });
+    getDb()
+      .prepare("UPDATE provider_profiles SET fresh_tail_count = ? WHERE id = ?")
+      .run(2, "profile_default");
+    const conversation = createConversation();
+
+    for (let index = 0; index < 8; index += 1) {
+      createMessage({
+        conversationId: conversation.id, role: "user", content: `User ${index} ${"context ".repeat(250)}` });
+      createMessage({ conversationId: conversation.id, role: "assistant", content: `Assistant ${index} ${"context ".repeat(250)}` });
+    }
+
+    const { callProviderText } = await import("@/lib/provider");
+    const { stripThinkingDelimiters } = await import("@/lib/thinking-delimiter-parsing");
+    vi.mocked(callProviderText).mockImplementationOnce(() => {
+      const cleaned = stripThinkingDelimiters("<think>reasoning with no answer</think>");
+      if (!cleaned.trim()) {
+        return Promise.reject(new Error("Provider returned an empty response"));
+      }
+      return Promise.resolve(cleaned);
+    });
+
+    await expect(
+      ensureCompactedContext(conversation.id, getDefaultProviderProfileWithApiKey()!)
+    ).rejects.toThrow("Provider returned an empty response");
+
+    expect(
+      getDb()
+        .prepare("SELECT COUNT(*) AS count FROM memory_nodes WHERE conversation_id = ?")
+        .get(conversation.id)
+    ).toEqual({ count: 0 });
+    expect(
+      getDb()
+        .prepare("SELECT COUNT(*) AS count FROM messages WHERE conversation_id = ? AND compacted_at IS NOT NULL")
+        .get(conversation.id)
+    ).toEqual({ count: 0 });
+  });
+
   it("replays only the freshest completed turns instead of the whole visible raw history", async () => {
     updateDefaultProfile({
       modelContextLimit: 20000,

--- a/tests/unit/conversation-title-generator.test.ts
+++ b/tests/unit/conversation-title-generator.test.ts
@@ -69,4 +69,40 @@ describe("conversation title generator", () => {
 
     expect(title).toBe("Build a deployment checklist for me");
   });
+
+  it("skips leading blank lines left after a stripped think block", async () => {
+    const { sanitizeGeneratedConversationTitle } = await import("@/lib/conversation-title-generator");
+
+    expect(sanitizeGeneratedConversationTitle("\n\nExplaining Gravity")).toBe(
+      "Explaining Gravity"
+    );
+  });
+
+  it("uses the answer text when a thinking model returns a think block via the same provider", async () => {
+    const { getSettings } = await import("@/lib/settings");
+    (getSettings as ReturnType<typeof vi.fn>).mockReturnValue({
+      titleGenerationMode: "same",
+      defaultProviderProfileId: "profile-1",
+      titleGenerationProfileId: null
+    });
+    const { listProviderProfilesWithApiKeys } = await import("@/lib/settings");
+    (listProviderProfilesWithApiKeys as ReturnType<typeof vi.fn>).mockReturnValue([
+      { id: "profile-1", model: "MiniMax-M3", name: "Default", providerKind: "openai_compatible", apiMode: "chat_completions" }
+    ]);
+    const { getConversation } = await import("@/lib/conversations");
+    (getConversation as ReturnType<typeof vi.fn>).mockReturnValue({
+      providerProfileId: "profile-1"
+    });
+
+    const { callProviderText } = await import("@/lib/provider");
+    (callProviderText as ReturnType<typeof vi.fn>).mockResolvedValue("\nExplaining Gravity");
+
+    const { generateConversationTitle } = await import("@/lib/conversation-title-generator");
+    const title = await generateConversationTitle({
+      firstMessage: "explain gravity",
+      conversationId: "conv-1"
+    });
+
+    expect(title).toBe("Explaining Gravity");
+  });
 });

--- a/tests/unit/provider.test.ts
+++ b/tests/unit/provider.test.ts
@@ -303,6 +303,27 @@ describe("provider integration", () => {
     ).resolves.toBe("\nExplaining Gravity");
   });
 
+  it("throws when a chat completion text response contains only a think block", async () => {
+    chatCreate.mockResolvedValue({
+      choices: [{ message: { content: "<think>reasoning with no answer</think>" } }]
+    });
+
+    const { callProviderText } = await import("@/lib/provider");
+
+    await expect(
+      callProviderText({
+        settings: createSettings({
+          apiMode: "chat_completions",
+          apiBaseUrl: "https://api.minimaxi.chat/v1",
+          model: "MiniMax-M3",
+          reasoningSummaryEnabled: false
+        }),
+        prompt: "Summarize",
+        purpose: "compaction"
+      })
+    ).rejects.toThrow("Provider returned an empty response");
+  });
+
   it("streams responses events into normalized deltas", async () => {
     responsesCreate.mockResolvedValue(
       createAsyncStream([

--- a/tests/unit/provider.test.ts
+++ b/tests/unit/provider.test.ts
@@ -275,6 +275,34 @@ describe("provider integration", () => {
     );
   });
 
+  it("strips <think> reasoning from chat completion text responses", async () => {
+    chatCreate.mockResolvedValue({
+      choices: [
+        {
+          message: {
+            content:
+              "<think>\nThe user wants a concise title.\n</think>\nExplaining Gravity"
+          }
+        }
+      ]
+    });
+
+    const { callProviderText } = await import("@/lib/provider");
+
+    await expect(
+      callProviderText({
+        settings: createSettings({
+          apiMode: "chat_completions",
+          apiBaseUrl: "https://api.minimaxi.chat/v1",
+          model: "MiniMax-M3",
+          reasoningSummaryEnabled: false
+        }),
+        prompt: "Generate a title",
+        purpose: "title"
+      })
+    ).resolves.toBe("\nExplaining Gravity");
+  });
+
   it("streams responses events into normalized deltas", async () => {
     responsesCreate.mockResolvedValue(
       createAsyncStream([
@@ -630,6 +658,55 @@ describe("provider integration", () => {
     expect(answerText).toBe("Let me take a screenshot.\n");
     expect(answerText).not.toContain("<tool_call>");
     expect(answerText).not.toContain("execute_shell_command");
+  });
+
+  it("extracts <think> reasoning embedded in chat_completions content into thinking and strips it from the answer", async () => {
+    chatCreate.mockResolvedValue(
+      createAsyncStream([
+        { choices: [{ delta: { content: "<think>Let me " } }] },
+        { choices: [{ delta: { content: "reason this through.</think>" } }] },
+        { choices: [{ delta: { content: "\n\nHere is the answer." } }] }
+      ])
+    );
+
+    const { streamProviderResponse } = await import("@/lib/provider");
+    const stream = streamProviderResponse({
+      settings: createSettings({
+        apiMode: "chat_completions",
+        apiBaseUrl: "https://api.minimaxi.chat/v1",
+        model: "MiniMax-M3",
+        reasoningSummaryEnabled: true
+      }),
+      promptMessages: [{ role: "user", content: "Explain it" }]
+    });
+
+    const events: ChatStreamEvent[] = [];
+    let result: Awaited<ReturnType<typeof stream.next>>["value"] | undefined;
+
+    while (true) {
+      const next = await stream.next();
+      if (next.done) {
+        result = next.value;
+        break;
+      }
+      events.push(next.value);
+    }
+
+    expect(result?.answer).toBe("\n\nHere is the answer.");
+    expect(result?.thinking).toBe("Let me reason this through.");
+
+    const answerText = events
+      .filter((event) => event.type === "answer_delta")
+      .map((event) => (event as { text: string }).text)
+      .join("");
+    const thinkingText = events
+      .filter((event) => event.type === "thinking_delta")
+      .map((event) => (event as { text: string }).text)
+      .join("");
+
+    expect(answerText).toBe("\n\nHere is the answer.");
+    expect(answerText).not.toContain("<think>");
+    expect(thinkingText).toBe("Let me reason this through.");
   });
 
   it("updates streamed chat tool call names and arguments across chunks", async () => {

--- a/tests/unit/provider.test.ts
+++ b/tests/unit/provider.test.ts
@@ -145,6 +145,43 @@ describe("provider integration", () => {
     vi.doUnmock("@/lib/github-copilot");
   });
 
+  it("throws when a github copilot response contains only a think block", async () => {
+    vi.resetModules();
+    const runGithubCopilotChat = vi.fn().mockResolvedValue("<think>reasoning with no answer</think>");
+
+    vi.doMock("@/lib/github-copilot", () => ({
+      runGithubCopilotChat,
+      ensureFreshGithubAccessToken: vi.fn(async (profile) => profile),
+      streamGithubCopilotChat: vi.fn(),
+      buildGithubCopilotClient: vi.fn(),
+      listGithubCopilotModels: vi.fn(),
+      getGithubConnectionStatus: vi.fn(),
+      shouldRefreshGithubToken: vi.fn(),
+      clearGithubCopilotConnection: vi.fn(),
+      createGithubOauthState: vi.fn(),
+      verifyGithubOauthState: vi.fn(),
+      getGithubAuthorizeUrl: vi.fn(),
+      exchangeGithubCodeForTokens: vi.fn(),
+      refreshGithubUserToken: vi.fn()
+    }));
+
+    const { callProviderText } = await import("@/lib/provider");
+
+    await expect(
+      callProviderText({
+        settings: createSettings({
+          providerKind: "github_copilot",
+          apiKey: "",
+          apiBaseUrl: ""
+        }),
+        prompt: "Summarize",
+        purpose: "compaction"
+      })
+    ).rejects.toThrow("Provider returned an empty response");
+
+    vi.doUnmock("@/lib/github-copilot");
+  });
+
   it("calls responses text generation and returns output text", async () => {
     responsesCreate.mockResolvedValue({
       output_text: "connected"

--- a/tests/unit/thinking-delimiter-parsing.test.ts
+++ b/tests/unit/thinking-delimiter-parsing.test.ts
@@ -65,6 +65,30 @@ describe("createThinkingDelimiterInterceptor", () => {
     expect(result.thinking).toBe("");
   });
 
+  it("does not treat <thinking> tags as a thinking delimiter", () => {
+    const interceptor = createThinkingDelimiterInterceptor();
+    const result = interceptor.feed("Use <thinking>carefully</thinking> in prose");
+
+    expect(result.answer).toBe("Use <thinking>carefully</thinking> in prose");
+    expect(result.thinking).toBe("");
+  });
+
+  it("does not treat a self-closing <think/> tag as a thinking delimiter", () => {
+    const interceptor = createThinkingDelimiterInterceptor();
+    const result = interceptor.feed("Literal <think/> tag after this text");
+
+    expect(result.answer).toBe("Literal <think/> tag after this text");
+    expect(result.thinking).toBe("");
+  });
+
+  it("does not treat <thinkable> or attribute-bearing tags as a thinking delimiter", () => {
+    const interceptor = createThinkingDelimiterInterceptor();
+    const result = interceptor.feed('<thinkable data="x">keep me</thinkable>');
+
+    expect(result.answer).toBe('<thinkable data="x">keep me</thinkable>');
+    expect(result.thinking).toBe("");
+  });
+
   it("holds back a partial open tag until it resolves", () => {
     const interceptor = createThinkingDelimiterInterceptor();
 
@@ -96,14 +120,6 @@ describe("createThinkingDelimiterInterceptor", () => {
 
     expect(tail.answer).toBe("<thin");
     expect(tail.thinking).toBe("");
-  });
-
-  it("handles an open tag with attributes", () => {
-    const interceptor = createThinkingDelimiterInterceptor();
-    const result = interceptor.feed('<think type="reasoning">hidden</think>visible');
-
-    expect(result.thinking).toBe("hidden");
-    expect(result.answer).toBe("visible");
   });
 
   it("handles multiple sequential think blocks", () => {

--- a/tests/unit/thinking-delimiter-parsing.test.ts
+++ b/tests/unit/thinking-delimiter-parsing.test.ts
@@ -1,0 +1,189 @@
+import { createThinkingDelimiterInterceptor, stripThinkingDelimiters } from "@/lib/thinking-delimiter-parsing";
+import { createTextToolCallInterceptor } from "@/lib/tool-call-text-parsing";
+
+describe("createThinkingDelimiterInterceptor", () => {
+  it("extracts a think block streamed in a single chunk", () => {
+    const interceptor = createThinkingDelimiterInterceptor();
+    const result = interceptor.feed("<think>reasoning here</think>the answer");
+
+    expect(result.thinking).toBe("reasoning here");
+    expect(result.answer).toBe("the answer");
+  });
+
+  it("extracts a think block streamed token-by-token across many chunks", () => {
+    const interceptor = createThinkingDelimiterInterceptor();
+    const tokens = [
+      "<thi",
+      "nk>",
+      "let me reason ",
+      "step by step",
+      "</thin",
+      "k>",
+      "\n\nHere is the answer."
+    ];
+
+    let answer = "";
+    let thinking = "";
+    for (const token of tokens) {
+      const result = interceptor.feed(token);
+      answer += result.answer;
+      thinking += result.thinking;
+    }
+    const tail = interceptor.flush();
+    answer += tail.answer;
+    thinking += tail.thinking;
+
+    expect(thinking).toBe("let me reason step by step");
+    expect(answer).toBe("\n\nHere is the answer.");
+  });
+
+  it("keeps text before and after a think block as answer", () => {
+    const interceptor = createThinkingDelimiterInterceptor();
+    const result = interceptor.feed("before <think>hidden</think> after");
+    interceptor.flush();
+
+    expect(result.answer).toBe("before  after");
+    expect(result.thinking).toBe("hidden");
+  });
+
+  it("passes ordinary answer text through unchanged when no tags are present", () => {
+    const interceptor = createThinkingDelimiterInterceptor();
+
+    expect(interceptor.feed("Hello ")).toEqual({ answer: "Hello ", thinking: "" });
+    expect(interceptor.feed("world")).toEqual({ answer: "world", thinking: "" });
+    const tail = interceptor.flush();
+
+    expect(tail.answer).toBe("");
+    expect(tail.thinking).toBe("");
+  });
+
+  it("does not treat the word 'think' in prose as a delimiter", () => {
+    const interceptor = createThinkingDelimiterInterceptor();
+    const result = interceptor.feed("I think therefore I am");
+
+    expect(result.answer).toBe("I think therefore I am");
+    expect(result.thinking).toBe("");
+  });
+
+  it("holds back a partial open tag until it resolves", () => {
+    const interceptor = createThinkingDelimiterInterceptor();
+
+    expect(interceptor.feed("see <")).toEqual({ answer: "see ", thinking: "" });
+    expect(interceptor.feed("thi")).toEqual({ answer: "", thinking: "" });
+    expect(interceptor.feed("nk>")).toEqual({ answer: "", thinking: "" });
+    const thinkResult = interceptor.feed("reasoning");
+    expect(thinkResult).toEqual({ answer: "", thinking: "reasoning" });
+    interceptor.feed("</think>");
+    const tail = interceptor.flush();
+
+    expect(tail.answer).toBe("");
+  });
+
+  it("keeps accumulated reasoning as thinking when the stream ends before the close tag", () => {
+    const interceptor = createThinkingDelimiterInterceptor();
+    interceptor.feed("<think>partial reasoning with no close");
+
+    const tail = interceptor.flush();
+
+    expect(tail.thinking).toBe("");
+    expect(tail.answer).toBe("");
+  });
+
+  it("restores a bare partial open tag as answer text on flush", () => {
+    const interceptor = createThinkingDelimiterInterceptor();
+    interceptor.feed("if a <thin");
+    const tail = interceptor.flush();
+
+    expect(tail.answer).toBe("<thin");
+    expect(tail.thinking).toBe("");
+  });
+
+  it("handles an open tag with attributes", () => {
+    const interceptor = createThinkingDelimiterInterceptor();
+    const result = interceptor.feed('<think type="reasoning">hidden</think>visible');
+
+    expect(result.thinking).toBe("hidden");
+    expect(result.answer).toBe("visible");
+  });
+
+  it("handles multiple sequential think blocks", () => {
+    const interceptor = createThinkingDelimiterInterceptor();
+    let answer = "";
+    let thinking = "";
+    for (const token of [
+      "<think>first</think>",
+      "middle ",
+      "<think>second</think>",
+      "end"
+    ]) {
+      const result = interceptor.feed(token);
+      answer += result.answer;
+      thinking += result.thinking;
+    }
+    interceptor.flush();
+
+    expect(thinking).toBe("firstsecond");
+    expect(answer).toBe("middle end");
+  });
+
+  it("feeds extracted answer text through a downstream tool-call interceptor", () => {
+    const thinking = createThinkingDelimiterInterceptor();
+    const tools = createTextToolCallInterceptor();
+
+    const stream = [
+      "<think>I should run a command.</think>",
+      "Let me try.\n<tool_call> <function=execute_shell_command> <parameter=command>pwd </tool_call>"
+    ];
+
+    let answer = "";
+    for (const chunk of stream) {
+      const split = thinking.feed(chunk);
+      answer += tools.feed(split.answer);
+    }
+    const thinkingTail = thinking.flush();
+    if (thinkingTail.answer) {
+      answer += tools.feed(thinkingTail.answer);
+    }
+    answer += tools.flush();
+
+    expect(tools.toolCalls).toEqual([
+      {
+        id: "text_call_0",
+        name: "execute_shell_command",
+        arguments: JSON.stringify({ command: "pwd" })
+      }
+    ]);
+    expect(answer).toBe("Let me try.\n");
+  });
+});
+
+describe("stripThinkingDelimiters", () => {
+  it("removes a complete think block and returns only the answer", () => {
+    expect(
+      stripThinkingDelimiters("<think>internal reasoning</think>public answer")
+    ).toBe("public answer");
+  });
+
+  it("strips a multi-line think block leaving the trailing answer", () => {
+    const raw = "<think>\nThe user wants a title.\nOptions:\n- A\n- B\n</think>\nExplaining Gravity";
+    expect(stripThinkingDelimiters(raw)).toBe("\nExplaining Gravity");
+  });
+
+  it("returns text unchanged when no think tags are present", () => {
+    expect(stripThinkingDelimiters("just a normal answer")).toBe("just a normal answer");
+  });
+
+  it("returns empty string when the response is only a think block", () => {
+    expect(stripThinkingDelimiters("<think>only reasoning</think>")).toBe("");
+  });
+
+  it("handles think tags split across the string", () => {
+    expect(
+      stripThinkingDelimiters("<thi" + "nk>half</thin" + "k>rest")
+    ).toBe("rest");
+  });
+
+  it("returns falsy input unchanged", () => {
+    expect(stripThinkingDelimiters("")).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary

Some OpenAI-compatible models (e.g. **MiniMax M3**, DeepSeek-R1 distillations, QwQ) embed reasoning directly in the streamed `content` field wrapped in `<think>...</think>` tags instead of using a structured reasoning field. Previously these tags surfaced verbatim in the conversation and broke title generation (the title became `"<think>"`).

### Changes

- **`lib/thinking-delimiter-parsing.ts`** (new): A `ThinkingDelimiterInterceptor` that streams extraction of `<think>...</think>` into a separate thinking channel, mirroring the existing tool-call interceptor design — including correct handling of tags split across stream chunks and flush semantics for unterminated blocks. Also exposes a `stripThinkingDelimiters(text)` helper for complete (non-streaming) strings.
- **`lib/provider.ts`**:
  - In the chat-completions streaming path, the thinking interceptor is chained *before* the tool-call interceptor so reasoning is routed to `thinking_delta` and stripped from the answer (and never misparsed as a tool call).
  - In `callProviderText` (one-shot text generation), `stripThinkingDelimiters` is applied to the returned text in all branches so titles and compaction summaries never surface `<think>` tags.
- **`lib/conversation-title-generator.ts`**: The title sanitizer now trims leading whitespace/newlines before extracting the first line, so the newline left after `</think>` no longer yields an empty title.

### Behavior

For a response like `<think>reasoning…</think>\nExplaining Gravity`:
- Streaming: reasoning streams as `thinking_delta`; answer is `Explaining Gravity`.
- Title generation: raw → stripped to `\nExplaining Gravity` → sanitized to `Explaining Gravity`.

### Tests

Full suite: **1505 passing**, global coverage **90.55%**. Added coverage for the interceptor (single chunk, split chunks, partial tags, unterminated blocks, multiple blocks), `stripThinkingDelimiters`, `callProviderText` source stripping, and an end-to-end title-generation test reproducing the original failing `mode=same model=MiniMax-M3` log.