### PR TITLE
Route OpenCode Go GPT-5.6 image requests through Responses API

### DIFF
--- a/lib/model-capabilities.ts
+++ b/lib/model-capabilities.ts
@@ -11,6 +11,7 @@ type CapabilityFlag = boolean | { apiModes: ApiMode[] };
 type ResolvedCapabilities = {
   reasoning: boolean;
   vision: boolean;
+  supportsTemperature: boolean;
   thinkingReplay: boolean;
   extraBody: "none" | "thinking" | "reasoning_effort";
   strictExtraRejection: boolean;
@@ -26,6 +27,7 @@ function bareModelId(model: string) {
 const DEFAULT_CAPABILITIES: ResolvedCapabilities = {
   reasoning: false,
   vision: false,
+  supportsTemperature: true,
   thinkingReplay: false,
   extraBody: "none",
   strictExtraRejection: false,

--- a/lib/model-registry.ts
+++ b/lib/model-registry.ts
@@ -2,6 +2,7 @@ export type ModelCapabilityOverride = {
   prefix: string;
   reasoning?: boolean | { apiModes: Array<"responses" | "chat_completions"> };
   vision?: boolean | { apiModes: Array<"responses" | "chat_completions"> };
+  supportsTemperature?: boolean;
 };
 
 export type ModelRequestQuirk = {
@@ -12,7 +13,12 @@ export type ModelRequestQuirk = {
 };
 
 export const MODEL_REGISTRY: ModelCapabilityOverride[] = [
-  { prefix: "gpt-5", reasoning: { apiModes: ["responses"] }, vision: true },
+  {
+    prefix: "gpt-5",
+    reasoning: { apiModes: ["responses"] },
+    vision: true,
+    supportsTemperature: false
+  },
   { prefix: "o1", reasoning: { apiModes: ["responses"] }, vision: true },
   { prefix: "o3", reasoning: { apiModes: ["responses"] }, vision: true },
   { prefix: "o4", reasoning: { apiModes: ["responses"] }, vision: true },

--- a/lib/provider-catalog.ts
+++ b/lib/provider-catalog.ts
@@ -5,6 +5,11 @@ export type ProcessingMode = "standard" | "fast";
 export type ReasoningEffort = "none" | "low" | "medium" | "high" | "xhigh" | "max";
 export type VisionMode = "none" | "native" | "mcp";
 
+export type ProviderModelRequestRule = {
+  modelPrefix: string;
+  apiMode: ApiMode;
+};
+
 export const DEFAULT_PROFILE_BEHAVIOR = {
   systemPrompt:
     "You are an helpful AI assistant with advanced reasoning capabilities. You excel at complex problem-solving, analysis, coding, mathematics, and tasks requiring careful, step-by-step thinking.\nWhen responding:\n1. **Think step by step** - Break down complex problems into logical steps. Show your reasoning process clearly before arriving at conclusions.\n2. **Be thorough but concise** - Explore ideas deeply, but avoid unnecessary verbosity. Focus on substantive reasoning over filler text.\n3. **Verify your logic** - Double-check your reasoning for consistency, accuracy, and completeness before finalizing your answer.\n4. **Acknowledge uncertainty** - When appropriate, indicate confidence levels or alternative interpretations of the problem.\n5. **Use structured formats** - For complex answers, use numbered steps, bullet points, or sections to organize your thinking.\n6. **Adapt depth to the task** - Match the depth of your reasoning to the complexity of the question. Simple questions don't need elaborate analysis.\n7. **Use emojis sparingly** - You may use an occasional emoji when it genuinely improves tone or clarity, but keep usage infrequent and minimal. Do not use emojis in every response, avoid repeated or decorative emoji use, and never let them clutter the message.\nAlways aim to be helpful, accurate, and honest in your responses.",
@@ -150,6 +155,12 @@ export const PROVIDER_PRESETS = [
     id: "opencode_go",
     label: "OpenCode Go",
     providerKind: "openai_compatible",
+    requestRules: [
+      {
+        modelPrefix: "gpt-5.6",
+        apiMode: "responses"
+      }
+    ],
     values: {
       name: "OpenCode Go",
       apiBaseUrl: "https://opencode.ai/zen/go/v1",
@@ -242,10 +253,18 @@ export const PROVIDER_PRESETS = [
   id: string;
   label: string;
   providerKind: ProviderKind;
+  requestRules?: readonly ProviderModelRequestRule[];
   values: ProviderPresetValues;
 }>;
 
 export type ProviderPresetId = (typeof PROVIDER_PRESETS)[number]["id"];
+
+type ProviderRequestProfile = {
+  providerKind: ProviderKind;
+  apiBaseUrl: string;
+  apiMode: ApiMode;
+  model: string;
+};
 
 type PresetCompatibleProfile = ProviderPresetValues & {
   providerKind?: string;
@@ -259,6 +278,33 @@ export function getProviderPreset(id: ProviderPresetId) {
   const preset = PROVIDER_PRESETS.find((entry) => entry.id === id);
   if (!preset) throw new Error(`Unknown provider preset: ${id}`);
   return preset;
+}
+
+function normalizeApiBaseUrl(value: string) {
+  return value.trim().replace(/\/+$/, "").toLowerCase();
+}
+
+function normalizeModelId(value: string) {
+  const normalized = value.trim().toLowerCase();
+  return normalized.includes("/")
+    ? normalized.slice(normalized.lastIndexOf("/") + 1)
+    : normalized;
+}
+
+export function resolveProviderRequestApiMode(profile: ProviderRequestProfile): ApiMode {
+  const matchingPreset = PROVIDER_PRESETS.find((preset) =>
+    preset.providerKind === profile.providerKind &&
+    normalizeApiBaseUrl(preset.values.apiBaseUrl) === normalizeApiBaseUrl(profile.apiBaseUrl)
+  );
+  if (!matchingPreset || !("requestRules" in matchingPreset)) {
+    return profile.apiMode;
+  }
+
+  const model = normalizeModelId(profile.model);
+  const rule = matchingPreset.requestRules.find((candidate) =>
+    model.startsWith(candidate.modelPrefix.trim().toLowerCase())
+  );
+  return rule?.apiMode ?? profile.apiMode;
 }
 
 export function applyProviderPreset<T extends PresetCompatibleProfile>(

--- a/lib/provider-profile.ts
+++ b/lib/provider-profile.ts
@@ -1,5 +1,6 @@
 import {
   PROVIDER_CATALOG,
+  resolveProviderRequestApiMode,
   type ApiMode,
   type ProviderConnectionMode,
   type ProviderKind,
@@ -9,7 +10,7 @@ import {
   type ReasoningEffort,
   type VisionMode
 } from "@/lib/provider-catalog";
-import { modelMatchesPrefix } from "@/lib/model-capabilities";
+import { modelMatchesPrefix, resolveCapabilities } from "@/lib/model-capabilities";
 
 export type ProviderConnectionStatus = "disconnected" | "connected" | "expired";
 
@@ -101,9 +102,15 @@ export type ProviderProfileSummary = ProviderProfile & {
 };
 
 export function getProviderApiMode(profile: ProviderProfile): ApiMode {
-  return profile.providerKind === "openai_compatible"
-    ? profile.providerConfig.apiMode
-    : "chat_completions";
+  if (profile.providerKind !== "openai_compatible") {
+    return "chat_completions";
+  }
+  return resolveProviderRequestApiMode({
+    providerKind: profile.providerKind,
+    apiBaseUrl: profile.providerConfig.apiBaseUrl,
+    apiMode: profile.providerConfig.apiMode,
+    model: profile.model
+  });
 }
 
 export function getProviderApiBaseUrl(profile: ProviderProfile) {
@@ -131,10 +138,13 @@ export function resolveProviderProfileCapabilities(
       "https://api.openai.com/v1";
   const hasExtendedReasoning = isOfficialEndpoint && modelMatchesPrefix(profile.model, "gpt-5.6");
   const reasoningEfforts = ["none", "low", "medium", "high", "xhigh"] as const;
+  const modelCapabilities = resolveCapabilities(profile.model, getProviderApiMode(profile));
 
   return {
     supportsTemperature:
-      PROVIDER_CATALOG[profile.providerKind].editor.sampling && !isOfficialEndpoint,
+      PROVIDER_CATALOG[profile.providerKind].editor.sampling &&
+      !isOfficialEndpoint &&
+      modelCapabilities.supportsTemperature,
     processingModes: isOfficialEndpoint ? ["standard", "fast"] : [],
     reasoningEfforts: hasExtendedReasoning
       ? [...reasoningEfforts, "max"]

--- a/tests/unit/model-capabilities.test.ts
+++ b/tests/unit/model-capabilities.test.ts
@@ -11,6 +11,7 @@ describe("resolveCapabilities", () => {
     const caps = resolveCapabilities("unknown-model", "chat_completions");
     expect(caps.reasoning).toBe(false);
     expect(caps.vision).toBe(false);
+    expect(caps.supportsTemperature).toBe(true);
     expect(caps.thinkingReplay).toBe(false);
     expect(caps.extraBody).toBe("none");
     expect(caps.strictExtraRejection).toBe(false);
@@ -29,6 +30,10 @@ describe("resolveCapabilities", () => {
     expect(caps.strictExtraRejection).toBe(true);
     expect(caps.thinkingReplay).toBe(false);
     expect(caps.extraBody).toBe("none");
+  });
+
+  it("omits temperature for GPT-5 models", () => {
+    expect(resolveCapabilities("gpt-5.6-luna", "responses").supportsTemperature).toBe(false);
   });
 
   it("applies registry overrides for glm-5", () => {

--- a/tests/unit/provider-presets.test.ts
+++ b/tests/unit/provider-presets.test.ts
@@ -2,7 +2,8 @@ import {
   applyProviderPreset,
   DEFAULT_PROFILE_BEHAVIOR,
   getMatchingProviderPresetId,
-  getProviderPreset
+  getProviderPreset,
+  resolveProviderRequestApiMode
 } from "@/lib/provider-catalog";
 
 function createProfile() {
@@ -98,6 +99,33 @@ describe("provider presets", () => {
     };
 
     expect(getMatchingProviderPresetId(profile)).toBe("opencode_go");
+  });
+
+  it("uses responses for OpenCode Go GPT-5.6 models", () => {
+    expect(resolveProviderRequestApiMode({
+      providerKind: "openai_compatible",
+      apiBaseUrl: "https://opencode.ai/zen/go/v1/",
+      apiMode: "chat_completions",
+      model: "openai/gpt-5.6-luna"
+    })).toBe("responses");
+  });
+
+  it("keeps OpenCode Go Kimi models on chat completions", () => {
+    expect(resolveProviderRequestApiMode({
+      providerKind: "openai_compatible",
+      apiBaseUrl: "https://opencode.ai/zen/go/v1",
+      apiMode: "chat_completions",
+      model: "kimi-k2.6"
+    })).toBe("chat_completions");
+  });
+
+  it("preserves the configured mode for unmatched compatible endpoints", () => {
+    expect(resolveProviderRequestApiMode({
+      providerKind: "openai_compatible",
+      apiBaseUrl: "https://custom.example.com/v1",
+      apiMode: "chat_completions",
+      model: "gpt-5.6-luna"
+    })).toBe("chat_completions");
   });
 
   it("matches a profile back to its preset even with a different name", () => {

--- a/tests/unit/provider.test.ts
+++ b/tests/unit/provider.test.ts
@@ -287,7 +287,7 @@ describe("provider integration", () => {
     await callProviderText({
       settings: createSettings({
         apiBaseUrl: "https://custom.example.com/v1",
-        model: "gpt-5.6-luna",
+        model: "custom-chat-model",
         temperature: 0.6
       }),
       prompt: "Reply with connected",
@@ -1014,6 +1014,82 @@ describe("provider integration", () => {
         signal: expect.any(AbortSignal)
       })
     );
+  });
+
+  it("uses responses image input for OpenCode Go GPT-5.6 models saved in chat mode", async () => {
+    responsesCreate.mockResolvedValue(
+      createAsyncStream([{ type: "response.output_text.delta", delta: "done" }])
+    );
+
+    const { streamProviderResponse } = await import("@/lib/provider");
+    const stream = streamProviderResponse({
+      settings: createSettings({
+        apiBaseUrl: "https://opencode.ai/zen/go/v1",
+        apiMode: "chat_completions",
+        model: "gpt-5.6-luna",
+        providerPresetId: "opencode_go",
+        temperature: 0.6
+      }),
+      promptMessages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "Describe this image" },
+            {
+              type: "image",
+              attachmentId: "att_1",
+              filename: "photo.png",
+              mimeType: "image/png",
+              relativePath: "conv_1/att_1_photo.png"
+            }
+          ]
+        }
+      ]
+    });
+
+    await stream.next();
+
+    expect(responsesCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: expect.arrayContaining([
+          {
+            role: "user",
+            content: [
+              { type: "input_text", text: "Describe this image" },
+              { type: "input_image", image_url: "data:image/png;base64,abc123" }
+            ]
+          }
+        ])
+      }),
+      expect.objectContaining({
+        signal: expect.any(AbortSignal)
+      })
+    );
+    expect(responsesCreate.mock.calls.at(-1)?.[0]).not.toHaveProperty("temperature");
+    expect(chatCreate).not.toHaveBeenCalled();
+  });
+
+  it("keeps OpenCode Go Kimi models on chat completions", async () => {
+    chatCreate.mockResolvedValue(
+      createAsyncStream([{ choices: [{ delta: { content: "done" } }] }])
+    );
+
+    const { streamProviderResponse } = await import("@/lib/provider");
+    const stream = streamProviderResponse({
+      settings: createSettings({
+        apiBaseUrl: "https://opencode.ai/zen/go/v1",
+        apiMode: "chat_completions",
+        model: "kimi-k2.6",
+        providerPresetId: "opencode_go",
+        reasoningSummaryEnabled: false
+      }),
+      promptMessages: [{ role: "user", content: "Hello" }]
+    });
+
+    await stream.next();
+
+    expect(chatCreate).toHaveBeenCalledOnce();
+    expect(responsesCreate).not.toHaveBeenCalled();
   });
 
   it("serializes tool outputs and assistant tool calls for responses mode streams", async () => {


### PR DESCRIPTION
## Summary

- Route OpenCode Go GPT-5.6 models through the Responses API, including image inputs.
- Add model capability handling to omit unsupported temperature parameters.
- Keep other OpenCode Go models, such as Kimi, on Chat Completions.
- Add coverage for provider mode resolution and request serialization.

## Testing

- Not run (not requested)