### PR TITLE
Stop killing WebSocket clients on large conversation snapshots

### DIFF
--- a/lib/ws-handler.ts
+++ b/lib/ws-handler.ts
@@ -37,6 +37,7 @@ import {
 
 const MAX_WS_ERROR_MESSAGE_CHARS = 1_000;
 const MAX_MOBILE_SNAPSHOT_BYTES = 768 * 1024;
+const MAX_PRE_SETUP_MESSAGES = 64;
 
 function buildSnapshotMessage(
   conversationId: string,
@@ -194,6 +195,22 @@ export async function handleConnection(
   let mgr: ConversationManager | null = null;
   const currentSubscription = new Set<string>();
 
+  let dispatchIncoming: ((raw: WebSocket.RawData) => void) | null = null;
+  const preSetupMessages: WebSocket.RawData[] = [];
+  ws.on("message", (raw: WebSocket.RawData) => {
+    if (dispatchIncoming) {
+      dispatchIncoming(raw);
+      return;
+    }
+
+    if (preSetupMessages.length >= MAX_PRE_SETUP_MESSAGES) {
+      closeAfterMessageFailure(ws);
+      return;
+    }
+
+    preSetupMessages.push(raw);
+  });
+
   ws.on("close", () => {
     closed = true;
     if (!mgr) {
@@ -276,7 +293,7 @@ export async function handleConnection(
     }))
   }, versioned);
 
-  ws.on("message", (raw: WebSocket.RawData) => {
+  dispatchIncoming = (raw: WebSocket.RawData) => {
     try {
       const msg = parseClientMessage(raw.toString());
       if (!msg) return;
@@ -286,7 +303,11 @@ export async function handleConnection(
     } catch (error) {
       handleMessageFailure(ws, error, versioned);
     }
-  });
+  };
+
+  for (const raw of preSetupMessages.splice(0)) {
+    dispatchIncoming(raw);
+  }
 }
 
 function handleMessageFailure(ws: WebSocket, error: unknown, versioned = false) {

--- a/lib/ws-send.ts
+++ b/lib/ws-send.ts
@@ -7,8 +7,11 @@ export function sendWebSocketData(ws: WebSocket, data: string) {
     return false;
   }
 
-  const queuedBytes = (ws.bufferedAmount ?? 0) + Buffer.byteLength(data, "utf8");
-  if (queuedBytes > MAX_WS_BUFFERED_BYTES) {
+  const backlogBytes = ws.bufferedAmount ?? 0;
+  if (backlogBytes > MAX_WS_BUFFERED_BYTES) {
+    console.warn(
+      `[ws-send] closing slow WebSocket client: ${backlogBytes} bytes still queued before a ${Buffer.byteLength(data, "utf8")}-byte send`
+    );
     ws.close(1013, "WebSocket client is too slow");
     return false;
   }

--- a/tests/unit/conversation-manager.test.ts
+++ b/tests/unit/conversation-manager.test.ts
@@ -226,18 +226,18 @@ describe("conversation-manager", () => {
     expect(ws.close).toHaveBeenCalledWith(1013, "WebSocket client is too slow");
   });
 
-  it("includes the pending payload bytes in the backpressure limit", async () => {
+  it("delivers a single payload larger than the backlog limit when the client keeps up", async () => {
     const { sendWebSocketData, MAX_WS_BUFFERED_BYTES } = await import("@/lib/ws-send");
     const ws = {
       readyState: 1,
-      bufferedAmount: MAX_WS_BUFFERED_BYTES - 3,
+      bufferedAmount: 0,
       send: vi.fn(),
       close: vi.fn()
     } as unknown as WebSocket;
 
-    expect(sendWebSocketData(ws, "four")).toBe(false);
-    expect(ws.send).not.toHaveBeenCalled();
-    expect(ws.close).toHaveBeenCalledWith(1013, "WebSocket client is too slow");
+    expect(sendWebSocketData(ws, "x".repeat(MAX_WS_BUFFERED_BYTES + 1))).toBe(true);
+    expect(ws.send).toHaveBeenCalled();
+    expect(ws.close).not.toHaveBeenCalled();
   });
 
   it("enforces a process-wide manager connection cap", async () => {

--- a/tests/unit/ws-handler.test.ts
+++ b/tests/unit/ws-handler.test.ts
@@ -265,6 +265,69 @@ describe("ws-handler", () => {
     vi.doUnmock("@/lib/ws-singleton");
   });
 
+  it("processes a subscribe that arrives while authentication is still pending", async () => {
+    let resolveSession!: (value: { sessionId: string; userId: string }) => void;
+    const pendingSession = new Promise<{ sessionId: string; userId: string }>((resolve) => {
+      resolveSession = resolve;
+    });
+    const { verifySessionToken } = await import("@/lib/auth");
+    (verifySessionToken as ReturnType<typeof vi.fn>).mockReturnValue(pendingSession);
+    const { getConversationSnapshot, listActiveConversations, listQueuedMessages } = await import("@/lib/conversations");
+    (listActiveConversations as ReturnType<typeof vi.fn>).mockReturnValue([]);
+    (listQueuedMessages as ReturnType<typeof vi.fn>).mockReturnValue([]);
+    (getConversationSnapshot as ReturnType<typeof vi.fn>).mockReturnValue({
+      messages: [],
+      queuedMessages: []
+    });
+
+    const mockMgr = {
+      addConnection: vi.fn().mockReturnValue(true),
+      removeConnection: vi.fn(),
+      subscribe: vi.fn(),
+      unsubscribe: vi.fn(),
+      disconnect: vi.fn(),
+      broadcast: vi.fn(),
+      broadcastAll: vi.fn(),
+      hasSubscribers: vi.fn(),
+      setActive: vi.fn(),
+      isActive: vi.fn(),
+      getActiveConversationIds: vi.fn()
+    };
+    vi.doMock("@/lib/ws-singleton", () => ({ getConversationManager: () => mockMgr }));
+
+    const { handleConnection } = await import("@/lib/ws-handler");
+    const sent: string[] = [];
+    const messageHandlers: Array<(data: string) => void> = [];
+    const ws = {
+      readyState: 1,
+      bufferedAmount: 0,
+      send: vi.fn((data: string) => sent.push(data)),
+      close: vi.fn(),
+      terminate: vi.fn(),
+      on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+        if (event === "message") messageHandlers.push((data: string) => handler(data));
+      })
+    } as unknown as WebSocket;
+
+    try {
+      const connection = handleConnection(ws, "valid-token");
+      await Promise.resolve();
+
+      messageHandlers[0]?.(JSON.stringify({ type: "subscribe", conversationId: "conv-1" }));
+      expect(mockMgr.subscribe).not.toHaveBeenCalled();
+
+      resolveSession({ sessionId: "session-1", userId: "user-1" });
+      await connection;
+
+      expect(mockMgr.subscribe).toHaveBeenCalledWith("conv-1", ws);
+      const types = sent.map((raw) => JSON.parse(raw).type);
+      expect(types).toContain("ready");
+      expect(types).toContain("snapshot");
+    } finally {
+      vi.doUnmock("@/lib/ws-singleton");
+    }
+  });
+
   it("scopes login-disabled sockets to the bootstrap user", async () => {
     const previous = process.env.EIDON_PASSWORD_LOGIN_ENABLED;
     process.env.EIDON_PASSWORD_LOGIN_ENABLED = "false";


### PR DESCRIPTION
## Problem

Once a conversation's subscribe snapshot serializes past 1 MiB, `sendWebSocketData` closed the socket (`1013 "WebSocket client is too slow"`) on every `subscribe` — an endless reconnect loop. The client's outgoing messages still got through during the brief open windows (the turn ran server-side), but it never received the snapshot, deltas, or `conversation_activity` events: the chat sat on "Working…" until a full page refresh, and activity from other clients never showed in the sidebar.

This was fixed for mobile in "Fit mobile websocket snapshots inside the single-frame send budget", but browser connections were never actually exempt from the send guard.

Reproduced with a plain Node ws probe against a conversation whose snapshot is ~1.4 MB: before this change every subscribe died in ~9 ms with code 1013; after, the snapshot is delivered and the socket stays healthy.

## Changes

- `lib/ws-send.ts`: close a socket only when its **already-queued backlog** exceeds `MAX_WS_BUFFERED_BYTES`, never because a single outgoing frame is large. Slow-client protection is preserved (a stalled client accumulates backlog and is culled on the next send) and now logs a warning so occurrences are visible in production logs.
- `lib/ws-handler.ts`: buffer client messages that arrive before async auth/setup completes. The `ws` library drops messages received before a `message` listener is attached, so a client's immediate `subscribe` could be silently lost, leaving a connected socket that never receives conversation events.
- Regression tests for both (oversized single-frame delivery, pre-auth subscribe buffering).

## Testing

- Node ws probe before/after against a >1 MiB conversation (death loop → snapshot delivered)
- Full unit suite: 158 test files passing; `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)