### PR TITLE
Fix web search calls hanging turns forever with end-to-end timeouts

### DIFF
--- a/lib/mcp-client.ts
+++ b/lib/mcp-client.ts
@@ -286,9 +286,19 @@ export async function getConnectedClient(server: McpServer, abortSignal?: AbortS
   return connection;
 }
 
+const MCP_TERMINATE_SESSION_TIMEOUT_MS = 5_000;
+const closedTransports = new WeakSet<StdioClientTransport | StreamableHTTPClientTransport>();
+
 async function closeTransport(transport: StdioClientTransport | StreamableHTTPClientTransport) {
+  if (closedTransports.has(transport)) {
+    return;
+  }
+  closedTransports.add(transport);
   if (transport instanceof StreamableHTTPClientTransport && transport.sessionId) {
-    await transport.terminateSession().catch(() => undefined);
+    await Promise.race([
+      transport.terminateSession().catch(() => undefined),
+      new Promise<void>((resolve) => setTimeout(resolve, MCP_TERMINATE_SESSION_TIMEOUT_MS))
+    ]);
   }
 
   await transport.close().catch(() => undefined);

--- a/lib/web-search-pipeline.ts
+++ b/lib/web-search-pipeline.ts
@@ -249,6 +249,22 @@ export function buildPlanningPrompt(input: {
   return lines.join("\n");
 }
 
+function withAbortGuard<T>(promise: Promise<T>, signal: AbortSignal | undefined, createError: () => Error): Promise<T> {
+  if (!signal) return promise;
+  promise.catch(() => undefined);
+  return Promise.race([
+    promise,
+    new Promise<never>((_, reject) => {
+      const abort = () => reject(createError());
+      if (signal.aborted) {
+        abort();
+        return;
+      }
+      signal.addEventListener("abort", abort, { once: true });
+    })
+  ]);
+}
+
 export async function planWebSearch(input: {
   providerProfile?: RuntimeProviderProfile;
   query: string;
@@ -260,17 +276,22 @@ export async function planWebSearch(input: {
   if (!input.providerProfile) return { action: "direct" };
   try {
     const timeoutSignal = AbortSignal.timeout(WEB_SEARCH_PLANNING_TIMEOUT_MS);
-    const text = await callProviderText({
-      settings: input.providerProfile,
-      prompt: buildPlanningPrompt({
-        query: input.query,
-        userContext: input.userContext,
-        forceFanOut: input.forceFanOut,
-        maxQueries: input.maxQueries
+    const planningSignal = combinedAbortSignal([input.abortSignal, timeoutSignal]);
+    const text = await withAbortGuard(
+      callProviderText({
+        settings: input.providerProfile,
+        prompt: buildPlanningPrompt({
+          query: input.query,
+          userContext: input.userContext,
+          forceFanOut: input.forceFanOut,
+          maxQueries: input.maxQueries
+        }),
+        purpose: "web_search_planning",
+        abortSignal: planningSignal
       }),
-      purpose: "web_search_planning",
-      abortSignal: combinedAbortSignal([input.abortSignal, timeoutSignal])
-    });
+      planningSignal,
+      () => new Error(`Web search planning timed out after ${Math.round(WEB_SEARCH_PLANNING_TIMEOUT_MS / 1000)} seconds`)
+    );
     return parsePlanningResponse(text) ?? { action: "direct" };
   } catch {
     throwIfChatTurnAborted(input.abortSignal);
@@ -297,13 +318,22 @@ async function runSearchWithTimeout(input: {
     input.abortSignal,
     AbortSignal.timeout(input.timeoutMs)
   ]);
-  return searchWeb({
-    settings: input.settings,
-    query: input.query,
-    maxResults: input.maxResults,
-    abortSignal: perSearchSignal,
-    timeout: input.timeoutMs
-  });
+  return withAbortGuard(
+    searchWeb({
+      settings: input.settings,
+      query: input.query,
+      maxResults: input.maxResults,
+      abortSignal: perSearchSignal,
+      timeout: input.timeoutMs
+    }),
+    perSearchSignal,
+    () =>
+      input.abortSignal?.aborted
+        ? input.abortSignal.reason instanceof Error
+          ? input.abortSignal.reason
+          : new Error("Web search aborted")
+        : new Error(`Web search timed out after ${Math.round(input.timeoutMs / 1000)} seconds`)
+  );
 }
 
 const MAX_CONCURRENT_SEARCHES = 4;

--- a/tests/unit/assistant-runtime.test.ts
+++ b/tests/unit/assistant-runtime.test.ts
@@ -566,6 +566,58 @@ ${JSON.stringify({
     expect(result.answer).toBe("Final answer");
   });
 
+  it("recovers the turn with an error tool result when a Tavily search never settles", async () => {
+    streamProviderResponse
+      .mockReturnValueOnce(
+        createProviderStream([], {
+          answer: "",
+          thinking: "",
+          toolCalls: [{
+            id: "call_1",
+            name: "web_search",
+            arguments: JSON.stringify({ query: "latest AI" })
+          }],
+          usage: { inputTokens: 9 }
+        })
+      )
+      .mockReturnValueOnce(
+        createProviderStream([{ type: "answer_delta", text: "Answer without search" }], {
+          answer: "Answer without search",
+          thinking: "",
+          usage: { inputTokens: 11, outputTokens: 3 }
+        })
+      );
+    discoverMcpTools.mockResolvedValue([{ name: "tavily_search" }]);
+    callMcpTool.mockImplementation(() => new Promise(() => {}));
+
+    const errored: Array<{ handle?: string; resultSummary?: string }> = [];
+    const { resolveAssistantTurn } = await import("@/lib/assistant-runtime");
+
+    const result = await resolveAssistantTurn({
+      settings: createSettings(),
+      promptMessages: [{ role: "user", content: "Find AI news" }],
+      skills: [],
+      mcpToolSets: [],
+      mcpTimeout: 500,
+      appSettings: createAppSettings({
+        webSearch: {
+          providerId: "tavily",
+          credentials: { apiKey: "tavily-test-key" }
+        }
+      }),
+      onEvent: () => {},
+      onActionStart: () => "act_tool",
+      onActionError: (handle, patch) => {
+        errored.push({ handle, resultSummary: patch.resultSummary });
+      }
+    });
+
+    expect(errored).toEqual([
+      { handle: "act_tool", resultSummary: expect.stringMatching(/Web search timed out after \d+ seconds/) }
+    ]);
+    expect(result.answer).toBe("Answer without search");
+  }, 15_000);
+
   it("exposes the parallel queries tool schema while the pipeline is active", async () => {
     const { buildToolDefinitions } = await import("@/lib/tool-definitions");
 

--- a/tests/unit/mcp-client.test.ts
+++ b/tests/unit/mcp-client.test.ts
@@ -1,3 +1,5 @@
+import http from "node:http";
+import type { AddressInfo } from "node:net";
 import { fileURLToPath } from "node:url";
 
 import type { McpServer } from "@/lib/types";
@@ -646,4 +648,98 @@ describe("MCP client", () => {
       }));
     }
   }, 30_000);
+
+  it("settles hanging HTTP tool calls on timeout and abort without wedging the event loop", async () => {
+    vi.doUnmock("@modelcontextprotocol/sdk/client/index.js");
+    vi.doUnmock("@modelcontextprotocol/sdk/client/stdio.js");
+    vi.doUnmock("@modelcontextprotocol/sdk/client/streamableHttp.js");
+
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const openResponses = new Set<http.ServerResponse>();
+    const mcpServer = http.createServer((req, res) => {
+      openResponses.add(res);
+      res.on("close", () => openResponses.delete(res));
+      if (req.method === "GET") {
+        res.writeHead(200, { "content-type": "text/event-stream" });
+        res.write(": keepalive\n\n");
+        return;
+      }
+      const chunks: Buffer[] = [];
+      req.on("data", (chunk: Buffer) => chunks.push(chunk));
+      req.on("end", () => {
+        let body: { id?: number; method?: string } = {};
+        try {
+          body = JSON.parse(Buffer.concat(chunks).toString("utf8") || "{}");
+        } catch {
+          res.writeHead(400);
+          res.end();
+          return;
+        }
+        if (body.method === "initialize") {
+          res.writeHead(200, {
+            "content-type": "text/event-stream",
+            "mcp-session-id": "session_hanging_test"
+          });
+          res.write(
+            `event: message\ndata: ${JSON.stringify({
+              jsonrpc: "2.0",
+              id: body.id,
+              result: {
+                protocolVersion: "2025-03-26",
+                capabilities: { tools: {} },
+                serverInfo: { name: "hanging-mcp", version: "1.0.0" }
+              }
+            })}\n\n`
+          );
+          res.end();
+          return;
+        }
+        if (body.method === "tools/call") {
+          res.writeHead(200, { "content-type": "text/event-stream" });
+          res.write(": keepalive\n\n");
+          return;
+        }
+        res.writeHead(202);
+        res.end();
+      });
+    });
+
+    try {
+      await new Promise<void>((resolve) => mcpServer.listen(0, "127.0.0.1", resolve));
+      const baseUrl = `http://127.0.0.1:${(mcpServer.address() as AddressInfo).port}/mcp`;
+      const makeServer = (): McpServer => ({
+        ...createHttpServer(),
+        id: `hanging_${Math.random().toString(36).slice(2)}`,
+        url: baseUrl
+      });
+      const { callMcpTool, disconnectMcpServer } = await import("@/lib/mcp-client");
+
+      const timedOut = await callMcpTool(makeServer(), "tavily_search", { query: "x" }, 800);
+      expect(timedOut.isError).toBe(true);
+      expect(timedOut.content[0]?.text).toContain("Request timed out");
+
+      const controller = new AbortController();
+      setTimeout(() => controller.abort(), 300);
+      const abortServer = makeServer();
+      await expect(
+        callMcpTool(abortServer, "tavily_search", { query: "x" }, 60_000, controller.signal)
+      ).rejects.toThrow(/abort/i);
+
+      await disconnectMcpServer(abortServer);
+    } finally {
+      consoleError.mockRestore();
+      for (const res of openResponses) res.destroy();
+      mcpServer.closeAllConnections?.();
+      await new Promise<void>((resolve) => mcpServer.close(() => resolve()));
+      vi.doMock("@modelcontextprotocol/sdk/client/index.js", () => ({
+        Client: MockClient
+      }));
+      vi.doMock("@modelcontextprotocol/sdk/client/stdio.js", () => ({
+        StdioClientTransport: MockStdioTransport
+      }));
+      vi.doMock("@modelcontextprotocol/sdk/client/streamableHttp.js", () => ({
+        StreamableHTTPClientTransport: MockStreamableHTTPTransport
+      }));
+    }
+  }, 20_000);
 });

--- a/tests/unit/web-search-pipeline.test.ts
+++ b/tests/unit/web-search-pipeline.test.ts
@@ -431,6 +431,67 @@ describe("runWebSearchPipeline", () => {
 
     expect(result.resultSummary.length).toBeLessThanOrEqual(32_000);
   });
+
+  it("bounds a never-settling direct search with mcpTimeout and rejects with a timeout error", async () => {
+    searchWebMock.mockImplementation(() => new Promise<string>(() => {}));
+    const startedAt = Date.now();
+
+    await expect(runWebSearchPipeline({
+      query: "stuck search",
+      mode: "auto",
+      maxQueries: 4,
+      settings: makeSettings(),
+      mcpTimeout: 2_000
+    })).rejects.toThrow("Web search timed out after 2 seconds");
+
+    expect(Date.now() - startedAt).toBeLessThan(10_000);
+  }, 15_000);
+
+  it("bounds every never-settling fan-out sub-search with mcpTimeout", async () => {
+    searchWebMock.mockImplementation(() => new Promise<string>(() => {}));
+
+    await expect(runWebSearchPipeline({
+      queries: ["stuck one", "stuck two"],
+      mode: "always",
+      maxQueries: 4,
+      settings: makeSettings(),
+      mcpTimeout: 500
+    })).rejects.toThrow(/All 2 web searches failed: .*Web search timed out after 1 seconds/);
+  }, 15_000);
+
+  it("cancels a never-settling search promptly when the turn aborts", async () => {
+    searchWebMock.mockImplementation(() => new Promise<string>(() => {}));
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(new ChatTurnStoppedError()), 50);
+    const startedAt = Date.now();
+
+    await expect(runWebSearchPipeline({
+      query: "stuck search",
+      mode: "auto",
+      maxQueries: 4,
+      settings: makeSettings(),
+      mcpTimeout: 60_000,
+      abortSignal: controller.signal
+    })).rejects.toThrow(ChatTurnStoppedError);
+
+    expect(Date.now() - startedAt).toBeLessThan(5_000);
+  });
+
+  it("bounds a never-settling planning call and falls back to a direct search", async () => {
+    callProviderTextMock.mockImplementation(() => new Promise<string>(() => {}));
+    searchWebMock.mockResolvedValue("provider text");
+
+    const result = await runWebSearchPipeline({
+      query: "planning hangs",
+      mode: "auto",
+      maxQueries: 4,
+      settings: makeSettings(),
+      providerProfile: createRuntimeProviderProfile()
+    });
+
+    expect(result.strategy).toBe("direct");
+    expect(result.resultSummary).toBe("provider text");
+  }, 25_000);
 });
 
 describe("cross-call duplicate query cache", () => {


### PR DESCRIPTION
## Problem

Sometimes a web search (or the planning step before it) would never finish — like waiting on a phone call that never gets answered. The assistant's whole turn would hang forever with no error and no answer.

## Solution

Put a hard timer on every step so the turn always finishes, even when a search provider or MCP server goes silent:

- Add an abort guard (`withAbortGuard`) in `lib/web-search-pipeline.ts` that races planning and search calls against their abort/timeout signals, so stuck promises resolve with a clear timeout or abort error instead of hanging.
- In `lib/mcp-client.ts`, guard transport teardown: skip double-closing via a `WeakSet` and cap `terminateSession()` at 5 seconds so cleanup can't wedge shutdown.

## Testing

- New unit test: a turn with a never-settling Tavily search recovers with an error tool result and still produces an answer.
- New MCP client test (real HTTP server): hanging tool calls settle on timeout and abort without wedging the event loop.
- New pipeline tests: never-settling direct/fan-out searches, abort mid-search, and a hanging planning call all bounded and rejected/fallback correctly.