### PR TITLE
Restrict non-admin SearXNG base URLs to public http(s) endpoints (SSRF fix)

### DIFF
--- a/app/api/settings/general/route.ts
+++ b/app/api/settings/general/route.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 import { requireUser } from "@/lib/auth";
-import { badRequest, ok } from "@/lib/http";
+import { badRequest, forbidden, ok } from "@/lib/http";
 import {
   imageGenerationIntegrationUpdateSchema,
   speechTranscriptionIntegrationUpdateSchema,
@@ -9,6 +9,7 @@ import {
 } from "@/lib/integration-settings";
 import { disposeTitleModel, initTitleModel } from "@/lib/local-title-model";
 import { updateGeneralSettingsBundleForUser } from "@/lib/settings";
+import { getWebSearchEndpointUrl, isPublicHttpUrl } from "@/lib/web-search-catalog";
 
 const inputSchema = z.object({
   preferences: z.object({
@@ -34,6 +35,14 @@ export async function PUT(request: Request) {
   const body = inputSchema.safeParse(await request.json().catch(() => null));
   if (!body.success) {
     return badRequest(body.error.issues.map((issue) => issue.message).join("; "));
+  }
+  const webSearchEndpointUrl = getWebSearchEndpointUrl(body.data.webSearch);
+  if (
+    webSearchEndpointUrl !== null
+    && user.role !== "admin"
+    && !(await isPublicHttpUrl(webSearchEndpointUrl))
+  ) {
+    return forbidden("Only admins can point web search at private network addresses.");
   }
   try {
     const settings = updateGeneralSettingsBundleForUser(

--- a/app/api/settings/general/route.ts
+++ b/app/api/settings/general/route.ts
@@ -9,7 +9,8 @@ import {
 } from "@/lib/integration-settings";
 import { disposeTitleModel, initTitleModel } from "@/lib/local-title-model";
 import { updateGeneralSettingsBundleForUser } from "@/lib/settings";
-import { getWebSearchEndpointUrl, isPublicHttpUrl } from "@/lib/web-search-catalog";
+import { isPublicHttpUrl } from "@/lib/public-http-url";
+import { getWebSearchEndpointUrl } from "@/lib/web-search-catalog";
 
 const inputSchema = z.object({
   preferences: z.object({

--- a/lib/public-http-url.ts
+++ b/lib/public-http-url.ts
@@ -1,0 +1,48 @@
+import net from "node:net";
+import { lookup } from "node:dns/promises";
+
+function isNonPublicIpAddress(address: string): boolean {
+  if (net.isIPv4(address)) {
+    const [a, b] = address.split(".").map(Number);
+    return a === 0
+      || a === 10
+      || a === 127
+      || (a === 169 && b === 254)
+      || (a === 172 && b >= 16 && b <= 31)
+      || (a === 192 && b === 168);
+  }
+  const normalized = address.toLowerCase();
+  const mappedIpv4 = normalized.match(/^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/);
+  if (mappedIpv4) return isNonPublicIpAddress(mappedIpv4[1]);
+  const mappedHex = normalized.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+  if (mappedHex) {
+    const high = parseInt(mappedHex[1], 16);
+    const low = parseInt(mappedHex[2], 16);
+    return isNonPublicIpAddress(`${high >>> 8}.${high & 0xff}.${low >>> 8}.${low & 0xff}`);
+  }
+  if (!net.isIPv6(normalized)) return false;
+  if (normalized === "::" || normalized === "::1") return true;
+  const firstGroup = parseInt(normalized.split(":")[0], 16);
+  if (Number.isNaN(firstGroup)) return true;
+  return (firstGroup >= 0xfe80 && firstGroup <= 0xfebf)
+    || (firstGroup & 0xfe00) === 0xfc00;
+}
+
+export async function isPublicHttpUrl(rawUrl: string): Promise<boolean> {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return false;
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") return false;
+  const hostname = url.hostname.replace(/^\[(.+)\]$/, "$1");
+  if (isNonPublicIpAddress(hostname)) return false;
+  let addresses: Array<{ address: string }>;
+  try {
+    addresses = await lookup(hostname, { all: true });
+  } catch {
+    return false;
+  }
+  return addresses.every((entry) => !isNonPublicIpAddress(entry.address));
+}

--- a/lib/searxng.ts
+++ b/lib/searxng.ts
@@ -63,6 +63,10 @@ async function readJsonResponse(response: Response) {
 
 export async function searchSearxng(input: SearxngSearchInput) {
   const baseUrl = normalizeBaseUrl(input.baseUrl);
+  const parsedBaseUrl = new URL(baseUrl);
+  if (parsedBaseUrl.protocol !== "http:" && parsedBaseUrl.protocol !== "https:") {
+    throw new Error("SearXNG base URL must use http or https.");
+  }
   const url = new URL(`${baseUrl}/search`);
   url.searchParams.set("q", input.query);
   url.searchParams.set("format", "json");

--- a/lib/web-search-catalog.ts
+++ b/lib/web-search-catalog.ts
@@ -1,6 +1,3 @@
-import net from "node:net";
-import { lookup } from "node:dns/promises";
-
 import { z } from "zod";
 
 import type { IntegrationProviderDescriptor } from "@/lib/integration-types";
@@ -25,52 +22,6 @@ export const searxngBaseUrlSchema = z.string().url().refine((value) => {
     return false;
   }
 }, "SearXNG base URL must be an http(s) URL without credentials or fragments.");
-
-function isNonPublicIpAddress(address: string): boolean {
-  if (net.isIPv4(address)) {
-    const [a, b] = address.split(".").map(Number);
-    return a === 0
-      || a === 10
-      || a === 127
-      || (a === 169 && b === 254)
-      || (a === 172 && b >= 16 && b <= 31)
-      || (a === 192 && b === 168);
-  }
-  const normalized = address.toLowerCase();
-  const mappedIpv4 = normalized.match(/^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/);
-  if (mappedIpv4) return isNonPublicIpAddress(mappedIpv4[1]);
-  const mappedHex = normalized.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
-  if (mappedHex) {
-    const high = parseInt(mappedHex[1], 16);
-    const low = parseInt(mappedHex[2], 16);
-    return isNonPublicIpAddress(`${high >>> 8}.${high & 0xff}.${low >>> 8}.${low & 0xff}`);
-  }
-  if (!net.isIPv6(normalized)) return false;
-  if (normalized === "::" || normalized === "::1") return true;
-  const firstGroup = parseInt(normalized.split(":")[0], 16);
-  if (Number.isNaN(firstGroup)) return true;
-  return (firstGroup >= 0xfe80 && firstGroup <= 0xfebf)
-    || (firstGroup & 0xfe00) === 0xfc00;
-}
-
-export async function isPublicHttpUrl(rawUrl: string): Promise<boolean> {
-  let url: URL;
-  try {
-    url = new URL(rawUrl);
-  } catch {
-    return false;
-  }
-  if (url.protocol !== "http:" && url.protocol !== "https:") return false;
-  const hostname = url.hostname.replace(/^\[(.+)\]$/, "$1");
-  if (isNonPublicIpAddress(hostname)) return false;
-  let addresses: Array<{ address: string }>;
-  try {
-    addresses = await lookup(hostname, { all: true });
-  } catch {
-    return false;
-  }
-  return addresses.every((entry) => !isNonPublicIpAddress(entry.address));
-}
 
 export const webSearchIntegrationUpdateSchema = z.discriminatedUnion("providerId", [
   z.object({ providerId: z.literal("disabled"), configuration: z.object({}).strict(), ...credentialFields }).strict(),

--- a/lib/web-search-catalog.ts
+++ b/lib/web-search-catalog.ts
@@ -1,3 +1,6 @@
+import net from "node:net";
+import { lookup } from "node:dns/promises";
+
 import { z } from "zod";
 
 import type { IntegrationProviderDescriptor } from "@/lib/integration-types";
@@ -11,16 +14,83 @@ const credentialFields = {
   credentialAction: z.enum(["preserve", "replace", "clear"]).default("preserve")
 };
 
+export const searxngBaseUrlSchema = z.string().url().refine((value) => {
+  try {
+    const url = new URL(value);
+    return (url.protocol === "http:" || url.protocol === "https:")
+      && url.username === ""
+      && url.password === ""
+      && url.hash === "";
+  } catch {
+    return false;
+  }
+}, "SearXNG base URL must be an http(s) URL without credentials or fragments.");
+
+function isNonPublicIpAddress(address: string): boolean {
+  if (net.isIPv4(address)) {
+    const [a, b] = address.split(".").map(Number);
+    return a === 0
+      || a === 10
+      || a === 127
+      || (a === 169 && b === 254)
+      || (a === 172 && b >= 16 && b <= 31)
+      || (a === 192 && b === 168);
+  }
+  const normalized = address.toLowerCase();
+  const mappedIpv4 = normalized.match(/^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/);
+  if (mappedIpv4) return isNonPublicIpAddress(mappedIpv4[1]);
+  const mappedHex = normalized.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+  if (mappedHex) {
+    const high = parseInt(mappedHex[1], 16);
+    const low = parseInt(mappedHex[2], 16);
+    return isNonPublicIpAddress(`${high >>> 8}.${high & 0xff}.${low >>> 8}.${low & 0xff}`);
+  }
+  if (!net.isIPv6(normalized)) return false;
+  if (normalized === "::" || normalized === "::1") return true;
+  const firstGroup = parseInt(normalized.split(":")[0], 16);
+  if (Number.isNaN(firstGroup)) return true;
+  return (firstGroup >= 0xfe80 && firstGroup <= 0xfebf)
+    || (firstGroup & 0xfe00) === 0xfc00;
+}
+
+export async function isPublicHttpUrl(rawUrl: string): Promise<boolean> {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return false;
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") return false;
+  const hostname = url.hostname.replace(/^\[(.+)\]$/, "$1");
+  if (isNonPublicIpAddress(hostname)) return false;
+  let addresses: Array<{ address: string }>;
+  try {
+    addresses = await lookup(hostname, { all: true });
+  } catch {
+    return false;
+  }
+  return addresses.every((entry) => !isNonPublicIpAddress(entry.address));
+}
+
 export const webSearchIntegrationUpdateSchema = z.discriminatedUnion("providerId", [
   z.object({ providerId: z.literal("disabled"), configuration: z.object({}).strict(), ...credentialFields }).strict(),
   z.object({ providerId: z.literal("exa"), configuration: z.object({}).strict(), ...credentialFields }).strict(),
   z.object({ providerId: z.literal("tavily"), configuration: z.object({}).strict(), ...credentialFields }).strict(),
   z.object({
     providerId: z.literal("searxng"),
-    configuration: z.object({ baseUrl: z.string().url() }).strict(),
+    configuration: z.object({ baseUrl: searxngBaseUrlSchema }).strict(),
     ...credentialFields
   }).strict()
 ]);
+
+export type WebSearchIntegrationUpdate = z.infer<typeof webSearchIntegrationUpdateSchema>;
+
+export function getWebSearchEndpointUrl(
+  update: WebSearchIntegrationUpdate | undefined
+): string | null {
+  if (update?.providerId !== "searxng") return null;
+  return update.configuration.baseUrl;
+}
 
 export const WEB_SEARCH_PROVIDER_CATALOG = {
   disabled: {

--- a/tests/unit/searxng.test.ts
+++ b/tests/unit/searxng.test.ts
@@ -103,6 +103,17 @@ describe("searxng search", () => {
     ).rejects.toThrow("SearXNG search failed with status 403.");
   });
 
+  it("rejects non-http base URLs before issuing any request", async () => {
+    await expect(
+      searchSearxng({ baseUrl: "file:///etc/passwd", query: "secrets" })
+    ).rejects.toThrow("SearXNG base URL must use http or https.");
+    await expect(
+      searchSearxng({ baseUrl: "ftp://files.example.com", query: "secrets" })
+    ).rejects.toThrow("SearXNG base URL must use http or https.");
+
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
   it("passes cancellation through to fetch and rejects oversized responses", async () => {
     const controller = new AbortController();
     vi.mocked(global.fetch).mockResolvedValueOnce(

--- a/tests/unit/settings-route.test.ts
+++ b/tests/unit/settings-route.test.ts
@@ -2,7 +2,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createLocalUser } from "@/lib/users";
 
-const { requireUserMock } = vi.hoisted(() => ({
+const { lookupMock, requireUserMock } = vi.hoisted(() => ({
+  lookupMock: vi.fn(),
   requireUserMock: vi.fn()
 }));
 
@@ -10,9 +11,15 @@ vi.mock("@/lib/auth", () => ({
   requireUser: requireUserMock
 }));
 
+vi.mock("node:dns/promises", () => ({
+  lookup: lookupMock
+}));
+
 describe("settings route", () => {
   beforeEach(() => {
     requireUserMock.mockReset();
+    lookupMock.mockReset();
+    lookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
   });
 
   it("accepts provider-neutral speech settings on the general settings endpoint", async () => {
@@ -114,6 +121,113 @@ describe("settings route", () => {
           providerId: "assemblyai",
           configuration: { model: "universal-2", language: "sw" },
           credentialStored: true
+        })
+      })
+    }));
+  });
+
+  it("blocks non-admin users from pointing SearXNG at private network addresses", async () => {
+    const user = await createLocalUser({
+      username: "searxng-private-user",
+      password: "Password123!",
+      role: "user"
+    });
+    requireUserMock.mockResolvedValue(user);
+
+    const { PUT } = await import("@/app/api/settings/general/route");
+    const putWebSearch = (baseUrl: string) => PUT(
+      new Request("http://localhost/api/settings", {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          preferences: {},
+          webSearch: { providerId: "searxng", configuration: { baseUrl } }
+        })
+      })
+    );
+
+    const metadata = await putWebSearch("http://169.254.169.254/latest/meta-data");
+    expect(metadata.status).toBe(403);
+    await expect(metadata.json()).resolves.toEqual({
+      error: "Only admins can point web search at private network addresses."
+    });
+
+    lookupMock.mockRejectedValueOnce(new Error("ENOTFOUND"));
+    const unresolvable = await putWebSearch("http://searxng.missing.example");
+    expect(unresolvable.status).toBe(403);
+
+    lookupMock.mockResolvedValueOnce([{ address: "127.0.0.1", family: 4 }]);
+    const localhost = await putWebSearch("http://localhost:8888");
+    expect(localhost.status).toBe(403);
+  });
+
+  it("lets non-admin users save SearXNG base URLs that resolve publicly", async () => {
+    const user = await createLocalUser({
+      username: "searxng-public-user",
+      password: "Password123!",
+      role: "user"
+    });
+    requireUserMock.mockResolvedValue(user);
+
+    const { PUT } = await import("@/app/api/settings/general/route");
+    const response = await PUT(
+      new Request("http://localhost/api/settings", {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          preferences: {},
+          webSearch: {
+            providerId: "searxng",
+            configuration: { baseUrl: "https://search.example.com" }
+          }
+        })
+      })
+    );
+
+    expect(lookupMock).toHaveBeenCalledWith("search.example.com", { all: true });
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual(expect.objectContaining({
+      settings: expect.objectContaining({
+        webSearch: expect.objectContaining({
+          providerId: "searxng",
+          configuration: { baseUrl: "https://search.example.com" },
+          configured: true,
+          scope: "user"
+        })
+      })
+    }));
+  });
+
+  it("lets admins keep pointing SearXNG at private network addresses", async () => {
+    const admin = await createLocalUser({
+      username: "searxng-admin-user",
+      password: "Password123!",
+      role: "admin"
+    });
+    requireUserMock.mockResolvedValue(admin);
+
+    const { PUT } = await import("@/app/api/settings/general/route");
+    const response = await PUT(
+      new Request("http://localhost/api/settings", {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          preferences: {},
+          webSearch: {
+            providerId: "searxng",
+            configuration: { baseUrl: "http://192.168.1.10:8888" }
+          }
+        })
+      })
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual(expect.objectContaining({
+      settings: expect.objectContaining({
+        webSearch: expect.objectContaining({
+          providerId: "searxng",
+          configuration: { baseUrl: "http://192.168.1.10:8888" },
+          configured: true
         })
       })
     }));

--- a/tests/unit/web-search.test.ts
+++ b/tests/unit/web-search.test.ts
@@ -2,18 +2,28 @@ import {
   getWebSearchReadinessError,
   searchWeb
 } from "@/lib/web-search";
+import {
+  isPublicHttpUrl,
+  webSearchIntegrationUpdateSchema
+} from "@/lib/web-search-catalog";
 import { createRuntimeAppSettings } from "@/tests/provider-fixtures";
 
 const {
   callMcpToolMock,
   discoverMcpToolsMock,
   getToolResultTextMock,
+  lookupMock,
   searchSearxngMock
 } = vi.hoisted(() => ({
   callMcpToolMock: vi.fn(),
   discoverMcpToolsMock: vi.fn(),
   getToolResultTextMock: vi.fn(),
+  lookupMock: vi.fn(),
   searchSearxngMock: vi.fn()
+}));
+
+vi.mock("node:dns/promises", () => ({
+  lookup: lookupMock
 }));
 
 vi.mock("@/lib/mcp-client", () => ({
@@ -33,6 +43,8 @@ describe("web search providers", () => {
     callMcpToolMock.mockResolvedValue({ isError: false });
     getToolResultTextMock.mockReturnValue("search result");
     searchSearxngMock.mockResolvedValue("self-hosted result");
+    lookupMock.mockReset();
+    lookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
   });
 
   it("reports disabled search through the shared readiness boundary", async () => {
@@ -139,5 +151,88 @@ describe("web search providers", () => {
     callMcpToolMock.mockResolvedValueOnce({ isError: true });
     getToolResultTextMock.mockReturnValueOnce("provider failed");
     await expect(searchWeb({ query: "query", settings })).rejects.toThrow("provider failed");
+  });
+});
+
+describe("searxng base URL safety", () => {
+  beforeEach(() => {
+    lookupMock.mockReset();
+    lookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+  });
+
+  it("classifies literal private, loopback, and metadata addresses as non-public", async () => {
+    for (const baseUrl of [
+      "http://127.0.0.1:8080",
+      "http://127.8.9.10",
+      "http://10.1.2.3",
+      "http://172.16.0.1",
+      "http://172.31.255.255",
+      "http://192.168.1.1",
+      "http://169.254.169.254",
+      "http://0.0.0.0",
+      "http://[::1]",
+      "http://[::]",
+      "http://[fe80::1]",
+      "http://[fc00::1]",
+      "http://[fd12:3456:789a::1]",
+      "http://[::ffff:169.254.169.254]"
+    ]) {
+      await expect(isPublicHttpUrl(baseUrl)).resolves.toBe(false);
+    }
+    expect(lookupMock).not.toHaveBeenCalled();
+  });
+
+  it("classifies public literal and resolved addresses as public", async () => {
+    await expect(isPublicHttpUrl("https://8.8.8.8")).resolves.toBe(true);
+    await expect(isPublicHttpUrl("https://search.example.com")).resolves.toBe(true);
+    expect(lookupMock).toHaveBeenCalledWith("search.example.com", { all: true });
+  });
+
+  it("treats hostnames resolving into private ranges as non-public", async () => {
+    lookupMock.mockResolvedValue([{ address: "192.168.0.5", family: 4 }]);
+    await expect(isPublicHttpUrl("https://internal.example.com")).resolves.toBe(false);
+
+    lookupMock.mockResolvedValue([
+      { address: "93.184.216.34", family: 4 },
+      { address: "10.0.0.2", family: 4 }
+    ]);
+    await expect(isPublicHttpUrl("https://mixed.example.com")).resolves.toBe(false);
+
+    lookupMock.mockResolvedValue([{ address: "::ffff:10.0.0.2", family: 6 }]);
+    await expect(isPublicHttpUrl("https://mapped.example.com")).resolves.toBe(false);
+  });
+
+  it("treats unresolvable hostnames and non-http URLs as non-public", async () => {
+    lookupMock.mockRejectedValue(new Error("ENOTFOUND"));
+    await expect(isPublicHttpUrl("https://missing.example.com")).resolves.toBe(false);
+
+    await expect(isPublicHttpUrl("file:///etc/passwd")).resolves.toBe(false);
+    await expect(isPublicHttpUrl("ftp://files.example.com")).resolves.toBe(false);
+    await expect(isPublicHttpUrl("not a url")).resolves.toBe(false);
+  });
+
+  it("rejects non-http schemes, embedded credentials, and fragments in the update schema", () => {
+    const valid = webSearchIntegrationUpdateSchema.parse({
+      providerId: "searxng",
+      configuration: { baseUrl: "http://169.254.169.254/latest/meta-data" }
+    });
+    expect(valid).toMatchObject({
+      providerId: "searxng",
+      configuration: { baseUrl: "http://169.254.169.254/latest/meta-data" }
+    });
+
+    for (const baseUrl of [
+      "file:///etc/passwd",
+      "ftp://files.example.com",
+      "https://user:pass@search.example.com",
+      "https://user@search.example.com",
+      "https://search.example.com/#fragment"
+    ]) {
+      const result = webSearchIntegrationUpdateSchema.safeParse({
+        providerId: "searxng",
+        configuration: { baseUrl }
+      });
+      expect(result.success).toBe(false);
+    }
   });
 });

--- a/tests/unit/web-search.test.ts
+++ b/tests/unit/web-search.test.ts
@@ -3,7 +3,9 @@ import {
   searchWeb
 } from "@/lib/web-search";
 import {
-  isPublicHttpUrl,
+  isPublicHttpUrl
+} from "@/lib/public-http-url";
+import {
   webSearchIntegrationUpdateSchema
 } from "@/lib/web-search-catalog";
 import { createRuntimeAppSettings } from "@/tests/provider-fixtures";


### PR DESCRIPTION
## Problem

Any user could set their SearXNG web-search base URL to an internal address such as `http://169.254.169.254` or `http://localhost`. Because the server then fetches that URL, a non-admin user could probe or read internal services and cloud metadata — a classic SSRF (server-side request forgery) hole. Non-http schemes like `file:///etc/passwd` were also accepted.

## Solution

In plain terms: regular users may only point web search at real public websites; only admins can point it at internal machines.

Details:

- `lib/web-search-catalog.ts`
  - New `searxngBaseUrlSchema` requires an http(s) URL with no embedded credentials and no fragment.
  - New `isNonPublicIpAddress()` detects private/reserved ranges: IPv4 loopback, `0.0.0.0/8`, `10/8`, `172.16/12`, `192.168/16`, `169.254/16` (cloud metadata), IPv6 `::`, `::1`, link-local `fe80::/10`, unique-local `fc00::/7`, and IPv4-mapped IPv6 forms.
  - New `isPublicHttpUrl()` checks the scheme and literal host, then resolves the hostname via DNS and requires every resolved address to be public; unresolvable hosts are rejected.
  - New `getWebSearchEndpointUrl()` helper extracts the SearXNG base URL from an update payload.
- `app/api/settings/general/route.ts`: non-admin users who submit a SearXNG base URL that is not a public http(s) endpoint get a `403` ("Only admins can point web search at private network addresses."); admins are unaffected.
- `lib/searxng.ts`: `searchSearxng` now refuses base URLs whose protocol is not `http`/`https` before issuing any request.

## Testing

- `tests/unit/web-search.test.ts`: covers literal private/loopback/metadata/IPv6 addresses classified non-public without DNS, public literal and resolved hosts, hostnames resolving (fully or partially) into private ranges, unresolvable hosts, non-http URLs, and schema rejection of non-http schemes, credentials, and fragments.
- `tests/unit/settings-route.test.ts`: verifies non-admins are blocked for `169.254.169.254`, unresolvable hosts, and `localhost`; verifies public URLs save for non-admins and private URLs still save for admins.
- `tests/unit/searxng.test.ts`: verifies `file://` and `ftp://` base URLs throw before `fetch` is called.

## Notes

- DNS-rebinding between validation and the actual fetch is not addressed; mitigations such as pinning resolved IPs or egress allowlists could be a follow-up.