### PR TITLE
fix(chat): keep the transcript anchored when the composer or keyboard resizes

### DIFF
--- a/components/ai-elements/conversation.tsx
+++ b/components/ai-elements/conversation.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
+import { IOS_PWA_CONVERSATION_VIEWPORT_EVENT } from "@/lib/use-ios-pwa";
+import { cn, isScrolledToBottom } from "@/lib/utils";
 import type { UIMessage } from "ai";
 import { ArrowDownIcon, DownloadIcon } from "lucide-react";
 import type { ComponentProps } from "react";
-import { useCallback } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { StickToBottom, useStickToBottomContext } from "use-stick-to-bottom";
 
 export type ConversationProps = ComponentProps<typeof StickToBottom>;
@@ -90,14 +91,50 @@ export const ConversationScrollButton = ({
   className,
   ...props
 }: ConversationScrollButtonProps) => {
-  const { isAtBottom, scrollToBottom } = useStickToBottomContext();
+  const stickToBottom = useStickToBottomContext();
+  const { contentRef, scrollRef, scrollToBottom, state, stopScroll } = stickToBottom;
+  const [hasContentBelow, setHasContentBelow] = useState(false);
+
+  useEffect(() => {
+    const scrollElement = scrollRef.current;
+    const contentElement = contentRef.current;
+    if (!scrollElement || !contentElement) return;
+
+    const update = () => {
+      setHasContentBelow(!isScrolledToBottom(scrollElement));
+    };
+
+    update();
+    scrollElement.addEventListener("scroll", update, { passive: true });
+    window.addEventListener("resize", update);
+    window.addEventListener(IOS_PWA_CONVERSATION_VIEWPORT_EVENT, update);
+    const observer = typeof ResizeObserver === "undefined" ? null : new ResizeObserver(update);
+    observer?.observe(contentElement);
+
+    return () => {
+      observer?.disconnect();
+      scrollElement.removeEventListener("scroll", update);
+      window.removeEventListener("resize", update);
+      window.removeEventListener(IOS_PWA_CONVERSATION_VIEWPORT_EVENT, update);
+    };
+  }, [contentRef, scrollRef]);
 
   const handleScrollToBottom = useCallback(() => {
-    void scrollToBottom(SCROLL_TO_LATEST_OPTIONS);
-  }, [scrollToBottom]);
+    const targetScrollTop = state.targetScrollTop;
+    stickToBottom.targetScrollTop = () => targetScrollTop;
+
+    const releaseScroll = () => {
+      stopScroll();
+    };
+
+    void Promise.resolve(scrollToBottom(SCROLL_TO_LATEST_OPTIONS)).then(
+      releaseScroll,
+      releaseScroll
+    );
+  }, [scrollToBottom, state, stickToBottom, stopScroll]);
 
   return (
-    !isAtBottom && (
+    hasContentBelow && (
       <Button
         aria-label="Scroll to latest messages"
         className={cn(

--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -37,6 +37,7 @@ import { clearChatBootstrap, readChatBootstrap } from "@/lib/chat-bootstrap";
 import { createStreamBuffer } from "@/lib/stream-buffer";
 import { StreamingMessage } from "@/components/streaming-message";
 import { useStableHandler } from "@/lib/use-stable-handler";
+import { IOS_PWA_CONVERSATION_VIEWPORT_EVENT } from "@/lib/use-ios-pwa";
 import { useContextTokens } from "@/lib/context-tokens-context";
 import {
   dispatchConversationActivityUpdated,
@@ -46,7 +47,7 @@ import { useWebSocket } from "@/lib/ws-client";
 import { deleteConversationIfStillEmpty } from "@/lib/conversation-drafts";
 import { appendTranscriptToDraft } from "@/lib/speech/append-transcript-to-draft";
 import { useSpeechInput } from "@/lib/speech/use-speech-input";
-import { shouldAutofocusTextInput } from "@/lib/utils";
+import { isScrolledToBottom, shouldAutofocusTextInput } from "@/lib/utils";
 import type { AppSettings } from "@/lib/types";
 import type {
   ChatStreamEvent,
@@ -79,19 +80,32 @@ type ConversationPayload = {
 
 const INITIAL_VISIBLE_MESSAGE_COUNT = 60;
 const VISIBLE_MESSAGE_INCREMENT = 100;
+const PINNED_TURN_TOP_INSET_PX = 12;
 const EMPTY_TIMELINE: MessageTimelineItem[] = [];
 
 function StickToBottomBridge({
-  scrollToBottomRef
+  scrollToBottomRef,
+  setScrollTargetRef
 }: {
   scrollToBottomRef: React.RefObject<(() => void) | null>;
+  setScrollTargetRef: React.RefObject<((target: number | null) => void) | null>;
 }) {
-  const { scrollToBottom } = useStickToBottomContext();
+  const stickToBottom = useStickToBottomContext();
+  const { scrollToBottom, stopScroll } = stickToBottom;
 
   useEffect(() => {
     scrollToBottomRef.current = scrollToBottom;
-    return () => { scrollToBottomRef.current = null; };
-  }, [scrollToBottom, scrollToBottomRef]);
+    setScrollTargetRef.current = (target) => {
+      stickToBottom.targetScrollTop = target === null ? null : () => target;
+      if (target !== null) {
+        stopScroll();
+      }
+    };
+    return () => {
+      scrollToBottomRef.current = null;
+      setScrollTargetRef.current = null;
+    };
+  }, [scrollToBottom, scrollToBottomRef, setScrollTargetRef, stickToBottom, stopScroll]);
 
   return null;
 }
@@ -178,9 +192,12 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
   const [personas, setPersonas] = useState<Array<{ id: string; name: string }>>([]);
   const [personaId, setPersonaId] = useState<string | null>(null);
   const scrollToBottomRef = useRef<(() => void) | null>(null);
-  const anchorSpacerRef = useRef<HTMLDivElement>(null);
+  const setScrollTargetRef = useRef<((target: number | null) => void) | null>(null);
+  const contentEndRef = useRef<HTMLDivElement>(null);
   const composerAreaRef = useRef<HTMLDivElement>(null);
   const [composerAreaHeight, setComposerAreaHeight] = useState(160);
+  const composerAreaHeightRef = useRef(160);
+  const absorbComposerGrowthRef = useRef(false);
   const finalizePendingRef = useRef(false);
 
   const {
@@ -459,15 +476,44 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
   }, []);
 
   useEffect(() => {
+    contentEndRef.current?.parentElement?.style.removeProperty("min-height");
+    setScrollTargetRef.current?.(null);
     scrollToBottomRef.current?.();
   }, [payload.conversation.id]);
+
+  useEffect(() => {
+    const preserveKeyboardViewport = (event: Event) => {
+      const scrollTop = (event as CustomEvent<number>).detail;
+      if (Number.isFinite(scrollTop)) {
+        setScrollTargetRef.current?.(scrollTop);
+      }
+    };
+
+    window.addEventListener(
+      IOS_PWA_CONVERSATION_VIEWPORT_EVENT,
+      preserveKeyboardViewport,
+    );
+    return () => {
+      window.removeEventListener(
+        IOS_PWA_CONVERSATION_VIEWPORT_EVENT,
+        preserveKeyboardViewport,
+      );
+    };
+  }, []);
 
   useLayoutEffect(() => {
     const el = composerAreaRef.current;
     if (!el) return;
     const measure = () => {
       const next = el.offsetHeight;
-      setComposerAreaHeight((current) => (current === next ? current : next));
+      if (next === composerAreaHeightRef.current) return;
+      const scroller = contentEndRef.current?.closest(".conversation-scroller");
+      absorbComposerGrowthRef.current =
+        next > composerAreaHeightRef.current &&
+        scroller instanceof HTMLElement &&
+        isScrolledToBottom(scroller);
+      composerAreaHeightRef.current = next;
+      setComposerAreaHeight(next);
     };
     measure();
     if (typeof ResizeObserver === "undefined") return;
@@ -475,6 +521,14 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
     observer.observe(el);
     return () => observer.disconnect();
   }, []);
+
+  useLayoutEffect(() => {
+    if (!absorbComposerGrowthRef.current) return;
+    absorbComposerGrowthRef.current = false;
+    const scroller = contentEndRef.current?.closest(".conversation-scroller");
+    if (!(scroller instanceof HTMLElement)) return;
+    scroller.scrollTop = Math.max(0, scroller.scrollHeight - scroller.clientHeight);
+  }, [composerAreaHeight]);
 
   useEffect(() => {
     if (!pendingAnchorMessageIdRef.current) return;
@@ -484,18 +538,29 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
 
     pendingAnchorMessageIdRef.current = null;
     requestAnimationFrame(() => {
-      if (anchorSpacerRef.current) {
-        const scrollerHeight =
-          anchorSpacerRef.current.closest(".conversation-scroller")?.clientHeight ?? 800;
-        anchorSpacerRef.current.style.height = `${scrollerHeight}px`;
-      }
       const targetEl = document.querySelector(`[data-message-id="${messageId}"]`);
-      targetEl?.scrollIntoView({ block: "start", behavior: "auto" });
-      requestAnimationFrame(() => {
-        if (anchorSpacerRef.current) {
-          anchorSpacerRef.current.style.height = "";
-        }
-      });
+      const content = contentEndRef.current?.parentElement;
+      const scroller = contentEndRef.current?.closest(".conversation-scroller");
+      const behavior =
+        typeof window.matchMedia === "function" &&
+        window.matchMedia("(prefers-reduced-motion: reduce)").matches
+          ? "auto"
+          : "smooth";
+      if (targetEl && content && scroller) {
+        const targetTop = Math.max(
+          0,
+          scroller.scrollTop +
+            targetEl.getBoundingClientRect().top -
+            scroller.getBoundingClientRect().top -
+            PINNED_TURN_TOP_INSET_PX
+        );
+        content.style.minHeight = `${targetTop + scroller.clientHeight}px`;
+        setScrollTargetRef.current?.(targetTop);
+        scroller.scrollTo({ top: targetTop, behavior });
+      } else {
+        setScrollTargetRef.current?.(scroller?.scrollTop ?? 0);
+        targetEl?.scrollIntoView({ block: "start", behavior });
+      }
     });
   }, [visibleMessages]);
 
@@ -1743,7 +1808,6 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
         return;
       }
 
-      scrollToBottomRef.current?.();
       setError("");
       setInput("");
       dismissComposerKeyboardOnTouch();
@@ -1979,7 +2043,10 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
         style={{ ["--composer-height" as string]: `${composerAreaHeight}px` }}
       >
       <ConversationContainer>
-        <StickToBottomBridge scrollToBottomRef={scrollToBottomRef} />
+        <StickToBottomBridge
+          scrollToBottomRef={scrollToBottomRef}
+          setScrollTargetRef={setScrollTargetRef}
+        />
         <ConversationContent
           className="gap-2.5 px-2 pt-4 md:gap-4 md:px-8"
         >
@@ -2046,7 +2113,7 @@ export function ChatView({ payload }: { payload: ConversationPayload }) {
               {error}
             </div>
           ) : null}
-          <div ref={anchorSpacerRef} />
+          <div ref={contentEndRef} />
           <div aria-hidden style={{ height: "calc(var(--composer-height, 160px) + 24px)" }} />
         </ConversationContent>
         <ConversationScrollButton />

--- a/lib/use-ios-pwa.ts
+++ b/lib/use-ios-pwa.ts
@@ -2,8 +2,12 @@
 
 import { useEffect } from "react";
 
+import { isScrolledToBottom } from "@/lib/utils";
+
 const IOS_PWA_CLASS = "ios-pwa";
 const FOCUS_SETTLE_DELAY_MS = 300;
+export const IOS_PWA_CONVERSATION_VIEWPORT_EVENT =
+  "eidon:ios-pwa-conversation-viewport-preserved";
 
 function isIosStandalone(): boolean {
   if (typeof navigator === "undefined") {
@@ -37,6 +41,53 @@ export function useIosPwa() {
     let frameHandle: number | null = null;
     let focusTimeout: number | null = null;
     let lastHeight = -1;
+    let focusedConversationViewport: {
+      element: HTMLElement;
+      clientHeight: number;
+    } | null = null;
+
+    const captureConversationViewport = () => {
+      const element = document.querySelector<HTMLElement>(".conversation-scroller");
+      if (!element || !isScrolledToBottom(element)) {
+        focusedConversationViewport = null;
+        return;
+      }
+
+      focusedConversationViewport = { element, clientHeight: element.clientHeight };
+    };
+
+    const preserveConversationViewport = () => {
+      if (!focusedConversationViewport) {
+        return;
+      }
+
+      const { element, clientHeight } = focusedConversationViewport;
+      if (!element.isConnected) {
+        focusedConversationViewport = null;
+        return;
+      }
+
+      focusedConversationViewport.clientHeight = element.clientHeight;
+      const viewportHeightLoss = clientHeight - element.clientHeight;
+      if (viewportHeightLoss <= 0) {
+        return;
+      }
+      const maximumScrollTop = Math.max(0, element.scrollHeight - element.clientHeight);
+      element.scrollTop = Math.min(element.scrollTop + viewportHeightLoss, maximumScrollTop);
+    };
+
+    const lockConversationViewport = () => {
+      const element = document.querySelector<HTMLElement>(".conversation-scroller");
+      if (!element) {
+        return;
+      }
+
+      window.dispatchEvent(
+        new CustomEvent<number>(IOS_PWA_CONVERSATION_VIEWPORT_EVENT, {
+          detail: element.scrollTop,
+        }),
+      );
+    };
 
     const correctScroll = () => {
       if (window.scrollX !== 0 || window.scrollY !== 0) {
@@ -59,18 +110,22 @@ export function useIosPwa() {
 
     const applyHeight = () => {
       frameHandle = null;
-      correctScroll();
       const vv = window.visualViewport;
       const scale = vv?.scale ?? 1;
       const height =
         vv && scale === 1
           ? Math.min(Math.round(window.innerHeight), Math.round(vv.height))
           : Math.round(window.innerHeight);
-      if (height === lastHeight) {
-        return;
+      if (height !== lastHeight) {
+        const hasMeasuredHeight = lastHeight >= 0;
+        lastHeight = height;
+        root.style.setProperty("--ios-app-height", `${height}px`);
+        preserveConversationViewport();
+        if (hasMeasuredHeight) {
+          lockConversationViewport();
+        }
       }
-      lastHeight = height;
-      root.style.setProperty("--ios-app-height", `${height}px`);
+      correctScroll();
     };
 
     const scheduleApply = () => {
@@ -80,15 +135,32 @@ export function useIosPwa() {
       frameHandle = window.requestAnimationFrame(applyHeight);
     };
 
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target;
+      if (target instanceof Element && isEditableElement(target)) {
+        captureConversationViewport();
+        return;
+      }
+
+      focusedConversationViewport = null;
+    };
+
     const handleFocusIn = () => {
+      if (!focusedConversationViewport) {
+        captureConversationViewport();
+      }
       scheduleApply();
       if (focusTimeout !== null) {
         window.clearTimeout(focusTimeout);
       }
       focusTimeout = window.setTimeout(() => {
         focusTimeout = null;
-        correctScroll();
+        applyHeight();
       }, FOCUS_SETTLE_DELAY_MS);
+    };
+
+    const handleFocusOut = () => {
+      focusedConversationViewport = null;
     };
 
     applyHeight();
@@ -96,7 +168,9 @@ export function useIosPwa() {
     window.addEventListener("orientationchange", scheduleApply);
     window.visualViewport?.addEventListener("resize", scheduleApply);
     window.visualViewport?.addEventListener("scroll", scheduleApply);
+    document.addEventListener("pointerdown", handlePointerDown, true);
     document.addEventListener("focusin", handleFocusIn);
+    document.addEventListener("focusout", handleFocusOut);
 
     return () => {
       if (frameHandle !== null) {
@@ -111,7 +185,9 @@ export function useIosPwa() {
       window.removeEventListener("orientationchange", scheduleApply);
       window.visualViewport?.removeEventListener("resize", scheduleApply);
       window.visualViewport?.removeEventListener("scroll", scheduleApply);
+      document.removeEventListener("pointerdown", handlePointerDown, true);
       document.removeEventListener("focusin", handleFocusIn);
+      document.removeEventListener("focusout", handleFocusOut);
     };
   }, []);
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -24,3 +24,15 @@ export function shouldAutofocusTextInput() {
 export function nowIso() {
   return new Date().toISOString();
 }
+
+const AT_BOTTOM_TOLERANCE_PX = 8;
+
+type ScrollGeometry = {
+  scrollHeight: number;
+  clientHeight: number;
+  scrollTop: number;
+};
+
+export function isScrolledToBottom(element: ScrollGeometry) {
+  return element.scrollHeight - element.clientHeight - element.scrollTop <= AT_BOTTOM_TOLERANCE_PX;
+}

--- a/tests/unit/chat-view.test.ts
+++ b/tests/unit/chat-view.test.ts
@@ -8,6 +8,7 @@ import { ShareConversationProvider } from "@/components/share-conversation-conte
 import { ContextTokensProvider } from "@/lib/context-tokens-context";
 import type { SpeechSessionSnapshot, SttEngine, SttLanguage } from "@/lib/speech/types";
 import type { Message, MessageAttachment, MessageTimelineItem, QueuedMessage } from "@/lib/types";
+import { IOS_PWA_CONVERSATION_VIEWPORT_EVENT } from "@/lib/use-ios-pwa";
 
 const push = vi.fn();
 const refresh = vi.fn();
@@ -144,6 +145,8 @@ vi.mock("@/lib/speech/speech-controller", () => ({
 const stickToBottomMock = vi.hoisted(() => ({
   isAtBottomValue: true,
   scrollToBottom: vi.fn(),
+  stopScroll: vi.fn(),
+  targetScrollTop: null as (() => number) | null,
   listeners: new Set<() => void>(),
   _forceRender: null as (() => void) | null,
 }));
@@ -165,6 +168,9 @@ vi.mock("use-stick-to-bottom", () => ({
   useStickToBottomContext: () => ({
     get isAtBottom() { return stickToBottomMock.isAtBottomValue; },
     scrollToBottom: stickToBottomMock.scrollToBottom,
+    stopScroll: stickToBottomMock.stopScroll,
+    get targetScrollTop() { return stickToBottomMock.targetScrollTop; },
+    set targetScrollTop(value: (() => number) | null) { stickToBottomMock.targetScrollTop = value; },
   }),
 }));
 
@@ -184,7 +190,11 @@ vi.mock("@/components/ai-elements/conversation", () => {
       React.useEffect(() => {
         if (scrollerRef) scrollerRef(divRef.current);
       }, [divRef, scrollerRef]);
-      return React.createElement("div", { "data-testid": "conversation-content", ref: divRef }, children as React.ReactNode);
+      return React.createElement(
+        "div",
+        { "data-testid": "conversation-content", className: "conversation-scroller", ref: divRef },
+        React.createElement("div", null, children as React.ReactNode)
+      );
     },
     ConversationScrollButton: () => {
       const isAtBottom = React.useSyncExternalStore(
@@ -559,6 +569,8 @@ describe("chat view", () => {
     window.ResizeObserver = originalResizeObserver;
     stickToBottomMock.isAtBottomValue = true;
     stickToBottomMock.scrollToBottom.mockClear();
+    stickToBottomMock.stopScroll.mockClear();
+    stickToBottomMock.targetScrollTop = null;
   });
 
   function renderWithProvider(ui: React.ReactElement) {
@@ -685,6 +697,21 @@ describe("chat view", () => {
     renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
 
     expect(screen.getByRole("textbox").closest(".ios-keyboard-lift")).toBeNull();
+  });
+
+  it("keeps the keyboard-compensated viewport locked against streaming follow", () => {
+    renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent<number>(IOS_PWA_CONVERSATION_VIEWPORT_EVENT, {
+          detail: 420,
+        }),
+      );
+    });
+
+    expect(stickToBottomMock.targetScrollTop?.()).toBe(420);
+    expect(stickToBottomMock.stopScroll).toHaveBeenCalledTimes(1);
   });
 
   it("does not autofocus the composer on touch devices", () => {
@@ -3018,7 +3045,7 @@ describe("chat view", () => {
     });
   });
 
-  it("jumps back to the latest messages when a scrolled-up user queues another prompt", async () => {
+  it("keeps the viewport fixed when a scrolled-up user queues another prompt", async () => {
     renderWithProvider(
       React.createElement(ChatView, {
         payload: createPayload({
@@ -3055,7 +3082,7 @@ describe("chat view", () => {
       });
     });
 
-    expect(stickToBottomMock.scrollToBottom).toHaveBeenCalled();
+    expect(stickToBottomMock.scrollToBottom).not.toHaveBeenCalled();
   });
 
   it("does not force-scroll streaming updates when the user has scrolled away from the bottom", async () => {
@@ -3145,7 +3172,7 @@ describe("chat view", () => {
     });
   });
 
-  it("follows streaming overflow after sending", async () => {
+  it("keeps rendering streaming overflow after releasing auto-follow", async () => {
     renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
     const textarea = screen.getByRole("textbox");
 
@@ -3264,11 +3291,112 @@ describe("chat view", () => {
     expect(messageIds).toEqual(["msg_prior", "msg_user_server"]);
   });
 
-  it("scrolls to anchor the user message near the top after sending", async () => {
-    renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
-    const textarea = screen.getByRole("textbox");
+  function measureComposerGrowth(nextComposerHeight: number) {
+    const conversationContent = getScrollContainer()!;
+    const composerArea = document.querySelector<HTMLElement>(
+      ".absolute.inset-x-0.bottom-0.z-50"
+    )!;
+    const composerHeightVar = () => {
+      const holder = document.querySelector<HTMLElement>('[style*="--composer-height"]');
+      return Number.parseFloat(holder?.style.getPropertyValue("--composer-height") ?? "0") || 0;
+    };
+    const metrics = { scrollTop: 0 };
+    Object.defineProperties(conversationContent, {
+      clientHeight: { configurable: true, get: () => 600 },
+      scrollHeight: { configurable: true, get: () => 1000 + composerHeightVar() + 24 },
+      scrollTop: {
+        configurable: true,
+        get: () => metrics.scrollTop,
+        set: (value: number) => {
+          metrics.scrollTop = value;
+        }
+      }
+    });
 
-    const scrollIntoViewSpy2 = vi.spyOn(Element.prototype, 'scrollIntoView').mockImplementation(() => {});
+    return {
+      metrics,
+      grow: async () => {
+        Object.defineProperty(composerArea, "offsetHeight", {
+          configurable: true,
+          value: nextComposerHeight
+        });
+        await flushResizeObservers();
+      }
+    };
+  }
+
+  it("keeps the transcript against the composer when the composer grows on focus", async () => {
+    renderWithProvider(
+      React.createElement(ChatView, {
+        payload: createPayload({
+          messages: [createMessage({ id: "msg_assistant_first", content: "First answer" })]
+        })
+      })
+    );
+
+    const { metrics, grow } = measureComposerGrowth(60);
+    metrics.scrollTop = 424;
+
+    await grow();
+
+    expect(metrics.scrollTop).toBe(484);
+  });
+
+  it("leaves a scrolled-up transcript alone when the composer grows on focus", async () => {
+    renderWithProvider(
+      React.createElement(ChatView, {
+        payload: createPayload({
+          messages: [createMessage({ id: "msg_assistant_first", content: "First answer" })]
+        })
+      })
+    );
+
+    const { metrics, grow } = measureComposerGrowth(60);
+    metrics.scrollTop = 120;
+
+    await grow();
+
+    expect(metrics.scrollTop).toBe(120);
+  });
+
+  it("animates a second user message to the top with empty space for the response", async () => {
+    renderWithProvider(
+      React.createElement(ChatView, {
+        payload: createPayload({
+          messages: [
+            createMessage({ id: "msg_user_first", role: "user", content: "First question" }),
+            createMessage({ id: "msg_assistant_first", content: "First answer" })
+          ]
+        })
+      })
+    );
+    const textarea = screen.getByRole("textbox");
+    const conversationContent = getScrollContainer()!;
+    Object.defineProperty(conversationContent, "clientHeight", {
+      configurable: true,
+      value: 640
+    });
+    Object.defineProperty(conversationContent, "scrollTop", {
+      configurable: true,
+      writable: true,
+      value: 500
+    });
+    const getBoundingClientRectSpy = vi
+      .spyOn(Element.prototype, "getBoundingClientRect")
+      .mockImplementation(function(this: Element) {
+        if (this === conversationContent) {
+          return { top: 80 } as DOMRect;
+        }
+        if (
+          this instanceof HTMLElement &&
+          this.hasAttribute("data-message-id") &&
+          this.textContent?.includes("Hello world")
+        ) {
+          return { top: 200 } as DOMRect;
+        }
+        return { top: 0 } as DOMRect;
+      });
+    const scrollToSpy = vi.spyOn(conversationContent, "scrollTo");
 
     fireEvent.change(textarea, { target: { value: "Hello world" } });
     fireEvent.keyDown(textarea, { key: "Enter" });
@@ -3279,14 +3407,87 @@ describe("chat view", () => {
 
     await flushAnimationFrame();
     await flushAnimationFrame();
+    await flushAnimationFrame();
 
-    expect(scrollIntoViewSpy2).toHaveBeenCalledWith(
-      expect.objectContaining({ block: "start", behavior: "auto" })
-    );
-    scrollIntoViewSpy2.mockRestore();
+    expect(scrollToSpy).toHaveBeenCalledWith({ top: 608, behavior: "smooth" });
+    expect(conversationContent.firstElementChild).toHaveStyle({ minHeight: "1248px" });
+    expect(stickToBottomMock.targetScrollTop?.()).toBe(608);
+    expect(stickToBottomMock.stopScroll).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      wsMock.onMessage!({
+        type: "delta",
+        conversationId: "conv_1",
+        event: { type: "message_start", messageId: "msg_assistant_streaming" }
+      });
+      wsMock.onMessage!({
+        type: "delta",
+        conversationId: "conv_1",
+        event: { type: "answer_delta", text: "The response starts here." }
+      });
+    });
+
+    await flushAnimationFrame();
+    await flushAnimationFrame();
+
+    await waitFor(() => {
+      expect(screen.getByText(streamedText("The response starts here."))).toBeInTheDocument();
+    });
+    expect(conversationContent.firstElementChild).toHaveStyle({ minHeight: "1248px" });
+    scrollToSpy.mockRestore();
+    getBoundingClientRectSpy.mockRestore();
   });
 
-  it("scrolls to bottom when queuing a follow-up during an active turn", async () => {
+  it("anchors the user message instantly when reduced motion is preferred", async () => {
+    const originalMatchMedia = window.matchMedia;
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: query === "(prefers-reduced-motion: reduce)",
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn()
+      }))
+    });
+
+    try {
+      renderWithProvider(
+        React.createElement(ChatView, {
+          payload: createPayload({
+            messages: [createMessage({ id: "msg_assistant_first", content: "First answer" })]
+          })
+        })
+      );
+      const textarea = screen.getByRole("textbox");
+      const conversationContent = getScrollContainer()!;
+      const scrollToSpy = vi.spyOn(conversationContent, "scrollTo");
+
+      fireEvent.change(textarea, { target: { value: "Second question" } });
+      fireEvent.keyDown(textarea, { key: "Enter" });
+
+      await waitFor(() => {
+        expect(screen.getByText("Second question")).toBeInTheDocument();
+      });
+      await flushAnimationFrame();
+      await flushAnimationFrame();
+
+      expect(scrollToSpy).toHaveBeenCalledWith({ top: 0, behavior: "auto" });
+      scrollToSpy.mockRestore();
+    } finally {
+      Object.defineProperty(window, "matchMedia", {
+        configurable: true,
+        writable: true,
+        value: originalMatchMedia
+      });
+    }
+  });
+
+  it("does not scroll when queuing a follow-up during an active turn", async () => {
     renderWithProvider(
       React.createElement(ChatView, {
         payload: createPayload({
@@ -3324,7 +3525,7 @@ describe("chat view", () => {
 
     await flushAnimationFrame();
 
-    expect(stickToBottomMock.scrollToBottom).toHaveBeenCalled();
+    expect(stickToBottomMock.scrollToBottom).not.toHaveBeenCalled();
   });
 
   it("cancels streaming follow immediately when the user wheels away", async () => {
@@ -3418,7 +3619,8 @@ describe("chat view", () => {
       })
     );
 
-    const scrollIntoViewSpy3 = vi.spyOn(Element.prototype, 'scrollIntoView').mockImplementation(() => {});
+    const conversationContent = getScrollContainer()!;
+    const scrollToSpy = vi.spyOn(conversationContent, "scrollTo");
 
     fireEvent.click(screen.getByRole("button", { name: "Edit message" }));
     fireEvent.change(screen.getByDisplayValue("Original prompt"), {
@@ -3441,10 +3643,8 @@ describe("chat view", () => {
     await flushAnimationFrame();
     await flushAnimationFrame();
 
-    expect(scrollIntoViewSpy3).toHaveBeenCalledWith(
-      expect.objectContaining({ block: "start", behavior: "auto" })
-    );
-    scrollIntoViewSpy3.mockRestore();
+    expect(scrollToSpy).toHaveBeenCalledWith({ top: 0, behavior: "smooth" });
+    scrollToSpy.mockRestore();
   });
 
   it("shows regenerate button only on the last user message", async () => {

--- a/tests/unit/conversation-scroll-button.test.tsx
+++ b/tests/unit/conversation-scroll-button.test.tsx
@@ -1,12 +1,18 @@
 // @vitest-environment jsdom
 
 import React from "react";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
+import { IOS_PWA_CONVERSATION_VIEWPORT_EVENT } from "@/lib/use-ios-pwa";
+
 const stickContextMock = vi.hoisted(() => ({
-  isAtBottom: false,
-  scrollToBottom: vi.fn()
+  contentRef: { current: null as HTMLElement | null },
+  scrollRef: { current: null as HTMLElement | null },
+  scrollToBottom: vi.fn(),
+  state: { targetScrollTop: 480 },
+  stopScroll: vi.fn(),
+  targetScrollTop: null as (() => number) | null
 }));
 
 vi.mock("use-stick-to-bottom", () => ({
@@ -20,15 +26,54 @@ vi.mock("use-stick-to-bottom", () => ({
 import { ConversationScrollButton } from "@/components/ai-elements/conversation";
 
 describe("ConversationScrollButton", () => {
-  it("renders nothing while pinned to the bottom", () => {
-    stickContextMock.isAtBottom = true;
+  const originalResizeObserver = globalThis.ResizeObserver;
+  let resizeObserverCallbacks: ResizeObserverCallback[] = [];
+  let scrollMetrics = { scrollTop: 0, scrollHeight: 100, clientHeight: 100 };
+
+  beforeEach(() => {
+    resizeObserverCallbacks = [];
+    scrollMetrics = { scrollTop: 0, scrollHeight: 100, clientHeight: 100 };
+    const scroller = document.createElement("div");
+    Object.defineProperties(scroller, {
+      scrollTop: {
+        configurable: true,
+        get: () => scrollMetrics.scrollTop,
+        set: (value: number) => { scrollMetrics.scrollTop = value; }
+      },
+      scrollHeight: { configurable: true, get: () => scrollMetrics.scrollHeight },
+      clientHeight: { configurable: true, get: () => scrollMetrics.clientHeight }
+    });
+    stickContextMock.scrollRef.current = scroller;
+    stickContextMock.contentRef.current = document.createElement("div");
+    stickContextMock.scrollToBottom.mockReset();
+    stickContextMock.stopScroll.mockReset();
+    stickContextMock.targetScrollTop = null;
+    globalThis.ResizeObserver = class {
+      constructor(callback: ResizeObserverCallback) {
+        resizeObserverCallbacks.push(callback);
+      }
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as typeof ResizeObserver;
+  });
+
+  afterAll(() => {
+    globalThis.ResizeObserver = originalResizeObserver;
+  });
+
+  function placeContentBelowViewport() {
+    scrollMetrics = { scrollTop: 0, scrollHeight: 600, clientHeight: 100 };
+  }
+
+  it("renders nothing when there is no content below the viewport", () => {
     render(React.createElement(ConversationScrollButton));
     expect(screen.queryByRole("button", { name: "Scroll to latest messages" })).toBeNull();
   });
 
-  it("scrolls decisively on click, overriding in-flight user scrolling", () => {
-    stickContextMock.isAtBottom = false;
-    stickContextMock.scrollToBottom.mockClear();
+  it("scrolls decisively on click, overriding in-flight user scrolling", async () => {
+    placeContentBelowViewport();
+    stickContextMock.scrollToBottom.mockResolvedValue(true);
     render(React.createElement(ConversationScrollButton));
 
     fireEvent.click(screen.getByRole("button", { name: "Scroll to latest messages" }));
@@ -40,10 +85,106 @@ describe("ConversationScrollButton", () => {
         animation: expect.objectContaining({ stiffness: expect.any(Number) })
       })
     );
+
+    await waitFor(() => {
+      expect(stickContextMock.stopScroll).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("jumps only to the latest content present at click time and releases auto-follow", async () => {
+    let finishScroll = (_value: boolean) => {};
+    placeContentBelowViewport();
+    stickContextMock.state.targetScrollTop = 480;
+    stickContextMock.scrollToBottom.mockReturnValueOnce(
+      new Promise<boolean>((resolve) => {
+        finishScroll = resolve;
+      })
+    );
+    render(React.createElement(ConversationScrollButton));
+
+    fireEvent.click(screen.getByRole("button", { name: "Scroll to latest messages" }));
+
+    expect(stickContextMock.targetScrollTop?.()).toBe(480);
+    expect(stickContextMock.stopScroll).not.toHaveBeenCalled();
+
+    finishScroll(true);
+
+    await waitFor(() => {
+      expect(stickContextMock.targetScrollTop?.()).toBe(480);
+      expect(stickContextMock.stopScroll).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("shows when streamed content grows beyond the fixed viewport", async () => {
+    render(React.createElement(ConversationScrollButton));
+    expect(screen.queryByRole("button", { name: "Scroll to latest messages" })).toBeNull();
+
+    scrollMetrics.scrollHeight = 140;
+    act(() => {
+      for (const callback of resizeObserverCallbacks) {
+        callback([], {} as ResizeObserver);
+      }
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Scroll to latest messages" })).toBeInTheDocument();
+    });
+  });
+
+  it("stays hidden when the transcript rests a sub-pixel short of the bottom", async () => {
+    scrollMetrics = { scrollTop: 498.5, scrollHeight: 600, clientHeight: 100 };
+    render(React.createElement(ConversationScrollButton));
+
+    act(() => {
+      for (const callback of resizeObserverCallbacks) {
+        callback([], {} as ResizeObserver);
+      }
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: "Scroll to latest messages" })).toBeNull();
+    });
+  });
+
+  it("re-evaluates the latest state when the viewport resizes", async () => {
+    render(React.createElement(ConversationScrollButton));
+
+    scrollMetrics.clientHeight = 40;
+    act(() => {
+      window.dispatchEvent(new Event("resize"));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Scroll to latest messages" })).toBeInTheDocument();
+    });
+  });
+
+  it("hides a stale Latest state after the iOS keyboard viewport is compensated", async () => {
+    render(React.createElement(ConversationScrollButton));
+
+    scrollMetrics.clientHeight = 50;
+    act(() => {
+      for (const callback of resizeObserverCallbacks) {
+        callback([], {} as ResizeObserver);
+      }
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Scroll to latest messages" })).toBeInTheDocument();
+    });
+
+    scrollMetrics.scrollTop = 50;
+    act(() => {
+      window.dispatchEvent(new Event(IOS_PWA_CONVERSATION_VIEWPORT_EVENT));
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: "Scroll to latest messages" })).toBeNull();
+    });
   });
 
   it("sits flush against the composer area top", () => {
-    stickContextMock.isAtBottom = false;
+    placeContentBelowViewport();
     render(React.createElement(ConversationScrollButton));
 
     const button = screen.getByRole("button", { name: "Scroll to latest messages" });

--- a/tests/unit/use-ios-pwa.test.ts
+++ b/tests/unit/use-ios-pwa.test.ts
@@ -2,7 +2,10 @@
 
 import { act, renderHook } from "@testing-library/react";
 
-import { useIosPwa } from "@/lib/use-ios-pwa";
+import {
+  IOS_PWA_CONVERSATION_VIEWPORT_EVENT,
+  useIosPwa,
+} from "@/lib/use-ios-pwa";
 
 function setNavigatorStandalone(value: boolean | undefined) {
   if (value === undefined) {
@@ -52,6 +55,29 @@ function setElementScroll(element: Element, top: number, left: number) {
     get: () => leftValue,
     set: (value: number) => {
       leftValue = value;
+    },
+  });
+}
+
+function setScrollMetrics(
+  element: HTMLElement,
+  metrics: { scrollTop: number; scrollHeight: number; clientHeight: number },
+) {
+  Object.defineProperties(element, {
+    scrollTop: {
+      configurable: true,
+      get: () => metrics.scrollTop,
+      set: (value: number) => {
+        metrics.scrollTop = value;
+      },
+    },
+    scrollHeight: {
+      configurable: true,
+      get: () => metrics.scrollHeight,
+    },
+    clientHeight: {
+      configurable: true,
+      get: () => metrics.clientHeight,
     },
   });
 }
@@ -687,6 +713,444 @@ describe("useIosPwa", () => {
     input.remove();
   });
 
+  it("remeasures the visual viewport after focus when WebKit misses the keyboard resize event", () => {
+    vi.useFakeTimers();
+    setNavigatorStandalone(true);
+    setInnerHeight(812);
+
+    const fakeVisualViewport = {
+      height: 812,
+      scale: 1,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    };
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: fakeVisualViewport,
+    });
+    Element.prototype.scrollIntoView = vi.fn();
+
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+
+    renderHook(() => useIosPwa());
+    expect(appHeightVar()).toBe("812px");
+
+    act(() => {
+      input.focus();
+      flushRaf();
+    });
+
+    fakeVisualViewport.height = 500;
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(appHeightVar()).toBe("500px");
+
+    input.remove();
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: undefined,
+    });
+  });
+
+  it("keeps the latest transcript content above the composer when the keyboard opens", () => {
+    vi.useFakeTimers();
+    setNavigatorStandalone(true);
+    setInnerHeight(812);
+
+    const fakeVisualViewport = {
+      height: 812,
+      scale: 1,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    };
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: fakeVisualViewport,
+    });
+    Element.prototype.scrollIntoView = vi.fn();
+
+    const transcript = document.createElement("div");
+    transcript.className = "conversation-scroller";
+    const metrics = { scrollTop: 400, scrollHeight: 1000, clientHeight: 600 };
+    setScrollMetrics(transcript, metrics);
+    document.body.appendChild(transcript);
+
+    const input = document.createElement("textarea");
+    document.body.appendChild(input);
+    const viewportPreserved = vi.fn();
+    window.addEventListener(IOS_PWA_CONVERSATION_VIEWPORT_EVENT, viewportPreserved);
+
+    renderHook(() => useIosPwa());
+
+    act(() => {
+      input.focus();
+      flushRaf();
+    });
+
+    fakeVisualViewport.height = 500;
+    metrics.clientHeight = 300;
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(metrics.scrollTop).toBe(700);
+    expect(metrics.scrollHeight - metrics.clientHeight - metrics.scrollTop).toBe(0);
+    expect(viewportPreserved).toHaveBeenCalledTimes(1);
+    expect((viewportPreserved.mock.calls[0]?.[0] as CustomEvent<number>).detail).toBe(700);
+
+    fakeVisualViewport.height = 812;
+    metrics.clientHeight = 600;
+    metrics.scrollTop = 400;
+    act(() => {
+      input.blur();
+      window.dispatchEvent(new Event("resize"));
+      vi.runOnlyPendingTimers();
+      flushRaf();
+    });
+
+    expect(viewportPreserved).toHaveBeenCalledTimes(2);
+    expect((viewportPreserved.mock.calls[1]?.[0] as CustomEvent<number>).detail).toBe(400);
+
+    window.removeEventListener(IOS_PWA_CONVERSATION_VIEWPORT_EVENT, viewportPreserved);
+    input.remove();
+    transcript.remove();
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: undefined,
+    });
+  });
+
+  it("compensates a viewport shrink that lands after the focus settle delay", () => {
+    vi.useFakeTimers();
+    setNavigatorStandalone(true);
+    setInnerHeight(812);
+
+    const fakeVisualViewport = {
+      height: 812,
+      scale: 1,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    };
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: fakeVisualViewport,
+    });
+    Element.prototype.scrollIntoView = vi.fn();
+
+    const transcript = document.createElement("div");
+    transcript.className = "conversation-scroller";
+    const metrics = { scrollTop: 400, scrollHeight: 1000, clientHeight: 600 };
+    setScrollMetrics(transcript, metrics);
+    document.body.appendChild(transcript);
+
+    const input = document.createElement("textarea");
+    document.body.appendChild(input);
+
+    renderHook(() => useIosPwa());
+
+    act(() => {
+      input.focus();
+      flushRaf();
+    });
+
+    fakeVisualViewport.height = 500;
+    metrics.clientHeight = 300;
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(metrics.scrollTop).toBe(700);
+
+    fakeVisualViewport.height = 456;
+    metrics.clientHeight = 256;
+    act(() => {
+      window.dispatchEvent(new Event("resize"));
+      vi.runOnlyPendingTimers();
+      flushRaf();
+    });
+
+    expect(metrics.scrollTop).toBe(744);
+    expect(metrics.scrollHeight - metrics.clientHeight - metrics.scrollTop).toBe(0);
+
+    act(() => {
+      input.blur();
+    });
+    input.remove();
+    transcript.remove();
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: undefined,
+    });
+  });
+
+  it("compensates a transcript parked a pixel short of the bottom", () => {
+    vi.useFakeTimers();
+    setNavigatorStandalone(true);
+    setInnerHeight(812);
+
+    const fakeVisualViewport = {
+      height: 812,
+      scale: 1,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    };
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: fakeVisualViewport,
+    });
+    Element.prototype.scrollIntoView = vi.fn();
+
+    const transcript = document.createElement("div");
+    transcript.className = "conversation-scroller";
+    const metrics = { scrollTop: 399, scrollHeight: 1000, clientHeight: 600 };
+    setScrollMetrics(transcript, metrics);
+    document.body.appendChild(transcript);
+
+    const input = document.createElement("textarea");
+    document.body.appendChild(input);
+
+    renderHook(() => useIosPwa());
+
+    act(() => {
+      input.focus();
+      flushRaf();
+    });
+
+    fakeVisualViewport.height = 500;
+    metrics.clientHeight = 300;
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(metrics.scrollTop).toBe(699);
+
+    act(() => {
+      input.blur();
+    });
+    input.remove();
+    transcript.remove();
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: undefined,
+    });
+  });
+
+  it("compensates the viewport loss from wherever the transcript has followed to", () => {
+    vi.useFakeTimers();
+    setNavigatorStandalone(true);
+    setInnerHeight(812);
+
+    const fakeVisualViewport = {
+      height: 812,
+      scale: 1,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    };
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: fakeVisualViewport,
+    });
+    Element.prototype.scrollIntoView = vi.fn();
+
+    const transcript = document.createElement("div");
+    transcript.className = "conversation-scroller";
+    const metrics = { scrollTop: 400, scrollHeight: 1000, clientHeight: 600 };
+    setScrollMetrics(transcript, metrics);
+    document.body.appendChild(transcript);
+
+    const input = document.createElement("textarea");
+    document.body.appendChild(input);
+
+    renderHook(() => useIosPwa());
+
+    act(() => {
+      input.focus();
+      flushRaf();
+    });
+
+    fakeVisualViewport.height = 500;
+    metrics.clientHeight = 300;
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(metrics.scrollTop).toBe(700);
+
+    metrics.scrollHeight = 1400;
+    metrics.scrollTop = 1100;
+    fakeVisualViewport.height = 456;
+    metrics.clientHeight = 256;
+    act(() => {
+      window.dispatchEvent(new Event("resize"));
+      vi.runOnlyPendingTimers();
+      flushRaf();
+    });
+
+    expect(metrics.scrollTop).toBe(1144);
+    expect(metrics.scrollHeight - metrics.clientHeight - metrics.scrollTop).toBe(0);
+
+    act(() => {
+      input.blur();
+    });
+    input.remove();
+    transcript.remove();
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: undefined,
+    });
+  });
+
+  it("captures the latest transcript before iOS moves the composer ahead of focus", () => {
+    vi.useFakeTimers();
+    setNavigatorStandalone(true);
+    setInnerHeight(812);
+
+    const fakeVisualViewport = {
+      height: 812,
+      scale: 1,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    };
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: fakeVisualViewport,
+    });
+    Element.prototype.scrollIntoView = vi.fn();
+
+    const transcript = document.createElement("div");
+    transcript.className = "conversation-scroller";
+    const metrics = { scrollTop: 400, scrollHeight: 1000, clientHeight: 600 };
+    setScrollMetrics(transcript, metrics);
+    document.body.appendChild(transcript);
+
+    const input = document.createElement("textarea");
+    document.body.appendChild(input);
+
+    renderHook(() => useIosPwa());
+
+    act(() => {
+      input.dispatchEvent(new Event("pointerdown", { bubbles: true }));
+      fakeVisualViewport.height = 500;
+      metrics.clientHeight = 300;
+      input.focus();
+      flushRaf();
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(metrics.scrollTop).toBe(700);
+    expect(metrics.scrollHeight - metrics.clientHeight - metrics.scrollTop).toBe(0);
+
+    input.remove();
+    transcript.remove();
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: undefined,
+    });
+  });
+
+  it("does not follow streamed content while compensating for the keyboard viewport", () => {
+    vi.useFakeTimers();
+    setNavigatorStandalone(true);
+    setInnerHeight(812);
+
+    const fakeVisualViewport = {
+      height: 812,
+      scale: 1,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    };
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: fakeVisualViewport,
+    });
+    Element.prototype.scrollIntoView = vi.fn();
+
+    const transcript = document.createElement("div");
+    transcript.className = "conversation-scroller";
+    const metrics = { scrollTop: 400, scrollHeight: 1000, clientHeight: 600 };
+    setScrollMetrics(transcript, metrics);
+    document.body.appendChild(transcript);
+
+    const input = document.createElement("textarea");
+    document.body.appendChild(input);
+
+    renderHook(() => useIosPwa());
+
+    act(() => {
+      input.focus();
+      flushRaf();
+    });
+
+    fakeVisualViewport.height = 500;
+    metrics.clientHeight = 300;
+    metrics.scrollHeight = 1100;
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(metrics.scrollTop).toBe(700);
+    expect(metrics.scrollHeight - metrics.clientHeight - metrics.scrollTop).toBe(100);
+
+    input.remove();
+    transcript.remove();
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: undefined,
+    });
+  });
+
+  it("keeps a manually browsed transcript fixed when the keyboard opens", () => {
+    vi.useFakeTimers();
+    setNavigatorStandalone(true);
+    setInnerHeight(812);
+
+    const fakeVisualViewport = {
+      height: 812,
+      scale: 1,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    };
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: fakeVisualViewport,
+    });
+    Element.prototype.scrollIntoView = vi.fn();
+
+    const transcript = document.createElement("div");
+    transcript.className = "conversation-scroller";
+    const metrics = { scrollTop: 250, scrollHeight: 1000, clientHeight: 600 };
+    setScrollMetrics(transcript, metrics);
+    document.body.appendChild(transcript);
+
+    const input = document.createElement("textarea");
+    document.body.appendChild(input);
+
+    renderHook(() => useIosPwa());
+
+    act(() => {
+      input.focus();
+      flushRaf();
+    });
+
+    fakeVisualViewport.height = 500;
+    metrics.clientHeight = 300;
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(metrics.scrollTop).toBe(250);
+
+    input.remove();
+    transcript.remove();
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: undefined,
+    });
+  });
+
   it("clears the trailing focus correction on unmount", () => {
     vi.useFakeTimers();
     setNavigatorStandalone(true);
@@ -741,7 +1205,7 @@ describe("useIosPwa", () => {
     button.remove();
   });
 
-  it("does not listen for focusin and never corrects scroll when not standalone", () => {
+  it("does not listen for focus events and never corrects scroll when not standalone", () => {
     setNavigatorStandalone(false);
     setInnerHeight(812);
 
@@ -752,13 +1216,15 @@ describe("useIosPwa", () => {
 
     renderHook(() => useIosPwa());
 
+    expect(docAddSpy).not.toHaveBeenCalledWith("pointerdown", expect.any(Function), true);
     expect(docAddSpy).not.toHaveBeenCalledWith("focusin", expect.any(Function));
+    expect(docAddSpy).not.toHaveBeenCalledWith("focusout", expect.any(Function));
     expect(scrollToMock).not.toHaveBeenCalled();
 
     docAddSpy.mockRestore();
   });
 
-  it("removes the visualViewport scroll and document focusin listeners on unmount", () => {
+  it("removes the visualViewport scroll and document focus listeners on unmount", () => {
     setNavigatorStandalone(true);
     setInnerHeight(812);
 
@@ -780,12 +1246,16 @@ describe("useIosPwa", () => {
     const { unmount } = renderHook(() => useIosPwa());
 
     expect(fakeVisualViewport.addEventListener).toHaveBeenCalledWith("scroll", expect.any(Function));
+    expect(docAddSpy).toHaveBeenCalledWith("pointerdown", expect.any(Function), true);
     expect(docAddSpy).toHaveBeenCalledWith("focusin", expect.any(Function));
+    expect(docAddSpy).toHaveBeenCalledWith("focusout", expect.any(Function));
 
     unmount();
 
     expect(fakeVisualViewport.removeEventListener).toHaveBeenCalledWith("scroll", expect.any(Function));
+    expect(docRemoveSpy).toHaveBeenCalledWith("pointerdown", expect.any(Function), true);
     expect(docRemoveSpy).toHaveBeenCalledWith("focusin", expect.any(Function));
+    expect(docRemoveSpy).toHaveBeenCalledWith("focusout", expect.any(Function));
 
     docAddSpy.mockRestore();
     docRemoveSpy.mockRestore();


### PR DESCRIPTION
## Summary

- **Anchor a new user turn to the top.** Sending a message now scrolls that user bubble to the top of the conversation and reserves a viewport-height spacer below it, so the assistant response streams into empty space instead of pushing the view around.
- **Drive the "Latest" button from real scroll geometry.** `use-stick-to-bottom` reports `isAtBottom` while the view is deliberately pinned to a turn, so the button was unreliable. It now derives from the scroller's own geometry, jumps only to the content present at click time, and releases auto-follow afterwards.
- **Absorb composer growth.** Focusing the composer on mobile expands its toolbar (and drops the safe-area padding), which grows the transcript's trailing spacer. An at-bottom transcript was left short of the bottom, so the composer covered the last message's action icons and "Latest" reappeared. Chat view now re-snaps to the bottom when the composer grows and the transcript was already there.
- **Fix iOS keyboard viewport compensation.** It previously expired 300 ms after `focusin`, so late keyboard/accessory-bar resizes went uncompensated. The bottom pin now lasts the whole focus session and compensates incrementally from the current scroll position, so it composes with composer growth instead of snapping back to a stale baseline.
- **Share one at-bottom check with tolerance.** Both call sites used a 1 px threshold, but `use-stick-to-bottom` parks 1 px short of the bottom and iOS client heights are fractional — an at-bottom transcript could read as "not at bottom". Replaced with a shared `isScrolledToBottom` helper (8 px tolerance).

## Testing

- `npm test`: 138 files, 1527 tests pass; coverage 90.63% statements / 85.5% branches.
- `tsc --noEmit` and `eslint .` clean.
- Not verified on device: the keyboard path only runs in an iOS standalone PWA, so it is covered by geometry-level unit tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)