### PR TITLE
Add parallel web search pipeline with query decomposition

### DIFF
--- a/components/settings/integration-settings/web-search-settings.tsx
+++ b/components/settings/integration-settings/web-search-settings.tsx
@@ -9,11 +9,19 @@ import {
 import { fieldLabel, inputLike, selectLike } from "@/lib/settings-styles";
 import type { AppSettings } from "@/lib/types";
 import {
+  DEFAULT_WEB_SEARCH_PIPELINE,
   WEB_SEARCH_PROVIDER_CATALOG,
+  type WebSearchPipelineMode,
   type WebSearchProviderId
 } from "@/lib/web-search-catalog";
 
 type Draft = IntegrationDraft<AppSettings["webSearch"]>;
+
+const PIPELINE_MODE_LABELS: Record<WebSearchPipelineMode, string> = {
+  auto: "Auto — decompose complex queries",
+  always: "Always fan out",
+  off: "Off — single search"
+};
 
 export function WebSearchSettings({
   draft,
@@ -35,9 +43,24 @@ export function WebSearchSettings({
       draft,
       persisted,
       providerId,
-      providerId === "searxng" ? { baseUrl: "" } : {}
+      {
+        ...(providerId === "searxng" ? { baseUrl: "" } : {}),
+        pipeline: draft.configuration.pipeline ?? { ...DEFAULT_WEB_SEARCH_PIPELINE }
+      }
     ));
   }
+
+  function updatePipeline(patch: Partial<NonNullable<Draft["configuration"]["pipeline"]>>) {
+    onChange({
+      ...draft,
+      configuration: {
+        ...draft.configuration,
+        pipeline: { ...(draft.configuration.pipeline ?? DEFAULT_WEB_SEARCH_PIPELINE), ...patch }
+      }
+    });
+  }
+
+  const pipeline = draft.configuration.pipeline ?? DEFAULT_WEB_SEARCH_PIPELINE;
 
   return (
     <div className="space-y-3">
@@ -100,11 +123,53 @@ export function WebSearchSettings({
             placeholder="https://search.example.com"
             onChange={(event) => onChange({
               ...draft,
-              configuration: { baseUrl: event.target.value }
+              configuration: { ...draft.configuration, baseUrl: event.target.value }
             })}
             className={`${inputLike} w-full sm:w-[22rem] ${dirty ? "!border-amber-500/40" : ""}`}
           />
         </div>
+      ) : null}
+
+      {draft.providerId !== "disabled" ? (
+        <>
+          <div>
+            <label htmlFor="web-search-pipeline-mode" className={fieldLabel}>Search pipeline</label>
+            <p className="mb-2 text-xs text-[var(--muted)]">
+              Complex questions are decomposed into parallel sub-queries whose results are merged.
+            </p>
+            <select
+              id="web-search-pipeline-mode"
+              aria-label="Search pipeline mode"
+              value={pipeline.mode}
+              onChange={(event) => updatePipeline({ mode: event.target.value as WebSearchPipelineMode })}
+              className={`${selectLike} w-full sm:w-[22rem] ${dirty ? "!border-amber-500/40" : ""}`}
+            >
+              {(Object.keys(PIPELINE_MODE_LABELS) as WebSearchPipelineMode[]).map((mode) => (
+                <option key={mode} value={mode}>{PIPELINE_MODE_LABELS[mode]}</option>
+              ))}
+            </select>
+          </div>
+
+          {pipeline.mode !== "off" ? (
+            <div>
+              <label htmlFor="web-search-max-queries" className={fieldLabel}>Max parallel queries</label>
+              <p className="mb-2 text-xs text-[var(--muted)]">
+                Upper bound on sub-queries fanned out per search.
+              </p>
+              <select
+                id="web-search-max-queries"
+                aria-label="Max parallel queries"
+                value={pipeline.maxQueries ?? DEFAULT_WEB_SEARCH_PIPELINE.maxQueries}
+                onChange={(event) => updatePipeline({ maxQueries: Number(event.target.value) })}
+                className={`${selectLike} w-full sm:w-[10rem] ${dirty ? "!border-amber-500/40" : ""}`}
+              >
+                {[1, 2, 3, 4, 5].map((count) => (
+                  <option key={count} value={count}>{count}</option>
+                ))}
+              </select>
+            </div>
+          ) : null}
+        </>
       ) : null}
     </div>
   );

--- a/lib/assistant-runtime.ts
+++ b/lib/assistant-runtime.ts
@@ -1,5 +1,6 @@
 import { resolveAttachmentPath } from "@/lib/attachments";
 import { ChatTurnStoppedError } from "@/lib/chat-turn-control";
+import { getWebSearchPipeline } from "@/lib/web-search-catalog";
 import { streamProviderResponse } from "@/lib/provider";
 import { getProviderAdapter, getProviderReadinessError } from "@/lib/provider-adapters";
 import { withStreamRetry } from "@/lib/provider-retry";
@@ -8,7 +9,7 @@ import { MARKDOWN_FORMATTING_RULES } from "@/lib/markdown/formatting-rules-promp
 import { supportsImageInput } from "@/lib/model-capabilities";
 import { getProviderApiMode } from "@/lib/provider-profile";
 import { getSkillResolvedName, getSkillResolvedDescription, getLatestUserPromptContent, shouldAddInlineAttachmentDirective, filterSkillsForTurn, hasUnfulfilledMemoryIntent, hasUnfulfilledImageGenerationIntent } from "./prompt-analysis";
-import { type ToolSet, buildToolDefinitions } from "./tool-definitions";
+import { type ToolSet, buildToolDefinitions, mcpToolFunctionName } from "./tool-definitions";
 import { type RuntimeAction, type SuccessfulReadOnlyToolResult, buildToolResultMessage, isMemoryProposalToolCall, executeToolCall } from "./tool-executors";
 import type {
   ChatStreamEvent,
@@ -38,6 +39,8 @@ const IMAGE_TOOL_LATEST_REQUEST_DIRECTIVE =
   "When calling generate_image, Base the prompt and count on only the latest user image request. Treat each new image request as independent by default. Do not combine earlier image requests or count them again unless the latest user message explicitly asks to modify, continue, or combine prior results.";
 const IMAGE_TOOL_POST_SUCCESS_DIRECTIVE =
   "Image generation is available in this environment and a generated image is already attached in this turn. Do not claim that image generation is unavailable. Refer to the generated image result directly, do not call generate_image again in this turn, and do not embed markdown image tags or local file links in your response.";
+const WEB_SEARCH_RESULTS_SUFFICIENT_DIRECTIVE =
+  "Web search results have been received in this turn. Answer the user now by synthesizing the results above. Only call web_search again if the results clearly cannot answer the question — never to re-run or refine similar queries, and never for additional confirmation. Users wait while you search, so prefer answering from what you already have.";
 const IMAGE_TOOL_REQUIRED_DIRECTIVE =
   "The latest user request requires generating a new image. Do not claim that an image was generated unless you call generate_image in this response. Call generate_image now.";
 const INLINE_ATTACHMENT_DIRECTIVE =
@@ -47,7 +50,7 @@ const NON_NATIVE_VISION_DIRECTIVE =
 const MERMAID_DIAGRAM_DIRECTIVE =
   "When you need to present diagrams (flowcharts, sequence diagrams, class diagrams, state diagrams, ER diagrams, Gantt charts, pie charts, mind maps, or any other diagram type), use mermaid.js syntax inside a fenced code block with the `mermaid` language identifier. For example:\n\n```mermaid\ngraph TD\n    A[Start] --> B{Decision}\n    B -->|Yes| C[Success]\n    B -->|No| D[Try Again]\n```\n\nAlways prefer mermaid diagrams over ASCII art or text-based diagrams.";
 
-function buildCapabilitiesStableSegment(mcpServers: McpServer[], hasWebSearch: boolean) {
+function buildCapabilitiesStableSegment(mcpServers: McpServer[], hasWebSearch: boolean, parallelWebSearch: boolean) {
   const lines: string[] = [];
 
   if (mcpServers.length) {
@@ -75,7 +78,14 @@ function buildCapabilitiesStableSegment(mcpServers: McpServer[], hasWebSearch: b
       "Web search guidance: prefer answering from your own knowledge whenever possible.",
       "Only use web search when the question involves recent events, time-sensitive information,",
       "topics you are uncertain about, or when the user explicitly requests a search.",
-      "If you can answer confidently and accurately from your training data, do so without searching."
+      ...(parallelWebSearch
+        ? [
+            "When one question spans multiple facets, pass several distinct queries in a single web_search call (queries) — they execute in parallel.",
+            "A single complex query is automatically decomposed into parallel sub-queries, so one call is usually enough."
+          ]
+        : [
+            "If you can answer confidently and accurately from your training data, do so without searching."
+          ])
     );
   }
 
@@ -362,6 +372,18 @@ export async function resolveAssistantTurn(input: {
   };
   const loadedSkillIds = new Set<string>();
   const successfulReadOnlyToolResults = new Map<string, SuccessfulReadOnlyToolResult>();
+
+  const parallelizableToolNames = new Set<string>(["web_search"]);
+  let webSearchDirectiveAdded = false;
+  for (const { server, tools } of input.mcpToolSets) {
+    if (server.isVisionMcp && effectiveVisionMode !== "mcp") continue;
+    for (const tool of tools) {
+      if (tool.annotations?.readOnlyHint) {
+        parallelizableToolNames.add(mcpToolFunctionName(server.slug, tool.name));
+      }
+    }
+  }
+
   let imageGenerationToolConsumed = false;
   let visibleImageActionStarted = false;
   let visibleImageActionHandle: string | undefined;
@@ -369,6 +391,8 @@ export async function resolveAssistantTurn(input: {
   const hasWebSearch = Boolean(
     input.appSettings && input.appSettings.webSearch.providerId !== "disabled"
   );
+  const webSearchPipeline = getWebSearchPipeline(input.appSettings?.webSearch.configuration);
+  const parallelWebSearch = hasWebSearch && webSearchPipeline.mode !== "off";
   const hasImageGeneration = Boolean(
     input.appSettings && input.appSettings.imageGeneration.providerId !== "disabled"
   );
@@ -380,7 +404,7 @@ export async function resolveAssistantTurn(input: {
   if (turnSkills.length || visibleMcpServers.length || input.mcpToolSets.length) {
     promptMessages = mergeSystemMessage(
       promptMessages,
-      buildCapabilitiesStableSegment(visibleMcpServers, hasWebSearch)
+      buildCapabilitiesStableSegment(visibleMcpServers, hasWebSearch, parallelWebSearch)
     );
   }
   const dynamicSkillsGuidance = buildDynamicSkillsSegment(turnSkills);
@@ -429,6 +453,7 @@ export async function resolveAssistantTurn(input: {
       memoriesEnabled: input.memoriesEnabled ?? false,
       memoriesRigor: input.memoriesRigor,
       webSearchEnabled: hasWebSearch,
+      webSearchPipelineMode: hasWebSearch ? webSearchPipeline.mode : undefined,
       imageGenerationProviderId: input.appSettings?.imageGeneration.providerId,
       imageGenerationToolEnabled: !imageGenerationToolConsumed,
       restrictToGenerateImage,
@@ -584,25 +609,8 @@ export async function resolveAssistantTurn(input: {
 
     let imageGenerationToolAttemptedThisStep = false;
 
-    for (const toolCall of toolCalls) {
-      assertRunning();
-
-      if (toolCall.name === "generate_image") {
-        if (imageGenerationToolConsumed || imageGenerationToolAttemptedThisStep) {
-          promptMessages = [
-            ...promptMessages,
-            buildToolResultMessage(
-              toolCall.id,
-              "Error: generate_image can only be called once per assistant turn. Respond to the user with the generated result instead."
-            )
-          ];
-          continue;
-        }
-
-        imageGenerationToolAttemptedThisStep = true;
-      }
-
-      const result = await executeToolCall(toolCall, {
+    const runToolCall = (toolCall: ProviderToolCall, sortOrder: number) =>
+      executeToolCall(toolCall, {
         input: {
           ...toolRuntimeInput,
           imageGenerationActionHandle: visibleImageActionHandle,
@@ -611,23 +619,84 @@ export async function resolveAssistantTurn(input: {
         mcpServers,
         loadedSkillIds,
         successfulReadOnlyToolResults,
-        timelineSortOrder,
+        timelineSortOrder: sortOrder,
         promptMessages,
         memoryUserId: input.memoryUserId
       });
+
+    const stepIsFullyParallelizable =
+      toolCalls.length > 1 && toolCalls.every((toolCall) => parallelizableToolNames.has(toolCall.name));
+
+    if (stepIsFullyParallelizable) {
       assertRunning();
+      const baseSortOrder = timelineSortOrder;
+      const settled = await Promise.allSettled(
+        toolCalls.map((toolCall, index) => runToolCall(toolCall, baseSortOrder + index))
+      );
+      assertRunning();
+      const rejection = settled.find(
+        (entry): entry is PromiseRejectedResult => entry.status === "rejected"
+      );
+      if (rejection) throw rejection.reason;
+      promptMessages = [
+        ...promptMessages,
+        ...settled.flatMap((entry) => {
+          const result = (entry as PromiseFulfilledResult<{
+            nextSortOrder: number;
+            promptMessages: PromptMessage[];
+          }>).value;
+          return result.promptMessages.slice(promptMessages.length);
+        })
+      ];
+      timelineSortOrder = baseSortOrder + toolCalls.length;
 
-      timelineSortOrder = result.nextSortOrder;
-      promptMessages = result.promptMessages;
+      const anyWebSearchSucceeded = settled.some((entry, index) => {
+        if (toolCalls[index].name !== "web_search") return false;
+        return entry.status === "fulfilled" && Boolean((entry as PromiseFulfilledResult<{ toolSucceeded?: boolean }>).value.toolSucceeded);
+      });
+      if (anyWebSearchSucceeded && !webSearchDirectiveAdded) {
+        webSearchDirectiveAdded = true;
+        promptMessages = mergeSystemMessage(promptMessages, WEB_SEARCH_RESULTS_SUFFICIENT_DIRECTIVE);
+      }
+    } else {
+      for (const toolCall of toolCalls) {
+        assertRunning();
 
-      if (toolCall.name === "generate_image" && result.toolSucceeded) {
-        imageGenerationToolConsumed = true;
-        visibleImageActionStarted = false;
-        visibleImageActionHandle = undefined;
-        promptMessages = mergeSystemMessage(promptMessages, IMAGE_TOOL_POST_SUCCESS_DIRECTIVE);
-      } else if (toolCall.name === "generate_image") {
-        visibleImageActionStarted = false;
-        visibleImageActionHandle = undefined;
+        if (toolCall.name === "generate_image") {
+          if (imageGenerationToolConsumed || imageGenerationToolAttemptedThisStep) {
+            promptMessages = [
+              ...promptMessages,
+              buildToolResultMessage(
+                toolCall.id,
+                "Error: generate_image can only be called once per assistant turn. Respond to the user with the generated result instead."
+              )
+            ];
+            continue;
+          }
+
+          imageGenerationToolAttemptedThisStep = true;
+        }
+
+        const result = await runToolCall(toolCall, timelineSortOrder);
+        assertRunning();
+
+        timelineSortOrder = result.nextSortOrder;
+        promptMessages = result.promptMessages;
+
+        if (toolCall.name === "web_search" && result.toolSucceeded && !webSearchDirectiveAdded) {
+          webSearchDirectiveAdded = true;
+          promptMessages = mergeSystemMessage(promptMessages, WEB_SEARCH_RESULTS_SUFFICIENT_DIRECTIVE);
+        }
+
+        if (toolCall.name === "generate_image" && result.toolSucceeded) {
+          imageGenerationToolConsumed = true;
+          visibleImageActionStarted = false;
+          visibleImageActionHandle = undefined;
+          promptMessages = mergeSystemMessage(promptMessages, IMAGE_TOOL_POST_SUCCESS_DIRECTIVE);
+        } else if (toolCall.name === "generate_image") {
+          visibleImageActionStarted = false;
+          visibleImageActionHandle = undefined;
+        }
       }
     }
 

--- a/lib/copilot-tools.ts
+++ b/lib/copilot-tools.ts
@@ -1,6 +1,7 @@
 import type { Tool } from "@github/copilot-sdk";
 
 import { throwIfChatTurnAborted } from "@/lib/chat-turn-control";
+import { getWebSearchPipeline } from "@/lib/web-search-catalog";
 import {
   buildToolDefinitions
 } from "@/lib/tool-definitions";
@@ -32,6 +33,9 @@ export function buildCopilotTools(context: RuntimeToolContext): Tool[] {
     webSearchEnabled: Boolean(
       context.appSettings && context.appSettings.webSearch.providerId !== "disabled"
     ),
+    webSearchPipelineMode: context.appSettings
+      ? getWebSearchPipeline(context.appSettings.webSearch.configuration).mode
+      : undefined,
     imageGenerationProviderId: context.appSettings?.imageGeneration.providerId,
     imageGenerationToolEnabled: context.imageGenerationToolEnabled,
     restrictToGenerateImage: context.restrictToGenerateImage,

--- a/lib/provider-adapters/anthropic.ts
+++ b/lib/provider-adapters/anthropic.ts
@@ -11,11 +11,14 @@ import { getProviderApiBaseUrl, getProviderApiKey } from "@/lib/provider-profile
 import type {
   ProviderStreamInput,
   ProviderStreamResult,
-  ProviderTextInput
+  ProviderTextInput,
+  ProviderTextPurpose
 } from "@/lib/provider-adapters/types";
 
+const LOW_EFFORT_PURPOSES: ReadonlySet<ProviderTextPurpose> = new Set(["title", "web_search_planning"]);
+
 export async function callAnthropicAdapterText(input: ProviderTextInput) {
-  const settings = input.purpose === "title"
+  const settings = LOW_EFFORT_PURPOSES.has(input.purpose)
     ? {
         ...input.settings,
         reasoningEffort: (input.settings.reasoningEffort === "none" ? "none" : "low") as ReasoningEffort,

--- a/lib/provider-adapters/github-copilot.ts
+++ b/lib/provider-adapters/github-copilot.ts
@@ -26,7 +26,8 @@ import type {
 import type {
   ProviderStreamInput,
   ProviderStreamResult,
-  ProviderTextInput
+  ProviderTextInput,
+  ProviderTextPurpose
 } from "@/lib/provider-adapters/types";
 
 export const githubCopilotConnectionFlows = {
@@ -35,8 +36,10 @@ export const githubCopilotConnectionFlows = {
   cancel: cancelGithubProviderConnectionFlow
 };
 
+const LOW_EFFORT_PURPOSES: ReadonlySet<ProviderTextPurpose> = new Set(["title", "web_search_planning"]);
+
 export async function callGithubCopilotText(input: ProviderTextInput) {
-  const settings = input.purpose === "title"
+  const settings = LOW_EFFORT_PURPOSES.has(input.purpose)
     ? {
         ...input.settings,
         reasoningEffort: (input.settings.reasoningEffort === "none" ? "none" : "low") as ReasoningEffort,

--- a/lib/provider-adapters/openai-compatible.ts
+++ b/lib/provider-adapters/openai-compatible.ts
@@ -33,7 +33,8 @@ import type {
 import type {
   ProviderStreamInput,
   ProviderStreamResult,
-  ProviderTextInput
+  ProviderTextInput,
+  ProviderTextPurpose
 } from "@/lib/provider-adapters/types";
 
 function normalizeReasoningEffort(
@@ -141,9 +142,11 @@ function buildRequestParameters(settings: ProviderProfile) {
   };
 }
 
+const LOW_EFFORT_PURPOSES: ReadonlySet<ProviderTextPurpose> = new Set(["title", "web_search_planning"]);
+
 export async function callOpenAiCompatibleText(input: ProviderTextInput) {
   const { settings } = input;
-  const profile = input.purpose === "title"
+  const profile = LOW_EFFORT_PURPOSES.has(input.purpose)
     ? {
         ...settings,
         reasoningEffort: (settings.reasoningEffort === "none" ? "none" : "low") as ReasoningEffort,

--- a/lib/provider-adapters/types.ts
+++ b/lib/provider-adapters/types.ts
@@ -10,7 +10,12 @@ import type {
   ToolDefinition
 } from "@/lib/types";
 
-export type ProviderTextPurpose = "compaction" | "test" | "title" | "image_instruction";
+export type ProviderTextPurpose =
+  | "compaction"
+  | "test"
+  | "title"
+  | "image_instruction"
+  | "web_search_planning";
 
 export type ProviderTextInput = {
   settings: RuntimeProviderProfile;

--- a/lib/tool-definitions.ts
+++ b/lib/tool-definitions.ts
@@ -1,6 +1,7 @@
 import { buildCreateMemoryDescription } from "@/lib/memory-guidance";
 import { extractEnumHints } from "@/lib/tool-schema-helpers";
 import { getSkillResolvedName } from "./skill-runtime";
+import type { WebSearchPipelineMode } from "@/lib/web-search-catalog";
 import type { McpServer, McpTool, MemoryRigor, Skill, ToolDefinition, VisionMode } from "@/lib/types";
 
 export type ToolSet = {
@@ -35,6 +36,7 @@ export function buildToolDefinitions(input: {
   memoriesEnabled: boolean;
   memoriesRigor?: MemoryRigor;
   webSearchEnabled?: boolean;
+  webSearchPipelineMode?: WebSearchPipelineMode;
   imageGenerationProviderId?: string | null;
   imageGenerationToolEnabled?: boolean;
   restrictToGenerateImage?: boolean;
@@ -156,22 +158,43 @@ export function buildToolDefinitions(input: {
   });
 
   if (input.webSearchEnabled) {
+    const parallelSearch = (input.webSearchPipelineMode ?? "auto") !== "off";
     tools.push({
       type: "function",
       function: {
         name: "web_search",
-        description: "Search the web using the configured provider. Only use this tool for recent events, time-sensitive information, or topics you are uncertain about. Prefer your own knowledge when you can answer confidently.",
-        parameters: {
-          type: "object",
-          properties: {
-            query: { type: "string", description: "Search query" },
-            max_results: {
-              type: "number",
-              description: "Maximum number of results to return (default 5, max 10)"
+        description: parallelSearch
+          ? "Search the web using the configured provider. Pass multiple distinct queries in `queries` when the question has several facets or complementary phrasings — they run in parallel and their results are merged. A single complex query is automatically decomposed into parallel sub-queries. Provide every facet query needed to answer in this single call — one comprehensive call is much faster for the user than multiple sequential search rounds. Only use this tool for recent events, time-sensitive information, or topics you are uncertain about. Prefer your own knowledge when you can answer confidently."
+          : "Search the web using the configured provider. Only use this tool for recent events, time-sensitive information, or topics you are uncertain about. Prefer your own knowledge when you can answer confidently.",
+        parameters: parallelSearch
+          ? {
+              type: "object",
+              properties: {
+                query: { type: "string", description: "Single search query" },
+                queries: {
+                  type: "array",
+                  items: { type: "string" },
+                  minItems: 1,
+                  maxItems: 5,
+                  description: "Multiple distinct search queries to run in parallel; each should target a different facet of the question"
+                },
+                max_results: {
+                  type: "number",
+                  description: "Maximum number of results to return per query (default 5, max 10)"
+                }
+              }
             }
-          },
-          required: ["query"]
-        }
+          : {
+              type: "object",
+              properties: {
+                query: { type: "string", description: "Search query" },
+                max_results: {
+                  type: "number",
+                  description: "Maximum number of results to return (default 5, max 10)"
+                }
+              },
+              required: ["query"]
+            }
       }
     });
   }

--- a/lib/tool-executors.ts
+++ b/lib/tool-executors.ts
@@ -11,7 +11,11 @@ import { getSettings } from "@/lib/settings";
 import { executeLocalShellCommand, getShellCommandLabel, summarizeShellResult } from "@/lib/local-shell";
 import { callMcpTool, getToolResultText } from "@/lib/mcp-client";
 import { coerceEnumValues } from "@/lib/tool-schema-helpers";
-import { searchWeb } from "@/lib/web-search";
+import { getWebSearchPipeline } from "@/lib/web-search-catalog";
+import {
+  getPipelineUserContext,
+  runWebSearchPipeline
+} from "@/lib/web-search-pipeline";
 import { throwIfChatTurnAborted as throwIfAborted } from "@/lib/chat-turn-control";
 import { MAX_RUNTIME_TOOL_RESULT_CHARS, truncateText } from "@/lib/bounded-text";
 import {
@@ -83,8 +87,11 @@ export async function executeWebSearch(
   args: Record<string, unknown>,
   context: {
     input: {
+      settings?: RuntimeProviderProfile;
       appSettings?: RuntimeAppSettings;
       mcpTimeout?: number;
+      conversationId?: string;
+      assistantMessageId?: string;
       abortSignal?: AbortSignal;
       onActionStart?: (action: RuntimeAction) => Promise<string | void> | string | void;
       onActionComplete?: (handle: string | undefined, patch: { detail?: string; resultSummary?: string }) => Promise<void> | void;
@@ -97,6 +104,12 @@ export async function executeWebSearch(
   throwIfAborted(context.input.abortSignal);
   let sortOrder = context.timelineSortOrder;
   const query = String(args.query ?? "").trim();
+  const queries = Array.isArray(args.queries)
+    ? args.queries
+        .filter((item): item is string => typeof item === "string")
+        .map((item) => item.trim())
+        .filter(Boolean)
+    : [];
   const maxResults =
     typeof args.max_results === "number" && Number.isFinite(args.max_results)
       ? Math.max(1, Math.min(10, Math.round(args.max_results)))
@@ -107,51 +120,73 @@ export async function executeWebSearch(
     return { nextSortOrder: sortOrder, promptMessages: [...context.promptMessages, resultMsg] };
   }
 
-  if (!query) {
+  if (!query && !queries.length) {
     const resultMsg = buildToolResultMessage(toolCallId, "Error: query is required");
     return { nextSortOrder: sortOrder, promptMessages: [...context.promptMessages, resultMsg] };
   }
 
+  const pipeline = getWebSearchPipeline(context.input.appSettings.webSearch.configuration);
+  const detail = truncateText(
+    queries.length ? queries.join("; ") : query,
+    300
+  );
+
   const handle = await context.input.onActionStart?.({
     kind: "mcp_tool_call",
     label: "Web search",
-    detail: query,
+    detail,
     serverId: "integration_web_search",
     toolName: "web_search",
     arguments: {
-      query,
+      ...(query ? { query } : {}),
+      ...(queries.length ? { queries } : {}),
       ...(maxResults !== undefined ? { max_results: maxResults } : {})
     }
   });
   const actionHandle = typeof handle === "string" ? handle : undefined;
 
   try {
-    const resultSummary = await searchWeb({
-      settings: context.input.appSettings,
+    const result = await runWebSearchPipeline({
       query,
+      queries,
+      mode: pipeline.mode,
+      maxQueries: pipeline.maxQueries ?? 4,
       maxResults,
+      settings: context.input.appSettings,
+      providerProfile: context.input.settings,
+      userContext: getPipelineUserContext(context.promptMessages),
+      mcpTimeout: context.input.mcpTimeout,
       abortSignal: context.input.abortSignal,
-      timeout: context.input.mcpTimeout
+      assistantMessageId: context.input.assistantMessageId,
+      conversationId: context.input.conversationId
     });
     throwIfAborted(context.input.abortSignal);
 
     sortOrder += 1;
     await context.input.onActionComplete?.(actionHandle, {
-      detail: query,
-      resultSummary
+      detail,
+      resultSummary: result.resultSummary
     });
 
-    const resultMsg = buildToolResultMessage(toolCallId, resultSummary);
-    return { nextSortOrder: sortOrder, promptMessages: [...context.promptMessages, resultMsg] };
+    const resultMsg = buildToolResultMessage(toolCallId, result.resultSummary);
+    return {
+      nextSortOrder: sortOrder,
+      promptMessages: [...context.promptMessages, resultMsg],
+      toolSucceeded: !result.resultSummary.startsWith("Error:")
+    };
   } catch (error) {
     throwIfAborted(context.input.abortSignal);
     const message = error instanceof Error ? error.message : "Web search failed";
     await context.input.onActionError?.(actionHandle, {
-      detail: query,
+      detail,
       resultSummary: message
     });
     const resultMsg = buildToolResultMessage(toolCallId, `Error: ${message}`);
-    return { nextSortOrder: sortOrder, promptMessages: [...context.promptMessages, resultMsg] };
+    return {
+      nextSortOrder: sortOrder,
+      promptMessages: [...context.promptMessages, resultMsg],
+      toolSucceeded: false
+    };
   }
 }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -10,7 +10,7 @@ import type {
   ImageGenerationModelId,
   ImageGenerationProviderId
 } from "@/lib/image-generation/catalog";
-import type { WebSearchProviderId } from "@/lib/web-search-catalog";
+import type { WebSearchConfiguration, WebSearchProviderId } from "@/lib/web-search-catalog";
 import type {
   IntegrationSelection,
   RuntimeIntegrationSelection
@@ -119,7 +119,7 @@ type AppSettingsCore = {
 };
 
 export type AppSettings = AppSettingsCore & {
-  webSearch: IntegrationSelection<WebSearchProviderId, { baseUrl?: string }>;
+  webSearch: IntegrationSelection<WebSearchProviderId, WebSearchConfiguration>;
   imageGeneration: IntegrationSelection<ImageGenerationProviderId, { model?: ImageGenerationModelId }>;
   speechTranscription: IntegrationSelection<TranscriptionProviderId, {
     language: SttLanguage | ExternalSttLanguage;
@@ -128,10 +128,7 @@ export type AppSettings = AppSettingsCore & {
 };
 
 export type RuntimeAppSettings = AppSettingsCore & {
-  webSearch: RuntimeIntegrationSelection<
-    WebSearchProviderId,
-    { baseUrl?: string }
-  >;
+  webSearch: RuntimeIntegrationSelection<WebSearchProviderId, WebSearchConfiguration>;
   imageGeneration: RuntimeIntegrationSelection<
     ImageGenerationProviderId,
     { model?: ImageGenerationModelId }

--- a/lib/web-search-catalog.ts
+++ b/lib/web-search-catalog.ts
@@ -4,7 +4,47 @@ import type { IntegrationProviderDescriptor } from "@/lib/integration-types";
 
 export const WEB_SEARCH_PROVIDER_IDS = ["disabled", "exa", "tavily", "searxng"] as const;
 export type WebSearchProviderId = typeof WEB_SEARCH_PROVIDER_IDS[number];
-export type WebSearchConfiguration = { baseUrl?: string };
+
+export const WEB_SEARCH_PIPELINE_MODES = ["auto", "always", "off"] as const;
+export type WebSearchPipelineMode = typeof WEB_SEARCH_PIPELINE_MODES[number];
+
+export type WebSearchPipelineConfiguration = {
+  mode: WebSearchPipelineMode;
+  maxQueries?: number;
+};
+
+export type WebSearchConfiguration = {
+  baseUrl?: string;
+  pipeline?: WebSearchPipelineConfiguration;
+};
+
+export const DEFAULT_WEB_SEARCH_PIPELINE: WebSearchPipelineConfiguration = {
+  mode: "auto",
+  maxQueries: 4
+};
+
+export function normalizeWebSearchPipeline(value: unknown): WebSearchPipelineConfiguration {
+  if (!value || typeof value !== "object") return { ...DEFAULT_WEB_SEARCH_PIPELINE };
+  const candidate = value as Partial<WebSearchPipelineConfiguration>;
+  const maxQueries = candidate.maxQueries;
+  return {
+    mode: WEB_SEARCH_PIPELINE_MODES.includes(candidate.mode as WebSearchPipelineMode)
+      ? (candidate.mode as WebSearchPipelineMode)
+      : DEFAULT_WEB_SEARCH_PIPELINE.mode,
+    maxQueries:
+      typeof maxQueries === "number" && Number.isFinite(maxQueries)
+        ? Math.max(1, Math.min(5, Math.round(maxQueries)))
+        : DEFAULT_WEB_SEARCH_PIPELINE.maxQueries
+  };
+}
+
+export function getWebSearchPipeline(
+  configuration: WebSearchConfiguration | undefined
+): WebSearchPipelineConfiguration {
+  return configuration?.pipeline
+    ? normalizeWebSearchPipeline(configuration.pipeline)
+    : { ...DEFAULT_WEB_SEARCH_PIPELINE };
+}
 
 const credentialFields = {
   credential: z.string().optional(),
@@ -23,13 +63,30 @@ export const searxngBaseUrlSchema = z.string().url().refine((value) => {
   }
 }, "SearXNG base URL must be an http(s) URL without credentials or fragments.");
 
+const webSearchPipelineSchema = z.object({
+  mode: z.enum(WEB_SEARCH_PIPELINE_MODES).default("auto"),
+  maxQueries: z.number().int().min(1).max(5).optional()
+});
+
 export const webSearchIntegrationUpdateSchema = z.discriminatedUnion("providerId", [
-  z.object({ providerId: z.literal("disabled"), configuration: z.object({}).strict(), ...credentialFields }).strict(),
-  z.object({ providerId: z.literal("exa"), configuration: z.object({}).strict(), ...credentialFields }).strict(),
-  z.object({ providerId: z.literal("tavily"), configuration: z.object({}).strict(), ...credentialFields }).strict(),
+  z.object({
+    providerId: z.literal("disabled"),
+    configuration: z.object({ pipeline: webSearchPipelineSchema.optional() }).strict(),
+    ...credentialFields
+  }).strict(),
+  z.object({
+    providerId: z.literal("exa"),
+    configuration: z.object({ pipeline: webSearchPipelineSchema.optional() }).strict(),
+    ...credentialFields
+  }).strict(),
+  z.object({
+    providerId: z.literal("tavily"),
+    configuration: z.object({ pipeline: webSearchPipelineSchema.optional() }).strict(),
+    ...credentialFields
+  }).strict(),
   z.object({
     providerId: z.literal("searxng"),
-    configuration: z.object({ baseUrl: searxngBaseUrlSchema }).strict(),
+    configuration: z.object({ baseUrl: searxngBaseUrlSchema, pipeline: webSearchPipelineSchema.optional() }).strict(),
     ...credentialFields
   }).strict()
 ]);
@@ -88,14 +145,17 @@ export function normalizeWebSearchSelection(
   providerId: string,
   configuration: Record<string, unknown>
 ): { providerId: WebSearchProviderId; configuration: WebSearchConfiguration } {
-  if (!isWebSearchProviderId(providerId)) return { providerId: "exa", configuration: {} };
-  if (providerId !== "searxng") return { providerId, configuration: {} };
+  const pipeline = normalizeWebSearchPipeline(configuration.pipeline);
+  if (!isWebSearchProviderId(providerId)) {
+    return { providerId: "exa", configuration: { pipeline } };
+  }
+  if (providerId !== "searxng") return { providerId, configuration: { pipeline } };
   const baseUrl = String(configuration.baseUrl ?? "").trim();
   try {
     new URL(baseUrl);
-    return { providerId, configuration: { baseUrl } };
+    return { providerId, configuration: { baseUrl, pipeline } };
   } catch {
-    return { providerId: "exa", configuration: {} };
+    return { providerId: "exa", configuration: { pipeline } };
   }
 }
 

--- a/lib/web-search-pipeline.ts
+++ b/lib/web-search-pipeline.ts
@@ -1,0 +1,643 @@
+import { throwIfChatTurnAborted } from "@/lib/chat-turn-control";
+import { MAX_RUNTIME_TOOL_RESULT_CHARS, truncateText } from "@/lib/bounded-text";
+import { getLatestUserPromptContent } from "@/lib/prompt-analysis";
+import { callProviderText } from "@/lib/provider";
+import { searchWeb } from "@/lib/web-search";
+import type { WebSearchPipelineMode } from "@/lib/web-search-catalog";
+import type { PromptMessage, RuntimeAppSettings, RuntimeProviderProfile } from "@/lib/types";
+
+export type WebSearchPipelinePlan =
+  | { action: "direct" }
+  | { action: "fan_out"; subqueries: string[] };
+
+export type WebSearchPipelineStrategy = "direct" | "fan_out";
+
+export type WebSearchPipelineResult = {
+  resultSummary: string;
+  strategy: WebSearchPipelineStrategy;
+  plannedQueries: string[];
+  succeeded: number;
+  failed: number;
+  duplicates: number;
+};
+
+export const WEB_SEARCH_PLANNING_TIMEOUT_MS = 15_000;
+const PLANNING_USER_CONTEXT_MAX_CHARS = 2_000;
+const RRF_K = 60;
+const MIN_FAN_OUT_QUERIES = 2;
+
+const TRACKING_URL_PARAMS = new Set([
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_term",
+  "utm_content",
+  "utm_id",
+  "utm_name",
+  "fbclid",
+  "gclid",
+  "msclkid",
+  "igshid",
+  "mc_cid",
+  "mc_eid",
+  "ref",
+  "ref_src",
+  "ref_url",
+  "spm",
+  "vd_source",
+  "si"
+]);
+
+const URL_PATTERN = /(https?:\/\/[^\s<>"'`]+)/g;
+
+function combinedAbortSignal(signals: Array<AbortSignal | undefined>): AbortSignal | undefined {
+  const present = signals.filter((signal): signal is AbortSignal => Boolean(signal));
+  if (!present.length) return undefined;
+  if (present.length === 1) return present[0];
+  const controller = new AbortController();
+  const abort = () => {
+    for (const signal of present) signal.removeEventListener("abort", abort);
+    if (!controller.signal.aborted) {
+      controller.abort(present.find((signal) => signal.aborted)?.reason);
+    }
+  };
+  for (const signal of present) {
+    if (signal.aborted) {
+      abort();
+      break;
+    }
+    signal.addEventListener("abort", abort, { once: true });
+  }
+  return controller.signal;
+}
+
+export function normalizeResultUrl(raw: string): string | null {
+  try {
+    const url = new URL(raw);
+    url.hash = "";
+    url.username = "";
+    url.password = "";
+    for (const key of [...url.searchParams.keys()]) {
+      if (TRACKING_URL_PARAMS.has(key.toLowerCase())) url.searchParams.delete(key);
+    }
+    url.searchParams.sort();
+    let normalized = `${url.protocol}//${url.host}${url.pathname.replace(/\/+$/, "")}`;
+    const search = url.searchParams.toString();
+    if (search) normalized += `?${search}`;
+    return normalized;
+  } catch {
+    return null;
+  }
+}
+
+function extractUrls(text: string): string[] {
+  const matches = text.match(URL_PATTERN) ?? [];
+  return matches.map((match) => match.replace(/[)\]},.;:!?]+$/, ""));
+}
+
+export function parsePlanningResponse(text: unknown): WebSearchPipelinePlan | null {
+  if (typeof text !== "string" || !text.trim()) return null;
+  const candidates: string[] = [text.trim()];
+  const firstBrace = text.indexOf("{");
+  const lastBrace = text.lastIndexOf("}");
+  if (firstBrace >= 0 && lastBrace > firstBrace) {
+    candidates.unshift(text.slice(firstBrace, lastBrace + 1));
+  }
+
+  for (const candidate of candidates) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(candidate);
+    } catch {
+      continue;
+    }
+    if (!parsed || typeof parsed !== "object") continue;
+    const plan = parsed as { action?: unknown; subqueries?: unknown };
+    if (plan.action === "direct") return { action: "direct" };
+    if (plan.action !== "fan_out") continue;
+    if (!Array.isArray(plan.subqueries)) continue;
+    const subqueries = plan.subqueries
+      .filter((item): item is string => typeof item === "string")
+      .map((item) => item.trim())
+      .filter(Boolean);
+    if (subqueries.length < MIN_FAN_OUT_QUERIES) continue;
+    return { action: "fan_out", subqueries };
+  }
+  return null;
+}
+
+export function normalizeSubqueries(queries: string[], maxQueries: number): string[] {
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+  for (const query of queries) {
+    const trimmed = query.trim();
+    if (!trimmed) continue;
+    const key = trimmed.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    normalized.push(trimmed);
+    if (normalized.length >= maxQueries) break;
+  }
+  return normalized;
+}
+
+const QUERY_CACHE_TTL_MS = 15 * 60 * 1000;
+const DUPLICATE_SIMILARITY_THRESHOLD = 0.7;
+const DUPLICATE_MIN_WORDS = 5;
+
+type CachedQueryEntry = { query: string; words: Set<string>; at: number };
+const queryCache = new Map<string, Map<string, CachedQueryEntry>>();
+
+export function clearWebSearchQueryCache() {
+  queryCache.clear();
+}
+
+function queryWords(query: string): Set<string> {
+  return new Set(
+    query
+      .toLowerCase()
+      .replace(/[^\p{L}\p{N}]+/gu, " ")
+      .trim()
+      .split(/\s+/)
+      .filter(Boolean)
+  );
+}
+
+function normalizedQueryKey(query: string): string {
+  return [...queryWords(query)].sort().join(" ");
+}
+
+function jaccardSimilarity(a: Set<string>, b: Set<string>): number {
+  if (!a.size || !b.size) return 0;
+  let intersection = 0;
+  for (const word of a) {
+    if (b.has(word)) intersection += 1;
+  }
+  return intersection / (a.size + b.size - intersection);
+}
+
+export function findDuplicateQuery(scopeKey: string, query: string): string | null {
+  const scope = queryCache.get(scopeKey);
+  if (!scope) return null;
+  const now = Date.now();
+  const words = queryWords(query);
+  const exact = scope.get(normalizedQueryKey(query));
+  if (exact && now - exact.at <= QUERY_CACHE_TTL_MS) return exact.query;
+
+  let best: { query: string; similarity: number } | null = null;
+  for (const entry of scope.values()) {
+    if (now - entry.at > QUERY_CACHE_TTL_MS) continue;
+    if (words.size < DUPLICATE_MIN_WORDS || entry.words.size < DUPLICATE_MIN_WORDS) continue;
+    const similarity = jaccardSimilarity(words, entry.words);
+    if (!best || similarity > best.similarity) best = { query: entry.query, similarity };
+  }
+  return best && best.similarity >= DUPLICATE_SIMILARITY_THRESHOLD ? best.query : null;
+}
+
+function recordQuery(scopeKey: string, query: string) {
+  let scope = queryCache.get(scopeKey);
+  if (!scope) {
+    scope = new Map();
+    queryCache.set(scopeKey, scope);
+  }
+  scope.set(normalizedQueryKey(query), { query, words: queryWords(query), at: Date.now() });
+}
+
+function forgetQuery(scopeKey: string, query: string) {
+  queryCache.get(scopeKey)?.delete(normalizedQueryKey(query));
+}
+
+export function buildPlanningPrompt(input: {
+  query: string;
+  userContext?: string;
+  forceFanOut: boolean;
+  maxQueries: number;
+}): string {
+  const userContext = (input.userContext ?? "").slice(0, PLANNING_USER_CONTEXT_MAX_CHARS).trim();
+  const lines = [
+    "You plan web searches for an AI assistant. The assistant wants to search the web."
+  ];
+  if (userContext) {
+    lines.push("", "Latest user message:", userContext);
+  }
+  lines.push("", `Assistant's search query: "${input.query}"`, "");
+  if (input.forceFanOut) {
+    lines.push(
+      "Split this search into parallel sub-queries that together cover everything needed to answer.",
+      `Reply with ONLY minified JSON, no markdown fences, no extra text:`,
+      `{"action":"fan_out","subqueries":["<query 1>","<query 2>",...]}`
+    );
+  } else {
+    lines.push(
+      "Decide how to execute this search:",
+      '- "direct" if one straightforward search is enough: a single fact, entity, definition, price, score, date, or a navigational lookup.',
+      '- "fan_out" if the question spans multiple distinct facets, comparisons, multiple entities, or if different phrasings would surface different sources.',
+      "",
+      "Reply with ONLY minified JSON, no markdown fences, no extra text:",
+      '{"action":"direct"}',
+      "or",
+      '{"action":"fan_out","subqueries":["<query 1>","<query 2>",...]}'
+    );
+  }
+  lines.push(
+    "",
+    "Sub-query rules:",
+    `- Between ${MIN_FAN_OUT_QUERIES} and ${input.maxQueries} queries, each a standalone search-engine-style query.`,
+    "- Each targets a DIFFERENT facet needed to answer; no near-duplicates.",
+    "- Same language as the user's question. Keep each under roughly 12 words."
+  );
+  return lines.join("\n");
+}
+
+export async function planWebSearch(input: {
+  providerProfile?: RuntimeProviderProfile;
+  query: string;
+  userContext?: string;
+  forceFanOut: boolean;
+  maxQueries: number;
+  abortSignal?: AbortSignal;
+}): Promise<WebSearchPipelinePlan> {
+  if (!input.providerProfile) return { action: "direct" };
+  try {
+    const timeoutSignal = AbortSignal.timeout(WEB_SEARCH_PLANNING_TIMEOUT_MS);
+    const text = await callProviderText({
+      settings: input.providerProfile,
+      prompt: buildPlanningPrompt({
+        query: input.query,
+        userContext: input.userContext,
+        forceFanOut: input.forceFanOut,
+        maxQueries: input.maxQueries
+      }),
+      purpose: "web_search_planning",
+      abortSignal: combinedAbortSignal([input.abortSignal, timeoutSignal])
+    });
+    return parsePlanningResponse(text) ?? { action: "direct" };
+  } catch {
+    throwIfChatTurnAborted(input.abortSignal);
+    return { action: "direct" };
+  }
+}
+
+type FanOutSection = {
+  query: string;
+  status: "fulfilled" | "rejected";
+  text: string;
+  error?: string;
+  duplicateOf?: string;
+};
+
+async function runSearchWithTimeout(input: {
+  query: string;
+  settings: RuntimeAppSettings;
+  maxResults?: number;
+  timeoutMs: number;
+  abortSignal?: AbortSignal;
+}): Promise<string> {
+  const perSearchSignal = combinedAbortSignal([
+    input.abortSignal,
+    AbortSignal.timeout(input.timeoutMs)
+  ]);
+  return searchWeb({
+    settings: input.settings,
+    query: input.query,
+    maxResults: input.maxResults,
+    abortSignal: perSearchSignal,
+    timeout: input.timeoutMs
+  });
+}
+
+const MAX_CONCURRENT_SEARCHES = 4;
+const SEARCH_RETRY_DELAY_MS = 400;
+
+let activeConcurrentSearches = 0;
+const searchSlotWaiters: Array<() => void> = [];
+
+async function acquireSearchSlot(): Promise<void> {
+  if (activeConcurrentSearches >= MAX_CONCURRENT_SEARCHES) {
+    await new Promise<void>((resolve) => searchSlotWaiters.push(resolve));
+    return;
+  }
+  activeConcurrentSearches += 1;
+}
+
+function releaseSearchSlot(): void {
+  const next = searchSlotWaiters.shift();
+  if (next) {
+    next();
+    return;
+  }
+  activeConcurrentSearches = Math.max(0, activeConcurrentSearches - 1);
+}
+
+async function runSearchWithRetry(input: {
+  query: string;
+  settings: RuntimeAppSettings;
+  maxResults?: number;
+  timeoutMs: number;
+  abortSignal?: AbortSignal;
+}): Promise<string> {
+  await acquireSearchSlot();
+  try {
+    try {
+      return await runSearchWithTimeout(input);
+    } catch (error) {
+      if (input.abortSignal?.aborted) throw error;
+      await new Promise((resolve) => setTimeout(resolve, SEARCH_RETRY_DELAY_MS));
+      throwIfChatTurnAborted(input.abortSignal);
+      return await runSearchWithTimeout(input);
+    }
+  } finally {
+    releaseSearchSlot();
+  }
+}
+
+export async function runWebSearchFanOut(input: {
+  subqueries: string[];
+  settings: RuntimeAppSettings;
+  maxResults?: number;
+  timeoutMs?: number;
+  abortSignal?: AbortSignal;
+}): Promise<FanOutSection[]> {
+  const timeoutMs = input.timeoutMs ?? 120_000;
+  const results = await Promise.allSettled(
+    input.subqueries.map((query) =>
+      runSearchWithRetry({
+        query,
+        settings: input.settings,
+        maxResults: input.maxResults,
+        timeoutMs,
+        abortSignal: input.abortSignal
+      })
+    )
+  );
+  throwIfChatTurnAborted(input.abortSignal);
+  return results.map((result, index) => {
+    const query = input.subqueries[index];
+    if (result.status === "fulfilled") {
+      return { query, status: "fulfilled" as const, text: result.value };
+    }
+    const reason = result.reason;
+    const message =
+      reason instanceof Error ? reason.message : typeof reason === "string" ? reason : "search failed";
+    return { query, status: "rejected" as const, text: "", error: truncateText(message, 200) };
+  });
+}
+
+type SectionParagraph = {
+  text: string;
+  url?: string;
+  rrf?: number;
+};
+
+function splitIntoParagraphs(text: string): string[] {
+  return text
+    .split(/\n\s*\n/)
+    .map((paragraph) => paragraph.trim())
+    .filter(Boolean);
+}
+
+function buildSectionParagraphs(text: string): SectionParagraph[] {
+  return splitIntoParagraphs(text).map((paragraphText) => {
+    const firstUrl = extractUrls(paragraphText).map(normalizeResultUrl).find(Boolean);
+    return firstUrl ? { text: paragraphText, url: firstUrl } : { text: paragraphText };
+  });
+}
+
+function computeRrfScores(sections: Array<{ paragraphs: SectionParagraph[] }>): void {
+  const rankBySection = sections.map((section) => {
+    const ranks = new Map<string, number>();
+    let rank = 0;
+    for (const paragraph of section.paragraphs) {
+      if (!paragraph.url || ranks.has(paragraph.url)) continue;
+      rank += 1;
+      ranks.set(paragraph.url, rank);
+    }
+    return ranks;
+  });
+
+  sections.forEach((section, sectionIndex) => {
+    for (const paragraph of section.paragraphs) {
+      if (!paragraph.url) continue;
+      let score = 0;
+      for (const ranks of rankBySection) {
+        const rank = ranks.get(paragraph.url);
+        if (rank) score += 1 / (RRF_K + rank);
+      }
+      paragraph.rrf = score;
+    }
+  });
+}
+
+export function fuseFanOutResults(
+  sections: FanOutSection[],
+  maxChars = MAX_RUNTIME_TOOL_RESULT_CHARS
+): string {
+  const succeededSections = sections.filter(
+    (section) => section.status === "fulfilled" && !section.duplicateOf
+  );
+  const failedSections = sections.filter((section) => section.status === "rejected");
+  const duplicateSections = sections.filter((section) => section.duplicateOf);
+  const parsedSections = succeededSections.map((section) => ({
+    ...section,
+    paragraphs: buildSectionParagraphs(section.text)
+  }));
+
+  computeRrfScores(parsedSections);
+
+  const seenUrls = new Set<string>();
+  let duplicatesRemoved = 0;
+  for (const section of parsedSections) {
+    section.paragraphs = section.paragraphs.filter((paragraph) => {
+      if (!paragraph.url) return true;
+      if (seenUrls.has(paragraph.url)) {
+        duplicatesRemoved += 1;
+        return false;
+      }
+      seenUrls.add(paragraph.url);
+      return true;
+    });
+  }
+
+  const headerLines = [
+    `Parallel web search results (${sections.length} queries: ${succeededSections.length} succeeded, ${failedSections.length} failed${
+      duplicateSections.length
+        ? `, ${duplicateSections.length} already searched this turn`
+        : ""
+    }${duplicatesRemoved ? `, ${duplicatesRemoved} duplicate result${duplicatesRemoved === 1 ? "" : "s"} removed` : ""}).`
+  ];
+
+  const bodyBudget = Math.max(1_000, maxChars - 500);
+  const perSectionBudget = Math.max(200, Math.floor(bodyBudget / Math.max(1, parsedSections.length)));
+  const sectionBlocks: string[] = [];
+
+  for (const section of parsedSections) {
+    let kept = section.paragraphs;
+    let usedChars = kept.reduce((total, paragraph) => total + paragraph.text.length + 2, 0);
+    if (usedChars > perSectionBudget) {
+      const droppable = kept
+        .filter((paragraph) => paragraph.url !== undefined)
+        .sort((a, b) => (a.rrf ?? 0) - (b.rrf ?? 0));
+      for (const paragraph of droppable) {
+        if (usedChars <= perSectionBudget || kept.length <= 1) break;
+        kept = kept.filter((candidate) => candidate !== paragraph);
+        usedChars -= paragraph.text.length + 2;
+      }
+    }
+    sectionBlocks.push(
+      [`## Query: "${section.query}"`, truncateText(kept.map((paragraph) => paragraph.text).join("\n\n"), perSectionBudget)].join(
+        "\n"
+      )
+    );
+  }
+
+  for (const section of failedSections) {
+    sectionBlocks.push(`## Query: "${section.query}" (failed: ${section.error ?? "search failed"})`);
+  }
+
+  for (const section of duplicateSections) {
+    sectionBlocks.push(
+      `## Query: "${section.query}" (already searched this turn as "${section.duplicateOf}" — see its results above)`
+    );
+  }
+
+  return truncateText([...headerLines, "", ...sectionBlocks].join("\n\n"), maxChars);
+}
+
+export async function runWebSearchPipeline(input: {
+  query?: string;
+  queries?: string[];
+  mode: WebSearchPipelineMode;
+  maxQueries: number;
+  maxResults?: number;
+  settings: RuntimeAppSettings;
+  providerProfile?: RuntimeProviderProfile;
+  userContext?: string;
+  mcpTimeout?: number;
+  abortSignal?: AbortSignal;
+  assistantMessageId?: string;
+  conversationId?: string;
+}): Promise<WebSearchPipelineResult> {
+  throwIfChatTurnAborted(input.abortSignal);
+
+  const scopeKey = input.mode === "off"
+    ? undefined
+    : input.assistantMessageId ?? input.conversationId;
+
+  const explicitQueries = normalizeSubqueries(input.queries ?? [], input.maxQueries);
+  let strategy: WebSearchPipelineStrategy;
+  let plannedQueries: string[];
+
+  if (input.mode === "off") {
+    strategy = "direct";
+    plannedQueries = [input.query || explicitQueries[0] || ""].filter(Boolean);
+  } else if (explicitQueries.length >= MIN_FAN_OUT_QUERIES) {
+    strategy = "fan_out";
+    plannedQueries = explicitQueries;
+  } else {
+    const plan = await planWebSearch({
+      providerProfile: input.providerProfile,
+      query: input.query || explicitQueries[0] || "",
+      userContext: input.userContext,
+      forceFanOut: input.mode === "always",
+      maxQueries: input.maxQueries,
+      abortSignal: input.abortSignal
+    });
+    const subqueries = plan.action === "fan_out"
+      ? normalizeSubqueries(plan.subqueries, input.maxQueries)
+      : [];
+    if (subqueries.length >= MIN_FAN_OUT_QUERIES) {
+      strategy = "fan_out";
+      plannedQueries = subqueries;
+    } else {
+      strategy = "direct";
+      plannedQueries = [input.query || explicitQueries[0] || ""].filter(Boolean);
+    }
+  }
+
+  if (strategy === "direct") {
+    const query = plannedQueries[0];
+    if (!query) {
+      throw new Error("query is required");
+    }
+    if (scopeKey) {
+      const duplicateOf = findDuplicateQuery(scopeKey, query);
+      if (duplicateOf) {
+        return {
+          resultSummary: `Skipped search: this query is a near-duplicate of "${duplicateOf}" which was already searched earlier in this turn. Its results are already in the conversation above. Refine the query if you need different information, or answer using the results you already have.`,
+          strategy,
+          plannedQueries: [query],
+          succeeded: 0,
+          failed: 0,
+          duplicates: 1
+        };
+      }
+    }
+    const resultSummary = truncateText(
+      await runSearchWithRetry({
+        query,
+        settings: input.settings,
+        maxResults: input.maxResults,
+        timeoutMs: input.mcpTimeout ?? 120_000,
+        abortSignal: input.abortSignal
+      }),
+      MAX_RUNTIME_TOOL_RESULT_CHARS
+    );
+    if (scopeKey) recordQuery(scopeKey, query);
+    return { resultSummary, strategy, plannedQueries: [query], succeeded: 1, failed: 0, duplicates: 0 };
+  }
+
+  const freshSubqueries: string[] = [];
+  const duplicateOfByQuery = new Map<string, string>();
+  for (const subquery of plannedQueries) {
+    const duplicateOf = scopeKey ? findDuplicateQuery(scopeKey, subquery) : null;
+    if (duplicateOf) {
+      duplicateOfByQuery.set(subquery, duplicateOf);
+    } else {
+      if (scopeKey) recordQuery(scopeKey, subquery);
+      freshSubqueries.push(subquery);
+    }
+  }
+
+  const freshSections = await runWebSearchFanOut({
+    subqueries: freshSubqueries,
+    settings: input.settings,
+    maxResults: input.maxResults,
+    timeoutMs: input.mcpTimeout,
+    abortSignal: input.abortSignal
+  });
+  for (const section of freshSections) {
+    if (section.status === "rejected" && scopeKey) {
+      forgetQuery(scopeKey, section.query);
+    }
+  }
+
+  const sections: FanOutSection[] = plannedQueries.map((query) => {
+    const duplicateOf = duplicateOfByQuery.get(query);
+    if (duplicateOf) return { query, status: "fulfilled" as const, text: "", duplicateOf };
+    return freshSections.find((section) => section.query === query)!;
+  });
+
+  const succeeded = sections.filter(
+    (section) => section.status === "fulfilled" && !section.duplicateOf
+  ).length;
+  const duplicates = sections.filter((section) => section.duplicateOf).length;
+  const failed = sections.length - succeeded - duplicates;
+  if (!succeeded && !duplicates) {
+    const firstError = sections.find((section) => section.error)?.error ?? "search failed";
+    throw new Error(`All ${sections.length} web searches failed: ${firstError}`);
+  }
+
+  return {
+    resultSummary: fuseFanOutResults(sections),
+    strategy,
+    plannedQueries,
+    succeeded,
+    failed,
+    duplicates
+  };
+}
+
+export function getPipelineUserContext(promptMessages: PromptMessage[] | undefined): string {
+  if (!promptMessages?.length) return "";
+  return getLatestUserPromptContent(promptMessages);
+}

--- a/lib/web-search.ts
+++ b/lib/web-search.ts
@@ -4,7 +4,7 @@ import {
   getWebSearchReadinessError as getCatalogReadinessError,
   type WebSearchProviderId
 } from "@/lib/web-search-catalog";
-import type { McpServer, RuntimeAppSettings } from "@/lib/types";
+import type { McpServer, McpTool, RuntimeAppSettings } from "@/lib/types";
 
 type WebSearchInput = {
   query: string;
@@ -39,6 +39,37 @@ function mcpServer(url: string): McpServer {
   };
 }
 
+const WEB_SEARCH_DISCOVERY_CACHE_TTL_MS = 5 * 60 * 1000;
+
+type DiscoveryCacheEntry =
+  | { tools: McpTool[]; promise?: undefined; expiresAt: number }
+  | { tools?: undefined; promise: Promise<McpTool[]>; expiresAt: number };
+
+const discoveryCache = new Map<string, DiscoveryCacheEntry>();
+
+export function clearWebSearchDiscoveryCache() {
+  discoveryCache.clear();
+}
+
+async function discoverSearchToolsCached(server: McpServer, abortSignal?: AbortSignal): Promise<McpTool[]> {
+  const key = server.url;
+  const cached = discoveryCache.get(key);
+  if (cached?.tools) return cached.tools;
+  if (cached?.promise) return cached.promise;
+
+  const promise = discoverMcpTools(server, abortSignal)
+    .then((tools) => {
+      discoveryCache.set(key, { tools, expiresAt: Date.now() + WEB_SEARCH_DISCOVERY_CACHE_TTL_MS });
+      return tools;
+    })
+    .catch((error) => {
+      discoveryCache.delete(key);
+      throw error;
+    });
+  discoveryCache.set(key, { promise, expiresAt: Number.MAX_SAFE_INTEGER });
+  return promise;
+}
+
 async function callSearchMcp(input: {
   server: McpServer;
   preferredToolNames: string[];
@@ -46,11 +77,14 @@ async function callSearchMcp(input: {
   timeout?: number;
   abortSignal?: AbortSignal;
 }) {
-  const tools = await discoverMcpTools(input.server, input.abortSignal);
+  const tools = await discoverSearchToolsCached(input.server, input.abortSignal);
   const tool = input.preferredToolNames
     .map((name) => tools.find((candidate) => candidate.name === name))
     .find(Boolean);
-  if (!tool) throw new Error("The configured search provider did not expose its search tool");
+  if (!tool) {
+    discoveryCache.delete(input.server.url);
+    throw new Error("The configured search provider did not expose its search tool");
+  }
   const result = await callMcpTool(
     input.server,
     tool.name,

--- a/tests/unit/assistant-runtime.test.ts
+++ b/tests/unit/assistant-runtime.test.ts
@@ -497,7 +497,8 @@ ${JSON.stringify({
     expect(searchSearxng).toHaveBeenCalledWith({
       baseUrl: "https://search.example.com",
       query: "Eidon",
-      maxResults: undefined
+      maxResults: undefined,
+      abortSignal: expect.any(AbortSignal)
     });
     expect(started).toEqual([
       expect.objectContaining({
@@ -563,6 +564,290 @@ ${JSON.stringify({
       })
     ]);
     expect(result.answer).toBe("Final answer");
+  });
+
+  it("exposes the parallel queries tool schema while the pipeline is active", async () => {
+    const { buildToolDefinitions } = await import("@/lib/tool-definitions");
+
+    const tools = buildToolDefinitions({
+      mcpToolSets: [],
+      skills: [],
+      loadedSkillIds: new Set(),
+      memoriesEnabled: false,
+      webSearchEnabled: true,
+      webSearchPipelineMode: "auto",
+      effectiveVisionMode: "provider"
+    });
+    const webSearchTool = tools.find((tool) => tool.function.name === "web_search")!;
+
+    expect(webSearchTool.function.description).toContain("parallel");
+    expect(webSearchTool.function.parameters).toMatchObject({
+      properties: {
+        query: { type: "string" },
+        queries: { type: "array", items: { type: "string" } }
+      }
+    });
+    expect(webSearchTool.function.parameters).not.toHaveProperty("required");
+  });
+
+  it("keeps the legacy tool schema when the pipeline is off", async () => {
+    const { buildToolDefinitions } = await import("@/lib/tool-definitions");
+
+    const tools = buildToolDefinitions({
+      mcpToolSets: [],
+      skills: [],
+      loadedSkillIds: new Set(),
+      memoriesEnabled: false,
+      webSearchEnabled: true,
+      webSearchPipelineMode: "off",
+      effectiveVisionMode: "provider"
+    });
+    const webSearchTool = tools.find((tool) => tool.function.name === "web_search")!;
+
+    expect(webSearchTool.function.parameters).toMatchObject({
+      properties: { query: { type: "string" } },
+      required: ["query"]
+    });
+    expect((webSearchTool.function.parameters!.properties as Record<string, unknown>)).not.toHaveProperty("queries");
+  });
+
+  it("fans a single web search out into parallel sub-queries via the planner", async () => {
+    callProviderText.mockResolvedValueOnce(
+      '{"action":"fan_out","subqueries":["vision pro price","vision pro review 2026"]}'
+    );
+    streamProviderResponse
+      .mockReturnValueOnce(
+        createProviderStream([], {
+          answer: "",
+          thinking: "",
+          toolCalls: [{ id: "call_1", name: "web_search", arguments: JSON.stringify({ query: "vision pro" }) }],
+          usage: { inputTokens: 9 }
+        })
+      )
+      .mockReturnValueOnce(
+        createProviderStream([{ type: "answer_delta", text: "Synthesized answer" }], {
+          answer: "Synthesized answer",
+          thinking: "",
+          usage: { inputTokens: 11, outputTokens: 3 }
+        })
+      );
+    searchSearxng.mockResolvedValue("SearXNG result text");
+
+    const started: Array<{ label: string; detail?: string }> = [];
+    const completed: Array<{ handle?: string; resultSummary?: string }> = [];
+    const { resolveAssistantTurn } = await import("@/lib/assistant-runtime");
+
+    const result = await resolveAssistantTurn({
+      settings: createSettings(),
+      promptMessages: [{ role: "user", content: "What about the vision pro?" }],
+      skills: [],
+      mcpToolSets: [],
+      appSettings: createAppSettings({
+        webSearch: {
+          providerId: "searxng",
+          configuration: { baseUrl: "https://search.example.com" }
+        }
+      }),
+      onEvent: () => {},
+      onActionStart: (action) => {
+        started.push(action);
+        return "act_web_search";
+      },
+      onActionComplete: (handle, patch) => {
+        completed.push({ handle, resultSummary: patch.resultSummary });
+      }
+    });
+
+    expect(callProviderText).toHaveBeenCalledWith(expect.objectContaining({
+      purpose: "web_search_planning"
+    }));
+    const searchedQueries = searchSearxng.mock.calls.map((call) => call[0].query);
+    expect(searchedQueries).toEqual(["vision pro price", "vision pro review 2026"]);
+    expect(started).toHaveLength(1);
+    expect(completed).toHaveLength(1);
+    expect(completed[0].resultSummary).toContain("Parallel web search results (2 queries: 2 succeeded, 0 failed)");
+    expect(result.answer).toBe("Synthesized answer");
+  });
+
+  it("executes same-step web search calls concurrently", async () => {
+    const started: string[] = [];
+    let release: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    searchSearxng.mockImplementation(async ({ query }: { query: string }) => {
+      started.push(query);
+      await gate;
+      return `result ${query}`;
+    });
+
+    streamProviderResponse
+      .mockReturnValueOnce(
+        createProviderStream([], {
+          answer: "",
+          thinking: "",
+          toolCalls: [
+            { id: "call_1", name: "web_search", arguments: JSON.stringify({ query: "alpha query" }) },
+            { id: "call_2", name: "web_search", arguments: JSON.stringify({ query: "beta query" }) }
+          ],
+          usage: { inputTokens: 9 }
+        })
+      )
+      .mockReturnValueOnce(
+        createProviderStream([{ type: "answer_delta", text: "Done" }], {
+          answer: "Done",
+          thinking: "",
+          usage: { inputTokens: 11, outputTokens: 3 }
+        })
+      );
+
+    const { resolveAssistantTurn } = await import("@/lib/assistant-runtime");
+
+    const runPromise = resolveAssistantTurn({
+      settings: createSettings(),
+      promptMessages: [{ role: "user", content: "search two things" }],
+      skills: [],
+      mcpToolSets: [],
+      appSettings: createAppSettings({
+        webSearch: {
+          providerId: "searxng",
+          configuration: { baseUrl: "https://search.example.com" }
+        }
+      }),
+      onEvent: () => {},
+      onActionStart: () => "act_ws"
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(started).toEqual(["alpha query", "beta query"]);
+
+    release();
+    const result = await runPromise;
+    expect(result.answer).toBe("Done");
+
+    const followUpMessages = streamProviderResponse.mock.calls[1][0].promptMessages as Array<{
+      role: string;
+      content: unknown;
+    }>;
+    const toolResults = followUpMessages.filter((message) => message.role === "tool");
+    expect(toolResults.map((message) => message.content)).toEqual([
+      "result alpha query",
+      "result beta query"
+    ]);
+  });
+
+  it("keeps mixed steps sequential and appends results in call order", async () => {
+    searchSearxng.mockResolvedValue("SearXNG result text");
+    localShellMocks.executeLocalShellCommand.mockResolvedValue({
+      stdout: "ok",
+      stderr: "",
+      exitCode: 0,
+      timedOut: false,
+      isError: false
+    });
+    localShellMocks.summarizeShellResult.mockReturnValue("shell ok");
+
+    streamProviderResponse
+      .mockReturnValueOnce(
+        createProviderStream([], {
+          answer: "",
+          thinking: "",
+          toolCalls: [
+            { id: "call_1", name: "web_search", arguments: JSON.stringify({ query: "mixed search" }) },
+            {
+              id: "call_2",
+              name: "execute_shell_command",
+              arguments: JSON.stringify({ command: "echo hi" })
+            }
+          ],
+          usage: { inputTokens: 9 }
+        })
+      )
+      .mockReturnValueOnce(
+        createProviderStream([{ type: "answer_delta", text: "Done" }], {
+          answer: "Done",
+          thinking: "",
+          usage: { inputTokens: 11, outputTokens: 3 }
+        })
+      );
+
+    const { resolveAssistantTurn } = await import("@/lib/assistant-runtime");
+
+    const result = await resolveAssistantTurn({
+      settings: createSettings(),
+      promptMessages: [{ role: "user", content: "search and run a command" }],
+      skills: [],
+      mcpToolSets: [],
+      appSettings: createAppSettings({
+        webSearch: {
+          providerId: "searxng",
+          configuration: { baseUrl: "https://search.example.com" }
+        }
+      }),
+      onEvent: () => {},
+      onActionStart: () => "act_mixed"
+    });
+
+    expect(result.answer).toBe("Done");
+
+    const followUpMessages = streamProviderResponse.mock.calls[1][0].promptMessages as Array<{
+      role: string;
+      content: unknown;
+    }>;
+    const toolResults = followUpMessages.filter((message) => message.role === "tool");
+    expect(toolResults).toHaveLength(2);
+    expect(toolResults[0].content).toBe("SearXNG result text");
+    expect(String(toolResults[1].content)).toContain("shell ok");
+  });
+
+  it("tells the model to answer now after a successful web search", async () => {
+    streamProviderResponse
+      .mockReturnValueOnce(
+        createProviderStream([], {
+          answer: "",
+          thinking: "",
+          toolCalls: [{ id: "call_1", name: "web_search", arguments: JSON.stringify({ query: "breaking news" }) }],
+          usage: { inputTokens: 9 }
+        })
+      )
+      .mockReturnValueOnce(
+        createProviderStream([{ type: "answer_delta", text: "Here is the news." }], {
+          answer: "Here is the news.",
+          thinking: "",
+          usage: { inputTokens: 11, outputTokens: 3 }
+        })
+      );
+    searchSearxng.mockResolvedValue("SearXNG result text");
+
+    const { resolveAssistantTurn } = await import("@/lib/assistant-runtime");
+
+    const result = await resolveAssistantTurn({
+      settings: createSettings(),
+      promptMessages: [{ role: "user", content: "news?" }],
+      skills: [],
+      mcpToolSets: [],
+      appSettings: createAppSettings({
+        webSearch: {
+          providerId: "searxng",
+          configuration: { baseUrl: "https://search.example.com" }
+        }
+      }),
+      onEvent: () => {},
+      onActionStart: () => "act_ws"
+    });
+
+    expect(result.answer).toBe("Here is the news.");
+    const followUpMessages = streamProviderResponse.mock.calls[1][0].promptMessages as Array<{
+      role: string;
+      content: unknown;
+    }>;
+    const directiveMessage = followUpMessages.find(
+      (message) =>
+        message.role === "system" &&
+        typeof message.content === "string" &&
+        message.content.includes("Answer the user now by synthesizing the results above")
+    );
+    expect(directiveMessage).toBeDefined();
   });
 
   it("executes unrestricted shell commands via native function calling", async () => {

--- a/tests/unit/chat-turn.test.ts
+++ b/tests/unit/chat-turn.test.ts
@@ -8,7 +8,12 @@ const { requireUserMock } = vi.hoisted(() => ({
 }));
 
 vi.mock("@/lib/provider", () => ({
-  streamProviderResponse: vi.fn()
+  streamProviderResponse: vi.fn(),
+  callProviderText: vi.fn()
+}));
+
+vi.mock("@/lib/searxng", () => ({
+  searchSearxng: vi.fn().mockResolvedValue("SearXNG parallel result")
 }));
 
 vi.mock("@/lib/auth", () => ({
@@ -308,6 +313,102 @@ describe("chat-turn", () => {
     await startChatTurn(manager, conv.id, "Hi", []);
 
     expect(mockedGatherAllMcpTools).not.toHaveBeenCalled();
+  });
+
+  it("persists one umbrella action for a fanned-out web search", async () => {
+    const { streamProviderResponse, callProviderText } = await import("@/lib/provider");
+    const mockedStreamProviderResponse = vi.mocked(streamProviderResponse);
+    const mockedCallProviderText = vi.mocked(callProviderText);
+    const { searchSearxng } = await import("@/lib/searxng");
+    const mockedSearchSearxng = vi.mocked(searchSearxng);
+    const { createConversationManager } = await import("@/lib/conversation-manager");
+    const { updateProviderCatalog } = await import("@/lib/settings");
+    const { updateIntegrationSetting } = await import("@/lib/integration-settings");
+    const { createLocalUser: createFanoutUser } = await import("@/lib/users");
+
+    const user = await createFanoutUser({
+      username: "web-search-fanout-owner",
+      password: "changeme123",
+      role: "user"
+    });
+    const manager = createConversationManager();
+    const { profileId, profile } = setupProviderProfile();
+
+    updateProviderCatalog({
+      defaultProviderProfileId: profileId,
+      skillsEnabled: false,
+      providerProfiles: [profile]
+    });
+    updateIntegrationSetting({
+      capability: "web_search",
+      providerId: "searxng",
+      configuration: {
+        baseUrl: "https://search.example.com",
+        pipeline: { mode: "always", maxQueries: 2 }
+      },
+      credentialAction: "preserve"
+    }, user.id);
+
+    const conv = (await import("@/lib/conversations")).createConversation(
+      undefined,
+      undefined,
+      { providerProfileId: null },
+      user.id
+    );
+
+    mockedCallProviderText.mockResolvedValueOnce(
+      '{"action":"fan_out","subqueries":["acme revenue","acme products"]}'
+    );
+    mockedStreamProviderResponse
+      .mockReturnValueOnce(
+        (async function* () {
+          return {
+            answer: "",
+            thinking: "",
+            toolCalls: [
+              {
+                id: "call_1",
+                name: "web_search",
+                arguments: JSON.stringify({ query: "acme performance" })
+              }
+            ],
+            usage: { inputTokens: 5 }
+          };
+        })()
+      )
+      .mockReturnValueOnce(
+        (async function* () {
+          yield { type: "answer_delta", text: "Synthesized." };
+          return {
+            answer: "Synthesized.",
+            thinking: "",
+            usage: { inputTokens: 5, outputTokens: 2 }
+          };
+        })()
+      );
+
+    const { startChatTurn } = await import("@/lib/chat-turn");
+    await startChatTurn(manager, conv.id, "How is acme doing?", []);
+
+    expect(mockedSearchSearxng.mock.calls.map((call) => call[0].query)).toEqual([
+      "acme revenue",
+      "acme products"
+    ]);
+
+    const { listVisibleMessages } = await import("@/lib/conversations");
+    const assistant = listVisibleMessages(conv.id).find((message) => message.role === "assistant");
+    const searchActions = (assistant?.actions ?? []).filter(
+      (action) => action.kind === "mcp_tool_call" && action.toolName === "web_search"
+    );
+
+    expect(searchActions).toHaveLength(1);
+    expect(searchActions[0]).toEqual(
+      expect.objectContaining({
+        label: "Web search",
+        status: "completed",
+        resultSummary: expect.stringContaining("Parallel web search results (2 queries: 2 succeeded, 0 failed)")
+      })
+    );
   });
 
   it("persists a partial assistant message as stopped when the turn is cancelled", async () => {

--- a/tests/unit/general-section.test.tsx
+++ b/tests/unit/general-section.test.tsx
@@ -393,6 +393,61 @@ describe("general section", () => {
     expect(screen.queryByLabelText("SearXNG base URL")).toBeNull();
   });
 
+  it("shows default pipeline controls and hides them when search is disabled", () => {
+    render(React.createElement(GeneralSection, { settings: makeSettings() }));
+
+    fireEvent.click(screen.getByRole("button", { name: /Web search/ }));
+    expect(screen.getByLabelText("Search pipeline mode")).toHaveValue("auto");
+    expect(screen.getByLabelText("Max parallel queries")).toHaveValue("4");
+
+    fireEvent.change(screen.getByLabelText("Web search engine"), {
+      target: { value: "disabled" }
+    });
+    expect(screen.queryByLabelText("Search pipeline mode")).toBeNull();
+    expect(screen.queryByLabelText("Max parallel queries")).toBeNull();
+  });
+
+  it("saves the selected pipeline configuration", async () => {
+    render(React.createElement(GeneralSection, { settings: makeSettings() }));
+
+    fireEvent.click(screen.getByRole("button", { name: /Web search/ }));
+    fireEvent.change(screen.getByLabelText("Search pipeline mode"), {
+      target: { value: "always" }
+    });
+    fireEvent.change(screen.getByLabelText("Max parallel queries"), {
+      target: { value: "2" }
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+    const body = JSON.parse(String(vi.mocked(global.fetch).mock.calls[0][1]?.body));
+    expect(body.webSearch).toMatchObject({
+      providerId: "exa",
+      configuration: { pipeline: { mode: "always", maxQueries: 2 } }
+    });
+  });
+
+  it("preserves the pipeline selection while switching engines", () => {
+    render(React.createElement(GeneralSection, { settings: makeSettings() }));
+
+    fireEvent.click(screen.getByRole("button", { name: /Web search/ }));
+    fireEvent.change(screen.getByLabelText("Search pipeline mode"), {
+      target: { value: "off" }
+    });
+    expect(screen.queryByLabelText("Max parallel queries")).toBeNull();
+
+    fireEvent.change(screen.getByLabelText("Web search engine"), {
+      target: { value: "tavily" }
+    });
+    expect(screen.getByLabelText("Search pipeline mode")).toHaveValue("off");
+
+    fireEvent.change(screen.getByLabelText("Search pipeline mode"), {
+      target: { value: "auto" }
+    });
+    expect(screen.getByLabelText("Max parallel queries")).toHaveValue("4");
+  });
+
   it("preserves search values while switching engines and hides engine-specific fields when disabled", () => {
     render(React.createElement(GeneralSection, { settings: makeSettings() }));
 

--- a/tests/unit/settings-route.test.ts
+++ b/tests/unit/settings-route.test.ts
@@ -190,7 +190,10 @@ describe("settings route", () => {
       settings: expect.objectContaining({
         webSearch: expect.objectContaining({
           providerId: "searxng",
-          configuration: { baseUrl: "https://search.example.com" },
+          configuration: {
+            baseUrl: "https://search.example.com",
+            pipeline: { mode: "auto", maxQueries: 4 }
+          },
           configured: true,
           scope: "user"
         })
@@ -226,7 +229,10 @@ describe("settings route", () => {
       settings: expect.objectContaining({
         webSearch: expect.objectContaining({
           providerId: "searxng",
-          configuration: { baseUrl: "http://192.168.1.10:8888" },
+          configuration: {
+            baseUrl: "http://192.168.1.10:8888",
+            pipeline: { mode: "auto", maxQueries: 4 }
+          },
           configured: true
         })
       })

--- a/tests/unit/settings.test.ts
+++ b/tests/unit/settings.test.ts
@@ -476,6 +476,47 @@ describe("settings domains", () => {
     });
   });
 
+  it("persists web search pipeline configuration through the settings bundle", async () => {
+    saveProfiles();
+    const user = await createLocalUser({
+      username: "web-search-pipeline-user",
+      password: "password-123",
+      role: "user"
+    });
+
+    updateGeneralSettingsBundleForUser(user.id, {
+      preferences: {
+        conversationRetention: "forever",
+        mcpTimeout: 120000,
+        maxAssistantToolSteps: 25,
+        confirmExternalLinks: true
+      },
+      webSearch: {
+        providerId: "exa",
+        configuration: { pipeline: { mode: "always", maxQueries: 3 } },
+        credentialAction: "preserve"
+      },
+      speechTranscription: {
+        providerId: "browser",
+        configuration: { language: "auto" },
+        credentialAction: "clear"
+      }
+    }, false);
+
+    expect(getSettingsForUser(user.id).webSearch).toMatchObject({
+      providerId: "exa",
+      configuration: { pipeline: { mode: "always", maxQueries: 3 } }
+    });
+
+    getDb().prepare(`
+      UPDATE integration_settings SET configuration_json = ?
+      WHERE capability = 'web_search' AND user_id = ?
+    `).run(JSON.stringify({ pipeline: { mode: "nonsense", maxQueries: 42 } }), user.id);
+    expect(getSettingsForUser(user.id).webSearch.configuration).toEqual({
+      pipeline: { mode: "auto", maxQueries: 5 }
+    });
+  });
+
   it("normalizes AssemblyAI configuration and isolates credentials when providers change", async () => {
     saveProfiles();
     const user = await createLocalUser({

--- a/tests/unit/web-search-pipeline.test.ts
+++ b/tests/unit/web-search-pipeline.test.ts
@@ -1,0 +1,732 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ChatTurnStoppedError } from "@/lib/chat-turn-control";
+import {
+  clearWebSearchQueryCache,
+  fuseFanOutResults,
+  normalizeResultUrl,
+  normalizeSubqueries,
+  parsePlanningResponse,
+  planWebSearch,
+  runWebSearchFanOut,
+  runWebSearchPipeline
+} from "@/lib/web-search-pipeline";
+import { executeToolCall } from "@/lib/tool-executors";
+import type { ToolSet } from "@/lib/tool-definitions";
+import type {
+  PromptMessage,
+  RuntimeAppSettings,
+  RuntimeProviderProfile,
+  Skill
+} from "@/lib/types";
+import {
+  createRuntimeAppSettings,
+  createRuntimeProviderProfile
+} from "@/tests/provider-fixtures";
+
+const { callProviderTextMock, searchWebMock } = vi.hoisted(() => ({
+  callProviderTextMock: vi.fn(),
+  searchWebMock: vi.fn()
+}));
+
+vi.mock("@/lib/provider", () => ({
+  streamProviderResponse: vi.fn(),
+  callProviderText: callProviderTextMock
+}));
+
+vi.mock("@/lib/web-search", () => ({
+  searchWeb: searchWebMock,
+  getWebSearchReadinessError: vi.fn(() => null)
+}));
+
+function makeSettings() {
+  return createRuntimeAppSettings({ webSearch: { providerId: "exa" } });
+}
+
+describe("parsePlanningResponse", () => {
+  it("parses a direct plan", () => {
+    expect(parsePlanningResponse('{"action":"direct"}')).toEqual({ action: "direct" });
+  });
+
+  it("parses a fan_out plan with subqueries", () => {
+    expect(parsePlanningResponse('{"action":"fan_out","subqueries":["a","b"]}')).toEqual({
+      action: "fan_out",
+      subqueries: ["a", "b"]
+    });
+  });
+
+  it("extracts JSON from noisy model output", () => {
+    const noisy = 'Here is the plan:\n```json\n{"action":"fan_out","subqueries":["q1","q2"]}\n```\nDone.';
+    expect(parsePlanningResponse(noisy)).toEqual({ action: "fan_out", subqueries: ["q1", "q2"] });
+  });
+
+  it("rejects junk, unknown actions, and short subquery lists", () => {
+    expect(parsePlanningResponse("no json here")).toBeNull();
+    expect(parsePlanningResponse('{"action":"explode"}')).toBeNull();
+    expect(parsePlanningResponse('{"action":"fan_out","subqueries":["only-one"]}')).toBeNull();
+    expect(parsePlanningResponse('{"action":"fan_out","subqueries":"not-an-array"}')).toBeNull();
+    expect(parsePlanningResponse(undefined)).toBeNull();
+    expect(parsePlanningResponse(42)).toBeNull();
+  });
+});
+
+describe("normalizeSubqueries", () => {
+  it("trims, dedupes case-insensitively, and caps at maxQueries", () => {
+    expect(normalizeSubqueries([" A ", "a", "b", "", "C"], 2)).toEqual(["A", "b"]);
+    expect(normalizeSubqueries(["a", "A", "b"], 5)).toEqual(["a", "b"]);
+  });
+});
+
+describe("normalizeResultUrl", () => {
+  it("strips tracking params, hashes, and trailing slashes", () => {
+    expect(normalizeResultUrl("https://example.com/page/?utm_source=x&id=7#section")).toBe(
+      "https://example.com/page?id=7"
+    );
+    expect(normalizeResultUrl("https://example.com/alpha/")).toBe("https://example.com/alpha");
+  });
+
+  it("returns null for invalid URLs", () => {
+    expect(normalizeResultUrl("not a url")).toBeNull();
+  });
+});
+
+describe("planWebSearch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("falls back to direct without a provider profile", async () => {
+    const plan = await planWebSearch({
+      query: "q",
+      forceFanOut: false,
+      maxQueries: 4
+    });
+    expect(plan).toEqual({ action: "direct" });
+    expect(callProviderTextMock).not.toHaveBeenCalled();
+  });
+
+  it("returns the parsed fan_out plan", async () => {
+    callProviderTextMock.mockResolvedValue('{"action":"fan_out","subqueries":["a","b"]}');
+    const plan = await planWebSearch({
+      providerProfile: createRuntimeProviderProfile(),
+      query: "q",
+      forceFanOut: false,
+      maxQueries: 4
+    });
+    expect(plan).toEqual({ action: "fan_out", subqueries: ["a", "b"] });
+    expect(callProviderTextMock).toHaveBeenCalledWith(expect.objectContaining({
+      purpose: "web_search_planning"
+    }));
+  });
+
+  it("falls back to direct when the planning call fails or returns junk", async () => {
+    const input = {
+      providerProfile: createRuntimeProviderProfile(),
+      query: "q",
+      forceFanOut: false,
+      maxQueries: 4
+    };
+    callProviderTextMock.mockRejectedValueOnce(new Error("provider down"));
+    expect(await planWebSearch(input)).toEqual({ action: "direct" });
+
+    callProviderTextMock.mockResolvedValueOnce("not json");
+    expect(await planWebSearch(input)).toEqual({ action: "direct" });
+  });
+
+  it("rethrows when the turn is aborted during planning", async () => {
+    const controller = new AbortController();
+    callProviderTextMock.mockImplementation(async () => {
+      controller.abort();
+      throw new Error("aborted");
+    });
+    await expect(planWebSearch({
+      providerProfile: createRuntimeProviderProfile(),
+      query: "q",
+      forceFanOut: false,
+      maxQueries: 4,
+      abortSignal: controller.signal
+    })).rejects.toBeInstanceOf(ChatTurnStoppedError);
+  });
+
+  it("uses the force-fan-out prompt when requested", async () => {
+    callProviderTextMock.mockResolvedValue('{"action":"fan_out","subqueries":["a","b"]}');
+    await planWebSearch({
+      providerProfile: createRuntimeProviderProfile(),
+      query: "q",
+      forceFanOut: true,
+      maxQueries: 4
+    });
+    const prompt = callProviderTextMock.mock.calls[0][0].prompt as string;
+    expect(prompt).toContain("Split this search");
+    expect(prompt).toContain('"q"');
+  });
+});
+
+describe("runWebSearchFanOut", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    searchWebMock.mockResolvedValue("ok");
+  });
+
+  it("runs sub-queries concurrently and returns per-query sections", async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    searchWebMock.mockImplementation(async ({ query }: { query: string }) => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      inFlight -= 1;
+      return `result for ${query}`;
+    });
+
+    const sections = await runWebSearchFanOut({
+      subqueries: ["a", "b", "c"],
+      settings: makeSettings()
+    });
+
+    expect(maxInFlight).toBe(3);
+    expect(sections.map((section) => section.status)).toEqual(["fulfilled", "fulfilled", "fulfilled"]);
+    expect(sections[0].text).toBe("result for a");
+  });
+
+  it("applies a per-search timeout derived from mcpTimeout", async () => {
+    await runWebSearchFanOut({
+      subqueries: ["a"],
+      settings: makeSettings(),
+      timeoutMs: 5000
+    });
+    expect(searchWebMock).toHaveBeenCalledWith(expect.objectContaining({
+      query: "a",
+      timeout: 5000,
+      abortSignal: expect.any(AbortSignal)
+    }));
+  });
+
+  it("keeps partial failures as rejected sections", async () => {
+    searchWebMock.mockImplementation(async ({ query }: { query: string }) => {
+      if (query === "b") throw new Error("engine boom");
+      return "fine";
+    });
+
+    const sections = await runWebSearchFanOut({
+      subqueries: ["a", "b"],
+      settings: makeSettings()
+    });
+
+    expect(sections[0]).toMatchObject({ status: "fulfilled", text: "fine" });
+    expect(sections[1]).toMatchObject({ status: "rejected", error: "engine boom" });
+  });
+
+  it("rethrows ChatTurnStoppedError when the turn is aborted mid fan-out", async () => {
+    const controller = new AbortController();
+    searchWebMock.mockImplementation(async () => {
+      controller.abort();
+      throw new Error("This operation was aborted");
+    });
+
+    await expect(runWebSearchFanOut({
+      subqueries: ["a", "b"],
+      settings: makeSettings(),
+      abortSignal: controller.signal
+    })).rejects.toBeInstanceOf(ChatTurnStoppedError);
+  });
+});
+
+describe("fuseFanOutResults", () => {
+  it("dedupes URLs across sections and notes duplicates in the header", () => {
+    const fused = fuseFanOutResults([
+      {
+        query: "q1",
+        status: "fulfilled",
+        text: [
+          "Title: Alpha\nhttps://example.com/alpha\nSummary A1",
+          "Title: Beta\nhttps://example.com/beta?utm_source=x\nSummary B1"
+        ].join("\n\n")
+      },
+      {
+        query: "q2",
+        status: "fulfilled",
+        text: [
+          "Title: Alpha again\nhttps://example.com/alpha/\nSummary A2",
+          "Title: Gamma\nhttps://example.com/gamma\nSummary G1"
+        ].join("\n\n")
+      }
+    ]);
+
+    expect(fused).toContain("Parallel web search results (2 queries: 2 succeeded, 0 failed, 1 duplicate result removed)");
+    expect(fused).toContain('## Query: "q1"');
+    expect(fused).toContain('## Query: "q2"');
+    expect(fused.match(/example\.com\/alpha/g)?.length).toBe(1);
+    expect(fused).toContain("example.com/beta");
+    expect(fused).toContain("example.com/gamma");
+  });
+
+  it("includes failed sections with their error", () => {
+    const fused = fuseFanOutResults([
+      { query: "q1", status: "fulfilled", text: "Title: A\nhttps://example.com/a\nS" },
+      { query: "q2", status: "rejected", text: "", error: "timeout" }
+    ]);
+    expect(fused).toContain("(2 queries: 1 succeeded, 1 failed)");
+    expect(fused).toContain('## Query: "q2" (failed: timeout)');
+  });
+
+  it("drops lowest-ranked URL results first when over budget", () => {
+    const long = (label: string, url: string) =>
+      `${label}\n${url}\n${"x".repeat(380)}`;
+    const fused = fuseFanOutResults([
+      {
+        query: "q1",
+        status: "fulfilled",
+        text: [long("Shared", "https://example.com/shared"), long("Only1", "https://example.com/only1")].join("\n\n")
+      },
+      {
+        query: "q2",
+        status: "fulfilled",
+        text: [long("Shared2", "https://example.com/shared"), long("Only2", "https://example.com/only2")].join("\n\n")
+      }
+    ], 1600);
+
+    expect(fused).toContain("example.com/shared");
+    expect(fused).not.toContain("example.com/only1");
+    expect(fused).toContain("example.com/only2");
+    expect(fused.length).toBeLessThanOrEqual(1600);
+  });
+
+  it("hard-truncates the fused output to the budget", () => {
+    const section = {
+      query: "q1",
+      status: "fulfilled" as const,
+      text: `${"y".repeat(40_000)}\nhttps://example.com/big`
+    };
+    const fused = fuseFanOutResults([section], 1000);
+    expect(fused.length).toBeLessThanOrEqual(1000);
+    expect(fused).toContain("...[truncated]");
+  });
+});
+
+describe("runWebSearchPipeline", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearWebSearchQueryCache();
+    searchWebMock.mockResolvedValue("provider text");
+  });
+
+  it("runs a single direct search when mode is off", async () => {
+    const settings = createRuntimeAppSettings({
+      webSearch: {
+        providerId: "exa",
+        configuration: { pipeline: { mode: "off", maxQueries: 4 } }
+      }
+    });
+
+    const result = await runWebSearchPipeline({
+      query: "simple lookup",
+      queries: ["ignored multi"],
+      mode: "off",
+      maxQueries: 4,
+      settings
+    });
+
+    expect(result.strategy).toBe("direct");
+    expect(result.plannedQueries).toEqual(["simple lookup"]);
+    expect(searchWebMock).toHaveBeenCalledTimes(1);
+    expect(callProviderTextMock).not.toHaveBeenCalled();
+  });
+
+  it("fans out explicit queries without a planning call", async () => {
+    const result = await runWebSearchPipeline({
+      query: "",
+      queries: ["facet one", "facet two", "facet two"],
+      mode: "auto",
+      maxQueries: 4,
+      settings: makeSettings()
+    });
+
+    expect(result.strategy).toBe("fan_out");
+    expect(result.plannedQueries).toEqual(["facet one", "facet two"]);
+    expect(searchWebMock).toHaveBeenCalledTimes(2);
+    expect(callProviderTextMock).not.toHaveBeenCalled();
+    expect(result.resultSummary).toContain("Parallel web search results (2 queries: 2 succeeded, 0 failed)");
+  });
+
+  it("caps explicit queries at maxQueries", async () => {
+    const result = await runWebSearchPipeline({
+      queries: ["a", "b", "c", "d", "e", "f"],
+      mode: "always",
+      maxQueries: 3,
+      settings: makeSettings()
+    });
+    expect(result.plannedQueries).toEqual(["a", "b", "c"]);
+  });
+
+  it("follows a direct plan in auto mode", async () => {
+    callProviderTextMock.mockResolvedValue('{"action":"direct"}');
+
+    const result = await runWebSearchPipeline({
+      query: "who is ceo of acme",
+      mode: "auto",
+      maxQueries: 4,
+      settings: makeSettings(),
+      providerProfile: createRuntimeProviderProfile()
+    });
+
+    expect(result.strategy).toBe("direct");
+    expect(searchWebMock).toHaveBeenCalledTimes(1);
+    expect(result.resultSummary).toBe("provider text");
+  });
+
+  it("fans out when the planner decomposes the query", async () => {
+    callProviderTextMock.mockResolvedValue(
+      '{"action":"fan_out","subqueries":["acme revenue 2025","acme product launch"]}'
+    );
+
+    const result = await runWebSearchPipeline({
+      query: "acme performance and products",
+      mode: "auto",
+      maxQueries: 4,
+      settings: makeSettings(),
+      providerProfile: createRuntimeProviderProfile(),
+      userContext: "How did acme do this year?"
+    });
+
+    expect(result.strategy).toBe("fan_out");
+    expect(searchWebMock).toHaveBeenCalledTimes(2);
+    expect(searchWebMock).toHaveBeenCalledWith(expect.objectContaining({ query: "acme revenue 2025" }));
+    expect(result.succeeded).toBe(2);
+  });
+
+  it("forces fan-out planning in always mode", async () => {
+    callProviderTextMock.mockResolvedValue('{"action":"fan_out","subqueries":["x1","x2"]}');
+
+    await runWebSearchPipeline({
+      query: "anything",
+      mode: "always",
+      maxQueries: 4,
+      settings: makeSettings(),
+      providerProfile: createRuntimeProviderProfile()
+    });
+
+    expect((callProviderTextMock.mock.calls[0][0].prompt as string)).toContain("Split this search");
+  });
+
+  it("throws when every sub-search fails", async () => {
+    searchWebMock.mockRejectedValue(new Error("engine boom"));
+
+    await expect(runWebSearchPipeline({
+      queries: ["a", "b"],
+      mode: "always",
+      maxQueries: 4,
+      settings: makeSettings()
+    })).rejects.toThrow("All 2 web searches failed: engine boom");
+  });
+
+  it("truncates direct results to the runtime tool budget", async () => {
+    searchWebMock.mockResolvedValue("z".repeat(40_000));
+
+    const result = await runWebSearchPipeline({
+      query: "big",
+      mode: "auto",
+      maxQueries: 4,
+      settings: makeSettings()
+    });
+
+    expect(result.resultSummary.length).toBeLessThanOrEqual(32_000);
+  });
+});
+
+describe("cross-call duplicate query cache", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearWebSearchQueryCache();
+    searchWebMock.mockResolvedValue("provider text");
+  });
+
+  const base = (assistantMessageId: string) => ({
+    mode: "auto" as const,
+    maxQueries: 4,
+    settings: makeSettings(),
+    assistantMessageId
+  });
+
+  it("skips near-duplicate sub-queries on later calls in the same turn", async () => {
+    const input = base("msg_dedup");
+    const first = await runWebSearchPipeline({
+      ...input,
+      queries: ["AI news August 2026 OpenAI Google Anthropic Meta Nvidia", "other facet entirely different topic"]
+    });
+    expect(first.succeeded).toBe(2);
+    expect(searchWebMock).toHaveBeenCalledTimes(2);
+
+    const second = await runWebSearchPipeline({
+      ...input,
+      queries: ["August 17 2026 AI latest news Google OpenAI Anthropic Nvidia"]
+    });
+    expect(second.duplicates).toBe(1);
+    expect(searchWebMock).toHaveBeenCalledTimes(2);
+    expect(second.resultSummary).toContain("Skipped search");
+    expect(second.resultSummary).toContain('"AI news August 2026 OpenAI Google Anthropic Meta Nvidia"');
+  });
+
+  it("treats reordered queries as exact duplicates", async () => {
+    const input = base("msg_reorder");
+    await runWebSearchPipeline({
+      ...input,
+      queries: ["news AI august 2026 openai google anthropic meta nvidia"]
+    });
+    const second = await runWebSearchPipeline({
+      ...input,
+      queries: ["AI news August 2026 OpenAI Google Anthropic Meta Nvidia"]
+    });
+    expect(second.duplicates).toBe(1);
+    expect(searchWebMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fuzzy-match short queries", async () => {
+    const input = base("msg_short");
+    await runWebSearchPipeline({ ...input, queries: ["iPhone 17 price"] });
+    await runWebSearchPipeline({ ...input, queries: ["iPhone 17 Pro price"] });
+    expect(searchWebMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("scopes the cache per assistant message", async () => {
+    await runWebSearchPipeline({
+      ...base("msg_one"),
+      queries: ["AI news August 2026 OpenAI Google Anthropic Meta Nvidia"]
+    });
+    await runWebSearchPipeline({
+      ...base("msg_two"),
+      queries: ["AI news August 2026 OpenAI Google Anthropic Meta Nvidia"]
+    });
+    expect(searchWebMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns a skip note for duplicate direct searches", async () => {
+    const input = base("msg_direct");
+    await runWebSearchPipeline({
+      ...input,
+      queries: ["detailed revenue figures for acme corporation 2026"]
+    });
+    const second = await runWebSearchPipeline({
+      ...input,
+      query: "detailed revenue figures for acme corporation in 2026"
+    });
+    expect(second.duplicates).toBe(1);
+    expect(searchWebMock).toHaveBeenCalledTimes(1);
+    expect(second.resultSummary).toContain("Skipped search");
+    expect(second.resultSummary).toContain("already in the conversation above");
+  });
+
+  it("does not record failed searches as duplicates", async () => {
+    searchWebMock.mockImplementation(async ({ query }: { query: string }) => {
+      if (query.includes("boom")) throw new Error("boom");
+      return "ok";
+    });
+    const input = base("msg_fail");
+    const first = await runWebSearchPipeline({
+      ...input,
+      queries: ["query that will boom number one", "query that succeeds fine always"]
+    });
+    expect(first.failed).toBe(1);
+
+    const retry = await runWebSearchPipeline({
+      ...input,
+      queries: ["query that will boom number two", "query that succeeds fine always"]
+    });
+    expect(retry.failed).toBe(1);
+    expect(retry.duplicates).toBe(1);
+    expect(searchWebMock).toHaveBeenCalledTimes(5);
+  });
+
+  it("retries a transiently failed sub-query once inline", async () => {
+    searchWebMock.mockImplementation(async ({ query }: { query: string }) => {
+      if (query === "flaky" && searchWebMock.mock.calls.filter(([call]) => call.query === "flaky").length === 1) {
+        throw new Error("transient");
+      }
+      return "ok";
+    });
+
+    const sections = await runWebSearchFanOut({
+      subqueries: ["flaky", "stable"],
+      settings: makeSettings()
+    });
+
+    expect(sections[0]).toMatchObject({ status: "fulfilled", text: "ok" });
+    expect(sections[1]).toMatchObject({ status: "fulfilled" });
+    expect(searchWebMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("caps concurrent searches to avoid provider rate limits", async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    searchWebMock.mockImplementation(async () => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      inFlight -= 1;
+      return "ok";
+    });
+
+    const sections = await runWebSearchFanOut({
+      subqueries: ["q1", "q2", "q3", "q4", "q5", "q6"],
+      settings: makeSettings()
+    });
+
+    expect(sections.every((section) => section.status === "fulfilled")).toBe(true);
+    expect(maxInFlight).toBeLessThanOrEqual(4);
+  });
+
+  it("expires cache entries after the TTL", async () => {
+    vi.useFakeTimers();
+    try {
+      const input = base("msg_ttl");
+      await runWebSearchPipeline({
+        ...input,
+        queries: ["AI news August 2026 OpenAI Google Anthropic Meta Nvidia"]
+      });
+      vi.advanceTimersByTime(16 * 60 * 1000);
+      const second = await runWebSearchPipeline({
+        ...input,
+        queries: ["AI news August 2026 OpenAI Google Anthropic Meta Nvidia"]
+      });
+      expect(second.duplicates).toBe(0);
+      expect(searchWebMock).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("executeWebSearch pipeline integration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    searchWebMock.mockResolvedValue("provider text");
+  });
+
+  function makeContext(appSettings: RuntimeAppSettings | undefined = makeSettings()) {
+    const onActionStart = vi.fn().mockResolvedValue("act_1");
+    const onActionComplete = vi.fn();
+    const onActionError = vi.fn();
+    const context = {
+      input: {
+        settings: createRuntimeProviderProfile(),
+        appSettings,
+        mcpTimeout: 5000,
+        skills: [] as Skill[],
+        mcpToolSets: [] as ToolSet[],
+        onActionStart,
+        onActionComplete,
+        onActionError
+      } as {
+        settings: RuntimeProviderProfile;
+        appSettings?: RuntimeAppSettings;
+        mcpTimeout?: number;
+        skills: Skill[];
+        mcpToolSets: ToolSet[];
+        onActionStart: typeof onActionStart;
+        onActionComplete: typeof onActionComplete;
+        onActionError: typeof onActionError;
+      },
+      timelineSortOrder: 3,
+      promptMessages: [{ role: "user" as const, content: "Compare X and Y pricing" }] as PromptMessage[]
+    };
+    return { onActionStart, onActionComplete, onActionError, context };
+  }
+
+  async function callWebSearch(args: Record<string, unknown>, context: ReturnType<typeof makeContext>["context"]) {
+    return executeToolCall(
+      { id: "call_1", name: "web_search", arguments: JSON.stringify(args) },
+      {
+        input: context.input,
+        mcpServers: [],
+        loadedSkillIds: new Set(),
+        successfulReadOnlyToolResults: new Map(),
+        timelineSortOrder: context.timelineSortOrder,
+        promptMessages: context.promptMessages
+      }
+    );
+  }
+
+  it("runs one umbrella action around a fanned-out search", async () => {
+    callProviderTextMock.mockResolvedValue('{"action":"fan_out","subqueries":["x price","y price"]}');
+    const { context, onActionStart, onActionComplete, onActionError } = makeContext();
+
+    const result = await callWebSearch({ query: "x vs y price" }, context);
+
+    expect(searchWebMock).toHaveBeenCalledTimes(2);
+    expect(onActionStart).toHaveBeenCalledTimes(1);
+    expect(onActionStart).toHaveBeenCalledWith(expect.objectContaining({
+      label: "Web search",
+      detail: "x vs y price",
+      serverId: "integration_web_search",
+      toolName: "web_search"
+    }));
+    expect(onActionComplete).toHaveBeenCalledTimes(1);
+    expect(onActionComplete).toHaveBeenCalledWith("act_1", expect.objectContaining({
+      resultSummary: expect.stringContaining("Parallel web search results")
+    }));
+    expect(onActionError).not.toHaveBeenCalled();
+    expect(result.nextSortOrder).toBe(4);
+    const toolMessage = result.promptMessages.at(-1)!;
+    expect(String(toolMessage.content)).toContain('## Query: "x price"');
+  });
+
+  it("fans out explicit queries from the tool call arguments", async () => {
+    const { context, onActionStart } = makeContext();
+
+    await callWebSearch({ queries: ["q1", "q2"] }, context);
+
+    expect(callProviderTextMock).not.toHaveBeenCalled();
+    expect(searchWebMock).toHaveBeenCalledTimes(2);
+    expect(onActionStart).toHaveBeenCalledWith(expect.objectContaining({
+      detail: "q1; q2",
+      arguments: { queries: ["q1", "q2"] }
+    }));
+  });
+
+  it("keeps legacy single-search behavior when the pipeline is off", async () => {
+    const settings = createRuntimeAppSettings({
+      webSearch: {
+        providerId: "searxng",
+        configuration: { baseUrl: "https://search.example.com", pipeline: { mode: "off" } }
+      }
+    });
+    const { context, onActionStart } = makeContext(settings);
+
+    const result = await callWebSearch({ query: "legacy" }, context);
+
+    expect(searchWebMock).toHaveBeenCalledTimes(1);
+    expect(searchWebMock).toHaveBeenCalledWith(expect.objectContaining({ query: "legacy" }));
+    expect(callProviderTextMock).not.toHaveBeenCalled();
+    expect(onActionStart).toHaveBeenCalledWith(expect.objectContaining({ detail: "legacy" }));
+    expect(String(result.promptMessages.at(-1)!.content)).toBe("provider text");
+  });
+
+  it("surfaces total failure as an error tool message", async () => {
+    searchWebMock.mockRejectedValue(new Error("engine boom"));
+    const { context, onActionComplete, onActionError } = makeContext();
+
+    const result = await callWebSearch({ queries: ["a", "b"] }, context);
+
+    expect(onActionError).toHaveBeenCalledWith("act_1", expect.objectContaining({
+      resultSummary: "All 2 web searches failed: engine boom"
+    }));
+    expect(onActionComplete).not.toHaveBeenCalled();
+    expect(String(result.promptMessages.at(-1)!.content)).toBe(
+      "Error: All 2 web searches failed: engine boom"
+    );
+  });
+
+  it("rejects calls without a query", async () => {
+    const { context } = makeContext();
+    const result = await callWebSearch({}, context);
+    expect(String(result.promptMessages.at(-1)!.content)).toBe("Error: query is required");
+  });
+
+  it("reports unconfigured web search without starting an action", async () => {
+    const context = makeContext().context;
+    const result = await callWebSearch(
+      { query: "x" },
+      { ...context, input: { ...context.input, appSettings: undefined } }
+    );
+    expect(String(result.promptMessages.at(-1)!.content)).toBe("Error: Web search is not configured.");
+  });
+});

--- a/tests/unit/web-search.test.ts
+++ b/tests/unit/web-search.test.ts
@@ -1,4 +1,5 @@
 import {
+  clearWebSearchDiscoveryCache,
   getWebSearchReadinessError,
   searchWeb
 } from "@/lib/web-search";
@@ -6,6 +7,7 @@ import {
   isPublicHttpUrl
 } from "@/lib/public-http-url";
 import {
+  normalizeWebSearchSelection,
   webSearchIntegrationUpdateSchema
 } from "@/lib/web-search-catalog";
 import { createRuntimeAppSettings } from "@/tests/provider-fixtures";
@@ -41,6 +43,7 @@ vi.mock("@/lib/searxng", () => ({
 describe("web search providers", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    clearWebSearchDiscoveryCache();
     discoverMcpToolsMock.mockResolvedValue([{ name: "web_search", inputSchema: {} }]);
     callMcpToolMock.mockResolvedValue({ isError: false });
     getToolResultTextMock.mockReturnValue("search result");
@@ -154,6 +157,33 @@ describe("web search providers", () => {
     getToolResultTextMock.mockReturnValueOnce("provider failed");
     await expect(searchWeb({ query: "query", settings })).rejects.toThrow("provider failed");
   });
+
+  it("caches MCP tool discovery across searches on the same server", async () => {
+    const settings = createRuntimeAppSettings({ webSearch: { providerId: "exa" } });
+
+    await searchWeb({ query: "first", settings });
+    await searchWeb({ query: "second", settings });
+
+    expect(discoverMcpToolsMock).toHaveBeenCalledTimes(1);
+    expect(callMcpToolMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("re-discovers after a rejected discovery or a failed tool lookup", async () => {
+    const settings = createRuntimeAppSettings({ webSearch: { providerId: "exa" } });
+
+    discoverMcpToolsMock.mockRejectedValueOnce(new Error("boom"));
+    await expect(searchWeb({ query: "first", settings })).rejects.toThrow("boom");
+    await searchWeb({ query: "second", settings });
+    expect(discoverMcpToolsMock).toHaveBeenCalledTimes(2);
+
+    clearWebSearchDiscoveryCache();
+    discoverMcpToolsMock.mockResolvedValueOnce([{ name: "unrelated", inputSchema: {} }]);
+    await expect(searchWeb({ query: "third", settings })).rejects.toThrow(
+      "did not expose its search tool"
+    );
+    await searchWeb({ query: "fourth", settings });
+    expect(discoverMcpToolsMock).toHaveBeenCalledTimes(4);
+  });
 });
 
 describe("searxng base URL safety", () => {
@@ -236,5 +266,74 @@ describe("searxng base URL safety", () => {
       });
       expect(result.success).toBe(false);
     }
+  });
+});
+
+describe("web search pipeline configuration", () => {
+  it("accepts pipeline configuration on every provider branch", () => {
+    for (const providerId of ["disabled", "exa", "tavily"] as const) {
+      const parsed = webSearchIntegrationUpdateSchema.parse({
+        providerId,
+        configuration: { pipeline: { mode: "always", maxQueries: 3 } }
+      });
+      expect(parsed).toMatchObject({
+        providerId,
+        configuration: { pipeline: { mode: "always", maxQueries: 3 } }
+      });
+    }
+
+    const searxng = webSearchIntegrationUpdateSchema.parse({
+      providerId: "searxng",
+      configuration: {
+        baseUrl: "https://search.example.com",
+        pipeline: { mode: "off" }
+      }
+    });
+    expect(searxng).toMatchObject({
+      providerId: "searxng",
+      configuration: { baseUrl: "https://search.example.com", pipeline: { mode: "off" } }
+    });
+  });
+
+  it("rejects invalid pipeline modes and out-of-range query caps", () => {
+    expect(webSearchIntegrationUpdateSchema.safeParse({
+      providerId: "exa",
+      configuration: { pipeline: { mode: "sometimes" } }
+    }).success).toBe(false);
+    expect(webSearchIntegrationUpdateSchema.safeParse({
+      providerId: "exa",
+      configuration: { pipeline: { mode: "auto", maxQueries: 9 } }
+    }).success).toBe(false);
+  });
+
+  it("normalizes pipeline configuration and clamps maxQueries", () => {
+    expect(normalizeWebSearchSelection("exa", {
+      pipeline: { mode: "always", maxQueries: 99 }
+    })).toEqual({
+      providerId: "exa",
+      configuration: { pipeline: { mode: "always", maxQueries: 5 } }
+    });
+
+    expect(normalizeWebSearchSelection("searxng", {
+      baseUrl: "https://search.example.com",
+      pipeline: { mode: "off", maxQueries: 0 }
+    })).toEqual({
+      providerId: "searxng",
+      configuration: {
+        baseUrl: "https://search.example.com",
+        pipeline: { mode: "off", maxQueries: 1 }
+      }
+    });
+  });
+
+  it("defaults the pipeline to auto when unconfigured or invalid", () => {
+    expect(normalizeWebSearchSelection("exa", {})).toEqual({
+      providerId: "exa",
+      configuration: { pipeline: { mode: "auto", maxQueries: 4 } }
+    });
+    expect(normalizeWebSearchSelection("tavily", { pipeline: "nonsense" })).toEqual({
+      providerId: "tavily",
+      configuration: { pipeline: { mode: "auto", maxQueries: 4 } }
+    });
   });
 });


### PR DESCRIPTION
## Problem
When you ask a question with several parts, the assistant searches the web one query at a time. Each extra search round makes you wait longer, different searches return the same links over and over, and the model sometimes searches again for things it already found.

## Solution
Complex searches are now split into several smaller queries that all run at the same time, then their results are merged into one tidy answer. Simple questions still use a single search, and the model is nudged to answer after the first search instead of searching again.

### Details
- New `web_search` pipeline (`lib/web-search-pipeline.ts`) with three modes: `auto` (decompose complex queries via a low-effort LLM planning call), `always` (force fan-out), and `off` (legacy single search)
- Tool schema accepts a `queries` array for parallel facets; explicit multi-query calls skip the planning step
- Sub-queries run concurrently (capped at 4, with one inline retry for transient failures); results are fused via Reciprocal Rank Fusion with URL normalization, cross-query deduplication, and a character budget
- Per-turn query cache skips near-duplicate searches (exact and Jaccard-similarity matching, TTL-based) and reports them as skipped instead of re-searching
- Assistant runtime executes same-step read-only tool calls (web_search + read-only MCP tools) in parallel, keeping mixed steps sequential; adds an "answer now" directive after a successful web search
- Settings UI for pipeline mode and max parallel queries (1–5), persisted and normalized through the settings schemas for every provider
- New `web_search_planning` provider purpose reuses the low reasoning-effort path in the Anthropic, GitHub Copilot, and OpenAI-compatible adapters
- MCP tool discovery for search providers is cached (5 min TTL) to cut redundant round trips

### Testing
- New `tests/unit/web-search-pipeline.test.ts` covering planning parsing, fan-out concurrency, fusion/dedup, direct vs fan-out strategies, duplicate cache behavior, and executor integration
- Updated unit tests for assistant runtime (parallel and mixed tool steps, answer-now directive, tool schema variants), chat-turn umbrella action persistence, settings persistence/normalization, settings routes, and discovery caching

### Checklist
- [ ] Manually verify fan-out behavior with a real search provider