### PR TITLE
Use accent color for scroll-to-latest button on all breakpoints

### DIFF
--- a/components/ai-elements/conversation.tsx
+++ b/components/ai-elements/conversation.tsx
@@ -138,7 +138,7 @@ export const ConversationScrollButton = ({
       <Button
         aria-label="Scroll to latest messages"
         className={cn(
-          "absolute bottom-[calc(var(--composer-height,80px)+12px)] left-1/2 z-10 flex h-11 w-11 -translate-x-1/2 animate-fade-in items-center justify-center rounded-full bg-white p-0 text-zinc-950 shadow-[0_6px_20px_rgba(0,0,0,0.42)] transition-[background-color,transform] duration-150 hover:bg-zinc-100 hover:text-zinc-950 active:scale-[0.96] md:bottom-[var(--composer-height,160px)] md:h-8 md:w-auto md:gap-1 md:bg-[var(--accent)] md:px-3.5 md:text-[10px] md:font-bold md:uppercase md:tracking-wider md:text-white md:ring-1 md:ring-[var(--accent)] md:hover:bg-[var(--accent)] md:hover:text-white md:hover:opacity-90",
+          "absolute bottom-[var(--composer-height,80px)] left-1/2 z-[55] flex h-11 w-11 -translate-x-1/2 animate-fade-in items-center justify-center rounded-full bg-[var(--accent)] p-0 text-white shadow-[0_6px_20px_rgba(0,0,0,0.42)] transition-[background-color,transform] duration-150 hover:bg-[var(--accent)] hover:text-white hover:opacity-90 active:scale-[0.96] md:bottom-[var(--composer-height,160px)] md:h-8 md:w-auto md:gap-1 md:px-3.5 md:text-[10px] md:font-bold md:uppercase md:tracking-wider md:ring-1 md:ring-[var(--accent)]",
           className
         )}
         onClick={handleScrollToBottom}

--- a/tests/unit/conversation-scroll-button.test.tsx
+++ b/tests/unit/conversation-scroll-button.test.tsx
@@ -188,7 +188,7 @@ describe("ConversationScrollButton", () => {
     render(React.createElement(ConversationScrollButton));
 
     const button = screen.getByRole("button", { name: "Scroll to latest messages" });
-    expect(button.className).toContain("bottom-[calc(var(--composer-height,80px)+12px)]");
+    expect(button.className).toContain("bottom-[var(--composer-height,80px)]");
     expect(screen.getByText("Latest")).toHaveClass("hidden", "md:inline");
   });
 });


### PR DESCRIPTION
## Problem
The scroll-to-latest button used a white background on small screens and only switched to the accent color at the `md:` breakpoint, so its appearance was inconsistent across screen sizes.

## Solution
Apply the accent background, white text, and matching hover/ring styles at the base (mobile) level and drop the duplicated breakpoint-specific overrides, so the button looks the same on all breakpoints. Also adjusted the bottom offset and raised the z-index.

## Testing
- Updated `tests/unit/conversation-scroll-button.test.tsx` to assert the new bottom offset class.