### PR TITLE
Add Python 3 to the image and symlink python to python3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,8 @@ ENV AGENT_BROWSER_SOCKET_DIR=/app/data/runtime/agent-browser
 # Install uv for uvx (Python-based MCP servers)
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 
-RUN apt-get update && apt-get install -y --no-install-recommends chromium \
+RUN apt-get update && apt-get install -y --no-install-recommends chromium python3 \
+    && ln -s /usr/bin/python3 /usr/local/bin/python \
     && rm -rf /var/lib/apt/lists/* \
     && npm install -g agent-browser \
     && mv /usr/local/bin/agent-browser /usr/local/bin/agent-browser-core \

--- a/tests/unit/dockerfile.test.ts
+++ b/tests/unit/dockerfile.test.ts
@@ -25,6 +25,11 @@ describe("Dockerfile", () => {
     expect(dockerfile).toContain("--chown=eidon:eidon");
   });
 
+  it("installs Python 3 and symlinks the python command to python3", () => {
+    expect(dockerfile).toContain("apt-get install -y --no-install-recommends chromium python3");
+    expect(dockerfile).toContain("ln -s /usr/bin/python3 /usr/local/bin/python");
+  });
+
   it("bundles the scoped native integration seeder in the production image", () => {
     expect(dockerfile).toContain("scripts/seed-native-test.ts");
     expect(dockerfile).toContain("seed-native-test.cjs");


### PR DESCRIPTION
## Problem
The container image had `uv`/`uvx` for Python-based MCP servers but no actual Python interpreter, and no `python` command pointing to `python3`.

## Solution
Install `python3` alongside `chromium` in the existing apt layer and add a `python` -> `python3` symlink in `/usr/local/bin`. Added a unit test asserting both the install and symlink are present in the Dockerfile.

### Changes
- `Dockerfile`: add `python3` to the apt install and symlink `/usr/bin/python3` to `/usr/local/bin/python`.
- `tests/unit/dockerfile.test.ts`: assert Python 3 install and symlink are present.

### Testing
- Unit test added checks the Dockerfile contains the `python3` install and the `ln -s ... python` command.