### PR TITLE
Add dev image channel published from dev branch

### DIFF
--- a/.github/workflows/docker-dev.yml
+++ b/.github/workflows/docker-dev.yml
@@ -1,0 +1,107 @@
+name: Docker Dev
+
+on:
+  push:
+    branches: [dev]
+  pull_request:
+    branches: [dev]
+
+concurrency:
+  group: docker-dev-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      pull-requests: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Lowercase repository name
+        run: echo "REPO_LOWERCASE=${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
+
+      - name: Set dev build version
+        if: github.event_name == 'push'
+        run: echo "DEV_VERSION=dev-${GITHUB_SHA::7}" >> "$GITHUB_ENV"
+
+      - name: Detect deployment-sensitive changes
+        id: changes
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            deployment:
+              - 'Dockerfile'
+              - '.dockerignore'
+              - '.github/workflows/docker-stable.yml'
+              - '.github/workflows/docker-dev.yml'
+              - '.github/workflows/test.yml'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'next.config.*'
+              - 'public/**'
+              - 'server.cjs'
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish dev image
+        if: github.event_name == 'push'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          build-args: |
+            NEXT_PUBLIC_APP_VERSION=${{ env.DEV_VERSION }}
+          tags: |
+            ghcr.io/${{ env.REPO_LOWERCASE }}:dev
+            ghcr.io/${{ env.REPO_LOWERCASE }}:${{ env.DEV_VERSION }}
+          cache-from: |
+            type=gha
+            type=registry,ref=ghcr.io/${{ env.REPO_LOWERCASE }}/buildcache:main
+            type=registry,ref=ghcr.io/${{ env.REPO_LOWERCASE }}/buildcache:dev
+          cache-to: |
+            type=gha,mode=max
+            type=registry,ref=ghcr.io/${{ env.REPO_LOWERCASE }}/buildcache:dev,mode=max
+
+      - name: Build full production image (pull request)
+        if: github.event_name == 'pull_request' && steps.changes.outputs.deployment == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          tags: |
+            ghcr.io/${{ env.REPO_LOWERCASE }}:pr
+          cache-from: |
+            type=gha
+            type=registry,ref=ghcr.io/${{ env.REPO_LOWERCASE }}/buildcache:main
+            type=registry,ref=ghcr.io/${{ env.REPO_LOWERCASE }}/buildcache:dev
+          cache-to: |
+            type=gha,mode=max
+            type=registry,ref=ghcr.io/${{ env.REPO_LOWERCASE }}/buildcache:dev,mode=max
+
+      - name: Build lightweight builder image
+        if: github.event_name == 'pull_request' && steps.changes.outputs.deployment != 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: builder
+          push: false
+          cache-from: |
+            type=gha
+            type=registry,ref=ghcr.io/${{ env.REPO_LOWERCASE }}/buildcache:main
+            type=registry,ref=ghcr.io/${{ env.REPO_LOWERCASE }}/buildcache:dev
+          cache-to: |
+            type=gha,mode=max
+            type=registry,ref=ghcr.io/${{ env.REPO_LOWERCASE }}/buildcache:dev,mode=max

--- a/.github/workflows/docker-stable.yml
+++ b/.github/workflows/docker-stable.yml
@@ -1,15 +1,13 @@
-name: Docker Build
+name: Docker Stable
 
 on:
   pull_request:
-    branches: [main, dev]
-  push:
-    branches: [dev]
+    branches: [main]
   release:
     types: [published]
 
 concurrency:
-  group: docker-${{ github.ref }}
+  group: docker-stable-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -26,10 +24,6 @@ jobs:
       - name: Lowercase repository name
         run: echo "REPO_LOWERCASE=${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
 
-      - name: Set dev build version
-        if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
-        run: echo "DEV_VERSION=dev-${GITHUB_SHA::7}" >> "$GITHUB_ENV"
-
       - name: Detect deployment-sensitive changes
         id: changes
         if: github.event_name == 'pull_request'
@@ -39,7 +33,8 @@ jobs:
             deployment:
               - 'Dockerfile'
               - '.dockerignore'
-              - '.github/workflows/docker.yml'
+              - '.github/workflows/docker-stable.yml'
+              - '.github/workflows/docker-dev.yml'
               - '.github/workflows/test.yml'
               - 'package.json'
               - 'package-lock.json'
@@ -84,25 +79,6 @@ jobs:
           contracts/mobile-api-v1.openapi.json
           contracts/mobile-api-v1.websocket.schema.json
           --clobber
-
-      - name: Build full production image (dev)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          build-args: |
-            NEXT_PUBLIC_APP_VERSION=${{ env.DEV_VERSION }}
-          tags: |
-            ghcr.io/${{ env.REPO_LOWERCASE }}:dev
-            ghcr.io/${{ env.REPO_LOWERCASE }}:${{ env.DEV_VERSION }}
-          cache-from: |
-            type=gha
-            type=registry,ref=ghcr.io/${{ env.REPO_LOWERCASE }}/buildcache:main
-            type=registry,ref=ghcr.io/${{ env.REPO_LOWERCASE }}/buildcache:dev
-          cache-to: |
-            type=gha,mode=max
-            type=registry,ref=ghcr.io/${{ env.REPO_LOWERCASE }}/buildcache:dev,mode=max
 
       - name: Build full production image (pull request)
         if: github.event_name == 'pull_request' && steps.changes.outputs.deployment == 'true'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,10 +21,6 @@ jobs:
       pull-requests: read
 
     steps:
-      - name: Debounce rapid dev pushes
-        if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
-        run: sleep 300
-
       - uses: actions/checkout@v4
 
       - name: Lowercase repository name

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,9 +2,15 @@ name: Docker Build
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, dev]
+  push:
+    branches: [dev]
   release:
     types: [published]
+
+concurrency:
+  group: docker-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -15,10 +21,18 @@ jobs:
       pull-requests: read
 
     steps:
+      - name: Debounce rapid dev pushes
+        if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
+        run: sleep 300
+
       - uses: actions/checkout@v4
 
       - name: Lowercase repository name
         run: echo "REPO_LOWERCASE=${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
+
+      - name: Set dev build version
+        if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
+        run: echo "DEV_VERSION=dev-${GITHUB_SHA::7}" >> "$GITHUB_ENV"
 
       - name: Detect deployment-sensitive changes
         id: changes
@@ -74,6 +88,25 @@ jobs:
           contracts/mobile-api-v1.openapi.json
           contracts/mobile-api-v1.websocket.schema.json
           --clobber
+
+      - name: Build full production image (dev)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          build-args: |
+            NEXT_PUBLIC_APP_VERSION=${{ env.DEV_VERSION }}
+          tags: |
+            ghcr.io/${{ env.REPO_LOWERCASE }}:dev
+            ghcr.io/${{ env.REPO_LOWERCASE }}:${{ env.DEV_VERSION }}
+          cache-from: |
+            type=gha
+            type=registry,ref=ghcr.io/${{ env.REPO_LOWERCASE }}/buildcache:main
+            type=registry,ref=ghcr.io/${{ env.REPO_LOWERCASE }}/buildcache:dev
+          cache-to: |
+            type=gha,mode=max
+            type=registry,ref=ghcr.io/${{ env.REPO_LOWERCASE }}/buildcache:dev,mode=max
 
       - name: Build full production image (pull request)
         if: github.event_name == 'pull_request' && steps.changes.outputs.deployment == 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -164,6 +164,46 @@ docker compose up -d
 
 Eidon does not ship with a provider API key. The deployment is ready first; you bring the model access you want to use.
 
+### 5. Optional: run the dev channel
+
+Two image channels are published from GitHub:
+
+| Channel | Image tags | Published when |
+| --- | --- | --- |
+| Stable | `:latest`, `:<release version>` | A GitHub release is cut from `main` |
+| Dev | `:dev`, `:dev-<commit sha>` | Every push to the `dev` branch |
+
+To test changes before they are released, merge them into `dev`. Then run the dev image alongside your stable instance with its own data volume and port (save as `docker-compose.dev.yml`):
+
+```yaml
+services:
+  eidon-dev:
+    image: ghcr.io/quack6765/eidon-ai:dev
+    restart: unless-stopped
+    ports:
+      - "3001:3000"
+    environment:
+      EIDON_PASSWORD_LOGIN_ENABLED: "true"
+      EIDON_ADMIN_USERNAME: "admin"
+      EIDON_ADMIN_PASSWORD: "${EIDON_ADMIN_PASSWORD}"
+      EIDON_SESSION_SECRET: "${EIDON_SESSION_SECRET}"
+      EIDON_ENCRYPTION_SECRET: "${EIDON_ENCRYPTION_SECRET}"
+    volumes:
+      - eidon-dev-data:/app/data
+
+volumes:
+  eidon-dev-data:
+```
+
+The `:dev` tag is mutable and always points at the latest `dev` build, so pull before restarting:
+
+```bash
+docker compose -f docker-compose.dev.yml pull
+docker compose -f docker-compose.dev.yml up -d
+```
+
+The in-app version shows `dev-<commit sha>`, so you can confirm exactly which build you are testing. Once a dev build checks out, merge `dev` into `main` and cut a GitHub release. Your stable instance keeps running `:latest` and only changes when you pull after a release.
+
 ## Why the Docker Image Is Different
 
 The production image is meant to be useful on its own, not just a way to serve the UI.

--- a/README.md
+++ b/README.md
@@ -164,46 +164,6 @@ docker compose up -d
 
 Eidon does not ship with a provider API key. The deployment is ready first; you bring the model access you want to use.
 
-### 5. Optional: run the dev channel
-
-Two image channels are published from GitHub:
-
-| Channel | Image tags | Published when |
-| --- | --- | --- |
-| Stable | `:latest`, `:<release version>` | A GitHub release is cut from `main` |
-| Dev | `:dev`, `:dev-<commit sha>` | Every push to the `dev` branch |
-
-To test changes before they are released, merge them into `dev`. Then run the dev image alongside your stable instance with its own data volume and port (save as `docker-compose.dev.yml`):
-
-```yaml
-services:
-  eidon-dev:
-    image: ghcr.io/quack6765/eidon-ai:dev
-    restart: unless-stopped
-    ports:
-      - "3001:3000"
-    environment:
-      EIDON_PASSWORD_LOGIN_ENABLED: "true"
-      EIDON_ADMIN_USERNAME: "admin"
-      EIDON_ADMIN_PASSWORD: "${EIDON_ADMIN_PASSWORD}"
-      EIDON_SESSION_SECRET: "${EIDON_SESSION_SECRET}"
-      EIDON_ENCRYPTION_SECRET: "${EIDON_ENCRYPTION_SECRET}"
-    volumes:
-      - eidon-dev-data:/app/data
-
-volumes:
-  eidon-dev-data:
-```
-
-The `:dev` tag is mutable and always points at the latest `dev` build, so pull before restarting:
-
-```bash
-docker compose -f docker-compose.dev.yml pull
-docker compose -f docker-compose.dev.yml up -d
-```
-
-The in-app version shows `dev-<commit sha>`, so you can confirm exactly which build you are testing. Once a dev build checks out, merge `dev` into `main` and cut a GitHub release. Your stable instance keeps running `:latest` and only changes when you pull after a release.
-
 ## Why the Docker Image Is Different
 
 The production image is meant to be useful on its own, not just a way to serve the UI.
@@ -268,6 +228,46 @@ Generate secrets on macOS or Linux with:
 openssl rand -hex 32
 openssl rand -hex 32
 ```
+
+## Testing Pre-release Builds
+
+Two image channels are published from GitHub:
+
+| Channel | Image tags | Published when |
+| --- | --- | --- |
+| Stable | `:latest`, `:<release version>` | A GitHub release is cut from `main` |
+| Dev | `:dev`, `:dev-<commit sha>` | Every push to the `dev` branch |
+
+Most users should stay on the stable channel, which only moves when a release is cut. If you want to test changes before they are released, merge them into `dev`, then run the dev image alongside your stable instance with its own data volume and port (save as `docker-compose.dev.yml`):
+
+```yaml
+services:
+  eidon-dev:
+    image: ghcr.io/quack6765/eidon-ai:dev
+    restart: unless-stopped
+    ports:
+      - "3001:3000"
+    environment:
+      EIDON_PASSWORD_LOGIN_ENABLED: "true"
+      EIDON_ADMIN_USERNAME: "admin"
+      EIDON_ADMIN_PASSWORD: "${EIDON_ADMIN_PASSWORD}"
+      EIDON_SESSION_SECRET: "${EIDON_SESSION_SECRET}"
+      EIDON_ENCRYPTION_SECRET: "${EIDON_ENCRYPTION_SECRET}"
+    volumes:
+      - eidon-dev-data:/app/data
+
+volumes:
+  eidon-dev-data:
+```
+
+The `:dev` tag is mutable and always points at the latest `dev` build, so pull before restarting:
+
+```bash
+docker compose -f docker-compose.dev.yml pull
+docker compose -f docker-compose.dev.yml up -d
+```
+
+The in-app version shows `dev-<commit sha>`, so you can confirm exactly which build you are testing. Once a dev build checks out, merge `dev` into `main` and cut a GitHub release. Your stable instance keeps running `:latest` and only changes when you pull after a release.
 
 ## Local Development
 

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ docker compose -f docker-compose.dev.yml pull
 docker compose -f docker-compose.dev.yml up -d
 ```
 
-The in-app version shows `dev-<commit sha>`, so you can confirm exactly which build you are testing. Once a dev build checks out, merge `dev` into `main` and cut a GitHub release. Your stable instance keeps running `:latest` and only changes when you pull after a release.
+The in-app version shows `dev-<commit sha>`, so you can confirm exactly which build you are testing.
 
 ## Local Development
 

--- a/tests/unit/mobile-contracts.test.ts
+++ b/tests/unit/mobile-contracts.test.ts
@@ -300,8 +300,8 @@ describe("Mobile API v1 contracts", () => {
       path.join(process.cwd(), ".github/workflows/test.yml"),
       "utf8"
     );
-    const dockerWorkflow = fs.readFileSync(
-      path.join(process.cwd(), ".github/workflows/docker.yml"),
+    const dockerStableWorkflow = fs.readFileSync(
+      path.join(process.cwd(), ".github/workflows/docker-stable.yml"),
       "utf8"
     );
 
@@ -310,8 +310,8 @@ describe("Mobile API v1 contracts", () => {
       "contracts/mobile-api-v1.websocket.schema.json"
     ]) {
       expect(testWorkflow).toContain(contractPath);
-      expect(dockerWorkflow).toContain(contractPath);
+      expect(dockerStableWorkflow).toContain(contractPath);
     }
-    expect(dockerWorkflow).toContain("gh release upload");
+    expect(dockerStableWorkflow).toContain("gh release upload");
   });
 });


### PR DESCRIPTION
## Summary

- **New dev channel:** every push to a `dev` branch publishes `ghcr.io/quack6765/eidon-ai:dev` plus a pinned `:dev-<short-sha>` tag, with the app version baked in as `dev-<sha>` (visible in Settings) so you can confirm exactly which build you are testing
- **Burst-safe, low latency:** branch-scoped concurrency with `cancel-in-progress` means each new push to `dev` immediately cancels the in-flight build and starts a fresh one — rapid merges never queue, and the newest merge is always the one that finishes
- **Validation:** PRs targeting `dev` now run the same test/lint/typecheck and Docker-build validation as PRs to `main`
- **Cache isolation:** dev builds read the `main` registry build cache and write to their own `buildcache:dev` ref, so dev and release builds never race on the same cache
- **README:** documents both channels (`:latest` = release-only, `:dev` = pre-release) and a side-by-side staging compose setup with its own data volume and port

`:latest` behavior is unchanged: it is still published only when a GitHub release is cut from `main`.

## After merging

1. Create the branch: `git push origin main:dev`
2. The stale `stage` branch (324 commits behind) can be deleted
3. On the remote server, run the dev image per the new README section