### PR TITLE
Fix endless retry loops that stuck conversations during image generation

### DIFF
--- a/lib/assistant-runtime.ts
+++ b/lib/assistant-runtime.ts
@@ -385,6 +385,10 @@ export async function resolveAssistantTurn(input: {
   }
 
   let imageGenerationToolConsumed = false;
+  let imageGenerationToolAttempted = false;
+  let imageGenerationIntentRetries = 0;
+  let memoryIntentRetries = 0;
+  let emptyAnswerRetries = 0;
   let visibleImageActionStarted = false;
   let visibleImageActionHandle: string | undefined;
 
@@ -433,6 +437,8 @@ export async function resolveAssistantTurn(input: {
 
     const restrictToGenerateImage =
       !imageGenerationToolConsumed &&
+      !imageGenerationToolAttempted &&
+      imageGenerationIntentRetries === 0 &&
       hasImageGeneration &&
       hasUnfulfilledImageGenerationIntent(promptMessages);
 
@@ -542,30 +548,40 @@ export async function resolveAssistantTurn(input: {
     if (!toolCalls.length) {
       if (
         !imageGenerationToolConsumed &&
+        !imageGenerationToolAttempted &&
+        imageGenerationIntentRetries < 1 &&
         hasImageGeneration &&
         hasUnfulfilledImageGenerationIntent(promptMessages)
       ) {
+        imageGenerationIntentRetries += 1;
         input.onEvent?.({ type: "answer_reset" });
         promptMessages = mergeSystemMessage(promptMessages, IMAGE_TOOL_REQUIRED_DIRECTIVE);
         continue;
       }
 
       if ((input.memoriesEnabled ?? false) && hasUnfulfilledMemoryIntent(answer)) {
-        input.onEvent?.({ type: "answer_reset" });
-        promptMessages = mergeSystemMessage(
-          promptMessages,
-          "Do not say that you saved, stored, remembered, updated, or deleted a memory unless you actually call the corresponding memory tool in that same response. If a memory proposal is warranted, call the memory tool now. Otherwise, answer normally without mentioning memory-saving."
-        );
-        continue;
+        if (memoryIntentRetries < 1) {
+          memoryIntentRetries += 1;
+          input.onEvent?.({ type: "answer_reset" });
+          promptMessages = mergeSystemMessage(
+            promptMessages,
+            "Do not say that you saved, stored, remembered, updated, or deleted a memory unless you actually call the corresponding memory tool in that same response. If a memory proposal is warranted, call the memory tool now. Otherwise, answer normally without mentioning memory-saving."
+          );
+          continue;
+        }
       }
 
       if (!answer.trim()) {
-        input.onEvent?.({ type: "answer_reset" });
-        promptMessages = mergeSystemMessage(
-          promptMessages,
-          "Your previous response was empty. Answer the user directly. Do not emit an empty response."
-        );
-        continue;
+        if (emptyAnswerRetries < 1) {
+          emptyAnswerRetries += 1;
+          input.onEvent?.({ type: "answer_reset" });
+          promptMessages = mergeSystemMessage(
+            promptMessages,
+            "Your previous response was empty. Answer the user directly. Do not emit an empty response."
+          );
+          continue;
+        }
+        throw new Error("Provider returned an empty response");
       }
       await commitAnswerSegment(answer);
       return { answer, thinking, usage };
@@ -675,6 +691,7 @@ export async function resolveAssistantTurn(input: {
           }
 
           imageGenerationToolAttemptedThisStep = true;
+          imageGenerationToolAttempted = true;
         }
 
         const result = await runToolCall(toolCall, timelineSortOrder);

--- a/lib/chat-turn.ts
+++ b/lib/chat-turn.ts
@@ -433,7 +433,9 @@ async function startAssistantTurn(
           proposalPayload: action.proposalPayload,
           sortOrder: timelineSortOrder++
         });
-        runningActionHandles.add(persisted.id);
+        if (persisted.status === "running") {
+          runningActionHandles.add(persisted.id);
+        }
         manager.broadcast(conversationId, {
           type: "delta",
           conversationId,
@@ -482,6 +484,13 @@ async function startAssistantTurn(
     });
 
     await flushAnswerBuffer();
+
+    for (const handle of runningActionHandles) {
+      updateMessageAction(handle, {
+        status: "stopped",
+        completedAt: new Date().toISOString()
+      });
+    }
 
     updateMessage(assistantMessageId, {
       content: await contentPersistence?.finalize(providerResult.answer) ?? "",

--- a/tests/unit/assistant-runtime.test.ts
+++ b/tests/unit/assistant-runtime.test.ts
@@ -1341,6 +1341,76 @@ ${JSON.stringify({
     expect(generateGoogleNanoBananaImages).toHaveBeenCalledTimes(1);
   });
 
+  it("stops forcing generate_image after one retry and accepts the model's text answer instead of looping", async () => {
+    let providerCallCount = 0;
+    const emittedEvents: ChatStreamEvent[] = [];
+    streamProviderResponse.mockImplementation(() => {
+      providerCallCount += 1;
+      return createProviderStream(
+        [{ type: "answer_delta", text: "Here is some advice instead." }],
+        { answer: "Here is some advice instead.", thinking: "", usage: { outputTokens: 4 } }
+      );
+    });
+
+    const { resolveAssistantTurn } = await import("@/lib/assistant-runtime");
+
+    const result = await resolveAssistantTurn({
+      settings: createSettings(),
+      promptMessages: [{ role: "user", content: "Generate an image of a red square" }],
+      skills: [],
+      mcpToolSets: [],
+      appSettings: createAppSettings(),
+      conversationId: "conv_image",
+      assistantMessageId: "msg_assistant_image",
+      onEvent: (event) => emittedEvents.push(event)
+    });
+
+    expect(providerCallCount).toBe(2);
+    expect(result.answer).toBe("Here is some advice instead.");
+    expect(emittedEvents.filter((event) => event.type === "answer_reset")).toHaveLength(1);
+  });
+
+  it("does not force generate_image again after a failed generation attempt and accepts the failure explanation", async () => {
+    let providerCallCount = 0;
+    streamProviderResponse.mockImplementation(() => {
+      providerCallCount += 1;
+      if (providerCallCount === 1) {
+        return createProviderStream([], {
+          answer: "",
+          thinking: "",
+          toolCalls: [{
+            id: "call_image_fail",
+            name: "generate_image",
+            arguments: JSON.stringify({ prompt: "a red square" })
+          }],
+          usage: { inputTokens: 6 }
+        });
+      }
+      return createProviderStream(
+        [{ type: "answer_delta", text: "Sorry, image generation is unavailable right now." }],
+        { answer: "Sorry, image generation is unavailable right now.", thinking: "", usage: { outputTokens: 4 } }
+      );
+    });
+
+    generateGoogleNanoBananaImages.mockRejectedValue(new Error("backend failed"));
+
+    const { resolveAssistantTurn } = await import("@/lib/assistant-runtime");
+
+    const result = await resolveAssistantTurn({
+      settings: createSettings(),
+      promptMessages: [{ role: "user", content: "Generate an image of a red square" }],
+      skills: [],
+      mcpToolSets: [],
+      appSettings: createAppSettings(),
+      conversationId: "conv_image",
+      assistantMessageId: "msg_assistant_image"
+    });
+
+    expect(providerCallCount).toBe(2);
+    expect(result.answer).toBe("Sorry, image generation is unavailable right now.");
+    expect(generateGoogleNanoBananaImages).toHaveBeenCalledTimes(1);
+  });
+
   it("requires generate_image for another-one follow-up requests instead of accepting a hallucinated success message", async () => {
     let providerCallCount = 0;
     streamProviderResponse.mockImplementation(({ tools, promptMessages }: {
@@ -2375,6 +2445,57 @@ Run browser commands.`
       })
     );
     expect(result.answer).toBe("Connected");
+  });
+
+  it("fails with a clear error after one empty-answer retry instead of exhausting the step budget", async () => {
+    let providerCallCount = 0;
+    streamProviderResponse.mockImplementation(() => {
+      providerCallCount += 1;
+      return createProviderStream([], {
+        answer: "",
+        thinking: "reasoning only",
+        usage: { inputTokens: 5, reasoningTokens: 4 }
+      });
+    });
+
+    const { resolveAssistantTurn } = await import("@/lib/assistant-runtime");
+
+    await expect(
+      resolveAssistantTurn({
+        settings: createSettings(),
+        promptMessages: [{ role: "user", content: "Say hello" }],
+        skills: [],
+        mcpToolSets: [],
+        appSettings: createAppSettings()
+      })
+    ).rejects.toThrow("Provider returned an empty response");
+
+    expect(providerCallCount).toBe(2);
+  });
+
+  it("accepts a narrated memory answer after one retry instead of looping", async () => {
+    let providerCallCount = 0;
+    streamProviderResponse.mockImplementation(() => {
+      providerCallCount += 1;
+      return createProviderStream(
+        [{ type: "answer_delta", text: "I will remember that for later." }],
+        { answer: "I will remember that for later.", thinking: "", usage: { outputTokens: 4 } }
+      );
+    });
+
+    const { resolveAssistantTurn } = await import("@/lib/assistant-runtime");
+
+    const result = await resolveAssistantTurn({
+      settings: createSettings(),
+      promptMessages: [{ role: "user", content: "Hi, my name is Charles." }],
+      skills: [],
+      mcpToolSets: [],
+      memoriesEnabled: true,
+      appSettings: createAppSettings()
+    });
+
+    expect(providerCallCount).toBe(2);
+    expect(result.answer).toBe("I will remember that for later.");
   });
 
   it("streams thinking and answer deltas before the provider finishes", async () => {

--- a/tests/unit/chat-turn.test.ts
+++ b/tests/unit/chat-turn.test.ts
@@ -275,6 +275,63 @@ describe("chat-turn", () => {
     }
   });
 
+  it("marks still-running actions as stopped when the turn completes successfully", async () => {
+    const resolveAssistantTurn = vi.fn().mockImplementation(async (input: {
+      onActionStart?: (action: {
+        kind: "image_generation";
+        label: string;
+        detail?: string;
+      }) => Promise<string | void> | string | void;
+    }) => {
+      await input.onActionStart?.({
+        kind: "image_generation",
+        label: "Generate image",
+        detail: "Generate an image of a red square"
+      });
+      return { answer: "Here is some advice.", thinking: "", usage: { outputTokens: 4 } };
+    });
+    vi.doMock("@/lib/assistant-runtime", () => ({
+      resolveAssistantTurn
+    }));
+    try {
+      const { createConversationManager } = await import("@/lib/conversation-manager");
+      const { updateProviderCatalog } = await import("@/lib/settings");
+
+      const manager = createConversationManager();
+
+      const { profileId, profile } = setupProviderProfile();
+      updateProviderCatalog({
+        defaultProviderProfileId: profileId,
+        skillsEnabled: false,
+        providerProfiles: [profile]
+      });
+
+      const conv = (await import("@/lib/conversations")).createConversation(
+        undefined,
+        undefined,
+        { providerProfileId: null }
+      );
+
+      const { startChatTurn } = await import("@/lib/chat-turn");
+      const result = await startChatTurn(manager, conv.id, "Generate an image of a red square", []);
+
+      expect(result).toEqual({ status: "completed" });
+
+      const { listVisibleMessages } = await import("@/lib/conversations");
+      const assistantMsg = listVisibleMessages(conv.id).find((message) => message.role === "assistant");
+      expect(assistantMsg?.status).toBe("completed");
+      expect(assistantMsg?.actions).toEqual([
+        expect.objectContaining({
+          label: "Generate image",
+          status: "stopped"
+        })
+      ]);
+    } finally {
+      vi.doUnmock("@/lib/assistant-runtime");
+      vi.resetModules();
+    }
+  });
+
   it("does nothing if conversation not found", async () => {
     const { createConversationManager } = await import("@/lib/conversation-manager");
     const manager = createConversationManager();


### PR DESCRIPTION
## Problem
When the model kept refusing to call the image tool (or kept returning empty answers or fake memory confirmations), the assistant would retry the same request over and over forever. The conversation appeared stuck, and image-generation actions could stay in a "running" state forever after the turn finished.

## Solution
Cap each automatic retry path at one attempt so the loop always terminates:

- `lib/assistant-runtime.ts`
  - Track `imageGenerationToolAttempted` plus retry counters for image-gen intent, memory intent, and empty answers.
  - Stop forcing `generate_image` after the tool was already attempted once or after one intent retry; accept the model's text answer instead of looping.
  - Retry memory-intent and empty-answer nudges at most once; if the answer is still empty, throw a clear "Provider returned an empty response" error rather than burning the step budget.
- `lib/chat-turn.ts`
  - Only track actions actually persisted as "running".
  - When a turn completes, mark any still-running actions as "stopped" so they don't hang forever.

## Testing
- New unit tests in `tests/unit/assistant-runtime.test.ts` cover: accepting a text answer after one image-gen retry, accepting a failure explanation after a failed generation, failing fast on repeated empty answers, and accepting a narrated memory answer after one retry.
- New test in `tests/unit/chat-turn.test.ts` verifies still-running actions are marked "stopped" when the turn completes.