### PR TITLE
Fit mobile websocket snapshots inside the single-frame send budget

### DIFF
--- a/lib/ws-handler.ts
+++ b/lib/ws-handler.ts
@@ -20,6 +20,7 @@ import { isPasswordLoginEnabled } from "@/lib/env";
 import { requestStop } from "@/lib/chat-turn-control";
 import { parseClientMessage, serializeServerMessage } from "@/lib/ws-protocol";
 import type { ClientMessage } from "@/lib/ws-protocol";
+import type { Message, QueuedMessage } from "@/lib/types";
 import { initializeMcpServers, shutdownAllProcesses } from "@/lib/mcp-client";
 import { getConversationManager } from "@/lib/ws-singleton";
 import { disposeTitleModel, initTitleModel } from "@/lib/local-title-model";
@@ -35,6 +36,71 @@ import {
 } from "@/lib/ws-upgrade-router";
 
 const MAX_WS_ERROR_MESSAGE_CHARS = 1_000;
+
+/**
+ * Single-frame byte budget for mobile `snapshot` payloads. The generic send
+ * guard closes a socket whenever a queued frame would exceed
+ * `MAX_WS_BUFFERED_BYTES` (1 MiB), which native clients cannot tolerate: the
+ * subscription snapshot for a long conversation used to exceed that budget,
+ * so every `subscribe` killed the connection and mobile clients reconnected
+ * forever. Browser connections are exempt (their payloads stay full-fidelity)
+ * because desktop WebSocket consumers have no incoming-frame cap.
+ */
+const MAX_MOBILE_SNAPSHOT_BYTES = 768 * 1024;
+
+function buildSnapshotMessage(
+  conversationId: string,
+  messages: Message[],
+  queuedMessages: QueuedMessage[],
+  versioned: boolean
+): Parameters<typeof serializeServerMessage>[0] {
+  if (!versioned) {
+    return {
+      type: "snapshot",
+      conversationId,
+      messages,
+      actions: messages.flatMap(message => message.actions ?? []),
+      segments: messages.flatMap(message => message.textSegments ?? []),
+      queuedMessages
+    };
+  }
+
+  // Native clients rebuild each message's actions and text segments from the
+  // flattened collections and never read `timeline`, so the per-message
+  // duplicates are dropped to keep the frame small. If the conversation still
+  // exceeds the budget, the oldest messages are omitted — mobile clients load
+  // full history over REST — so the socket stays subscribed and live streaming
+  // keeps working instead of the server closing the connection.
+  let retained = messages.map(({ timeline: _timeline, actions: _actions, textSegments: _textSegments, ...rest }) => rest);
+  let actions = messages.flatMap(message => message.actions ?? []);
+  let segments = messages.flatMap(message => message.textSegments ?? []);
+
+  const serializedSize = () => Buffer.byteLength(serializeServerMessage({
+    type: "snapshot",
+    conversationId,
+    messages: retained,
+    actions,
+    segments,
+    queuedMessages
+  } as Parameters<typeof serializeServerMessage>[0]));
+
+  while (retained.length > 0 && serializedSize() > MAX_MOBILE_SNAPSHOT_BYTES) {
+    const removedIds = new Set(
+      retained.splice(0, Math.max(1, Math.ceil(retained.length / 8))).map(message => message.id)
+    );
+    actions = actions.filter(action => !removedIds.has(action.messageId));
+    segments = segments.filter(segment => !removedIds.has(segment.messageId));
+  }
+
+  return {
+    type: "snapshot",
+    conversationId,
+    messages: retained,
+    actions,
+    segments,
+    queuedMessages
+  };
+}
 
 export {
   bootstrapRuntimeState,
@@ -292,14 +358,12 @@ function handleMessage(
         currentSubscription.add(msg.conversationId);
         mgr.subscribe(msg.conversationId, ws);
       }
-      sendServerMessage(ws, {
-        type: "snapshot",
-        conversationId: msg.conversationId,
-        messages: snapshot.messages,
-        actions: snapshot.messages.flatMap(m => m.actions ?? []),
-        segments: snapshot.messages.flatMap(m => m.textSegments ?? []),
-        queuedMessages: snapshot.queuedMessages
-      }, versioned);
+      sendServerMessage(ws, buildSnapshotMessage(
+        msg.conversationId,
+        snapshot.messages,
+        snapshot.queuedMessages,
+        versioned
+      ), versioned);
       break;
     }
     case "unsubscribe": {

--- a/lib/ws-handler.ts
+++ b/lib/ws-handler.ts
@@ -36,16 +36,6 @@ import {
 } from "@/lib/ws-upgrade-router";
 
 const MAX_WS_ERROR_MESSAGE_CHARS = 1_000;
-
-/**
- * Single-frame byte budget for mobile `snapshot` payloads. The generic send
- * guard closes a socket whenever a queued frame would exceed
- * `MAX_WS_BUFFERED_BYTES` (1 MiB), which native clients cannot tolerate: the
- * subscription snapshot for a long conversation used to exceed that budget,
- * so every `subscribe` killed the connection and mobile clients reconnected
- * forever. Browser connections are exempt (their payloads stay full-fidelity)
- * because desktop WebSocket consumers have no incoming-frame cap.
- */
 const MAX_MOBILE_SNAPSHOT_BYTES = 768 * 1024;
 
 function buildSnapshotMessage(
@@ -65,12 +55,6 @@ function buildSnapshotMessage(
     };
   }
 
-  // Native clients rebuild each message's actions and text segments from the
-  // flattened collections and never read `timeline`, so the per-message
-  // duplicates are dropped to keep the frame small. If the conversation still
-  // exceeds the budget, the oldest messages are omitted — mobile clients load
-  // full history over REST — so the socket stays subscribed and live streaming
-  // keeps working instead of the server closing the connection.
   let retained = messages.map(({ timeline: _timeline, actions: _actions, textSegments: _textSegments, ...rest }) => rest);
   let actions = messages.flatMap(message => message.actions ?? []);
   let segments = messages.flatMap(message => message.textSegments ?? []);

--- a/tests/unit/ws-handler.test.ts
+++ b/tests/unit/ws-handler.test.ts
@@ -861,11 +861,193 @@ describe("ws-handler", () => {
     expect(sent[1]).toMatchObject({ type: "snapshot", conversationId: "conv-mobile" });
     expect(JSON.stringify(sent[1])).not.toContain("relativePath");
     expect(JSON.stringify(sent[1])).not.toContain("extractedText");
+    const mobileSnapshot = sent[1] as {
+      messages: Array<Record<string, unknown>>;
+      actions: Array<{ messageId: string }>;
+      segments: Array<{ messageId: string }>;
+    };
+    expect(mobileSnapshot.messages).toHaveLength(1);
+    expect(mobileSnapshot.messages[0]).not.toHaveProperty("timeline");
+    expect(mobileSnapshot.messages[0]).not.toHaveProperty("actions");
+    expect(mobileSnapshot.messages[0]).not.toHaveProperty("textSegments");
+    expect(mobileSnapshot.actions).toEqual([
+      expect.objectContaining({ id: "action-1", messageId: "message-1" })
+    ]);
+    expect(mobileSnapshot.segments).toEqual([
+      expect.objectContaining({ id: "segment-1", messageId: "message-1" })
+    ]);
     sent.forEach((message) => assertWebSocketMessage("ServerMessage", message));
     assertWebSocketMessage("ClientMessage", {
       type: "request_snapshot",
       conversationId: "conv-mobile"
     });
+    vi.doUnmock("@/lib/ws-singleton");
+  });
+
+  it("truncates oversized mobile snapshots to the newest messages instead of dropping the socket", async () => {
+    const { verifyMobileSessionToken } = await import("@/lib/auth");
+    vi.mocked(verifyMobileSessionToken).mockResolvedValue({
+      sessionId: "mobile-session-1",
+      userId: "mobile-user-1"
+    });
+    const { getConversationSnapshot, listActiveConversations } = await import("@/lib/conversations");
+    vi.mocked(listActiveConversations).mockReturnValue([]);
+    const largeContent = "x".repeat(80 * 1024);
+    const oversizedMessages = Array.from({ length: 40 }, (_, index) => ({
+      id: `message-${index}`,
+      conversationId: "conv-big",
+      role: index % 2 === 0 ? "user" : "assistant",
+      content: largeContent,
+      thinkingContent: "",
+      status: "completed",
+      estimatedTokens: 1,
+      systemKind: null,
+      compactedAt: null,
+      createdAt: `2026-01-01T00:00:${String(index).padStart(2, "0")}.000Z`,
+      textSegments: [{
+        id: `segment-${index}`,
+        messageId: `message-${index}`,
+        content: largeContent,
+        sortOrder: 0,
+        createdAt: `2026-01-01T00:00:${String(index).padStart(2, "0")}.000Z`
+      }],
+      timeline: [{
+        id: `segment-${index}`,
+        timelineKind: "text",
+        sortOrder: 0,
+        createdAt: `2026-01-01T00:00:${String(index).padStart(2, "0")}.000Z`,
+        content: largeContent
+      }]
+    }));
+    vi.mocked(getConversationSnapshot).mockReturnValue({
+      conversation: { id: "conv-big" },
+      messages: oversizedMessages,
+      queuedMessages: [{
+        id: "queued-1",
+        conversationId: "conv-big",
+        content: "Queued follow-up",
+        status: "pending",
+        sortOrder: 0,
+        failureMessage: null,
+        mode: "chat",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+        processingStartedAt: null
+      }]
+    } as never);
+
+    const mockMgr = {
+      addConnection: vi.fn().mockReturnValue(true),
+      removeConnection: vi.fn(),
+      subscribe: vi.fn(),
+      unsubscribe: vi.fn(),
+      disconnect: vi.fn(),
+      broadcast: vi.fn(),
+      broadcastAll: vi.fn(),
+      hasSubscribers: vi.fn(),
+      setActive: vi.fn(),
+      isActive: vi.fn(),
+      getActiveConversationIds: vi.fn()
+    };
+    vi.doMock("@/lib/ws-singleton", () => ({ getConversationManager: () => mockMgr }));
+
+    const { handleConnection } = await import("@/lib/ws-handler");
+    const sent: string[] = [];
+    const messageHandlers: Array<(data: string) => void> = [];
+    const ws = {
+      readyState: 1,
+      bufferedAmount: 0,
+      send: vi.fn((data: string) => sent.push(data)),
+      close: vi.fn(),
+      on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+        if (event === "message") messageHandlers.push((data: string) => handler(data));
+      })
+    } as unknown as WebSocket;
+
+    await handleConnection(ws, "mobile-bearer", { authMode: "mobile" });
+    messageHandlers[0]?.(JSON.stringify({ type: "subscribe", conversationId: "conv-big" }));
+
+    expect(mockMgr.subscribe).toHaveBeenCalledWith("conv-big", ws);
+    expect(ws.close).not.toHaveBeenCalled();
+    const snapshot = JSON.parse(sent[1]);
+    expect(snapshot.type).toBe("snapshot");
+    expect(snapshot.messages.length).toBeGreaterThan(0);
+    expect(snapshot.messages.length).toBeLessThan(40);
+    expect(snapshot.messages.at(-1).id).toBe("message-39");
+    expect(snapshot.messages[0].id).not.toBe("message-0");
+    expect(snapshot.queuedMessages).toEqual([
+      expect.objectContaining({ id: "queued-1", conversationId: "conv-big" })
+    ]);
+    expect(snapshot.segments.every((segment: { messageId: string }) =>
+      snapshot.messages.some((message: { id: string }) => message.id === segment.messageId)
+    )).toBe(true);
+    expect(Buffer.byteLength(sent[1])).toBeLessThanOrEqual(768 * 1024);
+    assertWebSocketMessage("ServerMessage", snapshot);
+    vi.doUnmock("@/lib/ws-singleton");
+  });
+
+  it("keeps browser snapshots full-fidelity with nested collections and timeline", async () => {
+    const { verifySessionToken } = await import("@/lib/auth");
+    (verifySessionToken as ReturnType<typeof vi.fn>).mockResolvedValue({ userId: "user-1" });
+    const { getConversationSnapshot, listActiveConversations } = await import("@/lib/conversations");
+    vi.mocked(listActiveConversations).mockReturnValue([]);
+    vi.mocked(getConversationSnapshot).mockReturnValue({
+      conversation: { id: "conv-browser" },
+      messages: [{
+        id: "message-1",
+        conversationId: "conv-browser",
+        role: "user",
+        content: "hello",
+        thinkingContent: "",
+        status: "completed",
+        estimatedTokens: 1,
+        systemKind: null,
+        compactedAt: null,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        actions: [{ id: "action-1", messageId: "message-1" }],
+        textSegments: [{ id: "segment-1", messageId: "message-1", content: "hello", sortOrder: 0, createdAt: "2026-01-01T00:00:00.000Z" }],
+        timeline: [{ id: "segment-1", timelineKind: "text", sortOrder: 0, createdAt: "2026-01-01T00:00:00.000Z", content: "hello" }]
+      }],
+      queuedMessages: []
+    } as never);
+
+    const mockMgr = {
+      addConnection: vi.fn().mockReturnValue(true),
+      removeConnection: vi.fn(),
+      subscribe: vi.fn(),
+      unsubscribe: vi.fn(),
+      disconnect: vi.fn(),
+      broadcast: vi.fn(),
+      broadcastAll: vi.fn(),
+      hasSubscribers: vi.fn(),
+      setActive: vi.fn(),
+      isActive: vi.fn(),
+      getActiveConversationIds: vi.fn()
+    };
+    vi.doMock("@/lib/ws-singleton", () => ({ getConversationManager: () => mockMgr }));
+
+    const { handleConnection } = await import("@/lib/ws-handler");
+    const sent: string[] = [];
+    const messageHandlers: Array<(data: string) => void> = [];
+    const ws = {
+      readyState: 1,
+      bufferedAmount: 0,
+      send: vi.fn((data: string) => sent.push(data)),
+      close: vi.fn(),
+      on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+        if (event === "message") messageHandlers.push((data: string) => handler(data));
+      })
+    } as unknown as WebSocket;
+
+    await handleConnection(ws, "session=valid-token");
+    messageHandlers[0]?.(JSON.stringify({ type: "subscribe", conversationId: "conv-browser" }));
+
+    const snapshot = JSON.parse(sent[1]);
+    expect(snapshot.type).toBe("snapshot");
+    expect(snapshot.messages[0].timeline).toBeDefined();
+    expect(snapshot.messages[0].actions).toEqual([{ id: "action-1", messageId: "message-1" }]);
+    expect(snapshot.messages[0].textSegments).toBeDefined();
+    expect(snapshot.actions).toEqual([{ id: "action-1", messageId: "message-1" }]);
     vi.doUnmock("@/lib/ws-singleton");
   });
 


### PR DESCRIPTION
## Problem

Native (iOS) clients could not open long conversations: the app reconnected forever and never became ready, while the web UI on the same server worked fine.

Root cause: `sendWebSocketData` refuses to queue any single frame larger than `MAX_WS_BUFFERED_BYTES` (1 MiB) and **closes the socket with 1013** instead. The `subscribe`/`request_snapshot` snapshot frame for a long conversation exceeds that budget (the payload duplicates every action and segment both nested per message *and* flattened, plus a `timeline` array per message — ~3.5× inflation), so every subscribe killed the connection and the client re-requested the identical oversized frame after each reconnect.

The web UI is unaffected because it renders the transcript server-side and never consumes subscribe snapshots.

Measured against a real database:
- 56-message conversation: full-fidelity frame **4.25 MB** → server closed 1013 on every subscribe.
- 216-message conversation: full-fidelity frame **3.4 MB** → same.

## Fix

For **versioned (mobile) connections only** — browser payloads are byte-for-byte unchanged:

1. **Deduplicate** the snapshot frame: drop per-message `timeline`, `actions`, and `textSegments`. Native clients rebuild per-message actions/segments from the flattened top-level collections and never read `timeline`, so this is lossless for them (verified against the iOS snapshot handler). Typical frame shrinks ~2.5× (390 KB → 158 KB measured).
2. **Truncate to the newest messages** when a deduplicated conversation still exceeds a 768 KB budget (headroom below the 1 MiB send guard): the oldest messages are omitted, actions/segments for dropped messages are removed with them, and the queue is always included. The socket **stays subscribed**, so live streaming keeps working; mobile clients load full history over REST on conversation open.

Frames now never exceed what released native binaries can receive (URLSessionWebSocketTask default 1 MiB incoming cap), so old clients stop hitting the reconnect loop too.

## Verification

- New/extended unit tests (`tests/unit/ws-handler.test.ts`, 20 passing):
  - mobile snapshot dedups nested collections and keeps flattened ones (contract-validated against `mobile-api-v1.websocket.schema.json`)
  - oversized mobile snapshot truncates to the newest messages, stays ≤ 768 KB, keeps the queue, keeps the subscription, and does not close the socket
  - browser snapshot keeps `timeline` + nested collections (full fidelity)
- Full suite: **1749 tests passing**, `tsc --noEmit` and `eslint` clean.
- Live end-to-end (local v3.12.0 server + staged database):
  - 216-message conversation: `CLOSE 1013` before → **741 KB snapshot with the newest 84 messages** after
  - 18-message conversation: 390 KB → 158 KB, all 18 messages
  - iOS app against the fixed server: connection **ready with zero reconnect churn**, full transcript via REST, and `request_snapshot` delivered over the socket for the oversized conversation (no REST fallback engaged)

## Follow-up (separate, optional)

The iOS app (this workspace) already tolerates servers without this fix (32 MiB receive cap + per-conversation REST fallback); with this fix it reverts to full realtime automatically — no client release required.