### PR TITLE
Scope analyze_image paths to the requesting conversation

### DIFF
--- a/lib/attachments.ts
+++ b/lib/attachments.ts
@@ -793,7 +793,10 @@ export function resolveAttachmentPath(attachment: Pick<MessageAttachment, "relat
   return absolutePath;
 }
 
-export function resolveAbsoluteImagePathPart(absolutePath: string): PromptImageContentPart {
+export function resolveAbsoluteImagePathPart(
+  absolutePath: string,
+  scope: { conversationId: string }
+): PromptImageContentPart {
   const root = getAttachmentsRoot();
   const requestedPath = path.resolve(absolutePath);
 
@@ -811,6 +814,10 @@ export function resolveAbsoluteImagePathPart(absolutePath: string): PromptImageC
     path.isAbsolute(relativeInsideRoot)
   ) {
     throw new Error("Image path is outside attachment storage");
+  }
+
+  if (relativeInsideRoot.split(path.sep)[0] !== scope.conversationId) {
+    throw new Error("Image path belongs to a different conversation");
   }
 
   let stats;

--- a/lib/tool-executors.ts
+++ b/lib/tool-executors.ts
@@ -700,6 +700,7 @@ export async function executeAnalyzeImage(
       onActionStart?: (action: RuntimeAction) => Promise<string | void> | string | void;
       onActionComplete?: (handle: string | undefined, patch: { detail?: string; resultSummary?: string }) => Promise<void> | void;
       onActionError?: (handle: string | undefined, patch: { detail?: string; resultSummary?: string }) => Promise<void> | void;
+      conversationId?: string;
     };
     timelineSortOrder: number;
     promptMessages: PromptMessage[];
@@ -724,11 +725,22 @@ export async function executeAnalyzeImage(
     return { nextSortOrder: sortOrder, promptMessages: [...context.promptMessages, resultMsg] };
   }
 
+  const conversationId = context.input.conversationId;
+  if (!conversationId) {
+    const resultMsg = buildToolResultMessage(
+      toolCallId,
+      "Error: conversation context is required for image analysis"
+    );
+    return { nextSortOrder: sortOrder, promptMessages: [...context.promptMessages, resultMsg] };
+  }
+
   const question = typeof args.question === "string" ? args.question.trim() : "";
 
   let imageParts: PromptImageContentPart[];
   try {
-    imageParts = rawPaths.map((filePath) => resolveAbsoluteImagePathPart(String(filePath)));
+    imageParts = rawPaths.map((filePath) =>
+      resolveAbsoluteImagePathPart(String(filePath), { conversationId })
+    );
   } catch (error) {
     const message = error instanceof Error ? error.message : "Invalid image path";
     const resultMsg = buildToolResultMessage(toolCallId, `Error: ${message}`);

--- a/tests/unit/assistant-runtime.test.ts
+++ b/tests/unit/assistant-runtime.test.ts
@@ -2952,6 +2952,7 @@ Run browser commands.`
       const result = await resolveAssistantTurn({
         settings: providerVisionSettings(),
         visionProfile: visionProfile(),
+        conversationId: "conv_vision",
         promptMessages: [imageMessage()],
         skills: [],
         mcpToolSets: [],
@@ -3006,6 +3007,7 @@ Run browser commands.`
       await expect(resolveAssistantTurn({
         settings: providerVisionSettings(),
         visionProfile: visionProfile(),
+        conversationId: "conv_vision",
         promptMessages: [imageMessage()],
         skills: [],
         mcpToolSets: [],
@@ -3052,6 +3054,7 @@ Run browser commands.`
       const result = await resolveAssistantTurn({
         settings: providerVisionSettings(),
         visionProfile: visionProfile(),
+        conversationId: "conv_vision",
         promptMessages: [imageMessage()],
         skills: [],
         mcpToolSets: []
@@ -3063,6 +3066,118 @@ Run browser commands.`
         (message) => message.role === "tool" && message.toolCallId === "call_analyze_bad"
       );
       expect(toolMessage?.content).toContain("outside attachment storage");
+    });
+
+    it("returns an error tool result without a vision call for paths from another conversation", async () => {
+      resolveAbsoluteImagePathPart.mockImplementation(
+        (absolutePath: string, scope?: { conversationId: string }) => {
+          if (!scope?.conversationId || !absolutePath.startsWith(`/tmp/${scope.conversationId}/`)) {
+            throw new Error("Image path belongs to a different conversation");
+          }
+          return {
+            type: "image" as const,
+            attachmentId: "att_photo",
+            filename: "att_photo_photo.png",
+            mimeType: "image/png",
+            relativePath: absolutePath.replace(/^\/tmp\//, "")
+          };
+        }
+      );
+
+      let providerCallCount = 0;
+      streamProviderResponse.mockImplementation(() => {
+        providerCallCount += 1;
+
+        if (providerCallCount === 1) {
+          return createProviderStream([], {
+            answer: "",
+            thinking: "",
+            toolCalls: [{
+              id: "call_analyze_cross",
+              name: "analyze_image",
+              arguments: JSON.stringify({ file_paths: ["/tmp/conv_other/att_secret_secret.png"] })
+            }],
+            usage: { inputTokens: 12 }
+          });
+        }
+
+        return createProviderStream([{ type: "answer_delta", text: "Recovered." }], {
+          answer: "Recovered.",
+          thinking: "",
+          usage: { outputTokens: 2 }
+        });
+      });
+
+      const { resolveAssistantTurn } = await import("@/lib/assistant-runtime");
+
+      const result = await resolveAssistantTurn({
+        settings: providerVisionSettings(),
+        visionProfile: visionProfile(),
+        conversationId: "conv_vision",
+        promptMessages: [imageMessage()],
+        skills: [],
+        mcpToolSets: []
+      });
+
+      expect(result.answer).toBe("Recovered.");
+      expect(streamProviderResponse).toHaveBeenCalledTimes(2);
+      expect(
+        streamProviderResponse.mock.calls.some(([call]) => call?.settings?.id === "profile_vision")
+      ).toBe(false);
+      expect(resolveAbsoluteImagePathPart).toHaveBeenCalledWith(
+        "/tmp/conv_other/att_secret_secret.png",
+        { conversationId: "conv_vision" }
+      );
+      const finalCall = streamProviderResponse.mock.calls.at(-1)?.[0];
+      const toolMessage = (finalCall.promptMessages as PromptMessage[]).find(
+        (message) => message.role === "tool" && message.toolCallId === "call_analyze_cross"
+      );
+      expect(toolMessage?.content).toContain("belongs to a different conversation");
+    });
+
+    it("returns an error tool result when conversation context is missing", async () => {
+      let providerCallCount = 0;
+      streamProviderResponse.mockImplementation(() => {
+        providerCallCount += 1;
+
+        if (providerCallCount === 1) {
+          return createProviderStream([], {
+            answer: "",
+            thinking: "",
+            toolCalls: [{
+              id: "call_analyze_no_context",
+              name: "analyze_image",
+              arguments: JSON.stringify({ file_paths: ["/tmp/conv_vision/att_photo_photo.png"] })
+            }],
+            usage: { inputTokens: 12 }
+          });
+        }
+
+        return createProviderStream([{ type: "answer_delta", text: "Recovered." }], {
+          answer: "Recovered.",
+          thinking: "",
+          usage: { outputTokens: 2 }
+        });
+      });
+
+      const { resolveAssistantTurn } = await import("@/lib/assistant-runtime");
+
+      const result = await resolveAssistantTurn({
+        settings: providerVisionSettings(),
+        visionProfile: visionProfile(),
+        promptMessages: [imageMessage()],
+        skills: [],
+        mcpToolSets: []
+      });
+
+      expect(result.answer).toBe("Recovered.");
+      expect(streamProviderResponse).toHaveBeenCalledTimes(2);
+      expect(resolveAbsoluteImagePathPart).not.toHaveBeenCalled();
+      const finalCall = streamProviderResponse.mock.calls.at(-1)?.[0];
+      const toolMessage = (finalCall.promptMessages as PromptMessage[]).find(
+        (message) => message.role === "tool" && message.toolCallId === "call_analyze_no_context"
+      );
+      expect(toolMessage?.content).toContain("conversation context is required");
     });
 
     it("returns an error tool result for empty file_paths", async () => {
@@ -3095,6 +3210,7 @@ Run browser commands.`
       const result = await resolveAssistantTurn({
         settings: providerVisionSettings(),
         visionProfile: visionProfile(),
+        conversationId: "conv_vision",
         promptMessages: [imageMessage()],
         skills: [],
         mcpToolSets: []

--- a/tests/unit/attachments.test.ts
+++ b/tests/unit/attachments.test.ts
@@ -71,7 +71,7 @@ describe("attachment helpers", () => {
       "attachments",
       attachment.relativePath
     );
-    const part = resolveAbsoluteImagePathPart(absolutePath);
+    const part = resolveAbsoluteImagePathPart(absolutePath, { conversationId: conversation.id });
 
     expect(part.type).toBe("image");
     expect(part.mimeType).toBe("image/png");
@@ -81,13 +81,52 @@ describe("attachment helpers", () => {
 
     const outsidePath = path.resolve(process.env.EIDON_DATA_DIR!, "outside.png");
     fs.writeFileSync(outsidePath, "png-bytes");
-    expect(() => resolveAbsoluteImagePathPart(outsidePath)).toThrow("outside attachment storage");
+    expect(() =>
+      resolveAbsoluteImagePathPart(outsidePath, { conversationId: conversation.id })
+    ).toThrow("outside attachment storage");
     expect(() =>
       resolveAbsoluteImagePathPart(
-        path.resolve(absolutePath, "..", "..", "..", "outside.png")
+        path.resolve(absolutePath, "..", "..", "..", "outside.png"),
+        { conversationId: conversation.id }
       )
     ).toThrow("outside attachment storage");
     fs.unlinkSync(outsidePath);
+  });
+
+  it("rejects image paths that belong to a different conversation", async () => {
+    const conversation = createConversation();
+    const otherConversation = createConversation();
+    const [attachment] = await createAttachments(conversation.id, [
+      {
+        filename: "photo.png",
+        mimeType: "image/png",
+        bytes: Buffer.from([0x89, 0x50, 0x4e, 0x47])
+      }
+    ]);
+    const [otherAttachment] = await createAttachments(otherConversation.id, [
+      {
+        filename: "secret.png",
+        mimeType: "image/png",
+        bytes: Buffer.from([0x89, 0x50, 0x4e, 0x47])
+      }
+    ]);
+
+    const absolutePath = path.resolve(
+      process.env.EIDON_DATA_DIR!,
+      "attachments",
+      attachment.relativePath
+    );
+    const otherAbsolutePath = path.resolve(
+      process.env.EIDON_DATA_DIR!,
+      "attachments",
+      otherAttachment.relativePath
+    );
+
+    const part = resolveAbsoluteImagePathPart(absolutePath, { conversationId: conversation.id });
+    expect(part.relativePath).toBe(attachment.relativePath);
+    expect(() =>
+      resolveAbsoluteImagePathPart(otherAbsolutePath, { conversationId: conversation.id })
+    ).toThrow("Image path belongs to a different conversation");
   });
 
   it("rejects non-image and missing files for image analysis", async () => {
@@ -101,7 +140,9 @@ describe("attachment helpers", () => {
       "attachments",
       attachment.relativePath
     );
-    expect(() => resolveAbsoluteImagePathPart(textPath)).toThrow("Unsupported image type");
+    expect(() =>
+      resolveAbsoluteImagePathPart(textPath, { conversationId: conversation.id })
+    ).toThrow("Unsupported image type");
 
     const missingPath = path.resolve(
       process.env.EIDON_DATA_DIR!,
@@ -109,7 +150,9 @@ describe("attachment helpers", () => {
       conversation.id,
       "missing.png"
     );
-    expect(() => resolveAbsoluteImagePathPart(missingPath)).toThrow("does not exist");
+    expect(() =>
+      resolveAbsoluteImagePathPart(missingPath, { conversationId: conversation.id })
+    ).toThrow("does not exist");
   });
 
   it("fsyncs a temporary file before atomic publication and syncs its directory and root", async () => {


### PR DESCRIPTION
## Problem

The `analyze_image` tool accepted any image path inside attachment storage, even if the file belonged to a different conversation. A model could analyze images uploaded in other users'/conversations' sessions, leaking data across conversation boundaries.

## Solution

Think of attachment storage like a big filing cabinet where each conversation has its own labeled drawer. Previously the tool only checked that a file was somewhere in the cabinet; now it also checks the drawer label and refuses to open files from anyone else's drawer.

- `resolveAbsoluteImagePathPart` (lib/attachments.ts) now requires a `scope: { conversationId }` argument and verifies the first path segment inside the attachments root matches that conversation, throwing `Image path belongs to a different conversation` otherwise.
- `executeAnalyzeImage` (lib/tool-executors.ts) reads `conversationId` from the conversation context input, returns an error tool result (`conversation context is required for image analysis`) when it is missing, and passes the conversation scope into the path resolver.

## Testing

- Updated `tests/unit/attachments.test.ts`: existing resolver calls now pass a conversation scope, plus a new case verifying a path from another conversation is rejected with `Image path belongs to a different conversation`.
- Updated `tests/unit/assistant-runtime.test.ts`: vision runtime tests pass `conversationId`, and new tests cover (1) cross-conversation paths returning an error tool result without triggering the vision profile call and (2) missing conversation context returning an error tool result without invoking the resolver.