### PR TITLE
Sanitize public share snapshot to visible fields only

### DIFF
--- a/app/api/share/[shareToken]/route.ts
+++ b/app/api/share/[shareToken]/route.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 import { getSharedConversationSnapshot } from "@/lib/conversations";
 import { badRequest, ok } from "@/lib/http";
+import { toSharedConversationView } from "@/lib/shared-conversation-view";
 
 const paramsSchema = z.object({
   shareToken: z.string().min(16)
@@ -22,5 +23,5 @@ export async function GET(
     return badRequest("Shared conversation not found", 404);
   }
 
-  return ok(snapshot);
+  return ok(toSharedConversationView(snapshot));
 }

--- a/app/share/[shareToken]/page.tsx
+++ b/app/share/[shareToken]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from "next/navigation";
 
 import { SharedConversationView } from "@/components/shared-conversation-view";
 import { getSharedConversationSnapshot } from "@/lib/conversations";
+import { toSharedConversationView } from "@/lib/shared-conversation-view";
 
 export default async function SharedConversationPage({
   params
@@ -15,10 +16,12 @@ export default async function SharedConversationPage({
     notFound();
   }
 
+  const view = toSharedConversationView(snapshot);
+
   return (
     <SharedConversationView
-      conversation={snapshot.conversation}
-      messages={snapshot.messages}
+      conversation={view.conversation}
+      messages={view.messages}
       shareToken={shareToken}
     />
   );

--- a/components/attachment-preview-modal.tsx
+++ b/components/attachment-preview-modal.tsx
@@ -3,11 +3,15 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { Download, FileText, X } from "lucide-react";
 
-import type { MessageAttachment } from "@/lib/types";
+import type { MessageAttachment, PublicMessageAttachment } from "@/lib/types";
 
 export type AttachmentUrlOptions = {
   format?: "text";
   download?: boolean;
+};
+
+type PreviewableAttachment = PublicMessageAttachment & {
+  extractedText?: MessageAttachment["extractedText"];
 };
 
 export type AttachmentUrlBuilder = (
@@ -23,7 +27,7 @@ export type AttachmentPreviewState =
   | { kind: "unsupported" };
 
 type AttachmentPreviewModalProps = {
-  attachment: MessageAttachment;
+  attachment: PreviewableAttachment;
   state: AttachmentPreviewState;
   onClose: () => void;
   onRetry?: () => void;
@@ -73,7 +77,7 @@ export function useAttachmentUrlBuilder() {
 
 export function useAttachmentPreviewController() {
   const buildAttachmentUrl = useAttachmentUrlBuilder();
-  const [previewAttachment, setPreviewAttachment] = useState<MessageAttachment | null>(null);
+  const [previewAttachment, setPreviewAttachment] = useState<PreviewableAttachment | null>(null);
   const [previewState, setPreviewState] = useState<AttachmentPreviewState>({
     kind: "unsupported"
   });
@@ -103,10 +107,10 @@ export function useAttachmentPreviewController() {
   }, []);
 
   const openAttachmentPreview = useCallback(
-    async (attachment: MessageAttachment) => {
+    async (attachment: PreviewableAttachment) => {
       const requestToken = previewRequestTokenRef.current + 1;
       const seededText =
-        attachment.kind === "text" && attachment.extractedText.length > 0
+        attachment.kind === "text" && attachment.extractedText && attachment.extractedText.length > 0
           ? attachment.extractedText
           : null;
 

--- a/components/message-attachments.tsx
+++ b/components/message-attachments.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import { FileText } from "lucide-react";
-import type { MessageAttachment } from "@/lib/types";
+import type { PublicMessageAttachment } from "@/lib/types";
 import { useAttachmentUrlBuilder } from "@/components/attachment-preview-modal";
 
 export function AttachmentTile({
@@ -10,9 +10,9 @@ export function AttachmentTile({
   compact = false,
   onPreview
 }: {
-  attachment: MessageAttachment;
+  attachment: PublicMessageAttachment;
   compact?: boolean;
-  onPreview: (attachment: MessageAttachment) => void;
+  onPreview: (attachment: PublicMessageAttachment) => void;
 }) {
   const buildAttachmentUrl = useAttachmentUrlBuilder();
 
@@ -60,9 +60,9 @@ export function MessageAttachments({
   compact = false,
   onPreview
 }: {
-  attachments: MessageAttachment[];
+  attachments: PublicMessageAttachment[];
   compact?: boolean;
-  onPreview: (attachment: MessageAttachment) => void;
+  onPreview: (attachment: PublicMessageAttachment) => void;
 }) {
   if (!attachments.length) {
     return null;
@@ -105,8 +105,8 @@ export function AssistantInlineImageAttachments({
   attachments,
   onPreview
 }: {
-  attachments: MessageAttachment[];
-  onPreview: (attachment: MessageAttachment) => void;
+  attachments: PublicMessageAttachment[];
+  onPreview: (attachment: PublicMessageAttachment) => void;
 }) {
   const buildAttachmentUrl = useAttachmentUrlBuilder();
 

--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -26,10 +26,10 @@ import {
 } from "@/components/message-attachments";
 import type {
   MemoryCategory,
-  Message as MessageType,
   MessageAction as MessageActionType,
-  MessageAttachment,
-  MessageTimelineItem
+  MessageTimelineItem,
+  PublicMessage,
+  PublicMessageAttachment
 } from "@/lib/types";
 import { normalizeLineBreaks } from "@/lib/text-utils";
 import { Textarea } from "@/components/ui/textarea";
@@ -335,7 +335,7 @@ function MessageBubbleImpl({
   onPreviewAttachment,
   readOnly = false
 }: {
-  message: MessageType;
+  message: PublicMessage;
   streamingTimeline?: MessageTimelineItem[];
   streamingThinking?: string;
   streamingAnswer?: string;
@@ -358,7 +358,7 @@ function MessageBubbleImpl({
   isRetrying?: boolean;
   onRegenerateUserMessage?: (messageId: string) => void;
   isRegenerating?: boolean;
-  onPreviewAttachment?: (attachment: MessageAttachment) => void;
+  onPreviewAttachment?: (attachment: PublicMessageAttachment) => void;
   readOnly?: boolean;
 }) {
   const [thinkingOpenItems, setThinkingOpenItems] = useState<Record<string, boolean>>({});
@@ -399,7 +399,7 @@ function MessageBubbleImpl({
 
   const derived = useMemo(() => {
     const rawContent = streamingAnswer ?? message.content;
-    const rawThinking = streamingThinking ?? message.thinkingContent;
+    const rawThinking = streamingThinking ?? message.thinkingContent ?? "";
     const actions = message.actions ?? [];
     const liveTimeline =
       streamingTimeline !== undefined && streamingAnswer !== undefined

--- a/components/shared-conversation-view.tsx
+++ b/components/shared-conversation-view.tsx
@@ -16,7 +16,11 @@ import {
 import { MessageBubble } from "@/components/message-bubble";
 import { Message as AiMessage } from "@/components/ai-elements/message";
 import { Wordmark } from "@/components/ui/wordmark";
-import type { Conversation, Message, MessageAttachment } from "@/lib/types";
+import type {
+  MessageAttachment,
+  PublicConversationSummary,
+  PublicMessage
+} from "@/lib/types";
 
 function buildSharedAttachmentUrl(
   shareToken: string,
@@ -43,8 +47,8 @@ export function SharedConversationView({
   messages,
   shareToken
 }: {
-  conversation: Conversation;
-  messages: Message[];
+  conversation: PublicConversationSummary;
+  messages: PublicMessage[];
   shareToken: string;
 }) {
   const buildAttachmentUrl = useCallback(
@@ -64,8 +68,8 @@ function SharedConversationTranscript({
   conversation,
   messages
 }: {
-  conversation: Conversation;
-  messages: Message[];
+  conversation: PublicConversationSummary;
+  messages: PublicMessage[];
 }) {
   const previewController = useAttachmentPreviewController();
 

--- a/components/streaming-message.tsx
+++ b/components/streaming-message.tsx
@@ -6,8 +6,8 @@ import type { StreamBuffer, StreamBufferSnapshot } from "@/lib/stream-buffer";
 import type {
   MemoryCategory,
   Message,
-  MessageAttachment,
-  MessageTimelineItem
+  MessageTimelineItem,
+  PublicMessageAttachment
 } from "@/lib/types";
 
 const INACTIVE_SNAPSHOT: StreamBufferSnapshot = Object.freeze({
@@ -50,7 +50,7 @@ function StreamingMessageImpl({
   compactionInProgress: boolean;
   thinkingDuration?: number;
   confirmExternalLinks: boolean;
-  onPreviewAttachment?: (attachment: MessageAttachment) => void;
+  onPreviewAttachment?: (attachment: PublicMessageAttachment) => void;
   onUpdateUserMessage?: (messageId: string, content: string) => Promise<void>;
   onApproveMemoryProposal?: (
     actionId: string,

--- a/lib/assistant-image-markdown.ts
+++ b/lib/assistant-image-markdown.ts
@@ -24,15 +24,19 @@ function getPosixDirname(target: string) {
   return normalizedTarget.slice(0, lastSlashIndex);
 }
 
-function sanitizeProseSegment(content: string, imageAttachments: MessageAttachment[], textAttachments: MessageAttachment[]) {
+type MarkdownTargetAttachment = Pick<MessageAttachment, "filename" | "kind"> & {
+  relativePath?: string;
+};
+
+function sanitizeProseSegment(content: string, imageAttachments: MarkdownTargetAttachment[], textAttachments: MarkdownTargetAttachment[]) {
   const matches = findMarkdownTargets(content);
   if (matches.length === 0) {
     return { content, changed: false };
   }
 
-  const buildLocalTargetSet = (attachments: MessageAttachment[]) =>
+  const buildLocalTargetSet = (attachments: MarkdownTargetAttachment[]) =>
     new Set(attachments.flatMap((attachment) => [attachment.filename, attachment.relativePath]));
-  const matchesTmpSourceTarget = (target: string, attachments: MessageAttachment[]) =>
+  const matchesTmpSourceTarget = (target: string, attachments: MarkdownTargetAttachment[]) =>
     target.startsWith("/") &&
     getPosixDirname(target) === "/tmp" &&
     attachments.some((attachment) => attachment.filename === getPosixBasename(target));
@@ -81,7 +85,7 @@ function sanitizeProseSegment(content: string, imageAttachments: MessageAttachme
 
 export function stripAttachmentStyleImageMarkdown(
   content: string,
-  attachments: MessageAttachment[] = []
+  attachments: MarkdownTargetAttachment[] = []
 ) {
   if (!content || !content.includes("[")) {
     return content;

--- a/lib/shared-conversation-view.ts
+++ b/lib/shared-conversation-view.ts
@@ -1,0 +1,36 @@
+import type {
+  ConversationSnapshot,
+  PublicConversationView
+} from "@/lib/types";
+
+export function toSharedConversationView(snapshot: ConversationSnapshot): PublicConversationView {
+  return {
+    conversation: {
+      id: snapshot.conversation.id,
+      title: snapshot.conversation.title,
+      createdAt: snapshot.conversation.createdAt,
+      updatedAt: snapshot.conversation.updatedAt
+    },
+    messages: snapshot.messages.map((message) => ({
+      id: message.id,
+      role: message.role,
+      content: message.content,
+      status: message.status,
+      createdAt: message.createdAt,
+      textSegments: (message.textSegments ?? []).map((segment) => ({
+        id: segment.id,
+        content: segment.content,
+        sortOrder: segment.sortOrder,
+        createdAt: segment.createdAt
+      })),
+      attachments: (message.attachments ?? []).map((attachment) => ({
+        id: attachment.id,
+        filename: attachment.filename,
+        mimeType: attachment.mimeType,
+        kind: attachment.kind,
+        byteSize: attachment.byteSize,
+        createdAt: attachment.createdAt
+      }))
+    }))
+  };
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -424,6 +424,37 @@ export type MessageTimelineItem =
       timelineKind: "action";
     } & MessageAction);
 
+export type PublicConversationSummary = Pick<
+  Conversation,
+  "id" | "title" | "createdAt" | "updatedAt"
+>;
+
+export type PublicMessageAttachment = Pick<
+  MessageAttachment,
+  "id" | "filename" | "mimeType" | "kind" | "byteSize" | "createdAt"
+>;
+
+export type PublicMessageTextSegment = Pick<
+  MessageTextSegment,
+  "id" | "content" | "sortOrder" | "createdAt"
+>;
+
+export type PublicMessage = Pick<
+  Message,
+  "id" | "role" | "content" | "status" | "createdAt"
+> & {
+  thinkingContent?: Message["thinkingContent"];
+  actions?: Message["actions"];
+  timeline?: Message["timeline"];
+  textSegments?: PublicMessageTextSegment[];
+  attachments?: PublicMessageAttachment[];
+};
+
+export type PublicConversationView = {
+  conversation: PublicConversationSummary;
+  messages: PublicMessage[];
+};
+
 export type MemoryNode = {
   id: string;
   conversationId: string;

--- a/tests/unit/conversation-sharing.test.ts
+++ b/tests/unit/conversation-sharing.test.ts
@@ -12,6 +12,7 @@ import {
   getSharedConversationSnapshot
 } from "@/lib/conversations";
 import { getDb } from "@/lib/db";
+import { toSharedConversationView } from "@/lib/shared-conversation-view";
 import { createLocalUser } from "@/lib/users";
 
 describe("conversation sharing", () => {
@@ -59,7 +60,7 @@ describe("conversation sharing", () => {
     expect(snapshot?.queuedMessages).toEqual([]);
   });
 
-  it("keeps attachments, thinking, tool actions, and timeline items in public snapshots", async () => {
+  it("keeps attachments, thinking, tool actions, and timeline items in internal snapshots and strips them from the public view", async () => {
     const user = await createLocalUser({
       username: "share-full-transcript-owner",
       password: "Password123!",
@@ -138,6 +139,52 @@ describe("conversation sharing", () => {
         ]
       })
     );
+
+    const view = toSharedConversationView(snapshot!);
+    expect(view.conversation).toEqual({
+      id: conversation.id,
+      title: "Full public transcript",
+      createdAt: expect.any(String),
+      updatedAt: expect.any(String)
+    });
+    const viewUserMessage = view.messages.find((message) => message.id === userMessage.id);
+    expect(viewUserMessage?.attachments).toEqual([
+      {
+        id: attachment.id,
+        filename: "receipt.txt",
+        mimeType: "text/plain",
+        kind: "text",
+        byteSize: expect.any(Number),
+        createdAt: expect.any(String)
+      }
+    ]);
+    expect(view.messages.find((message) => message.id === assistantMessage.id)).toEqual({
+      id: assistantMessage.id,
+      role: "assistant",
+      content: "I checked the file.",
+      status: expect.any(String),
+      createdAt: expect.any(String),
+      textSegments: [
+        expect.objectContaining({ content: "I checked " }),
+        expect.objectContaining({ content: "the file." })
+      ],
+      attachments: []
+    });
+
+    const serializedView = JSON.stringify(view);
+    expect(serializedView).not.toContain("queuedMessages");
+    expect(serializedView).not.toContain("thinkingContent");
+    expect(serializedView).not.toContain("Need to inspect the uploaded text.");
+    expect(serializedView).not.toContain("actions");
+    expect(serializedView).not.toContain("resultSummary");
+    expect(serializedView).not.toContain("Read public attachment");
+    expect(serializedView).not.toContain("timeline");
+    expect(serializedView).not.toContain("relativePath");
+    expect(serializedView).not.toContain("sha256");
+    expect(serializedView).not.toContain("extractedText");
+    expect(serializedView).not.toContain("public attachment");
+    expect(serializedView).not.toContain("messageId");
+    expect(serializedView).not.toContain("conversationId");
   });
 
   it("invalidates the public link when sharing is disabled and rotates on re-enable", async () => {

--- a/tests/unit/message-bubble.test.ts
+++ b/tests/unit/message-bubble.test.ts
@@ -4,7 +4,7 @@ import React from "react";
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 
 import { MessageBubble } from "@/components/message-bubble";
-import type { Message, MessageAction, MessageTimelineItem } from "@/lib/types";
+import type { Message, MessageAction, MessageAttachment, MessageTimelineItem } from "@/lib/types";
 
 const originalFetch = global.fetch;
 const OriginalImage = global.Image;
@@ -1654,50 +1654,48 @@ describe("message bubble", () => {
   });
 
   it("renders user attachments alongside the message body", () => {
-    render(
-      React.createElement(MessageBubble, {
-        message: {
-          id: "msg_user",
+    const message: Message = {
+      id: "msg_user",
+      conversationId: "conv_test",
+      role: "user",
+      content: "See attached",
+      thinkingContent: "",
+      status: "completed",
+      estimatedTokens: 0,
+      systemKind: null,
+      compactedAt: null,
+      createdAt: new Date().toISOString(),
+      attachments: ([
+        {
+          id: "att_image",
           conversationId: "conv_test",
-          role: "user",
-          content: "See attached",
-          thinkingContent: "",
-          status: "completed",
-          estimatedTokens: 0,
-          systemKind: null,
-          compactedAt: null,
-          createdAt: new Date().toISOString(),
-          attachments: [
-            {
-              id: "att_image",
-              conversationId: "conv_test",
-              messageId: "msg_user",
-              filename: "photo.png",
-              mimeType: "image/png",
-              byteSize: 10,
-              sha256: "hash",
-              relativePath: "conv_test/att_image_photo.png",
-              kind: "image",
-              extractedText: "",
-              createdAt: new Date().toISOString()
-            },
-            {
-              id: "att_text",
-              conversationId: "conv_test",
-              messageId: "msg_user",
-              filename: "notes.txt",
-              mimeType: "text/plain",
-              byteSize: 10,
-              sha256: "hash2",
-              relativePath: "conv_test/att_text_notes.txt",
-              kind: "text",
-              extractedText: "hello",
-              createdAt: new Date().toISOString()
-            }
-          ]
+          messageId: "msg_user",
+          filename: "photo.png",
+          mimeType: "image/png",
+          byteSize: 10,
+          sha256: "hash",
+          relativePath: "conv_test/att_image_photo.png",
+          kind: "image",
+          extractedText: "",
+          createdAt: new Date().toISOString()
+        },
+        {
+          id: "att_text",
+          conversationId: "conv_test",
+          messageId: "msg_user",
+          filename: "notes.txt",
+          mimeType: "text/plain",
+          byteSize: 10,
+          sha256: "hash2",
+          relativePath: "conv_test/att_text_notes.txt",
+          kind: "text",
+          extractedText: "hello",
+          createdAt: new Date().toISOString()
         }
-      })
-    );
+      ] as MessageAttachment[])
+    };
+
+    render(React.createElement(MessageBubble, { message }));
 
     expect(screen.getByRole("button", { name: "Preview photo.png" })).toBeInTheDocument();
     expect(screen.getByText("notes.txt")).toBeInTheDocument();
@@ -1715,7 +1713,7 @@ describe("message bubble", () => {
             "",
             "The real attachment preview should render below."
           ].join("\n"),
-          attachments: [
+          attachments: ([
             {
               id: "att_image",
               conversationId: "conv_test",
@@ -1729,7 +1727,7 @@ describe("message bubble", () => {
               extractedText: "",
               createdAt: new Date().toISOString()
             }
-          ]
+          ] as MessageAttachment[])
         }
       })
     );
@@ -1746,7 +1744,7 @@ describe("message bubble", () => {
         message: {
           ...createAssistantMessage(),
           content: "I've attached the generated image and notes below.",
-          attachments: [
+          attachments: ([
             {
               id: "att_image",
               conversationId: "conv_test",
@@ -1773,7 +1771,7 @@ describe("message bubble", () => {
               extractedText: "hello",
               createdAt: new Date().toISOString()
             }
-          ]
+          ] as MessageAttachment[])
         }
       })
     );
@@ -1800,7 +1798,7 @@ describe("message bubble", () => {
         message: {
           ...createAssistantMessage(),
           content: "Here is the generated image.",
-          attachments: [
+          attachments: ([
             {
               id: "att_image",
               conversationId: "conv_test",
@@ -1814,7 +1812,7 @@ describe("message bubble", () => {
               extractedText: "",
               createdAt: new Date().toISOString()
             }
-          ]
+          ] as MessageAttachment[])
         }
       })
     );
@@ -1842,7 +1840,7 @@ describe("message bubble", () => {
         message: {
           ...createUserMessage(),
           content: "See attached",
-          attachments: [
+          attachments: ([
             {
               id: "att_image",
               conversationId: "conv_test",
@@ -1856,7 +1854,7 @@ describe("message bubble", () => {
               extractedText: "",
               createdAt: new Date().toISOString()
             }
-          ]
+          ] as MessageAttachment[])
         }
       })
     );
@@ -1893,7 +1891,7 @@ describe("message bubble", () => {
         message: {
           ...createUserMessage(),
           content: "See attached",
-          attachments: [
+          attachments: ([
             {
               id: "att_text",
               conversationId: "conv_test",
@@ -1907,7 +1905,7 @@ describe("message bubble", () => {
               extractedText: "hello",
               createdAt: new Date().toISOString()
             }
-          ]
+          ] as MessageAttachment[])
         }
       })
     );
@@ -1941,7 +1939,7 @@ describe("message bubble", () => {
         message: {
           ...createUserMessage(),
           content: "See attached",
-          attachments: [
+          attachments: ([
             {
               id: "att_text",
               conversationId: "conv_test",
@@ -1955,7 +1953,7 @@ describe("message bubble", () => {
               extractedText: "",
               createdAt: new Date().toISOString()
             }
-          ]
+          ] as MessageAttachment[])
         }
       })
     );
@@ -1989,7 +1987,7 @@ describe("message bubble", () => {
         message: {
           ...createUserMessage(),
           content: "See attached",
-          attachments: [
+          attachments: ([
             {
               id: "att_image",
               conversationId: "conv_test",
@@ -2003,7 +2001,7 @@ describe("message bubble", () => {
               extractedText: "",
               createdAt: new Date().toISOString()
             }
-          ]
+          ] as MessageAttachment[])
         }
       })
     );
@@ -2024,7 +2022,7 @@ describe("message bubble", () => {
         message: {
           ...createUserMessage(),
           content: "See attached",
-          attachments: [
+          attachments: ([
             {
               id: "att_image",
               conversationId: "conv_test",
@@ -2038,7 +2036,7 @@ describe("message bubble", () => {
               extractedText: "",
               createdAt: new Date().toISOString()
             }
-          ]
+          ] as MessageAttachment[])
         }
       })
     );
@@ -2067,7 +2065,7 @@ describe("message bubble", () => {
         message: {
           ...createUserMessage(),
           content: "See attached",
-          attachments: [
+          attachments: ([
             {
               id: "att_binary",
               conversationId: "conv_test",
@@ -2081,7 +2079,7 @@ describe("message bubble", () => {
               extractedText: "",
               createdAt: new Date().toISOString()
             }
-          ]
+          ] as MessageAttachment[])
         }
       })
     );
@@ -2106,7 +2104,7 @@ describe("message bubble", () => {
         message: {
           ...createUserMessage(),
           content: "See attached",
-          attachments: [
+          attachments: ([
             {
               id: "att_text",
               conversationId: "conv_test",
@@ -2120,7 +2118,7 @@ describe("message bubble", () => {
               extractedText: "seeded preview content",
               createdAt: new Date().toISOString()
             }
-          ]
+          ] as MessageAttachment[])
         }
       })
     );
@@ -2144,7 +2142,7 @@ describe("message bubble", () => {
         message: {
           ...createUserMessage(),
           content: "See attached",
-          attachments: [
+          attachments: ([
             {
               id: "att_text",
               conversationId: "conv_test",
@@ -2158,7 +2156,7 @@ describe("message bubble", () => {
               extractedText: "hello from extracted text",
               createdAt: new Date().toISOString()
             }
-          ]
+          ] as MessageAttachment[])
         }
       })
     );
@@ -2200,7 +2198,7 @@ describe("message bubble", () => {
         message: {
           ...createUserMessage(),
           content: "See attached",
-          attachments: [
+          attachments: ([
             {
               id: "att_first",
               conversationId: "conv_test",
@@ -2227,7 +2225,7 @@ describe("message bubble", () => {
               extractedText: "second",
               createdAt: new Date().toISOString()
             }
-          ]
+          ] as MessageAttachment[])
         }
       })
     );
@@ -2273,7 +2271,7 @@ describe("message bubble", () => {
         message: {
           ...createUserMessage(),
           content: "See attached",
-          attachments: [
+          attachments: ([
             {
               id: "att_image",
               conversationId: "conv_test",
@@ -2287,7 +2285,7 @@ describe("message bubble", () => {
               extractedText: "",
               createdAt: new Date().toISOString()
             }
-          ]
+          ] as MessageAttachment[])
         }
       })
     );

--- a/tests/unit/public-share-route.test.ts
+++ b/tests/unit/public-share-route.test.ts
@@ -1,21 +1,44 @@
 import { describe, expect, it } from "vitest";
 
-import { createConversation, createMessage, enableConversationShare } from "@/lib/conversations";
+import { bindAttachmentsToMessage, createAttachments } from "@/lib/attachments";
+import { createConversation, createMessage, createMessageAction, enableConversationShare } from "@/lib/conversations";
 import { createLocalUser } from "@/lib/users";
 
 describe("public shared conversation route", () => {
-  it("returns a shared read-only snapshot without requiring auth", async () => {
+  it("returns a sanitized shared view without requiring auth", async () => {
     const user = await createLocalUser({
       username: "public-share-owner",
       password: "Password123!",
       role: "user"
     });
     const conversation = createConversation("Public route", null, {}, user.id);
-    createMessage({
+    const message = createMessage({
       conversationId: conversation.id,
       role: "assistant",
-      content: "Public answer"
+      content: "Public answer",
+      thinkingContent: "Private reasoning trace"
     });
+    createMessageAction({
+      messageId: message.id,
+      kind: "mcp_tool_call",
+      status: "completed",
+      serverId: "filesystem",
+      toolName: "run_shell",
+      label: "Run shell",
+      detail: "whoami",
+      arguments: { command: "whoami" },
+      resultSummary: "internal-hostname",
+      sortOrder: 0
+    });
+    const attachmentBody = "secret attachment body";
+    const [attachment] = await createAttachments(conversation.id, [
+      {
+        filename: "notes.txt",
+        mimeType: "text/plain",
+        bytes: Buffer.from(attachmentBody, "utf8")
+      }
+    ]);
+    bindAttachmentsToMessage(conversation.id, message.id, [attachment.id]);
     const share = enableConversationShare(conversation.id, user.id);
     expect(share).not.toBeNull();
 
@@ -25,22 +48,47 @@ describe("public shared conversation route", () => {
     });
 
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({
-      conversation: expect.objectContaining({
-        id: conversation.id,
-        title: "Public route",
-        shareEnabled: true,
-        shareToken: share!.token
-      }),
-      messages: [
-        expect.objectContaining({
-          role: "assistant",
-          content: "Public answer",
-          attachments: []
-        })
-      ],
-      queuedMessages: []
+    const payload = await response.json();
+    expect(Object.keys(payload).sort()).toEqual(["conversation", "messages"]);
+    expect(payload.conversation).toEqual({
+      id: conversation.id,
+      title: "Public route",
+      createdAt: expect.any(String),
+      updatedAt: expect.any(String)
     });
+    expect(payload.messages).toEqual([
+      {
+        id: message.id,
+        role: "assistant",
+        content: "Public answer",
+        status: expect.any(String),
+        createdAt: expect.any(String),
+        textSegments: [],
+        attachments: [
+          {
+            id: attachment.id,
+            filename: "notes.txt",
+            mimeType: "text/plain",
+            kind: "text",
+            byteSize: Buffer.byteLength(attachmentBody, "utf8"),
+            createdAt: expect.any(String)
+          }
+        ]
+      }
+    ]);
+
+    const serialized = JSON.stringify(payload);
+    expect(serialized).not.toContain("queuedMessages");
+    expect(serialized).not.toContain("thinkingContent");
+    expect(serialized).not.toContain("Private reasoning trace");
+    expect(serialized).not.toContain("actions");
+    expect(serialized).not.toContain("resultSummary");
+    expect(serialized).not.toContain("internal-hostname");
+    expect(serialized).not.toContain("timeline");
+    expect(serialized).not.toContain("relativePath");
+    expect(serialized).not.toContain("sha256");
+    expect(serialized).not.toContain("extractedText");
+    expect(serialized).not.toContain(attachmentBody);
   });
 
   it("returns not found for disabled or malformed share tokens", async () => {


### PR DESCRIPTION
## Problem

Public share links leaked private data. Anyone with a share URL received the full internal conversation snapshot, including the assistant's private thinking, tool-call details and results, attachment file paths, hashes, and extracted text, plus internal IDs and queued messages.

## Solution

Think of it like a redacted copy: before a shared conversation leaves the server, we copy only the safe fields into a new "public view" shape and drop everything else.

- Add public types (`PublicConversationView`, `PublicConversationSummary`, `PublicMessage`, `PublicMessageTextSegment`, `PublicMessageAttachment`) in `lib/types.ts`
- Add `toSharedConversationView()` in the new `lib/shared-conversation-view.ts` to map the full snapshot to the public shape: conversation id/title/timestamps and message id/role/content/status/timestamps, text segments, and attachment metadata only
- Apply the sanitizer in both the public share API route and the share page, so the API response and the server-rendered page expose the same safe fields
- Update share-view components (`message-bubble`, `message-attachments`, `attachment-preview-modal`, `streaming-message`, `shared-conversation-view`) and markdown sanitizing to work with the narrower public attachment types, with optional handling for private-only fields like `extractedText`

## Testing

- `public-share-route.test.ts` now asserts the unauthenticated API response contains only public fields and never `thinkingContent`, `actions`, `resultSummary`, `timeline`, `queuedMessages`, `relativePath`, `sha256`, `extractedText`, or attachment bodies
- `conversation-sharing.test.ts` verifies the internal snapshot still keeps thinking, tool actions, and timeline while the public view strips them
- `message-bubble.test.ts` fixtures updated for the new public message prop types