### PR TITLE
Fix chat ordering by clearing streamed preamble before tool calls

### DIFF
--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -715,6 +715,10 @@ export function ChatView({ payload }: { payload: ConversationViewPayload }) {
       }
     }
 
+    if (event.type === "answer_reset") {
+      streamBuffer.setAnswer("", { immediate: true });
+    }
+
     if (event.type === "system_notice") {
       setMessages((current) => [
         ...current,

--- a/lib/assistant-runtime.ts
+++ b/lib/assistant-runtime.ts
@@ -471,11 +471,13 @@ export async function resolveAssistantTurn(input: {
         hasImageGeneration &&
         hasUnfulfilledImageGenerationIntent(promptMessages)
       ) {
+        input.onEvent?.({ type: "answer_reset" });
         promptMessages = mergeSystemMessage(promptMessages, IMAGE_TOOL_REQUIRED_DIRECTIVE);
         continue;
       }
 
       if ((input.memoriesEnabled ?? false) && hasUnfulfilledMemoryIntent(answer)) {
+        input.onEvent?.({ type: "answer_reset" });
         promptMessages = mergeSystemMessage(
           promptMessages,
           "Do not say that you saved, stored, remembered, updated, or deleted a memory unless you actually call the corresponding memory tool in that same response. If a memory proposal is warranted, call the memory tool now. Otherwise, answer normally without mentioning memory-saving."
@@ -484,6 +486,7 @@ export async function resolveAssistantTurn(input: {
       }
 
       if (!answer.trim()) {
+        input.onEvent?.({ type: "answer_reset" });
         promptMessages = mergeSystemMessage(
           promptMessages,
           "Your previous response was empty. Answer the user directly. Do not emit an empty response."
@@ -494,8 +497,14 @@ export async function resolveAssistantTurn(input: {
       return { answer, thinking, usage };
     }
 
-    if (answer) {
+    const isMemoryProposalFinalStep =
+      Boolean(answer.trim()) &&
+      toolCalls.every((toolCall) => isMemoryProposalToolCall(toolCall.name));
+
+    if (isMemoryProposalFinalStep) {
       await commitAnswerSegment(answer);
+    } else {
+      input.onEvent?.({ type: "answer_reset" });
     }
 
     promptMessages = [
@@ -573,7 +582,7 @@ export async function resolveAssistantTurn(input: {
       }
     }
 
-    if (answer.trim() && toolCalls.every((toolCall) => isMemoryProposalToolCall(toolCall.name))) {
+    if (isMemoryProposalFinalStep) {
       return { answer, thinking, usage };
     }
   }

--- a/lib/chat-turn.ts
+++ b/lib/chat-turn.ts
@@ -376,6 +376,10 @@ async function startAssistantTurn(
           latestAnswer = "";
           latestThinking = "";
           sawStreamedAnswerSinceLastSegment = false;
+        } else if (event.type === "answer_reset") {
+          answerBuffer = "";
+          latestAnswer = "";
+          sawStreamedAnswerSinceLastSegment = false;
         }
       },
       async onAnswerSegment(segment) {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -469,6 +469,7 @@ export type ChatStreamEvent =
   | { type: "message_start"; messageId: string }
   | { type: "thinking_delta"; text: string }
   | { type: "answer_delta"; text: string }
+  | { type: "answer_reset" }
   | { type: "action_start"; action: MessageAction }
   | { type: "action_complete"; action: MessageAction }
   | { type: "action_error"; action: MessageAction }

--- a/tests/unit/assistant-runtime.test.ts
+++ b/tests/unit/assistant-runtime.test.ts
@@ -2198,7 +2198,7 @@ Run browser commands.`
     })]);
   });
 
-  it("commits answer text that appears before tool calls", async () => {
+  it("discards preamble answer text streamed before tool calls", async () => {
     streamProviderResponse
       .mockReturnValueOnce(
         createProviderStream([{ type: "answer_delta", text: "Let me search." }], {
@@ -2220,6 +2220,7 @@ Run browser commands.`
     });
 
     const persistedSegments: string[] = [];
+    const emitted: ChatStreamEvent[] = [];
     const { resolveAssistantTurn } = await import("@/lib/assistant-runtime");
 
     await resolveAssistantTurn({
@@ -2230,14 +2231,16 @@ Run browser commands.`
         server: { id: "mcp_docs", slug: "docs", name: "Docs", url: "https://mcp.example.com", headers: {}, transport: "streamable_http", command: null, args: null, env: null, enabled: true, isVisionMcp: false, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
         tools: [{ name: "search_docs", description: "Search docs", inputSchema: { type: "object" }, annotations: { readOnlyHint: true } }]
       }],
-      onEvent: () => {},
+      onEvent: (event) => { emitted.push(event); },
       onAnswerSegment: (segment) => { persistedSegments.push(segment); }
     });
 
-    expect(persistedSegments).toEqual([
+    expect(emitted.filter((event) => event.type === "answer_delta").map((event) => event.type === "answer_delta" && event.text)).toEqual([
       "Let me search.",
       "Here are the results."
     ]);
+    expect(emitted.some((event) => event.type === "answer_reset")).toBe(true);
+    expect(persistedSegments).toEqual(["Here are the results."]);
   });
 
   describe("memory tools", () => {

--- a/tests/unit/chat-view.test.ts
+++ b/tests/unit/chat-view.test.ts
@@ -4226,6 +4226,52 @@ describe("chat view", () => {
     });
   });
 
+  it("clears streamed preamble text on answer_reset before a tool action", async () => {
+    renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
+
+    const send = (event: unknown) =>
+      wsMock.onMessage!({ type: "delta", conversationId: "conv_1", event });
+
+    send({ type: "message_start", messageId: "msg_assistant" });
+    send({ type: "answer_delta", text: "Let me dig deeper to confirm. " });
+    send({ type: "answer_reset" });
+    send({
+      type: "action_start",
+      action: {
+        id: "act_search",
+        messageId: "msg_assistant",
+        kind: "mcp_tool_call",
+        status: "running",
+        serverId: "integration_web_search",
+        skillId: null,
+        toolName: "web_search",
+        label: "Web search",
+        detail: "palworld stacking",
+        arguments: { query: "palworld stacking" },
+        resultSummary: "",
+        sortOrder: 1,
+        startedAt: new Date().toISOString(),
+        completedAt: null,
+        proposalState: null,
+        proposalPayload: null,
+        proposalUpdatedAt: null
+      }
+    });
+    send({ type: "answer_delta", text: "Here are the confirmed results." });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("assistant-actions-shell")).toBeInTheDocument();
+    });
+
+    for (let i = 0; i < 40; i += 1) {
+      await flushAnimationFrame();
+    }
+
+    const content = screen.getAllByTestId("assistant-message-content").map((node) => node.textContent).join("");
+    expect(content).toContain("Here are the confirmed results.");
+    expect(content).not.toContain("Let me dig deeper");
+  });
+
   it("keeps a pending memory proposal visible when action_start and done arrive back to back", async () => {
     renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
 


### PR DESCRIPTION
## Problem
When the assistant streamed some text (a "preamble") before deciding to call a tool, that preamble text stayed on screen, so the final answer showed out-of-order or repeated text.

## Solution
Introduce a new `answer_reset` stream event and emit it whenever the assistant retries a turn (e.g. after an unfulfilled tool/memory intent or an empty answer) or when the only tool calls in a final answer are memory proposals. The chat turn runtime and chat view both reset the answer buffer and clear the streamed text on `answer_reset`, so the next segment starts clean.

- Added `answer_reset` to `ChatStreamEvent`.
- `assistant-runtime.ts` emits `answer_reset` on retry conditions and replaces the previous "commit any answer" behavior with commit-only-when-`isMemoryProposalFinalStep`, otherwise reset.
- `chat-turn.ts` clears the answer buffer, latest answer, and streamed-answer flag on `answer_reset`.
- `chat-view.tsx` immediately clears the streamed answer buffer on `answer_reset`.
- Updated unit tests in `assistant-runtime.test.ts` and `chat-view.test.ts` to verify preamble text is discarded and reset events are emitted.

## Testing
- `tests/unit/assistant-runtime.test.ts`: verifies preamble text streamed before tool calls is discarded and an `answer_reset` event is emitted.
- `tests/unit/chat-view.test.ts`: verifies the UI clears streamed preamble text on `answer_reset` before a tool action.