### PR TITLE
Fail closed on memory injection for null-owner conversations

### DIFF
--- a/lib/assistant-runtime.ts
+++ b/lib/assistant-runtime.ts
@@ -305,7 +305,7 @@ export async function resolveAssistantTurn(input: {
   visionMcpServers?: McpServer[];
   memoriesEnabled?: boolean;
   memoriesRigor?: MemoryRigor;
-  memoryUserId?: string;
+  memoryUserId?: string | null;
   mcpTimeout?: number;
   abortSignal?: AbortSignal;
   enableStreamRetry?: boolean;

--- a/lib/chat-turn.ts
+++ b/lib/chat-turn.ts
@@ -357,7 +357,7 @@ async function startAssistantTurn(
       visionMcpServers,
       memoriesEnabled: appSettings.memoriesEnabled,
       memoriesRigor: appSettings.memoriesRigor,
-      memoryUserId: conversationOwnerId ?? undefined,
+      memoryUserId: conversationOwnerId,
       mcpTimeout: appSettings.mcpTimeout,
       abortSignal: control.abortController.signal,
       enableStreamRetry: true,

--- a/lib/compaction.ts
+++ b/lib/compaction.ts
@@ -246,7 +246,7 @@ export function buildPromptMessages(input: {
   userInput?: string;
   maxAttachmentTextTokens?: number;
   memoriesEnabled?: boolean;
-  memoryUserId?: string;
+  memoryUserId?: string | null;
   memoriesRigor?: MemoryRigor;
 }): PromptMessage[] {
   const remainingAttachmentTextTokens = {
@@ -260,7 +260,7 @@ export function buildPromptMessages(input: {
   }
 
   if (input.memoriesEnabled) {
-    const memories = listMemories(input.memoryUserId);
+    const memories = input.memoryUserId ? listMemories(input.memoryUserId) : [];
     if (memories.length > 0) {
       systemParts.push(
         "<memory>\n" +
@@ -379,7 +379,7 @@ function computeFirstPassContext(
     maxAttachmentTextTokens: Math.floor(settings.modelContextLimit * MAX_ATTACHMENT_TEXT_RATIO),
     memoriesEnabled,
     memoriesRigor,
-    memoryUserId: conversationOwnerId ?? undefined
+    memoryUserId: conversationOwnerId
   });
 
   return { promptMessages, contextTokens: estimatePromptTokens(promptMessages), compactionLimit };
@@ -434,7 +434,7 @@ export async function ensureCompactedContext(
         maxAttachmentTextTokens: Math.floor(settings.modelContextLimit * MAX_ATTACHMENT_TEXT_RATIO),
         memoriesEnabled,
         memoriesRigor,
-        memoryUserId: conversationOwnerId ?? undefined
+        memoryUserId: conversationOwnerId
       });
 
     while (true) {

--- a/lib/memories.ts
+++ b/lib/memories.ts
@@ -53,7 +53,7 @@ export function listMemories(
   return rows.map(rowToMemory);
 }
 
-export function getMemory(memoryId: string, userId?: string): UserMemory | null {
+export function getMemory(memoryId: string, userId?: string | null): UserMemory | null {
   const row = (userId
     ? getDb()
         .prepare(
@@ -126,7 +126,7 @@ export function deleteMemory(memoryId: string, userId?: string): void {
   getDb().prepare("DELETE FROM user_memories WHERE id = ?").run(memoryId);
 }
 
-export function getMemoryCount(userId?: string): number {
+export function getMemoryCount(userId?: string | null): number {
   const row = (userId
     ? getDb().prepare("SELECT COUNT(*) as count FROM user_memories WHERE user_id = ?").get(userId)
     : getDb().prepare("SELECT COUNT(*) as count FROM user_memories").get()) as { count: number };

--- a/lib/runtime-tool-context.ts
+++ b/lib/runtime-tool-context.ts
@@ -20,7 +20,7 @@ export type RuntimeToolContext = {
   loadedSkillIds: Set<string>;
   memoriesEnabled: boolean;
   effectiveVisionMode: VisionMode;
-  memoryUserId?: string;
+  memoryUserId?: string | null;
   imageGenerationToolEnabled?: boolean;
   restrictToGenerateImage?: boolean;
   imageGenerationActionHandle?: string;

--- a/lib/tool-executors.ts
+++ b/lib/tool-executors.ts
@@ -533,7 +533,7 @@ export async function executeShellCommand(
 }
 
 type MemoryToolExecutionContext = {
-  memoryUserId?: string;
+  memoryUserId?: string | null;
   input: {
     abortSignal?: AbortSignal;
     onActionStart?: (action: RuntimeAction) => Promise<string | void> | string | void;
@@ -819,7 +819,7 @@ export async function executeToolCall(
       visionProfile?: RuntimeProviderProfile;
       skills: Skill[];
       mcpToolSets: ToolSet[];
-      memoryUserId?: string;
+      memoryUserId?: string | null;
       onActionStart?: (action: RuntimeAction) => Promise<string | void> | string | void;
       onActionComplete?: (handle: string | undefined, patch: { detail?: string; resultSummary?: string }) => Promise<void> | void;
       onActionError?: (handle: string | undefined, patch: { detail?: string; resultSummary?: string }) => Promise<void> | void;
@@ -836,7 +836,7 @@ export async function executeToolCall(
     successfulReadOnlyToolResults: Map<string, SuccessfulReadOnlyToolResult>;
     timelineSortOrder: number;
     promptMessages: PromptMessage[];
-    memoryUserId?: string;
+    memoryUserId?: string | null;
   }
 ): Promise<{
   nextSortOrder: number;

--- a/tests/unit/compaction.test.ts
+++ b/tests/unit/compaction.test.ts
@@ -16,6 +16,7 @@ import { getDb } from "@/lib/db";
 import { createConversation, createMessage, createMessageAction, listMessages } from "@/lib/conversations";
 import { getDefaultRuntimeProviderProfile, updateProviderCatalog } from "@/lib/settings";
 import { createMemory, deleteMemory } from "@/lib/memories";
+import { createLocalUser } from "@/lib/users";
 import type { Message, MessageAction, PromptMessage } from "@/lib/types";
 import { createProviderProfileInput } from "@/tests/provider-fixtures";
 
@@ -1513,36 +1514,143 @@ describe("buildPromptMessages with persona", () => {
 });
 
 describe("buildPromptMessages with memories", () => {
-  it("includes memory block and tool instructions when memoriesEnabled and memories exist", () => {
-    const mem = createMemory("User lives in Montreal", "location");
-    try {
-      const result = buildPromptMessages({
-        systemPrompt: "Be helpful.",
-        activeMemoryNodes: [],
-        messages: [
-          {
-            id: "1",
-            conversationId: "c1",
-            role: "user",
-            content: "Hi",
-            status: "completed",
-            estimatedTokens: 5,
-            thinkingContent: "",
-            systemKind: null,
-            compactedAt: null,
-            createdAt: new Date().toISOString()
-          }
-        ],
-        memoriesEnabled: true
-      });
+  async function seedTwoUsersWithMemories() {
+    const userA = await createLocalUser({
+      username: "compaction-owner-a",
+      password: "Password123!",
+      role: "user"
+    });
+    const userB = await createLocalUser({
+      username: "compaction-owner-b",
+      password: "Password123!",
+      role: "user"
+    });
 
-      const systemContent = result[0].content as string;
-      expect(systemContent).toContain("<memory>");
-      expect(systemContent).toContain("User lives in Montreal");
-      expect(systemContent).toContain("create_memory");
-    } finally {
-      deleteMemory(mem.id);
-    }
+    createMemory("User A lives in Montreal", "location", userA.id);
+    createMemory("User B prefers TypeScript", "preference", userB.id);
+
+    return { userA, userB };
+  }
+
+  function memoryPromptInput(memoryUserId?: string | null) {
+    return {
+      systemPrompt: "Be helpful.",
+      activeMemoryNodes: [],
+      messages: [
+        {
+          id: "1",
+          conversationId: "c1",
+          role: "user" as const,
+          content: "Hi",
+          status: "completed" as const,
+          estimatedTokens: 5,
+          thinkingContent: "",
+          systemKind: null,
+          compactedAt: null,
+          createdAt: new Date().toISOString()
+        }
+      ],
+      memoriesEnabled: true,
+      memoryUserId
+    };
+  }
+
+  it("includes only the owner's memory block and tool instructions when memoriesEnabled", async () => {
+    const { userA } = await seedTwoUsersWithMemories();
+
+    const result = buildPromptMessages(memoryPromptInput(userA.id));
+
+    const systemContent = result[0].content as string;
+    expect(systemContent).toContain("<memory>");
+    expect(systemContent).toContain("User A lives in Montreal");
+    expect(systemContent).not.toContain("User B prefers TypeScript");
+    expect(systemContent).toContain("create_memory");
+  });
+
+  it("injects zero memories when memoryUserId is null and multiple users have memories", async () => {
+    await seedTwoUsersWithMemories();
+
+    const result = buildPromptMessages(memoryPromptInput(null));
+
+    const systemContent = result[0].content as string;
+    expect(systemContent).not.toContain("<memory>");
+    expect(systemContent).not.toContain("User A lives in Montreal");
+    expect(systemContent).not.toContain("User B prefers TypeScript");
+  });
+
+  it("injects zero memories when memoryUserId is undefined and multiple users have memories", async () => {
+    await seedTwoUsersWithMemories();
+
+    const result = buildPromptMessages(memoryPromptInput());
+
+    const systemContent = result[0].content as string;
+    expect(systemContent).not.toContain("<memory>");
+    expect(systemContent).not.toContain("User A lives in Montreal");
+    expect(systemContent).not.toContain("User B prefers TypeScript");
+  });
+
+  function seedConversationProfile() {
+    updateProviderCatalog({
+      defaultProviderProfileId: "profile_default",
+      skillsEnabled: true,
+      providerProfiles: [
+        createProviderProfileInput({
+          id: "profile_default",
+          name: "Default"
+        })
+      ]
+    });
+  }
+
+  it("injects zero memories for a null-owner conversation even when multiple users have memories", async () => {
+    seedConversationProfile();
+    await seedTwoUsersWithMemories();
+
+    const conversation = createConversation();
+    createMessage({
+      conversationId: conversation.id,
+      role: "user",
+      content: "Hi"
+    });
+
+    const result = await ensureCompactedContext(
+      conversation.id,
+      getDefaultRuntimeProviderProfile()!,
+      {},
+      undefined,
+      true
+    );
+
+    const systemContent = result.promptMessages.find((message) => message.role === "system")!.content as string;
+    expect(systemContent).not.toContain("<memory>");
+    expect(systemContent).not.toContain("User A lives in Montreal");
+    expect(systemContent).not.toContain("User B prefers TypeScript");
+    expect(systemContent).toContain("create_memory");
+  });
+
+  it("injects only the owner's memories for an owned conversation", async () => {
+    seedConversationProfile();
+    const { userA } = await seedTwoUsersWithMemories();
+
+    const conversation = createConversation("Owned", null, undefined, userA.id);
+    createMessage({
+      conversationId: conversation.id,
+      role: "user",
+      content: "Hi"
+    });
+
+    const result = await ensureCompactedContext(
+      conversation.id,
+      getDefaultRuntimeProviderProfile()!,
+      {},
+      undefined,
+      true
+    );
+
+    const systemContent = result.promptMessages.find((message) => message.role === "system")!.content as string;
+    expect(systemContent).toContain("<memory>");
+    expect(systemContent).toContain("User A lives in Montreal");
+    expect(systemContent).not.toContain("User B prefers TypeScript");
   });
 
   it("does not include memory block when memoriesEnabled is false", () => {

--- a/tests/unit/memories.test.ts
+++ b/tests/unit/memories.test.ts
@@ -8,6 +8,7 @@ import {
   getMemoryCount
 } from "@/lib/memories";
 import { normalizeMemoryRigor } from "@/lib/global-preferences";
+import { buildPromptMessages } from "@/lib/compaction";
 import { createLocalUser } from "@/lib/users";
 
 describe("normalizeMemoryRigor", () => {
@@ -162,5 +163,76 @@ describe("memories", () => {
 
     expect(listMemories(userA.id).map((memory) => memory.content)).toEqual(["Admin memory"]);
     expect(listMemories(userB.id).map((memory) => memory.content)).toEqual(["Member memory"]);
+  });
+});
+
+describe("memory injection scoping", () => {
+  function promptInput(memoryUserId?: string | null) {
+    return {
+      systemPrompt: "Be helpful.",
+      activeMemoryNodes: [],
+      messages: [
+        {
+          id: "1",
+          conversationId: "c1",
+          role: "user" as const,
+          content: "Hi",
+          status: "completed" as const,
+          estimatedTokens: 5,
+          thinkingContent: "",
+          systemKind: null,
+          compactedAt: null,
+          createdAt: new Date().toISOString()
+        }
+      ],
+      memoriesEnabled: true,
+      memoryUserId
+    };
+  }
+
+  it("injects zero memories when the conversation owner is null or undefined and multiple users have memories", async () => {
+    const userA = await createLocalUser({
+      username: "memory-injection-a",
+      password: "Password123!",
+      role: "user"
+    });
+    const userB = await createLocalUser({
+      username: "memory-injection-b",
+      password: "Password123!",
+      role: "user"
+    });
+
+    createMemory("User A secret fact", "personal", userA.id);
+    createMemory("User B secret fact", "personal", userB.id);
+
+    for (const result of [buildPromptMessages(promptInput(null)), buildPromptMessages(promptInput())]) {
+      const systemContent = result[0].content as string;
+      expect(systemContent).not.toContain("<memory>");
+      expect(systemContent).not.toContain("User A secret fact");
+      expect(systemContent).not.toContain("User B secret fact");
+    }
+  });
+
+  it("injects only the owner's memories for an owned conversation", async () => {
+    const userA = await createLocalUser({
+      username: "memory-injection-owner",
+      password: "Password123!",
+      role: "user"
+    });
+    const userB = await createLocalUser({
+      username: "memory-injection-other",
+      password: "Password123!",
+      role: "user"
+    });
+
+    createMemory("Owner memory", "work", userA.id);
+    createMemory("Other user memory", "personal", userB.id);
+
+    const result = buildPromptMessages(promptInput(userA.id));
+
+    const systemContent = result[0].content as string;
+    expect(systemContent).toContain("<memory>");
+    expect(systemContent).toContain("Owner memory");
+    expect(systemContent).not.toContain("Other user memory");
   });
 });


### PR DESCRIPTION
## Problem

ELI5: The app remembers little facts about each user. When a chat had no owner, instead of remembering nothing, it dumped *everyone's* facts into the chat. That's like reading the whole class's diary because you don't know whose diary it is.

Details: when a conversation had a null owner, `conversationOwnerId ?? undefined` was passed down as `memoryUserId`, and `listMemories(undefined)`/`getMemory(id, undefined)` fall back to querying **all** rows in `user_memories`. Those memories were then injected into the system prompt during compaction, leaking every user's memories into null-owner conversations.

## Solution

ELI5: If we don't know whose memories to use, we use none. Simple and safe.

Details:
- `buildPromptMessages` now injects zero memories when `memoryUserId` is null/undefined instead of calling `listMemories` unscoped (`input.memoryUserId ? listMemories(input.memoryUserId) : []`).
- `memoryUserId` is typed as `string | null` across the runtime (`assistant-runtime.ts`, `compaction.ts`, `runtime-tool-context.ts`, `tool-executors.ts`), and the `?? undefined` coercions in `chat-turn.ts` and `compaction.ts` were removed so null flows through explicitly.
- `getMemory`, `getMemoryCount` accept `string | null` for the same fail-closed scoping semantics.
- Added unit tests covering: null and undefined `memoryUserId` inject no memories even when multiple users have memories, and owned conversations inject only the owner's memories (both at `buildPromptMessages` and `ensureCompactedContext` levels).

## Testing

- New tests in `tests/unit/compaction.test.ts` and `tests/unit/memories.test.ts` verify null-owner conversations inject zero memories and owned conversations inject only the owner's memories.