### PR TITLE
Replace typing dots with "Working" in-progress indicator

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -172,11 +172,6 @@ select {
   50% { opacity: 1; }
 }
 
-@keyframes typing-dot {
-  0%, 60%, 100% { transform: translateY(0); opacity: 0.3; }
-  30% { transform: translateY(calc(var(--typing-dot-lift, 6px) * -1)); opacity: 1; }
-}
-
 .animate-fade-in {
   animation: fade-in 0.3s ease-out forwards;
 }
@@ -556,8 +551,8 @@ select {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .typing-dot {
-    animation: none !important;
+  [data-testid="assistant-in-progress"] .animate-spin {
+    animation: none;
   }
 
   .animate-slide-up,

--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -125,20 +125,23 @@ const AssistantMarkdown = React.memo(
     previous.showCaret === next.showCaret
 );
 
-export function TypingIndicator({ compact = false }: { compact?: boolean }) {
+export function InProgressIndicator() {
   return (
-    <div className={compact ? "flex items-center gap-1" : "flex items-center gap-1.5 px-1 py-2"}>
-      {[0, 1, 2].map((i) => (
-        <div
-          key={i}
-          className="typing-dot h-1.5 w-1.5 rounded-full bg-white/40"
-          style={{
-            ["--typing-dot-lift" as string]: compact ? "2px" : "6px",
-            animation: "typing-dot 1.4s ease-in-out infinite",
-            animationDelay: `${i * 0.2}s`
-          }}
-        />
-      ))}
+    <div
+      className="w-fit rounded-lg border border-white/5 bg-white/[0.015] px-2 py-1 animate-fade-in"
+      data-testid="assistant-in-progress"
+      role="status"
+      aria-live="polite"
+    >
+      <span className="flex items-center gap-1.5">
+        <span className="flex h-3.5 w-3.5 shrink-0 items-center justify-center">
+          <LoaderCircle className="h-3 w-3 animate-spin text-white/45" aria-hidden="true" />
+        </span>
+        <span className="flex items-center gap-1 text-[11px] leading-[16.5px] text-white/50">
+          <span className="font-medium">Working</span>
+          <span className="text-white/30" aria-hidden="true">...</span>
+        </span>
+      </span>
     </div>
   );
 }
@@ -244,9 +247,6 @@ function CollapsibleActionRow({
 const ASSISTANT_CONTENT =
   "w-full max-w-full text-[var(--text)]";
 const ASSISTANT_ERROR_MAX_WIDTH = "max-w-full md:max-w-[95%]";
-const ASSISTANT_LOADING_SHELL =
-  "mt-[6px] inline-flex items-center overflow-hidden rounded-lg border border-white/5 bg-white/[0.015] px-2 py-1";
-
 type ThinkingTimelineItem = Extract<MessageTimelineItem, { timelineKind: "thinking" }>;
 type RenderedThinkingTimelineItem = ThinkingTimelineItem & { content: string };
 type AssistantBlock =
@@ -593,7 +593,7 @@ function MessageBubbleImpl({
           <span className="flex h-3.5 w-3.5 shrink-0 items-center justify-center">
             {statusIcon}
           </span>
-          <span className="flex items-center gap-1 text-[11px] text-white/50">
+          <span className="flex items-center gap-1 text-[11px] leading-[16.5px] text-white/50">
             <span className="font-medium">{isRunning ? "Thinking" : "Thought"}</span>
             {isRunning ? (
               <span className="text-white/30">...</span>
@@ -680,6 +680,25 @@ function MessageBubbleImpl({
         duration: thinkingDuration
       })
     : null;
+
+  const lastAssistantBlock = assistantBlocks[assistantBlocks.length - 1];
+  const lastBlockIsRunningAction =
+    lastAssistantBlock?.timelineKind === "action" && lastAssistantBlock.status === "running";
+  const lastBlockIsRunningThinking =
+    lastAssistantBlock?.timelineKind === "thinking" && lastAssistantBlock.status === "running";
+  const lastBlockIsStreamingText =
+    isAssistantStreaming &&
+    lastAssistantBlock?.timelineKind === "text" &&
+    lastAssistantBlock.id === lastRenderableAssistantTextId;
+  const showInProgressTail =
+    isAssistantStreaming &&
+    !awaitingFirstToken &&
+    message.status !== "error" &&
+    message.status !== "stopped" &&
+    !lastBlockIsRunningAction &&
+    !lastBlockIsRunningThinking &&
+    !lastBlockIsStreamingText &&
+    !(showThinkingShell && thinkingInProgress);
 
   function setCopyFeedback(nextState: "copied" | "error") {
     setCopyState(nextState);
@@ -869,12 +888,7 @@ function MessageBubbleImpl({
               compactionInProgress ? (
                 <CompactionIndicator />
               ) : (
-                <div
-                  className={ASSISTANT_LOADING_SHELL}
-                  data-testid="assistant-loading-shell"
-                >
-                  <TypingIndicator compact />
-                </div>
+                <InProgressIndicator />
               )
             ) : message.status === "error" ? (
               <div className="group flex w-full min-w-0 flex-col items-start">
@@ -984,6 +998,9 @@ function MessageBubbleImpl({
                         <Square className="h-2.5 w-2.5 fill-current" />
                         <span>Stopped</span>
                       </div>
+                    ) : null}
+                    {showInProgressTail ? (
+                      <InProgressIndicator />
                     ) : null}
                     {assistantFileAttachments.length ? (
                       <div>

--- a/tests/unit/message-bubble.test.ts
+++ b/tests/unit/message-bubble.test.ts
@@ -1493,6 +1493,117 @@ describe("message bubble", () => {
     ).toBeNull();
   });
 
+  it("shows an inline in-progress indicator while awaiting the first token", () => {
+    render(
+      React.createElement(MessageBubble, {
+        message: { ...createAssistantMessage(), status: "streaming", content: "" },
+        awaitingFirstToken: true
+      })
+    );
+
+    const indicator = screen.getByTestId("assistant-in-progress");
+    expect(indicator).toHaveTextContent("Working");
+  });
+
+  it("hides the in-progress indicator while answer text is streaming", () => {
+    render(
+      React.createElement(MessageBubble, {
+        message: { ...createAssistantMessage(), status: "streaming", content: "So far" },
+        streamingAnswer: "So far",
+        streamingTimeline: [
+          { id: "txt_1", timelineKind: "text", sortOrder: 0, createdAt: new Date().toISOString(), content: "So far" }
+        ]
+      })
+    );
+
+    expect(screen.queryByTestId("assistant-in-progress")).toBeNull();
+  });
+
+  it("shows the working indicator again after text finishes and a step completes", () => {
+    render(
+      React.createElement(MessageBubble, {
+        message: { ...createAssistantMessage(), status: "streaming", content: "Done so far" },
+        streamingAnswer: "Done so far",
+        streamingTimeline: [
+          { id: "txt_1", timelineKind: "text", sortOrder: 0, createdAt: new Date().toISOString(), content: "Done so far" },
+          {
+            ...createToolAction({
+              id: "act_done",
+              messageId: "msg_assistant",
+              label: "Read documentation",
+              detail: "url=https://example.com",
+              resultSummary: "Loaded",
+              status: "completed",
+              sortOrder: 1
+            }),
+            timelineKind: "action"
+          }
+        ]
+      })
+    );
+
+    expect(screen.getByTestId("assistant-in-progress")).toHaveTextContent("Working");
+  });
+
+  it("shows the working indicator between steps when the last action completed but the turn is still active", () => {
+    render(
+      React.createElement(MessageBubble, {
+        message: { ...createAssistantMessage(), status: "streaming", content: "" },
+        streamingAnswer: "",
+        streamingTimeline: [
+          {
+            ...createToolAction({
+              id: "act_done",
+              messageId: "msg_assistant",
+              label: "Read documentation",
+              detail: "url=https://example.com",
+              resultSummary: "Loaded",
+              status: "completed"
+            }),
+            timelineKind: "action"
+          }
+        ]
+      })
+    );
+
+    expect(screen.getByTestId("assistant-in-progress")).toHaveTextContent("Working");
+  });
+
+  it("hides the tail in-progress indicator when a running action is the last block", () => {
+    render(
+      React.createElement(MessageBubble, {
+        message: { ...createAssistantMessage(), status: "streaming", content: "" },
+        streamingAnswer: "",
+        streamingTimeline: [
+          {
+            ...createToolAction({
+              id: "act_run",
+              messageId: "msg_assistant",
+              label: "Searching the web",
+              detail: "query=Eidon",
+              resultSummary: "",
+              status: "running",
+              completedAt: null
+            }),
+            timelineKind: "action"
+          }
+        ]
+      })
+    );
+
+    expect(screen.queryByTestId("assistant-in-progress")).toBeNull();
+  });
+
+  it("does not show an in-progress indicator for completed assistant messages", () => {
+    render(
+      React.createElement(MessageBubble, {
+        message: createAssistantMessage()
+      })
+    );
+
+    expect(screen.queryByTestId("assistant-in-progress")).toBeNull();
+  });
+
   it("does not render a fork action for user messages", () => {
     render(
       React.createElement(MessageBubble as React.ComponentType<any>, {


### PR DESCRIPTION
## Problem
The old "typing dots" animation bounced three dots while the assistant was thinking, which looked generic and didn't explain what was happening. It also disappeared at confusing moments, like after a step finished but before the next text started streaming.

## Solution
Swap the bouncing dots for a clear "Working" label with a small spinner, and make it appear both before the first token and as a trailing indicator whenever the assistant is still active but not currently streaming text or running a visible step.

## Changes
- Replaced `TypingIndicator` (three bouncing dots) with a new `InProgressIndicator` component that renders a spinner + "Working" text in a subtle pill.
- Removed the `typing-dot` keyframes and `ASSISTANT_LOADING_SHELL` styles, and updated reduced-motion handling to disable the new spinner instead.
- Added `showInProgressTail` logic in `MessageBubbleImpl` to show the indicator after streaming text or a completed action while the turn is still active, while hiding it when a running action or in-progress thinking is already visible.
- Added unit tests covering: awaiting first token, during text streaming, between steps, after a completed action, while a running action is the last block, and for completed messages.

## Testing
- New unit tests in `tests/unit/message-bubble.test.ts` verify the indicator shows/hides correctly across streaming states.

## Notes
- Accessibility: the indicator uses `role="status"` and `aria-live="polite"` with an `aria-hidden` spinner.