### PR TITLE
fix(shell): hide new-chat plus button in top bar on settings pages

### DIFF
--- a/components/shell.tsx
+++ b/components/shell.tsx
@@ -390,7 +390,7 @@ export function Shell({
             </span>
           )}
 
-          {isAutomationsPage ? (
+          {(isAutomationsPage || isSettingsPage) ? (
             <div className="flex h-9 w-9 items-center justify-end">
               {shareConversation ? (
                 <button

--- a/tests/unit/settings-layout.test.tsx
+++ b/tests/unit/settings-layout.test.tsx
@@ -140,7 +140,7 @@ describe("settings mobile layout", () => {
     );
 
     expect(screen.getByRole("button", { name: "Open settings menu" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "New chat" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "New chat" })).not.toBeInTheDocument();
     expect(screen.getByText("Settings")).toBeInTheDocument();
     expect(screen.queryByText("Eidon")).not.toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary

- Hide the purple "new chat" plus button in the mobile top bar while the user is browsing settings pages, where creating a new conversation is confusing and out of context.
- Reuses the existing spacer branch (already used for automations pages) so the header stays visually balanced — the hamburger menu on the left is mirrored by an empty space on the right.
- Desktop was already correct (its new-chat button lives in the sidebar, which is swapped out for the settings nav on settings pages); this only affects the mobile top bar.
- Updates `tests/unit/settings-layout.test.tsx` to assert the new-chat button is no longer present on settings pages.

## Test plan
- [x] Full unit suite passes (1510 tests, 138 files)
- [x] Global coverage at 90.62% (above 85% threshold)
- [x] `tsc --noEmit` type check passes