### PR TITLE
Drain stdio MCP server stderr to prevent pipe deadlock

### DIFF
--- a/lib/mcp-client.ts
+++ b/lib/mcp-client.ts
@@ -15,6 +15,7 @@ export const MAX_MCP_RESULT_CHARS = MAX_RUNTIME_TOOL_RESULT_CHARS;
 export const MAX_MCP_DISCOVERED_TOOLS = 100;
 const MAX_MCP_TOOL_SCHEMA_CHARS = 32_000;
 export const MAX_MCP_TRANSPORT_MESSAGE_BYTES = 4 * 1024 * 1024;
+const MAX_MCP_STDERR_TAIL_CHARS = 8_192;
 
 export class BoundedMcpStdioReadBuffer {
   private buffer: Buffer | undefined;
@@ -207,6 +208,41 @@ function createClient() {
   );
 }
 
+function drainTransportStderr(transport: StdioClientTransport | StreamableHTTPClientTransport, serverName: string) {
+  if (!(transport instanceof StdioClientTransport)) {
+    return;
+  }
+
+  const stderr = transport.stderr;
+  if (!stderr) {
+    return;
+  }
+
+  let tail = "";
+  let closed = false;
+
+  stderr.on("data", (chunk: Buffer) => {
+    if (closed) {
+      return;
+    }
+    tail = (tail + chunk.toString()).slice(-MAX_MCP_STDERR_TAIL_CHARS);
+  });
+  stderr.on("error", (error: Error) => {
+    if (!closed) {
+      console.error(`[mcp-stderr ${serverName}] stream error: ${error.message}`);
+    }
+  });
+  stderr.on("close", () => {
+    if (closed) {
+      return;
+    }
+    closed = true;
+    if (tail.trim()) {
+      console.error(`[mcp-stderr ${serverName}] ${tail.trim()}`);
+    }
+  });
+}
+
 async function createConnectedClient(server: TestableMcpServer, abortSignal?: AbortSignal) {
   const transport = createTransport(server);
   const client = createClient();
@@ -233,6 +269,7 @@ async function createConnectedClient(server: TestableMcpServer, abortSignal?: Ab
     await closeTransport(transport);
     throw error;
   }
+  drainTransportStderr(transport, server.name);
   return { key: getServerKey(server), client, transport };
 }
 

--- a/tests/fixtures/fake-mcp-stdio-server.mjs
+++ b/tests/fixtures/fake-mcp-stdio-server.mjs
@@ -1,0 +1,72 @@
+import fs from "node:fs";
+import readline from "node:readline";
+
+const STDERR_SPAM_BYTES = 256 * 1024;
+
+function writeAllToStderr(buffer) {
+  let offset = 0;
+  while (offset < buffer.length) {
+    try {
+      offset += fs.writeSync(2, buffer, offset, buffer.length - offset);
+    } catch (error) {
+      if (error?.code === "EAGAIN") {
+        continue;
+      }
+      throw error;
+    }
+  }
+}
+
+function reply(message) {
+  process.stdout.write(`${JSON.stringify(message)}\n`);
+}
+
+const tools = [
+  {
+    name: "spam_stderr",
+    description: "Fills the stderr pipe and then succeeds",
+    inputSchema: { type: "object", properties: {} }
+  }
+];
+
+const lineReader = readline.createInterface({ input: process.stdin });
+
+lineReader.on("line", (line) => {
+  if (!line.trim()) {
+    return;
+  }
+
+  let message;
+  try {
+    message = JSON.parse(line);
+  } catch {
+    return;
+  }
+
+  if (message.method === "initialize") {
+    reply({
+      jsonrpc: "2.0",
+      id: message.id,
+      result: {
+        protocolVersion: message.params?.protocolVersion ?? "2025-03-26",
+        capabilities: { tools: {} },
+        serverInfo: { name: "fake-mcp-stdio-server", version: "1.0.0" }
+      }
+    });
+    return;
+  }
+
+  if (message.method === "tools/list") {
+    reply({ jsonrpc: "2.0", id: message.id, result: { tools } });
+    return;
+  }
+
+  if (message.method === "tools/call") {
+    writeAllToStderr(Buffer.alloc(STDERR_SPAM_BYTES, 0x78));
+    reply({
+      jsonrpc: "2.0",
+      id: message.id,
+      result: { content: [{ type: "text", text: "stderr drained" }] }
+    });
+  }
+});

--- a/tests/unit/mcp-client.test.ts
+++ b/tests/unit/mcp-client.test.ts
@@ -1,3 +1,5 @@
+import { fileURLToPath } from "node:url";
+
 import type { McpServer } from "@/lib/types";
 
 const clientInstances: MockClient[] = [];
@@ -602,4 +604,46 @@ describe("MCP client", () => {
     expect(result.stderr?.length).toBeLessThanOrEqual(MAX_MCP_RESULT_CHARS);
     expect(result.stderr).toContain("...[truncated]");
   });
+
+  it("drains chatty stdio server stderr so persistent tool calls complete", async () => {
+    vi.doUnmock("@modelcontextprotocol/sdk/client/index.js");
+    vi.doUnmock("@modelcontextprotocol/sdk/client/stdio.js");
+    vi.doUnmock("@modelcontextprotocol/sdk/client/streamableHttp.js");
+
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    try {
+      const { callMcpTool, disconnectMcpServer } = await import("@/lib/mcp-client");
+      const server = createStdioServer();
+      server.command = process.execPath;
+      server.args = [
+        fileURLToPath(new URL("../fixtures/fake-mcp-stdio-server.mjs", import.meta.url))
+      ];
+
+      const result = await callMcpTool(server, "spam_stderr", {}, 15_000);
+
+      expect(result.isError ?? false).toBe(false);
+      expect(result.content[0]?.text).toBe("stderr drained");
+
+      await disconnectMcpServer(server);
+      await vi.waitFor(() => {
+        expect(
+          consoleError.mock.calls.some(
+            ([message]) => typeof message === "string" && message.startsWith("[mcp-stderr stdio Server]")
+          )
+        ).toBe(true);
+      });
+    } finally {
+      consoleError.mockRestore();
+      vi.doMock("@modelcontextprotocol/sdk/client/index.js", () => ({
+        Client: MockClient
+      }));
+      vi.doMock("@modelcontextprotocol/sdk/client/stdio.js", () => ({
+        StdioClientTransport: MockStdioTransport
+      }));
+      vi.doMock("@modelcontextprotocol/sdk/client/streamableHttp.js", () => ({
+        StreamableHTTPClientTransport: MockStreamableHTTPTransport
+      }));
+    }
+  }, 30_000);
 });


### PR DESCRIPTION
## Problem

Stdio MCP servers that write a lot to stderr could hang forever. The client never read the stderr pipe, so once the OS pipe buffer filled up, the server blocked on writing and stopped responding to tool calls.

## Solution

ELI5: the server had a second "trash chute" for error messages that nobody emptied. When it got full, the server got stuck. We now empty it continuously and print the last bit of what came through when the server shuts down.

Details:

- Add `drainTransportStderr` in `lib/mcp-client.ts`, called after a stdio transport connects
- Continuously consume stderr data, keeping only the last 8 KiB (`MAX_MCP_STDERR_TAIL_CHARS`) in memory
- Log the retained tail via `console.error` on stream close, prefixed with `[mcp-stderr <serverName>]`, and log stream errors as they occur
- No-op for non-stdio transports (HTTP) and when no stderr stream exists
- Guard against duplicate handling after close via a `closed` flag

## Testing

- New fixture `tests/fixtures/fake-mcp-stdio-server.mjs` implements a minimal stdio MCP server whose `spam_stderr` tool writes 256 KiB to stderr before replying
- New unit test `drains chatty stdio server stderr so persistent tool calls complete` runs the real (unmocked) MCP client against the fixture and asserts the tool call succeeds and the stderr tail is logged