### PR TITLE
Optimize long conversation rendering performance

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -102,6 +102,11 @@ html.ios-pwa .app-shell {
   scrollbar-gutter: auto !important;
 }
 
+.message-row {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 160px;
+}
+
 ::selection {
   background: rgba(139, 92, 246, 0.35);
   color: white;

--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -231,6 +231,8 @@ export function ChatView({ payload }: { payload: ConversationViewPayload }) {
 
   const pendingAnchorMessageIdRef = useRef<string | null>(null);
   const expandAnchorMessageIdRef = useRef<string | null>(null);
+  const earlierMessagesSentinelRef = useRef<HTMLDivElement | null>(null);
+  const firstVisibleMessageIdRef = useRef<string | null>(null);
   const bootstrapPayloadRef = useRef<{
     message: string;
     attachments: MessageAttachment[];
@@ -301,6 +303,7 @@ export function ChatView({ payload }: { payload: ConversationViewPayload }) {
     () => (hiddenMessageCount > 0 ? renderableMessages.slice(hiddenMessageCount) : renderableMessages),
     [renderableMessages, hiddenMessageCount]
   );
+  firstVisibleMessageIdRef.current = visibleMessages[0]?.id ?? null;
   const hasPendingLocalSubmission = pendingLocalSubmissionsRef.current.length > 0;
   const lastUserMsgIndex = useMemo(() => {
     for (let i = visibleMessages.length - 1; i >= 0; i--) {
@@ -581,6 +584,29 @@ export function ChatView({ payload }: { payload: ConversationViewPayload }) {
         ?.scrollIntoView({ block: "start", behavior: "auto" });
     });
   }, [visibleMessages]);
+
+  const hasHiddenMessages = hiddenMessageCount > 0;
+
+  useEffect(() => {
+    if (!hasHiddenMessages || typeof IntersectionObserver === "undefined") return;
+    const sentinel = earlierMessagesSentinelRef.current;
+    if (!sentinel) return;
+    const scroller = contentEndRef.current?.closest(".conversation-scroller");
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (!entries.some((entry) => entry.isIntersecting)) return;
+        if (expandAnchorMessageIdRef.current !== null) return;
+        expandAnchorMessageIdRef.current = firstVisibleMessageIdRef.current;
+        setVisibleMessageLimit((current) => current + VISIBLE_MESSAGE_INCREMENT);
+      },
+      {
+        root: scroller instanceof HTMLElement ? scroller : null,
+        rootMargin: "600px 0px 0px 0px"
+      }
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [hasHiddenMessages]);
 
   useEffect(() => {
     if (!shouldAutofocusTextInput()) {
@@ -1931,6 +1957,14 @@ export function ChatView({ payload }: { payload: ConversationViewPayload }) {
           className="gap-2.5 px-2 pt-4 md:gap-4 md:px-8"
         >
           {hiddenMessageCount > 0 ? (
+            <div
+              ref={earlierMessagesSentinelRef}
+              aria-hidden
+              data-testid="earlier-messages-sentinel"
+              className="h-px w-full"
+            />
+          ) : null}
+          {hiddenMessageCount > 0 ? (
             <button
               type="button"
               onClick={() => {
@@ -1962,7 +1996,14 @@ export function ChatView({ payload }: { payload: ConversationViewPayload }) {
               <div
                 key={renderKeyByMessageIdRef.current.get(message.id) ?? message.id}
                 data-message-id={message.id}
-                className={shouldAnimate ? "animate-slide-up" : undefined}
+                className={
+                  [
+                    isStreamingMessage ? null : "message-row",
+                    shouldAnimate ? "animate-slide-up" : null
+                  ]
+                    .filter(Boolean)
+                    .join(" ") || undefined
+                }
                 style={shouldAnimate ? { animationFillMode: "forwards" } : undefined}
               >
                 <StreamingMessage
@@ -1970,9 +2011,9 @@ export function ChatView({ payload }: { payload: ConversationViewPayload }) {
                   buffer={streamBuffer}
                   message={message}
                   timeline={isStreamingMessage ? streamTimeline : EMPTY_TIMELINE}
-                  hasReceivedFirstToken={hasReceivedFirstToken}
-                  compactionInProgress={compactionInProgress}
-                  thinkingDuration={thinkingDuration}
+                  hasReceivedFirstToken={isStreamingMessage ? hasReceivedFirstToken : false}
+                  compactionInProgress={isStreamingMessage ? compactionInProgress : false}
+                  thinkingDuration={isStreamingMessage ? thinkingDuration : undefined}
                   confirmExternalLinks={payload.settings.confirmExternalLinks}
                   toolCallDisplay={payload.settings.toolCallDisplay}
                   onPreviewAttachment={onPreviewAttachmentStable}

--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -100,11 +100,13 @@ const AssistantMarkdown = React.memo(
     content,
     isAnimating = false,
     showCaret = false,
+    isStatic = false,
     linkSafety
   }: {
     content: string;
     isAnimating?: boolean;
     showCaret?: boolean;
+    isStatic?: boolean;
     linkSafety: ReturnType<typeof useLinkSafety>;
   }) {
     const plugins = useStreamdownPlugins(content);
@@ -115,6 +117,7 @@ const AssistantMarkdown = React.memo(
       <MarkdownErrorBoundary fallback={fallback} resetKey={content}>
         <Streamdown
           plugins={plugins}
+          mode={isStatic ? "static" : "streaming"}
           isAnimating={isAnimating}
           caret={showCaret ? "block" : undefined}
           linkSafety={linkSafety}
@@ -128,6 +131,7 @@ const AssistantMarkdown = React.memo(
     previous.content === next.content &&
     previous.isAnimating === next.isAnimating &&
     previous.showCaret === next.showCaret &&
+    previous.isStatic === next.isStatic &&
     previous.linkSafety === next.linkSafety
 );
 
@@ -393,6 +397,10 @@ function MessageBubbleImpl({
   const contentRef = useRef<HTMLDivElement | null>(null);
   const editRef = useRef<HTMLTextAreaElement | null>(null);
   const copyResetHandle = useRef<number | null>(null);
+  const stripCacheRef = useRef<{
+    key: string;
+    byBlockId: Map<string, { source: string; rendered: string }>;
+  } | null>(null);
   const previewController = useAttachmentPreviewController();
   const linkSafety = useLinkSafety(confirmExternalLinks);
   const useStatusLine = toolCallDisplay === "status_line";
@@ -537,27 +545,45 @@ function MessageBubbleImpl({
       )
       .map((item) => item.content)
       .join("");
-    const renderedAssistantText =
-      message.role === "assistant"
-        ? stripAttachmentStyleImageMarkdown(assistantText, message.attachments ?? [])
-        : assistantText;
     const renderedAssistantBlockContentById = new Map<string, string>();
     let lastRenderableAssistantTextId: string | null = null;
+    let renderedAssistantText = assistantText;
 
     if (message.role === "assistant") {
+      const attachments = message.attachments ?? [];
+      const cacheKey = `${message.id} ${attachments.map((attachment) => attachment.id).join(",")}`;
+
+      if (stripCacheRef.current?.key !== cacheKey) {
+        stripCacheRef.current = { key: cacheKey, byBlockId: new Map() };
+      }
+
+      const stripCache = stripCacheRef.current.byBlockId;
+      const renderedParts: string[] = [];
+
       assistantBlocks.forEach((item) => {
         if (item.timelineKind !== "text") {
           return;
         }
 
-        const renderedContent = stripAttachmentStyleImageMarkdown(item.content, message.attachments ?? []);
+        const cached = stripCache.get(item.id);
+        const renderedContent =
+          cached && cached.source === item.content
+            ? cached.rendered
+            : stripAttachmentStyleImageMarkdown(item.content, attachments);
+
+        if (cached?.source !== item.content) {
+          stripCache.set(item.id, { source: item.content, rendered: renderedContent });
+        }
 
         renderedAssistantBlockContentById.set(item.id, renderedContent);
+        renderedParts.push(renderedContent);
 
         if (renderedContent) {
           lastRenderableAssistantTextId = item.id;
         }
       });
+
+      renderedAssistantText = renderedParts.join("");
     }
 
     return {
@@ -1046,6 +1072,7 @@ function MessageBubbleImpl({
                               content={renderedContent}
                               isAnimating={isStreamingTailBlock}
                               showCaret={isStreamingTailBlock}
+                              isStatic={!isStreamingTailBlock && message.status === "completed"}
                               linkSafety={linkSafety}
                             />
                           </div>

--- a/lib/stream-buffer.ts
+++ b/lib/stream-buffer.ts
@@ -35,6 +35,20 @@ const DEFAULT_FINALIZE_DRAIN_WINDOW_MS = 175;
 const DEFAULT_MAX_WORD_HOLD_CHARS = 24;
 const DEFAULT_MAX_WORD_HOLD_MS = 350;
 const CARRY_CAP_FACTOR = 2;
+const LONG_CONTENT_NOTIFY_TIERS = [
+  { chars: 16000, intervalMs: 48 },
+  { chars: 48000, intervalMs: 112 }
+];
+
+function notifyIntervalFor(length: number) {
+  let interval = 0;
+  for (const tier of LONG_CONTENT_NOTIFY_TIERS) {
+    if (length >= tier.chars) {
+      interval = tier.intervalMs;
+    }
+  }
+  return interval;
+}
 
 const EMPTY_SNAPSHOT: StreamBufferSnapshot = Object.freeze({
   answerTarget: "",
@@ -202,6 +216,17 @@ export function createStreamBuffer(options: StreamBufferOptions = {}): StreamBuf
   function tick() {
     frameHandle = null;
     const current = now();
+
+    if (!finalized) {
+      const interval = notifyIntervalFor(
+        snapshot.answerTarget.length + snapshot.thinkingTarget.length
+      );
+      if (interval > 0 && current - lastTick < interval) {
+        scheduleTick();
+        return;
+      }
+    }
+
     const elapsed = Math.max(current - lastTick, 1);
     lastTick = current;
     const nextAnswer = advance("answer", snapshot.answerDisplay, snapshot.answerTarget, elapsed, current);

--- a/lib/text-utils.ts
+++ b/lib/text-utils.ts
@@ -1,4 +1,8 @@
 export function normalizeLineBreaks(text: string) {
+  if (!text.includes("\r") && !text.includes("\\")) {
+    return text;
+  }
+
   return text
     .replace(/\r\n?/g, "\n")
     .replace(/(?:\\\\)+r(?:\\\\)+n/g, "\n")

--- a/tests/unit/chat-view.test.ts
+++ b/tests/unit/chat-view.test.ts
@@ -5068,4 +5068,126 @@ describe("chat view", () => {
     expect(container.querySelectorAll("[data-message-id]")).toHaveLength(170);
     expect(screen.queryByRole("button", { name: /Show earlier messages/ })).toBeNull();
   }, 15000);
+
+  it("applies the content-visibility row class to settled rows but not the streaming row", async () => {
+    renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
+
+    const textarea = screen.getByRole("textbox");
+    fireEvent.change(textarea, { target: { value: "hello" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(screen.getByText("hello")).toBeInTheDocument();
+    });
+
+    act(() => {
+      wsMock.onMessage!({
+        type: "delta",
+        conversationId: "conv_1",
+        event: { type: "message_start", messageId: "msg_assistant" }
+      });
+    });
+
+    const streamingRow = document.querySelector('[data-message-id="msg_assistant"]');
+    expect(streamingRow).not.toBeNull();
+    expect(streamingRow!.classList.contains("message-row")).toBe(false);
+
+    for (const row of document.querySelectorAll("[data-message-id]")) {
+      if (row === streamingRow) continue;
+      expect(row.classList.contains("message-row")).toBe(true);
+    }
+  });
+
+  it("auto-loads earlier messages when the top sentinel comes into view", async () => {
+    type ObserverInstance = {
+      callback: IntersectionObserverCallback;
+      elements: Element[];
+    };
+    const instances: ObserverInstance[] = [];
+    const originalObserver = window.IntersectionObserver;
+    class MockIntersectionObserver {
+      private instance: ObserverInstance;
+      constructor(callback: IntersectionObserverCallback) {
+        this.instance = { callback, elements: [] };
+        instances.push(this.instance);
+      }
+      observe(element: Element) {
+        this.instance.elements.push(element);
+      }
+      unobserve() {}
+      disconnect() {}
+      takeRecords(): IntersectionObserverEntry[] {
+        return [];
+      }
+    }
+    Object.defineProperty(window, "IntersectionObserver", {
+      configurable: true,
+      writable: true,
+      value: MockIntersectionObserver
+    });
+
+    try {
+      const payload = createPayload({
+        messages: Array.from({ length: 170 }, (_, index) =>
+          createMessage({
+            id: `msg_auto_${index}`,
+            role: index % 2 === 0 ? "user" : "assistant",
+            content: `Auto message ${index}`
+          })
+        )
+      });
+
+      const { container } = renderWithProvider(React.createElement(ChatView, { payload }));
+
+      await waitFor(() => {
+        expect(screen.getByText("Test conversation")).toBeInTheDocument();
+      });
+
+      expect(container.querySelectorAll("[data-message-id]")).toHaveLength(60);
+
+      const sentinel = screen.getByTestId("earlier-messages-sentinel");
+      const observer = instances.find((instance) => instance.elements.includes(sentinel));
+      expect(observer).toBeDefined();
+
+      act(() => {
+        observer!.callback(
+          [{ isIntersecting: false } as IntersectionObserverEntry],
+          {} as IntersectionObserver
+        );
+      });
+      expect(container.querySelectorAll("[data-message-id]")).toHaveLength(60);
+
+      const scrollIntoViewSpy = vi.spyOn(Element.prototype, "scrollIntoView");
+
+      await act(async () => {
+        observer!.callback(
+          [{ isIntersecting: true } as IntersectionObserverEntry],
+          {} as IntersectionObserver
+        );
+      });
+      await flushAnimationFrame();
+
+      expect(container.querySelectorAll("[data-message-id]")).toHaveLength(160);
+      expect(screen.getByRole("button", { name: "Show earlier messages (10)" })).toBeInTheDocument();
+      expect(scrollIntoViewSpy).toHaveBeenCalledWith({ block: "start", behavior: "auto" });
+
+      scrollIntoViewSpy.mockRestore();
+    } finally {
+      Object.defineProperty(window, "IntersectionObserver", {
+        configurable: true,
+        writable: true,
+        value: originalObserver
+      });
+    }
+  }, 15000);
+
+  it("does not render an auto-load sentinel when all messages are visible", async () => {
+    renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Test conversation")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByTestId("earlier-messages-sentinel")).toBeNull();
+  });
 });

--- a/tests/unit/message-bubble.test.ts
+++ b/tests/unit/message-bubble.test.ts
@@ -4,6 +4,7 @@ import React from "react";
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 
 import { MessageBubble } from "@/components/message-bubble";
+import { stripAttachmentStyleImageMarkdown } from "@/lib/assistant-image-markdown";
 import type { Message, MessageAction, MessageAttachment, MessageTimelineItem } from "@/lib/types";
 
 const originalFetch = global.fetch;
@@ -1453,6 +1454,75 @@ describe("message bubble", () => {
 
     await waitFor(() => {
       expect(writeText).toHaveBeenCalled();
+    });
+  });
+
+  it("copies text with attachment image markdown stripped across timeline segments", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true
+    });
+    vi.stubGlobal("ClipboardItem", undefined);
+
+    const attachments = [
+      {
+        id: "att_chart",
+        filename: "chart.png",
+        mimeType: "image/png",
+        kind: "image" as const,
+        byteSize: 1024,
+        createdAt: new Date().toISOString()
+      }
+    ];
+    const firstSegment = "Look: ![chart](chart.png) first.";
+    const secondSegment = "And again ![chart](chart.png) done.";
+    const fullContent = `${firstSegment}${secondSegment}`;
+
+    render(
+      React.createElement(MessageBubble, {
+        message: {
+          ...createAssistantMessage(),
+          content: fullContent,
+          attachments,
+          timeline: [
+            {
+              id: "txt_strip_1",
+              timelineKind: "text",
+              sortOrder: 0,
+              createdAt: new Date().toISOString(),
+              content: firstSegment
+            },
+            {
+              ...createToolAction({
+                id: "act_between",
+                messageId: "msg_assistant",
+                label: "Search docs",
+                detail: "query=MCP",
+                resultSummary: "Found MCP documentation",
+                sortOrder: 1
+              }),
+              timelineKind: "action"
+            },
+            {
+              id: "txt_strip_2",
+              timelineKind: "text",
+              sortOrder: 2,
+              createdAt: new Date().toISOString(),
+              content: secondSegment
+            }
+          ]
+        }
+      })
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy message" }));
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(
+        stripAttachmentStyleImageMarkdown(fullContent, attachments)
+      );
     });
   });
 

--- a/tests/unit/stream-buffer.test.ts
+++ b/tests/unit/stream-buffer.test.ts
@@ -373,6 +373,70 @@ describe("createStreamBuffer", () => {
     expect(buffer.getSnapshot().answerDisplay).toBe("second turn ");
   });
 
+  it("throttles notifications for very long content while still catching up", () => {
+    const scheduler = createManualScheduler();
+    const buffer = createStreamBuffer({ ...scheduler, ...PACING });
+    let notifications = 0;
+    buffer.subscribe(() => {
+      notifications += 1;
+    });
+    buffer.appendAnswer(`${"word ".repeat(4000)}end`);
+
+    notifications = 0;
+    for (let i = 0; i < 6; i += 1) scheduler.advance(16);
+    expect(notifications).toBe(2);
+
+    const before = buffer.getSnapshot().answerDisplay.length;
+    scheduler.advance(48);
+    expect(buffer.getSnapshot().answerDisplay.length).toBeGreaterThan(before);
+  });
+
+  it("does not throttle short content", () => {
+    const scheduler = createManualScheduler();
+    const buffer = createStreamBuffer({
+      ...scheduler,
+      ...PACING,
+      baseCharsPerSecond: 1000
+    });
+    let notifications = 0;
+    buffer.subscribe(() => {
+      notifications += 1;
+    });
+    buffer.appendAnswer("word ".repeat(12));
+
+    notifications = 0;
+    for (let i = 0; i < 3; i += 1) scheduler.advance(16);
+    expect(notifications).toBe(3);
+  });
+
+  it("does not throttle the finalize drain and still settles", () => {
+    const scheduler = createManualScheduler();
+    const buffer = createStreamBuffer({ ...scheduler, ...PACING });
+    let notifications = 0;
+    let drained = false;
+    buffer.subscribe(() => {
+      notifications += 1;
+    });
+    buffer.appendAnswer(`${"word ".repeat(4000)}end`);
+    buffer.whenDrained(() => {
+      drained = true;
+    });
+    buffer.finalize();
+
+    notifications = 0;
+    for (let i = 0; i < 6; i += 1) scheduler.advance(16);
+    expect(notifications).toBe(6);
+
+    let frames = 0;
+    while (!buffer.getSnapshot().isSettled && frames < 200) {
+      scheduler.advance(16);
+      frames += 1;
+    }
+    expect(buffer.getSnapshot().isSettled).toBe(true);
+    expect(buffer.getSnapshot().answerDisplay.endsWith("end")).toBe(true);
+    expect(drained).toBe(true);
+  });
+
   it("unsubscribe stops notifications", () => {
     const scheduler = createManualScheduler();
     const buffer = createStreamBuffer({ ...scheduler, ...PACING });

--- a/tests/unit/text-utils.test.ts
+++ b/tests/unit/text-utils.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { normalizeLineBreaks } from "@/lib/text-utils";
+
+describe("normalizeLineBreaks", () => {
+  it("returns the same reference when no carriage returns or backslashes are present", () => {
+    const text = "Plain streamed prose\nwith regular newlines.";
+    expect(normalizeLineBreaks(text)).toBe(text);
+  });
+
+  it("normalizes carriage return line breaks", () => {
+    expect(normalizeLineBreaks("a\r\nb\rc")).toBe("a\nb\nc");
+  });
+
+  it("normalizes escaped line break sequences", () => {
+    expect(normalizeLineBreaks("a\\nb")).toBe("a\nb");
+    expect(normalizeLineBreaks("a\\r\\nb")).toBe("a\nb");
+    expect(normalizeLineBreaks("a\\rb")).toBe("a\nb");
+  });
+
+  it("normalizes double-escaped sequences", () => {
+    expect(normalizeLineBreaks("a\\\\nb")).toBe("a\nb");
+    expect(normalizeLineBreaks("a\\\\r\\\\nb")).toBe("a\nb");
+  });
+});


### PR DESCRIPTION
## Problem
Chat becomes slow when a conversation has many messages, especially long streaming replies: every off-screen message still renders, markdown stripping re-runs needlessly, and huge streamed answers notify the UI too often.

## Solution
Skip work that the user can't see yet, in a few places:

- **CSS `content-visibility`** – settled message rows get `content-visibility: auto` with `contain-intrinsic-size`, so the browser skips layout/paint for off-screen messages. The actively streaming row is excluded.
- **Auto-load earlier messages** – an `IntersectionObserver` sentinel above the visible window expands the message limit when the user scrolls near the top, instead of requiring a manual "Show earlier messages" click.
- **Cheaper markdown for finished blocks** – completed assistant text blocks render with Streamdown's `static` mode instead of `streaming` mode, and streaming-only props are no longer passed to settled messages.
- **Attachment-markdown strip cache** – `MessageBubble` memoizes `stripAttachmentStyleImageMarkdown` results per block keyed by message/attachment ids, and copy now strips across timeline segments correctly.
- **Throttled stream notifications** – the stream buffer reduces notification frequency for very long content (16k+ chars at 48ms, 48k+ at 112ms); short content and the finalize drain are unaffected.
- **Fast path for `normalizeLineBreaks`** – returns the input untouched when it contains no `\r` or backslashes.

## Testing
- New unit tests for content-visibility class application, sentinel auto-load behavior, cross-segment copy stripping, stream throttling/settling, and `normalizeLineBreaks` fast paths (`tests/unit/chat-view.test.ts`, `tests/unit/message-bubble.test.ts`, `tests/unit/stream-buffer.test.ts`, `tests/unit/text-utils.test.ts`).