### PR TITLE
Fix conversation getting stuck in long chats

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -102,11 +102,6 @@ html.ios-pwa .app-shell {
   scrollbar-gutter: auto !important;
 }
 
-.message-row {
-  content-visibility: auto;
-  contain-intrinsic-size: auto 160px;
-}
-
 ::selection {
   background: rgba(139, 92, 246, 0.35);
   color: white;

--- a/components/chat-view.tsx
+++ b/components/chat-view.tsx
@@ -592,20 +592,32 @@ export function ChatView({ payload }: { payload: ConversationViewPayload }) {
     const sentinel = earlierMessagesSentinelRef.current;
     if (!sentinel) return;
     const scroller = contentEndRef.current?.closest(".conversation-scroller");
+    const root = scroller instanceof HTMLElement ? scroller : null;
+    let hasScrolled = false;
+    const markScrolled = () => {
+      hasScrolled = true;
+    };
+    root?.addEventListener("scroll", markScrolled, { once: true, passive: true });
     const observer = new IntersectionObserver(
       (entries) => {
         if (!entries.some((entry) => entry.isIntersecting)) return;
         if (expandAnchorMessageIdRef.current !== null) return;
+        if (!hasScrolled) return;
+        const rootTop = root?.getBoundingClientRect().top ?? 0;
+        if (sentinel.getBoundingClientRect().bottom < rootTop - 600) return;
         expandAnchorMessageIdRef.current = firstVisibleMessageIdRef.current;
         setVisibleMessageLimit((current) => current + VISIBLE_MESSAGE_INCREMENT);
       },
       {
-        root: scroller instanceof HTMLElement ? scroller : null,
+        root,
         rootMargin: "600px 0px 0px 0px"
       }
     );
     observer.observe(sentinel);
-    return () => observer.disconnect();
+    return () => {
+      root?.removeEventListener("scroll", markScrolled);
+      observer.disconnect();
+    };
   }, [hasHiddenMessages]);
 
   useEffect(() => {
@@ -1996,14 +2008,7 @@ export function ChatView({ payload }: { payload: ConversationViewPayload }) {
               <div
                 key={renderKeyByMessageIdRef.current.get(message.id) ?? message.id}
                 data-message-id={message.id}
-                className={
-                  [
-                    isStreamingMessage ? null : "message-row",
-                    shouldAnimate ? "animate-slide-up" : null
-                  ]
-                    .filter(Boolean)
-                    .join(" ") || undefined
-                }
+                className={shouldAnimate ? "animate-slide-up" : undefined}
                 style={shouldAnimate ? { animationFillMode: "forwards" } : undefined}
               >
                 <StreamingMessage

--- a/tests/unit/chat-view.test.ts
+++ b/tests/unit/chat-view.test.ts
@@ -5069,35 +5069,6 @@ describe("chat view", () => {
     expect(screen.queryByRole("button", { name: /Show earlier messages/ })).toBeNull();
   }, 15000);
 
-  it("applies the content-visibility row class to settled rows but not the streaming row", async () => {
-    renderWithProvider(React.createElement(ChatView, { payload: createPayload() }));
-
-    const textarea = screen.getByRole("textbox");
-    fireEvent.change(textarea, { target: { value: "hello" } });
-    fireEvent.keyDown(textarea, { key: "Enter" });
-
-    await waitFor(() => {
-      expect(screen.getByText("hello")).toBeInTheDocument();
-    });
-
-    act(() => {
-      wsMock.onMessage!({
-        type: "delta",
-        conversationId: "conv_1",
-        event: { type: "message_start", messageId: "msg_assistant" }
-      });
-    });
-
-    const streamingRow = document.querySelector('[data-message-id="msg_assistant"]');
-    expect(streamingRow).not.toBeNull();
-    expect(streamingRow!.classList.contains("message-row")).toBe(false);
-
-    for (const row of document.querySelectorAll("[data-message-id]")) {
-      if (row === streamingRow) continue;
-      expect(row.classList.contains("message-row")).toBe(true);
-    }
-  });
-
   it("auto-loads earlier messages when the top sentinel comes into view", async () => {
     type ObserverInstance = {
       callback: IntersectionObserverCallback;
@@ -5157,6 +5128,16 @@ describe("chat view", () => {
       });
       expect(container.querySelectorAll("[data-message-id]")).toHaveLength(60);
 
+      act(() => {
+        observer!.callback(
+          [{ isIntersecting: true } as IntersectionObserverEntry],
+          {} as IntersectionObserver
+        );
+      });
+      expect(container.querySelectorAll("[data-message-id]")).toHaveLength(60);
+
+      fireEvent.scroll(getScrollContainer()!);
+
       const scrollIntoViewSpy = vi.spyOn(Element.prototype, "scrollIntoView");
 
       await act(async () => {
@@ -5190,4 +5171,59 @@ describe("chat view", () => {
 
     expect(screen.queryByTestId("earlier-messages-sentinel")).toBeNull();
   });
+
+  it("streams the assistant answer in a long conversation with status line mode", async () => {
+    const base = createPayload();
+    const payload = createPayload({
+      messages: Array.from({ length: 170 }, (_, index) =>
+        createMessage({
+          id: `msg_long_${index}`,
+          role: index % 2 === 0 ? "user" : "assistant",
+          content: `Long message ${index}`
+        })
+      ),
+      settings: { ...base.settings, toolCallDisplay: "status_line" }
+    });
+
+    renderWithProvider(React.createElement(ChatView, { payload }));
+
+    const textarea = screen.getByRole("textbox");
+    fireEvent.change(textarea, { target: { value: "follow-up question" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(screen.getByText("follow-up question")).toBeInTheDocument();
+    });
+
+    act(() => {
+      wsMock.onMessage!({
+        type: "delta",
+        conversationId: "conv_1",
+        event: { type: "message_start", messageId: "msg_assistant_long" }
+      });
+    });
+    act(() => {
+      wsMock.onMessage!({
+        type: "delta",
+        conversationId: "conv_1",
+        event: { type: "answer_delta", text: "Here is the streamed reply " }
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Here is the streamed/)).toBeInTheDocument();
+    }, { timeout: 4000 });
+
+    act(() => {
+      wsMock.onMessage!({
+        type: "delta",
+        conversationId: "conv_1",
+        event: { type: "done", messageId: "msg_assistant_long" }
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Here is the streamed reply/)).toBeInTheDocument();
+    }, { timeout: 4000 });
+  }, 20000);
 });


### PR DESCRIPTION
## Problem
In long conversations, the chat could appear stuck in the "working" state: the assistant reply never rendered and earlier messages loaded unexpectedly.

## Solution
In plain terms: we stopped the page from lazily skipping message rendering (which confused scroll/load logic), and made the "load earlier messages" trigger only fire after the user actually scrolls near the top.

Details:
- Remove the `message-row` `content-visibility: auto` optimization from `app/globals.css` and `components/chat-view.tsx`, since it interfered with rendering during streaming in large chats.
- Guard the top sentinel `IntersectionObserver` so it only expands the visible message window after a real scroll and when the sentinel is within the expanded root margin.
- Update unit tests: remove the obsolete `message-row` class test, verify the sentinel ignores pre-scroll intersections, and add a regression test streaming an answer in a 170-message conversation with status-line tool display.

## Testing
- Updated `tests/unit/chat-view.test.ts` covering sentinel behavior and long-conversation streaming.