### PR TITLE
Harden attachment serving to prevent XSS via non-image attachments

### DIFF
--- a/lib/attachment-response.ts
+++ b/lib/attachment-response.ts
@@ -30,12 +30,16 @@ export function buildAttachmentResponse(
 
   try {
     const buffer = readAttachmentBuffer(attachment);
+    const isImage = attachment.kind === "image";
+    const disposition = download || !isImage ? "attachment" : "inline";
 
     return new Response(buffer, {
       headers: {
-        "Content-Type": attachment.mimeType,
+        "Content-Type": isImage ? attachment.mimeType : "application/octet-stream",
         "Content-Length": String(buffer.length),
-        "Content-Disposition": `${download ? "attachment" : "inline"}; filename="${attachment.filename}"`
+        "Content-Disposition": `${disposition}; filename="${attachment.filename}"`,
+        "X-Content-Type-Options": "nosniff",
+        "Cache-Control": "private, no-store"
       }
     });
   } catch {

--- a/tests/unit/attachment-preview-route.test.ts
+++ b/tests/unit/attachment-preview-route.test.ts
@@ -210,7 +210,69 @@ describe("attachment preview route", () => {
     await expect(response.text()).resolves.toContain("Attachment cannot be previewed as text");
   });
 
-  it("keeps the default response path as raw attachment bytes", async () => {
+  it("serves html attachments as opaque downloads with nosniff", async () => {
+    const user = await createLocalUser({
+      username: "attachment-html-response-user",
+      password: "Password123!",
+      role: "user"
+    });
+    const conversation = createConversation("Html attachment response", null, undefined, user.id);
+    const [attachment] = await createAttachments(conversation.id, [
+      {
+        filename: "page.html",
+        mimeType: "text/html",
+        bytes: Buffer.from("<html><script>alert(1)</script></html>", "utf8")
+      }
+    ]);
+
+    requireUserMock.mockResolvedValue(user);
+
+    const { GET } = await import("@/app/api/attachments/[attachmentId]/route");
+    const response = await GET(
+      new Request(`http://localhost/api/attachments/${attachment.id}`),
+      { params: Promise.resolve({ attachmentId: attachment.id }) }
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("application/octet-stream");
+    expect(response.headers.get("Content-Disposition")).toBe('attachment; filename="page.html"');
+    expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
+    await expect(response.text()).resolves.toBe("<html><script>alert(1)</script></html>");
+  });
+
+  it("serves image attachments inline with their stored image content type", async () => {
+    const user = await createLocalUser({
+      username: "attachment-image-inline-user",
+      password: "Password123!",
+      role: "user"
+    });
+    const conversation = createConversation("Image attachment inline response", null, undefined, user.id);
+    const [attachment] = await createAttachments(conversation.id, [
+      {
+        filename: "photo.png",
+        mimeType: "image/png",
+        bytes: Buffer.from("png-binary", "utf8")
+      }
+    ]);
+
+    requireUserMock.mockResolvedValue(user);
+
+    const { GET } = await import("@/app/api/attachments/[attachmentId]/route");
+    const response = await GET(
+      new Request(`http://localhost/api/attachments/${attachment.id}`),
+      { params: Promise.resolve({ attachmentId: attachment.id }) }
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("image/png");
+    expect(response.headers.get("Content-Disposition")).toBe('inline; filename="photo.png"');
+    expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
+    await expect(response.text()).resolves.toBe("png-binary");
+  });
+
+  it("keeps the default response path as raw attachment bytes for text kinds", async () => {
     const user = await createLocalUser({
       username: "attachment-raw-response-user",
       password: "Password123!",
@@ -234,8 +296,9 @@ describe("attachment preview route", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(response.headers.get("Content-Type")).toBe("text/markdown");
-    expect(response.headers.get("Content-Disposition")).toBe('inline; filename="notes.md"');
+    expect(response.headers.get("Content-Type")).toBe("application/octet-stream");
+    expect(response.headers.get("Content-Disposition")).toBe('attachment; filename="notes.md"');
+    expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
     await expect(response.text()).resolves.toBe("# Notes\nRaw body");
   });
 
@@ -263,9 +326,40 @@ describe("attachment preview route", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(response.headers.get("Content-Type")).toBe("text/markdown");
+    expect(response.headers.get("Content-Type")).toBe("application/octet-stream");
     expect(response.headers.get("Content-Disposition")).toBe('attachment; filename="notes.md"');
+    expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
     await expect(response.text()).resolves.toBe("# Notes\nDownload body");
+  });
+
+  it("keeps download requests for image attachments on their stored image content type", async () => {
+    const user = await createLocalUser({
+      username: "attachment-image-download-user",
+      password: "Password123!",
+      role: "user"
+    });
+    const conversation = createConversation("Image attachment download response", null, undefined, user.id);
+    const [attachment] = await createAttachments(conversation.id, [
+      {
+        filename: "photo.png",
+        mimeType: "image/png",
+        bytes: Buffer.from("png-binary", "utf8")
+      }
+    ]);
+
+    requireUserMock.mockResolvedValue(user);
+
+    const { GET } = await import("@/app/api/attachments/[attachmentId]/route");
+    const response = await GET(
+      new Request(`http://localhost/api/attachments/${attachment.id}?download=1`),
+      { params: Promise.resolve({ attachmentId: attachment.id }) }
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("image/png");
+    expect(response.headers.get("Content-Disposition")).toBe('attachment; filename="photo.png"');
+    expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    await expect(response.text()).resolves.toBe("png-binary");
   });
 
   it("requires authentication for text preview access", async () => {


### PR DESCRIPTION
## Problem
Attachment responses previously echoed the client-provided MIME type and served files `inline`. A crafted attachment such as an HTML file could execute scripts in the site's origin when previewed (stored XSS).

## Solution
ELI5: only pictures are shown in the browser; everything else is handed over as a mystery box the browser just downloads, and the browser is told never to guess what's inside.

Details:
- Only `image` attachments are served `inline` with their stored MIME type
- All non-image attachments (and any `download=1` request) are served as `application/octet-stream` with `Content-Disposition: attachment`
- Added `X-Content-Type-Options: nosniff` to prevent content-type sniffing
- Added `Cache-Control: private, no-store` so private attachment bytes are never cached

## Testing
- Unit tests updated/added in `tests/unit/attachment-preview-route.test.ts` covering: HTML attachments served as opaque downloads with nosniff, image attachments served inline with stored image content type, raw/download paths for text kinds, and image downloads keeping their stored content type