### PR TITLE
Fix stale model provider on switch

### DIFF
--- a/components/settings/sections/providers-section.tsx
+++ b/components/settings/sections/providers-section.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { type FormEvent, useEffect, useMemo, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
 import {
   Copy,
   Plus,
@@ -96,6 +97,7 @@ function buildDirtySnapshot(
 }
 
 export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
+  const router = useRouter();
   const toast = useToastState();
   const [testResult, setTestResult] = useState<{ text: string; isSuccess: boolean } | null>(null);
   const [isTesting, setIsTesting] = useState(false);
@@ -385,6 +387,7 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
           savedSkillsEnabled
         )
       );
+      router.refresh();
 
       toast.showToast("success", "Provider deleted.");
     } else {
@@ -438,6 +441,7 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
         );
       }
       setMobileDetailVisible(true);
+      router.refresh();
       toast.showToast("success", "Provider duplicated");
     } catch {
       toast.showToast("error", "Unable to duplicate provider");
@@ -509,6 +513,7 @@ export function ProvidersSection({ settings }: { settings: SettingsPayload }) {
         persistedSkills
       )
     );
+    router.refresh();
 
     return true;
   }

--- a/tests/unit/providers-section.test.tsx
+++ b/tests/unit/providers-section.test.tsx
@@ -8,9 +8,11 @@ import { toProviderProfileSummary } from "@/lib/provider-profile";
 import type { AppSettings, ProviderProfileSummary } from "@/lib/types";
 import { createRuntimeProviderProfile } from "@/tests/provider-fixtures";
 
+const { routerRefreshMock } = vi.hoisted(() => ({ routerRefreshMock: vi.fn() }));
+
 vi.mock("next/navigation", () => ({
   useRouter: () => ({
-    refresh: vi.fn()
+    refresh: routerRefreshMock
   })
 }));
 
@@ -172,6 +174,7 @@ function makeSettings(overrides: SettingsOverrides = {}): SettingsFixture {
 
 describe("providers section", () => {
   beforeEach(() => {
+    routerRefreshMock.mockClear();
     global.fetch = vi.fn((input) => {
       const url = String(input);
 
@@ -481,6 +484,53 @@ describe("providers section", () => {
       credential: "",
       credentialAction: "clear"
     });
+  });
+
+  it("refreshes cached route data after a successful provider save", async () => {
+    const settings = makeSettings();
+    vi.mocked(global.fetch).mockImplementation((input, init) => {
+      if (String(input) === "/api/mcp-servers") {
+        return Promise.resolve({ ok: true, json: async () => ({ servers: [] }) } as Response);
+      }
+      if (String(input) === "/api/settings/providers" && init?.method === "PUT") {
+        return Promise.resolve({ ok: true, json: async () => ({ settings }) } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) } as Response);
+    });
+    render(React.createElement(ProvidersSection, { settings }));
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledWith("/api/mcp-servers"));
+
+    fireEvent.change(screen.getByDisplayValue("gpt-test"), {
+      target: { value: "gpt-new-model" }
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(routerRefreshMock).toHaveBeenCalledTimes(1));
+  });
+
+  it("does not refresh cached route data when the provider save fails", async () => {
+    vi.mocked(global.fetch).mockImplementation((input, init) => {
+      if (String(input) === "/api/mcp-servers") {
+        return Promise.resolve({ ok: true, json: async () => ({ servers: [] }) } as Response);
+      }
+      if (String(input) === "/api/settings/providers" && init?.method === "PUT") {
+        return Promise.resolve({
+          ok: false,
+          json: async () => ({ error: "boom" })
+        } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) } as Response);
+    });
+    render(React.createElement(ProvidersSection, { settings: makeSettings() }));
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledWith("/api/mcp-servers"));
+
+    fireEvent.change(screen.getByDisplayValue("gpt-test"), {
+      target: { value: "gpt-new-model" }
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(await screen.findByText("boom")).toBeInTheDocument();
+    expect(routerRefreshMock).not.toHaveBeenCalled();
   });
 
   it("keeps a rejected provider save in the editor", async () => {


### PR DESCRIPTION
## Problem
When you saved, duplicated, or deleted a provider, the app kept showing old cached data because the router cache was never refreshed.

## Solution
Think of the app's pages like photos taped to the wall. After changing a provider, we now take a fresh photo (`router.refresh()`) so what you see matches what was saved.

- Call `router.refresh()` after successful provider save, duplicate, and delete
- Only refresh on success; failed saves leave the cache untouched
- Update unit tests: hoisted `routerRefreshMock`, assert refresh fires on successful save and does not fire on failed save

## Testing
- Covered by new unit tests in `tests/unit/providers-section.test.tsx` (refresh on success, no refresh on failure)