### PR TITLE
Defer memory proposal card until assistant turn completes

### DIFF
--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -690,26 +690,34 @@ function MessageBubbleImpl({
   }
 
   function renderAssistantActionItem(item: Extract<MessageTimelineItem, { timelineKind: "action" }>) {
-    if (useStatusLine && !isMemoryProposalAction(item)) {
-      return null;
-    }
+    if (isMemoryProposalAction(item)) {
+      if (isAssistantStreaming) {
+        return null;
+      }
 
-    return (
-      <div key={item.id} data-testid="assistant-actions-shell">
-        {isMemoryProposalAction(item) ? (
+      return (
+        <div key={item.id} data-testid="assistant-actions-shell">
           <MemoryProposalCard
             action={item}
             onApprove={onApproveMemoryProposal}
             onDismiss={onDismissMemoryProposal}
             readOnly={readOnly}
           />
-        ) : (
-          <CollapsibleActionRow
-            action={item}
-            isOpen={toolOpenItems[item.id] ?? false}
-            onToggle={() => toggleToolItem(item.id)}
-          />
-        )}
+        </div>
+      );
+    }
+
+    if (useStatusLine) {
+      return null;
+    }
+
+    return (
+      <div key={item.id} data-testid="assistant-actions-shell">
+        <CollapsibleActionRow
+          action={item}
+          isOpen={toolOpenItems[item.id] ?? false}
+          onToggle={() => toggleToolItem(item.id)}
+        />
       </div>
     );
   }

--- a/tests/unit/message-bubble.test.ts
+++ b/tests/unit/message-bubble.test.ts
@@ -256,6 +256,27 @@ describe("message bubble", () => {
     expect(screen.queryByText(/query=MCP/)).toBeNull();
   });
 
+  it("defers the memory proposal card until the assistant turn stops streaming", () => {
+    const { rerender } = render(
+      React.createElement(MessageBubble, {
+        message: createMemoryProposalMessage({ status: "streaming" })
+      })
+    );
+
+    expect(screen.getByText("I can remember that.")).toBeInTheDocument();
+    expect(screen.queryByText("Save memory")).toBeNull();
+
+    rerender(
+      React.createElement(MessageBubble, {
+        message: createMemoryProposalMessage()
+      })
+    );
+
+    expect(screen.getByText("I can remember that.")).toBeInTheDocument();
+    expect(screen.getByText("Save memory")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+  });
+
   it("renders pending update proposals with before and after details", () => {
     render(
       React.createElement(MessageBubble, {


### PR DESCRIPTION
## Summary

- Pending memory proposal cards now render only after the assistant turn finishes streaming, instead of appearing mid-turn before the assistant's chat text arrives (e.g. "write to memory that I like Legos" used to pop the card before the answer).
- `renderAssistantActionItem` in `components/message-bubble.tsx` returns `null` for memory proposal actions while `isAssistantStreaming` is true; the card appears below the completed message text once the turn ends. This applies in both status-line and tool-pill display modes.
- Added unit test coverage: the card is hidden while `message.status === "streaming"` and appears on rerender once the message completes.

## Testing

- `npx vitest run tests/unit/message-bubble.test.ts` — 93 tests pass (includes the new deferral test).
- Full suite: 158 test files / 1778 tests passed with coverage thresholds enforced (exit 0).
