### PR TITLE
Restrict regenerate to latest user message and clear all trailing assistant replies

### DIFF
--- a/app/api/messages/[messageId]/regenerate/route.ts
+++ b/app/api/messages/[messageId]/regenerate/route.ts
@@ -7,7 +7,7 @@ import {
   restartAssistantTurnAfterMutation
 } from "@/lib/chat-turn";
 import {
-  deleteAssistantMessageAndChildren,
+  deleteAssistantMessagesAndChildren,
   getMessage,
   listMessages
 } from "@/lib/conversations";
@@ -33,6 +33,12 @@ export async function POST(
     return badRequest("Only user messages can be regenerated", 400);
   }
 
+  const allMessages = listMessages(message.conversationId);
+  const lastUserMessage = [...allMessages].reverse().find((m) => m.role === "user");
+  if (!lastUserMessage || lastUserMessage.id !== message.id) {
+    return badRequest("Only the latest user message can be regenerated", 409);
+  }
+
   const turn = prepareMessageManipulationTurn({
     conversationId: message.conversationId,
     userId: user.id,
@@ -46,17 +52,17 @@ export async function POST(
     turn,
     logTag: "message-regenerate-route",
     mutate: () => {
-    const allMessages = listMessages(message.conversationId);
-    const targetIndex = allMessages.findIndex((m) => m.id === message.id);
+      const targetIndex = allMessages.findIndex((m) => m.id === message.id);
+      const trailingAssistantIds = allMessages
+        .slice(targetIndex + 1)
+        .filter((m) => m.role === "assistant")
+        .map((m) => m.id);
 
-    let rewritten = turn.snapshot;
-    for (let i = targetIndex + 1; i < allMessages.length; i++) {
-      if (allMessages[i].role === "assistant") {
-        rewritten = deleteAssistantMessageAndChildren(allMessages[i].id, user.id);
-        break;
+      if (trailingAssistantIds.length === 0) {
+        return turn.snapshot;
       }
-    }
-    return rewritten;
+
+      return deleteAssistantMessagesAndChildren(trailingAssistantIds, user.id);
     }
   });
   return ok(rewritten);

--- a/lib/conversations.ts
+++ b/lib/conversations.ts
@@ -1448,33 +1448,55 @@ export function deleteAssistantMessageAndChildren(
   messageId: string,
   userId?: string
 ) {
+  return deleteAssistantMessagesAndChildren([messageId], userId);
+}
+
+export function deleteAssistantMessagesAndChildren(
+  messageIds: string[],
+  userId?: string
+) {
+  if (messageIds.length === 0) {
+    throw new Error("No messages to delete");
+  }
+
   const db = getDb();
   const deletedAttachmentPaths = new Set<string>();
   const transaction = db.transaction(() => {
-    const message = getMessage(messageId, userId);
+    const messages = messageIds.map((messageId) => {
+      const message = getMessage(messageId, userId);
 
-    if (!message) {
-      throw new Error("Message not found");
-    }
+      if (!message) {
+        throw new Error("Message not found");
+      }
 
-    if (message.role !== "assistant") {
-      throw new Error("Only assistant messages can be retried");
-    }
+      if (message.role !== "assistant") {
+        throw new Error("Only assistant messages can be retried");
+      }
 
-    const conversation = getConversation(message.conversationId, userId);
+      return message;
+    });
+
+    const conversation = getConversation(messages[0].conversationId, userId);
 
     if (!conversation) {
       throw new Error("Conversation not found");
     }
 
-    listAttachmentsForMessageIds([message.id]).forEach((attachment) => {
+    listAttachmentsForMessageIds(messages.map((message) => message.id)).forEach((attachment) => {
       deletedAttachmentPaths.add(attachment.relativePath);
     });
 
-    db.prepare("DELETE FROM message_actions WHERE message_id = ?").run(message.id);
-    db.prepare("DELETE FROM message_text_segments WHERE message_id = ?").run(message.id);
-    db.prepare("DELETE FROM message_attachments WHERE message_id = ?").run(message.id);
-    db.prepare("DELETE FROM messages WHERE id = ?").run(message.id);
+    const deleteActions = db.prepare("DELETE FROM message_actions WHERE message_id = ?");
+    const deleteSegments = db.prepare("DELETE FROM message_text_segments WHERE message_id = ?");
+    const deleteAttachments = db.prepare("DELETE FROM message_attachments WHERE message_id = ?");
+    const deleteMessage = db.prepare("DELETE FROM messages WHERE id = ?");
+
+    for (const message of messages) {
+      deleteActions.run(message.id);
+      deleteSegments.run(message.id);
+      deleteAttachments.run(message.id);
+      deleteMessage.run(message.id);
+    }
 
     setConversationActive(conversation.id, false);
 

--- a/tests/unit/message-regenerate-route.test.ts
+++ b/tests/unit/message-regenerate-route.test.ts
@@ -159,6 +159,146 @@ describe("message regenerate route", () => {
     });
   });
 
+  it("deletes every assistant message after the user message and starts a new turn", async () => {
+    const user = await createLocalUser({
+      username: "regen-route-multi-assistant",
+      password: "Password123!",
+      role: "user"
+    });
+    requireUserMock.mockResolvedValue(user);
+
+    const conversation = createConversation("Regenerate multi", null, {}, user.id);
+    const userMessage = createMessage({
+      conversationId: conversation.id,
+      role: "user",
+      content: "Hello"
+    });
+    const firstAssistantMessage = createMessage({
+      conversationId: conversation.id,
+      role: "assistant",
+      content: "First answer"
+    });
+    const secondAssistantMessage = createMessage({
+      conversationId: conversation.id,
+      role: "assistant",
+      content: "Second answer"
+    });
+
+    const { POST } = await import("@/app/api/messages/[messageId]/regenerate/route");
+    const response = await POST(
+      new Request(`http://localhost/api/messages/${userMessage.id}/regenerate`, {
+        method: "POST"
+      }),
+      { params: Promise.resolve({ messageId: userMessage.id }) }
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({
+        conversation: expect.objectContaining({ id: conversation.id }),
+        messages: [
+          expect.objectContaining({
+            id: userMessage.id,
+            role: "user",
+            content: "Hello"
+          })
+        ]
+      })
+    );
+    expect(getMessage(firstAssistantMessage.id)).toBeNull();
+    expect(getMessage(secondAssistantMessage.id)).toBeNull();
+    expect(startManipulationTurnMock).toHaveBeenCalledWith({
+      conversationId: conversation.id,
+      userMessageId: userMessage.id,
+      preflight: defaultPreflight,
+      control: claimTurnControl,
+      logTag: "message-regenerate-route"
+    });
+  });
+
+  it("rejects mid-history user messages with 409 and deletes nothing", async () => {
+    const user = await createLocalUser({
+      username: "regen-route-mid-history",
+      password: "Password123!",
+      role: "user"
+    });
+    requireUserMock.mockResolvedValue(user);
+
+    const conversation = createConversation("Mid history regenerate", null, {}, user.id);
+    const firstUserMessage = createMessage({
+      conversationId: conversation.id,
+      role: "user",
+      content: "First question"
+    });
+    const firstAssistantMessage = createMessage({
+      conversationId: conversation.id,
+      role: "assistant",
+      content: "First answer"
+    });
+    const lastUserMessage = createMessage({
+      conversationId: conversation.id,
+      role: "user",
+      content: "Second question"
+    });
+    const lastAssistantMessage = createMessage({
+      conversationId: conversation.id,
+      role: "assistant",
+      content: "Second answer"
+    });
+
+    const { POST } = await import("@/app/api/messages/[messageId]/regenerate/route");
+    const response = await POST(
+      new Request(`http://localhost/api/messages/${firstUserMessage.id}/regenerate`, {
+        method: "POST"
+      }),
+      { params: Promise.resolve({ messageId: firstUserMessage.id }) }
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      error: "Only the latest user message can be regenerated"
+    });
+    expect(getMessage(firstUserMessage.id)).not.toBeNull();
+    expect(getMessage(firstAssistantMessage.id)).not.toBeNull();
+    expect(getMessage(lastUserMessage.id)).not.toBeNull();
+    expect(getMessage(lastAssistantMessage.id)).not.toBeNull();
+    expect(startManipulationTurnMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when regenerating another user's message", async () => {
+    const owner = await createLocalUser({
+      username: "regen-route-owner",
+      password: "Password123!",
+      role: "user"
+    });
+    const intruder = await createLocalUser({
+      username: "regen-route-intruder",
+      password: "Password123!",
+      role: "user"
+    });
+    requireUserMock.mockResolvedValue(intruder);
+
+    const conversation = createConversation("Owned conversation", null, {}, owner.id);
+    const userMessage = createMessage({
+      conversationId: conversation.id,
+      role: "user",
+      content: "Not yours"
+    });
+
+    const { POST } = await import("@/app/api/messages/[messageId]/regenerate/route");
+    const response = await POST(
+      new Request(`http://localhost/api/messages/${userMessage.id}/regenerate`, {
+        method: "POST"
+      }),
+      { params: Promise.resolve({ messageId: userMessage.id }) }
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({ error: "Message not found" });
+    expect(getMessage(userMessage.id)).not.toBeNull();
+    expect(startManipulationTurnMock).not.toHaveBeenCalled();
+  });
+
   it("rejects assistant messages with 400", async () => {
     const user = await createLocalUser({
       username: "regen-assistant-reject",


### PR DESCRIPTION
## Problem

Regenerating a message was too loose and too tidy at the same time: you could regenerate any user message from the middle of the conversation, and doing so only removed the *first* assistant reply that followed it, leaving later assistant answers behind. That left conversations in a confusing, half-rewritten state.

## Solution

Think of it like an undo button for your last question: you can now only hit "regenerate" on the **most recent** question you asked, and when you do, **every** robot answer after it is wiped clean before a fresh one is written.

Details:

- `POST /api/messages/[messageId]/regenerate` now loads the conversation's messages and returns `409 Only the latest user message can be regenerated` unless the target is the last user message; nothing is deleted and no turn is started in that case.
- The mutation now collects **all** trailing assistant message IDs after the user message and removes them (previously it stopped after deleting the first one).
- New `deleteAssistantMessagesAndChildren(messageIds, userId)` in `lib/conversations.ts` deletes multiple assistant messages inside a single transaction, reusing prepared statements; `deleteAssistantMessageAndChildren` is now a thin wrapper over it, so existing callers keep working.

## Testing

- Added unit tests in `tests/unit/message-regenerate-route.test.ts` covering:
  - Regenerating the latest user message deletes every trailing assistant message and starts a new turn.
  - Regenerating a mid-history user message returns `409`, deletes nothing, and does not start a turn.
  - Regenerating another user's message returns `404` with no side effects.