### PR TITLE
Fix message anchor racing with server-persisted user message

### DIFF
--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -531,14 +531,18 @@ export function ChatView({ payload }: { payload: ConversationViewPayload }) {
   }, [composerAreaHeight]);
 
   useEffect(() => {
-    if (!pendingAnchorMessageIdRef.current) return;
-    const messageId = pendingAnchorMessageIdRef.current;
-    const exists = visibleMessages.some((m) => m.id === messageId);
+    const anchorMessageId = pendingAnchorMessageIdRef.current;
+    if (!anchorMessageId) return;
+    const exists = visibleMessages.some((m) => m.id === anchorMessageId);
     if (!exists) return;
 
-    pendingAnchorMessageIdRef.current = null;
     requestAnimationFrame(() => {
-      const targetEl = document.querySelector(`[data-message-id="${messageId}"]`);
+      const messageId = pendingAnchorMessageIdRef.current;
+      if (!messageId) return;
+      pendingAnchorMessageIdRef.current = null;
+      const targetEl =
+        document.querySelector(`[data-message-id="${messageId}"]`) ??
+        document.querySelector(`[data-message-id="${anchorMessageId}"]`);
       const content = contentEndRef.current?.parentElement;
       const scroller = contentEndRef.current?.closest(".conversation-scroller");
       const behavior =

--- a/tests/unit/chat-view.test.ts
+++ b/tests/unit/chat-view.test.ts
@@ -3461,6 +3461,75 @@ describe("chat view", () => {
     getBoundingClientRectSpy.mockRestore();
   });
 
+  it("pins the user message even when the server persists it before the anchor frame", async () => {
+    renderWithProvider(
+      React.createElement(ChatView, {
+        payload: createPayload({
+          messages: [
+            createMessage({ id: "msg_user_first", role: "user", content: "First question" }),
+            createMessage({ id: "msg_assistant_first", content: "First answer" })
+          ]
+        })
+      })
+    );
+    const textarea = screen.getByRole("textbox");
+    const conversationContent = getScrollContainer()!;
+    Object.defineProperty(conversationContent, "clientHeight", {
+      configurable: true,
+      value: 640
+    });
+    Object.defineProperty(conversationContent, "scrollTop", {
+      configurable: true,
+      writable: true,
+      value: 500
+    });
+    const getBoundingClientRectSpy = vi
+      .spyOn(Element.prototype, "getBoundingClientRect")
+      .mockImplementation(function(this: Element) {
+        if (this === conversationContent) {
+          return { top: 80 } as DOMRect;
+        }
+        if (
+          this instanceof HTMLElement &&
+          this.hasAttribute("data-message-id") &&
+          this.textContent?.includes("Race question")
+        ) {
+          return { top: 200 } as DOMRect;
+        }
+        return { top: 0 } as DOMRect;
+      });
+    const scrollToSpy = vi.spyOn(conversationContent, "scrollTo");
+
+    fireEvent.change(textarea, { target: { value: "Race question" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    act(() => {
+      wsMock.onMessage!({
+        type: "user_message_persisted",
+        conversationId: "conv_1",
+        message: createMessage({
+          id: "msg_user_server",
+          role: "user",
+          content: "Race question"
+        })
+      });
+    });
+
+    await waitFor(() => {
+      expect(document.querySelector('[data-message-id="msg_user_server"]')).not.toBeNull();
+    });
+    expect(document.querySelector('[data-message-id^="local_"]')).toBeNull();
+
+    await flushAnimationFrame();
+    await flushAnimationFrame();
+
+    expect(scrollToSpy).toHaveBeenCalledWith({ top: 608, behavior: "smooth" });
+    expect(conversationContent.firstElementChild).toHaveStyle({ minHeight: "1248px" });
+    expect(stickToBottomMock.targetScrollTop?.()).toBe(608);
+    scrollToSpy.mockRestore();
+    getBoundingClientRectSpy.mockRestore();
+  });
+
   it("anchors the user message instantly when reduced motion is preferred", async () => {
     const originalMatchMedia = window.matchMedia;
     Object.defineProperty(window, "matchMedia", {


### PR DESCRIPTION
## Problem

When you sent a message, the app tried to remember which message to scroll to. But sometimes the server saved your message first, which changed the message's ID. The app then looked for a message that no longer existed and the chat jumped to the wrong position.

## Solution

Keep the original anchor ID as a fallback when reading the pending anchor inside the animation frame, and clear the pending ref only after the scroll actually runs. This way, even if the server replaces the local message (and its ID) before the anchor frame fires, the chat still scrolls to the right message.

### Changes
- `components/chat-view.tsx`: capture the anchor ID up front, resolve the pending ID inside `requestAnimationFrame`, and fall back to the original anchor ID when querying the DOM element.
- `tests/unit/chat-view.test.ts`: add a regression test that persists a server user message before the anchor frame and asserts the chat pins to the correct scroll position.

### Testing
- Added unit test: "pins the user message even when the server persists it before the anchor frame", verifying scroll target (`top: 608`), spacer height, and stick-to-bottom behavior.