### PR TITLE
Fix folder submenu placement and viewport overflow

### DIFF
--- a/components/conversation-item.tsx
+++ b/components/conversation-item.tsx
@@ -39,21 +39,21 @@ export function DropdownPortal({
 }) {
   const [coords, setCoords] = useState<{ top: number; left: number; width: number } | null>(null);
 
-  React.useLayoutEffect(() => {
-    if (!open || !anchorRef.current) return;
+  const computeCoords = () => {
+    if (!anchorRef.current) return;
     const rect = anchorRef.current.getBoundingClientRect();
-    setCoords({ top: rect.bottom + 4, left: rect.right - 224, width: 224 });
+    setCoords({ top: rect.bottom + 4, left: Math.max(8, rect.right - 224), width: 224 });
+  };
+
+  React.useLayoutEffect(() => {
+    if (!open) return;
+    computeCoords();
   }, [anchorRef, open]);
 
   useEffect(() => {
     if (!open) return;
-    function handleScroll() {
-      if (!anchorRef.current) return;
-      const rect = anchorRef.current.getBoundingClientRect();
-      setCoords({ top: rect.bottom + 4, left: rect.right - 224, width: 224 });
-    }
-    window.addEventListener("scroll", handleScroll, true);
-    return () => window.removeEventListener("scroll", handleScroll, true);
+    window.addEventListener("scroll", computeCoords, true);
+    return () => window.removeEventListener("scroll", computeCoords, true);
   }, [anchorRef, open]);
 
   if (!open || !coords || typeof document === "undefined") return null;

--- a/components/folder-item.tsx
+++ b/components/folder-item.tsx
@@ -187,7 +187,7 @@ export function FolderItem({
       <DropdownPortal anchorRef={triggerRef} open={folderMenuOpen}>
         <div
           ref={menuRef}
-          className="w-48 rounded-2xl border border-white/5 bg-[#121214] p-2 shadow-2xl backdrop-blur-xl animate-fade-in relative"
+          className="w-full rounded-2xl border border-white/5 bg-[#121214] p-2 shadow-2xl backdrop-blur-xl animate-fade-in relative"
         >
           <button
             onClick={() => setFolderMenuOpen(false)}


### PR DESCRIPTION
## Problem
The folder submenu could render partially off-screen because its horizontal position wasn't clamped, and its fixed width didn't match the portal's computed width.

## Solution
Clamp the dropdown's left position to at least 8px so it never overflows the viewport edge, share the coordinate calculation between the layout effect and the scroll listener, and make the folder submenu use the full portal width (`w-full`) instead of a hard-coded `w-48` so it aligns correctly with the anchor.

- Extracted `computeCoords` and reused it for both initial placement and scroll repositioning
- Added `Math.max(8, rect.right - 224)` to keep the menu inside the viewport
- Changed folder menu width to `w-full` to match the portal's 224px width