### PR TITLE
fix: render LaTeX math in chat messages

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import { APP_NAME } from "@/lib/constants";
 import { ServiceWorkerRegistration } from "@/components/service-worker-registration";
 
 import "streamdown/styles.css";
+import "katex/dist/katex.min.css";
 import "@/app/globals.css";
 import { cn } from "@/lib/utils";
 

--- a/components/message-bubble.tsx
+++ b/components/message-bubble.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { Brain, Check, ChevronDown, ChevronRight, Copy, GitFork, LoaderCircle, Pencil, RefreshCw, Square, X } from "lucide-react";
 import { Streamdown } from "streamdown";
+import { math } from "@streamdown/math";
 import { MarkdownErrorBoundary } from "@/components/markdown-error-boundary";
 import {
   AttachmentPreviewModal,
@@ -32,7 +33,7 @@ import type {
   PublicMessageAttachment,
   ToolCallDisplayMode
 } from "@/lib/types";
-import { normalizeLineBreaks } from "@/lib/text-utils";
+import { normalizeRealLineBreaks } from "@/lib/text-utils";
 import { Textarea } from "@/components/ui/textarea";
 import {
   Message,
@@ -109,7 +110,8 @@ const AssistantMarkdown = React.memo(
     isStatic?: boolean;
     linkSafety: ReturnType<typeof useLinkSafety>;
   }) {
-    const plugins = useStreamdownPlugins(content);
+    const sharedPlugins = useStreamdownPlugins(content);
+    const plugins = useMemo(() => ({ math, ...sharedPlugins }), [sharedPlugins]);
     const fallback = (
       <pre className="whitespace-pre-wrap break-words text-sm">{content}</pre>
     );
@@ -404,8 +406,12 @@ function MessageBubbleImpl({
   const previewController = useAttachmentPreviewController();
   const linkSafety = useLinkSafety(confirmExternalLinks);
   const useStatusLine = toolCallDisplay === "status_line";
-  const userPlugins = useStreamdownPlugins(
+  const sharedUserPlugins = useStreamdownPlugins(
     message.role === "user" ? streamingAnswer ?? message.content : ""
+  );
+  const userPlugins = useMemo(
+    () => ({ math, ...sharedUserPlugins }),
+    [sharedUserPlugins]
   );
 
   useEffect(() => {
@@ -438,7 +444,7 @@ function MessageBubbleImpl({
       streamingTimeline !== undefined && streamingAnswer !== undefined
         ? clampStreamingTimeline(streamingTimeline, streamingAnswer)
         : streamingTimeline ?? message.timeline;
-    const contentForComparison = normalizeLineBreaks(rawContent);
+    const contentForComparison = normalizeRealLineBreaks(rawContent);
     const timeline = liveTimeline ?? actions.map((action) => ({
       ...action,
       timelineKind: "action" as const
@@ -513,7 +519,7 @@ function MessageBubbleImpl({
       )
       .map((item) => item.content)
       .join("");
-    const normalizedConsumedText = normalizeLineBreaks(consumedText);
+    const normalizedConsumedText = normalizeRealLineBreaks(consumedText);
 
     if (
       contentForComparison &&

--- a/lib/text-utils.ts
+++ b/lib/text-utils.ts
@@ -13,6 +13,14 @@ export function normalizeLineBreaks(text: string) {
     .replace(/\\r/g, "\n");
 }
 
+export function normalizeRealLineBreaks(text: string) {
+  if (!text.includes("\r")) {
+    return text;
+  }
+
+  return text.replace(/\r\n?/g, "\n");
+}
+
 export function formatTimestamp(value: string) {
   return new Intl.DateTimeFormat("en", {
     month: "short",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "framer-motion": "^12.38.0",
         "gpt-tokenizer": "^3.4.0",
         "jose": "^6.0.8",
+        "katex": "^0.16.46",
         "lucide-react": "^0.511.0",
         "mdast-util-to-string": "^4.0.0",
         "next": "^15.5.18",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "framer-motion": "^12.38.0",
     "gpt-tokenizer": "^3.4.0",
     "jose": "^6.0.8",
+    "katex": "^0.16.46",
     "lucide-react": "^0.511.0",
     "mdast-util-to-string": "^4.0.0",
     "next": "^15.5.18",

--- a/tests/unit/message-bubble-math.test.tsx
+++ b/tests/unit/message-bubble-math.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { math } from "@streamdown/math";
+
+const streamdownMock = vi.fn((props: { children?: React.ReactNode; plugins?: unknown }) =>
+  React.createElement("div", null, props.children)
+);
+
+vi.mock("streamdown", () => ({
+  Streamdown: (props: { children?: React.ReactNode; plugins?: unknown }) => streamdownMock(props)
+}));
+
+vi.mock("@streamdown/mermaid", () => ({
+  mermaid: { name: "mermaid", type: "diagram", language: "mermaid" }
+}));
+
+import { MessageBubble } from "@/components/message-bubble";
+import type { Message } from "@/lib/types";
+
+function createMessage(role: "user" | "assistant", content: string): Message {
+  return {
+    id: `msg_${role}`,
+    conversationId: "conv_test",
+    role,
+    content,
+    thinkingContent: "",
+    status: "completed",
+    estimatedTokens: 0,
+    systemKind: null,
+    compactedAt: null,
+    createdAt: new Date().toISOString(),
+    actions: []
+  };
+}
+
+function streamdownCallsFor(content: string) {
+  return streamdownMock.mock.calls.filter((call) => {
+    const children = call[0]?.children;
+    return typeof children === "string" && children.includes(content);
+  }) as Array<[{ children?: React.ReactNode; plugins?: { math?: unknown } }]>;
+}
+
+describe("math plugin wiring in chat messages", () => {
+  beforeEach(() => {
+    streamdownMock.mockClear();
+  });
+
+  it("passes the math plugin when rendering assistant content", () => {
+    render(
+      React.createElement(MessageBubble, {
+        message: createMessage("assistant", "Throughput is\n\n$$T = \\frac{1}{r + c}$$")
+      })
+    );
+
+    const calls = streamdownCallsFor("Throughput is");
+    expect(calls.length).toBeGreaterThan(0);
+    for (const [props] of calls) {
+      expect(props.plugins?.math).toBe(math);
+    }
+  });
+
+  it("passes the math plugin when rendering user content", () => {
+    render(
+      React.createElement(MessageBubble, {
+        message: createMessage("user", "What about $$E = mc^2$$?")
+      })
+    );
+
+    const calls = streamdownCallsFor("What about");
+    expect(calls.length).toBeGreaterThan(0);
+    for (const [props] of calls) {
+      expect(props.plugins?.math).toBe(math);
+    }
+  });
+
+  it("preserves literal LaTeX escape sequences in rendered content", () => {
+    const formula = "$$P(\\text{stampede}) = 1 - \\left(1 - \\frac{1}{N}\\right)^{k}$$";
+
+    render(
+      React.createElement(MessageBubble, {
+        message: createMessage("assistant", `Consider:\n\n${formula}\n\n**Bottom line:** safe.`)
+      })
+    );
+
+    const calls = streamdownCallsFor("Consider:");
+    expect(calls.length).toBeGreaterThan(0);
+    for (const [props] of calls) {
+      expect(props.children).toContain("\\left(1 - \\frac{1}{N}\\right)");
+      expect(props.children).not.toContain("\night");
+    }
+  });
+});

--- a/tests/unit/text-utils.test.ts
+++ b/tests/unit/text-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { normalizeLineBreaks } from "@/lib/text-utils";
+import { normalizeLineBreaks, normalizeRealLineBreaks } from "@/lib/text-utils";
 
 describe("normalizeLineBreaks", () => {
   it("returns the same reference when no carriage returns or backslashes are present", () => {
@@ -20,5 +20,24 @@ describe("normalizeLineBreaks", () => {
   it("normalizes double-escaped sequences", () => {
     expect(normalizeLineBreaks("a\\\\nb")).toBe("a\nb");
     expect(normalizeLineBreaks("a\\\\r\\\\nb")).toBe("a\nb");
+  });
+});
+
+describe("normalizeRealLineBreaks", () => {
+  it("returns the same reference when no carriage returns are present", () => {
+    const text = "Stored content\nwith newlines and \\left(\\right) LaTeX.";
+    expect(normalizeRealLineBreaks(text)).toBe(text);
+  });
+
+  it("normalizes real carriage returns without touching escape sequences", () => {
+    expect(normalizeRealLineBreaks("a\r\nb\rc")).toBe("a\nb\nc");
+    expect(normalizeRealLineBreaks("a\\nb")).toBe("a\\nb");
+    expect(normalizeRealLineBreaks("a\\rb")).toBe("a\\rb");
+  });
+
+  it("keeps LaTeX commands starting with backslash-r or backslash-n intact", () => {
+    expect(normalizeRealLineBreaks("\\rho \\ne \\nu \\right) \\not\\equiv")).toBe(
+      "\\rho \\ne \\nu \\right) \\not\\equiv"
+    );
   });
 });


### PR DESCRIPTION
## Summary

Two related bugs prevented LaTeX math from rendering in chat conversations:

- **Math plugin was never wired into the chat renderer.** The `math` plugin from `@streamdown/math` was only used by the shared-conversation view (`MessageResponse`); `components/message-bubble.tsx` (the main chat renderer) passed only the mermaid/code plugins, so `74413...`` display math rendered as raw text. This PR adds the plugin to both the assistant and user Streamdown paths and imports `katex/dist/katex.min.css` (katex added as a direct dependency). Inline single-dollar math (`$`) intentionally stays raw — the plugin disables single-dollar parsing by default to avoid false positives.

- **Display path corrupted LaTeX escape sequences.** Stored message content passed through `normalizeLineBreaks`, which converts *literal* `\r` / `\n` two-character sequences into real newlines (a workaround for providers that stream escaped line breaks). This mangled any LaTeX command starting with those letters — e.g. `\right)` became a newline + `ight)` — producing KaTeX parse errors (`Can't use function '$' in math mode`) and swallowing the markdown that followed the formula. The display path now uses a new `normalizeRealLineBreaks` that only normalizes real CR/CRLF characters; the provider adapters keep the original escaped-sequence behavior, which their existing tests assert.

## Testing

- New regression tests: `tests/unit/message-bubble-math.test.tsx` (math plugin wiring for assistant + user content; `\left(...\right)` escapes preserved through the render path) and 3 new `normalizeRealLineBreaks` cases in `tests/unit/text-utils.test.ts`.
- Full suite: 162 files / 1820 tests passing, coverage above the 85% threshold on all metrics (91.04% stmts / 85.7% branches / 94% funcs / 91.04% lines).
- Visually verified against a seeded 152-message fixture conversation: previously-broken formula `74413P(\text{stampede}) = 1 - \left(1 - \frac{1}{N}\right)^{k}$` now typesets (0 `.katex-error`), markdown following formulas renders correctly, and mermaid/code blocks/images show no regressions.