### PR TITLE
Tighten spacing between user message text and attachments

### DIFF
--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -729,7 +729,7 @@ function MessageBubbleImpl({
       <>
         <Message from="user" data-message-id={message.id}>
           <div className="group flex w-full flex-col items-end md:max-w-[95%]">
-            <MessageContent className={`${!readOnly && isEditing ? "w-full" : "w-fit max-w-full"} rounded-2xl border border-[var(--accent)]/10 bg-[var(--accent-soft)] px-4 py-3 text-[var(--text)]`}>
+            <MessageContent className={`${!readOnly && isEditing ? "w-full" : "w-fit max-w-full"} gap-1 rounded-2xl border border-[var(--accent)]/10 bg-[var(--accent-soft)] px-4 py-3 text-[var(--text)]`}>
               {!readOnly && isEditing ? (
                 <Textarea
                   ref={editRef}
@@ -754,7 +754,7 @@ function MessageBubbleImpl({
                 </div>
               ) : null}
               {message.attachments?.length ? (
-                <div className={content || (!readOnly && isEditing) ? "mt-3" : ""}>
+                <div>
                   <MessageAttachments
                     attachments={message.attachments}
                     compact

--- a/tests/unit/message-bubble.test.tsx
+++ b/tests/unit/message-bubble.test.tsx
@@ -75,6 +75,37 @@ describe("message bubble avatar", () => {
     expect(screen.queryByRole("button", { name: "Edit message" })).toBeNull();
   });
 
+  it("uses a 4px gap between user text and attachments", () => {
+    render(
+      React.createElement(MessageBubble, {
+        message: {
+          ...createUserMessage(),
+          attachments: [
+            {
+              id: "att_image",
+              conversationId: "conv_test",
+              messageId: "msg_user",
+              filename: "screenshot.png",
+              mimeType: "image/png",
+              byteSize: 10,
+              sha256: "hash-image",
+              relativePath: "conv_test/att_image_screenshot.png",
+              kind: "image",
+              extractedText: "",
+              createdAt: new Date().toISOString()
+            }
+          ]
+        }
+      })
+    );
+
+    const previewButton = screen.getByRole("button", { name: "Preview screenshot.png" });
+    const attachmentWrapper = previewButton.parentElement?.parentElement?.parentElement;
+
+    expect(attachmentWrapper).not.toHaveClass("mt-3");
+    expect(attachmentWrapper?.parentElement).toHaveClass("gap-1");
+  });
+
   it("renders buffered streaming text without a second word animation queue", () => {
     const { container } = render(
       React.createElement(MessageBubble, {


### PR DESCRIPTION
## Summary

- Reduce the spacing between user message text and attachments to 4px.
- Add unit coverage for the updated attachment layout.

## Testing

- Added and ran the message bubble unit test covering attachment spacing.