### PR TITLE
Fix build error by setting outputFileTracingRoot to project directory

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,9 @@
 import type { NextConfig } from "next";
+import path from "node:path";
 
 const nextConfig: NextConfig = {
   output: "standalone",
+  outputFileTracingRoot: path.resolve(),
   serverExternalPackages: [
     "onnxruntime-node",
     "@huggingface/transformers",


### PR DESCRIPTION
## Problem

The Next.js build was failing (or producing incorrect standalone output) because Next.js could not determine the correct root directory for output file tracing.

## Solution

Tell Next.js explicitly where the project root is.

### Details
- Added `outputFileTracingRoot: path.resolve()` to `nextConfig` in `next.config.ts`, pointing the file tracing root at the current project directory.
- Imported `path` from `node:path` to support the new config option.
- This works together with the existing `output: "standalone"` mode to ensure traced files are resolved relative to the project directory instead of an inferred (incorrect) root.