### PR TITLE
Add custom conversation scrollbar with touch scrubbing

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -75,6 +75,7 @@
 html {
   background: var(--background);
   color: var(--text);
+  overscroll-behavior: none;
 }
 
 body {

--- a/components/ai-elements/conversation.tsx
+++ b/components/ai-elements/conversation.tsx
@@ -6,7 +6,7 @@ import { cn, isScrolledToBottom } from "@/lib/utils";
 import type { UIMessage } from "ai";
 import { ArrowDownIcon, DownloadIcon } from "lucide-react";
 import type { ComponentProps } from "react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { StickToBottom, useStickToBottomContext } from "use-stick-to-bottom";
 
 export type ConversationProps = ComponentProps<typeof StickToBottom>;
@@ -33,7 +33,10 @@ export const ConversationContent = ({
   scrollerRef,
   ...props
 }: ConversationContentProps) => (
-  <div ref={scrollerRef as React.RefCallback<HTMLDivElement>} className="h-full overflow-hidden">
+  <div
+    ref={scrollerRef as React.RefCallback<HTMLDivElement>}
+    className="relative h-full overflow-hidden"
+  >
     <StickToBottom.Content
       scrollClassName={cn(
         "conversation-scroller overscroll-y-contain no-scrollbar",
@@ -42,6 +45,7 @@ export const ConversationContent = ({
       className={cn("flex w-full flex-col", className)}
       {...props}
     />
+    <ConversationScrollbar />
   </div>
 );
 
@@ -151,6 +155,390 @@ export const ConversationScrollButton = ({
         <span className="hidden md:inline">Latest</span>
       </Button>
     )
+  );
+};
+
+export type ConversationScrollbarProps = ComponentProps<"div">;
+
+const SCROLLBAR_THUMB_MIN_HEIGHT_PX = 28;
+const SCROLLBAR_HIDE_DELAY_MS = 1000;
+const SCROLLBAR_HOLD_DELAY_MS = 150;
+const SCROLLBAR_TOUCH_SLOP_PX = 10;
+
+const isTouchPointerType = (pointerType: string): boolean =>
+  pointerType === "touch" || pointerType === "pen";
+
+export const ConversationScrollbar = ({
+  className,
+  ...props
+}: ConversationScrollbarProps) => {
+  const { contentRef, scrollRef } = useStickToBottomContext();
+  const trackRef = useRef<HTMLDivElement | null>(null);
+  const hideTimerRef = useRef<number | null>(null);
+  const dragStateRef = useRef<{ startY: number; startScrollTop: number } | null>(null);
+  const isDraggingRef = useRef(false);
+  const isHoveringRef = useRef(false);
+  const holdTimerRef = useRef<number | null>(null);
+  const touchGestureRef = useRef<{
+    pointerId: number;
+    scrubbing: boolean;
+    startY: number;
+  } | null>(null);
+  const [dragging, setDragging] = useState(false);
+  const [scrubbing, setScrubbing] = useState(false);
+  const [isVisible, setIsVisible] = useState(false);
+  const [geometry, setGeometry] = useState({ overflowing: false, thumbHeight: 0, thumbTop: 0 });
+
+  const updateGeometry = useCallback(() => {
+    const scroller = scrollRef.current;
+    const track = trackRef.current;
+    if (!scroller || !track) return;
+    const maxScroll = scroller.scrollHeight - scroller.clientHeight;
+    const overflowing = maxScroll > 1;
+    const trackHeight = track.clientHeight;
+    let thumbHeight = 0;
+    let thumbTop = 0;
+    if (overflowing) {
+      thumbHeight = Math.min(
+        trackHeight,
+        Math.max(
+          SCROLLBAR_THUMB_MIN_HEIGHT_PX,
+          (scroller.clientHeight / Math.max(scroller.scrollHeight, 1)) * trackHeight
+        )
+      );
+      const range = Math.max(trackHeight - thumbHeight, 0);
+      thumbTop = Math.min(Math.max((scroller.scrollTop / maxScroll) * range, 0), range);
+    }
+    setGeometry((current) =>
+      current.overflowing === overflowing &&
+      current.thumbHeight === thumbHeight &&
+      current.thumbTop === thumbTop
+        ? current
+        : { overflowing, thumbHeight, thumbTop }
+    );
+  }, [scrollRef]);
+
+  const reveal = useCallback(() => {
+    if (hideTimerRef.current !== null) {
+      window.clearTimeout(hideTimerRef.current);
+      hideTimerRef.current = null;
+    }
+    setIsVisible(true);
+    if (
+      isDraggingRef.current ||
+      touchGestureRef.current?.scrubbing ||
+      isHoveringRef.current
+    )
+      return;
+    hideTimerRef.current = window.setTimeout(() => {
+      hideTimerRef.current = null;
+      setIsVisible(false);
+    }, SCROLLBAR_HIDE_DELAY_MS);
+  }, []);
+
+  useEffect(() => {
+    const scrollElement = scrollRef.current;
+    const contentElement = contentRef.current;
+    if (!scrollElement || !contentElement) return;
+
+    const handleScroll = () => {
+      updateGeometry();
+      reveal();
+    };
+
+    updateGeometry();
+    scrollElement.addEventListener("scroll", handleScroll, { passive: true });
+    window.addEventListener("resize", updateGeometry);
+    window.addEventListener(IOS_PWA_CONVERSATION_VIEWPORT_EVENT, updateGeometry);
+    const observer = typeof ResizeObserver === "undefined" ? null : new ResizeObserver(updateGeometry);
+    observer?.observe(contentElement);
+
+    return () => {
+      observer?.disconnect();
+      scrollElement.removeEventListener("scroll", handleScroll);
+      window.removeEventListener("resize", updateGeometry);
+      window.removeEventListener(IOS_PWA_CONVERSATION_VIEWPORT_EVENT, updateGeometry);
+      if (hideTimerRef.current !== null) window.clearTimeout(hideTimerRef.current);
+      if (holdTimerRef.current !== null) window.clearTimeout(holdTimerRef.current);
+    };
+  }, [contentRef, scrollRef, reveal, updateGeometry]);
+
+  const clearHoldTimer = () => {
+    if (holdTimerRef.current !== null) {
+      window.clearTimeout(holdTimerRef.current);
+      holdTimerRef.current = null;
+    }
+  };
+
+  const jumpToCenter = (clientY: number) => {
+    const scroller = scrollRef.current;
+    const track = trackRef.current;
+    if (!scroller || !track) return;
+    const rect = track.getBoundingClientRect();
+    if (rect.height <= 0) return;
+    const clickRatio = Math.min(Math.max((clientY - rect.top) / rect.height, 0), 1);
+    const maxScroll = scroller.scrollHeight - scroller.clientHeight;
+    scroller.scrollTop = Math.min(
+      Math.max(clickRatio * maxScroll - scroller.clientHeight / 2, 0),
+      Math.max(maxScroll, 0)
+    );
+  };
+
+  const scrubToClientY = (clientY: number) => {
+    const scroller = scrollRef.current;
+    const track = trackRef.current;
+    if (!scroller || !track) return;
+    const rect = track.getBoundingClientRect();
+    const range = track.clientHeight - geometry.thumbHeight;
+    const maxScroll = scroller.scrollHeight - scroller.clientHeight;
+    if (rect.height <= 0 || range <= 0 || maxScroll <= 0) return;
+    const thumbTop = Math.min(
+      Math.max(clientY - rect.top - geometry.thumbHeight / 2, 0),
+      range
+    );
+    scroller.scrollTop = (thumbTop / range) * maxScroll;
+  };
+
+  const enterScrubMode = (gesture: {
+    pointerId: number;
+    startY: number;
+  }) => {
+    const track = trackRef.current;
+    if (track) {
+      try {
+        track.setPointerCapture(gesture.pointerId);
+      } catch {
+        touchGestureRef.current = null;
+        return;
+      }
+    }
+    touchGestureRef.current = {
+      ...gesture,
+      scrubbing: true
+    };
+    setScrubbing(true);
+    reveal();
+    scrubToClientY(gesture.startY);
+  };
+
+  const exitScrubMode = (pointerId: number) => {
+    const gesture = touchGestureRef.current;
+    if (!gesture || !gesture.scrubbing || gesture.pointerId !== pointerId) return;
+    const track = trackRef.current;
+    if (track?.hasPointerCapture(pointerId)) {
+      track.releasePointerCapture(pointerId);
+    }
+    touchGestureRef.current = null;
+    setScrubbing(false);
+    reveal();
+  };
+
+  const handleThumbPointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (isTouchPointerType(event.pointerType)) return;
+    const scroller = scrollRef.current;
+    if (!scroller) return;
+    event.preventDefault();
+    event.stopPropagation();
+    event.currentTarget.setPointerCapture(event.pointerId);
+    dragStateRef.current = { startY: event.clientY, startScrollTop: scroller.scrollTop };
+    isDraggingRef.current = true;
+    setDragging(true);
+    reveal();
+  };
+
+  const handleThumbPointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    const scroller = scrollRef.current;
+    const dragState = dragStateRef.current;
+    if (!scroller || !dragState || !isDraggingRef.current) return;
+    scroller.scrollTop =
+      dragState.startScrollTop +
+      (event.clientY - dragState.startY) * (scroller.scrollHeight / scroller.clientHeight);
+  };
+
+  const handleThumbPointerEnd = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (!isDraggingRef.current) return;
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+    dragStateRef.current = null;
+    isDraggingRef.current = false;
+    setDragging(false);
+    reveal();
+  };
+
+  const handleTrackPointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+    const scroller = scrollRef.current;
+    const track = trackRef.current;
+    if (!scroller || !track) return;
+    event.preventDefault();
+    if (isTouchPointerType(event.pointerType)) {
+      if (touchGestureRef.current?.scrubbing) return;
+      clearHoldTimer();
+      touchGestureRef.current = {
+        pointerId: event.pointerId,
+        scrubbing: false,
+        startY: event.clientY
+      };
+      reveal();
+      holdTimerRef.current = window.setTimeout(() => {
+        holdTimerRef.current = null;
+        const gesture = touchGestureRef.current;
+        if (!gesture || gesture.scrubbing) return;
+        enterScrubMode(gesture);
+      }, SCROLLBAR_HOLD_DELAY_MS);
+      return;
+    }
+    jumpToCenter(event.clientY);
+  };
+
+  const handleTrackPointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    const gesture = touchGestureRef.current;
+    if (!gesture || gesture.pointerId !== event.pointerId) return;
+    if (gesture.scrubbing) {
+      scrubToClientY(event.clientY);
+      return;
+    }
+    if (Math.abs(event.clientY - gesture.startY) >= SCROLLBAR_TOUCH_SLOP_PX) {
+      clearHoldTimer();
+      enterScrubMode({ pointerId: gesture.pointerId, startY: event.clientY });
+    }
+  };
+
+  const handleTrackPointerUp = (event: React.PointerEvent<HTMLDivElement>) => {
+    const gesture = touchGestureRef.current;
+    if (!gesture || gesture.pointerId !== event.pointerId) return;
+    if (gesture.scrubbing) {
+      exitScrubMode(event.pointerId);
+      return;
+    }
+    clearHoldTimer();
+    touchGestureRef.current = null;
+    jumpToCenter(event.clientY);
+  };
+
+  const handleTrackPointerCancel = (event: React.PointerEvent<HTMLDivElement>) => {
+    const gesture = touchGestureRef.current;
+    if (!gesture || gesture.pointerId !== event.pointerId) return;
+    if (gesture.scrubbing) {
+      exitScrubMode(event.pointerId);
+      return;
+    }
+    clearHoldTimer();
+    touchGestureRef.current = null;
+  };
+
+  const handleTrackPointerEnter = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (isTouchPointerType(event.pointerType)) return;
+    isHoveringRef.current = true;
+    reveal();
+  };
+
+  const handleTrackPointerLeave = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (isTouchPointerType(event.pointerType)) return;
+    isHoveringRef.current = false;
+    reveal();
+  };
+
+  const handleTrackContextMenu = (event: React.MouseEvent<HTMLDivElement>) => {
+    event.preventDefault();
+  };
+
+  const handleWheel = (event: React.WheelEvent<HTMLDivElement>) => {
+    const scroller = scrollRef.current;
+    if (scroller) scroller.scrollTop += event.deltaY;
+  };
+
+  const scrubHandlersRef = useRef({
+    exit: (_pointerId: number) => {},
+    scrub: (_clientY: number) => {}
+  });
+
+  useEffect(() => {
+    scrubHandlersRef.current = {
+      exit: exitScrubMode,
+      scrub: scrubToClientY
+    };
+  });
+
+  useEffect(() => {
+    if (!scrubbing) return;
+    const handleUp = (event: PointerEvent) => {
+      scrubHandlersRef.current.exit(event.pointerId);
+    };
+    const handleMove = (event: PointerEvent) => {
+      if (touchGestureRef.current?.pointerId !== event.pointerId) return;
+      scrubHandlersRef.current.scrub(event.clientY);
+    };
+    window.addEventListener("pointerup", handleUp, true);
+    window.addEventListener("pointercancel", handleUp, true);
+    window.addEventListener("pointermove", handleMove, true);
+    return () => {
+      window.removeEventListener("pointerup", handleUp, true);
+      window.removeEventListener("pointercancel", handleUp, true);
+      window.removeEventListener("pointermove", handleMove, true);
+    };
+  }, [scrubbing]);
+
+  useEffect(() => {
+    const track = trackRef.current;
+    if (!track) return;
+    const preventTouchDefault = (event: TouchEvent) => {
+      event.preventDefault();
+    };
+    track.addEventListener("touchstart", preventTouchDefault, { passive: false });
+    track.addEventListener("touchmove", preventTouchDefault, { passive: false });
+    return () => {
+      track.removeEventListener("touchstart", preventTouchDefault);
+      track.removeEventListener("touchmove", preventTouchDefault);
+    };
+  }, []);
+
+  const shown = isVisible && geometry.overflowing;
+
+  return (
+    <div
+      ref={trackRef}
+      aria-hidden
+      className={cn(
+        "group absolute top-0 right-0 bottom-[var(--composer-height,0px)] z-10 touch-none [-webkit-touch-callout:none] select-none [-webkit-user-select:none] cursor-default transition-[width,opacity] pointer-coarse:w-11",
+        scrubbing ? "w-7 duration-150" : "w-4 duration-300",
+        shown
+          ? "opacity-100"
+          : geometry.overflowing
+            ? "pointer-fine:opacity-0"
+            : "opacity-0 pointer-events-none",
+        className
+      )}
+      onContextMenu={handleTrackContextMenu}
+      onPointerCancel={handleTrackPointerCancel}
+      onPointerDown={handleTrackPointerDown}
+      onPointerEnter={handleTrackPointerEnter}
+      onPointerLeave={handleTrackPointerLeave}
+      onPointerMove={handleTrackPointerMove}
+      onPointerUp={handleTrackPointerUp}
+      onWheel={handleWheel}
+      {...props}
+    >
+      <div
+        className={cn(
+          "absolute right-1 rounded-full bg-[var(--accent)] transition-[width,opacity,box-shadow] duration-300",
+          scrubbing
+            ? "w-3 shadow-[0_0_12px_var(--accent-glow)] duration-150"
+            : dragging
+              ? "w-1.5 shadow-[0_0_8px_var(--accent-glow)]"
+              : "w-1 group-hover:w-1.5 group-hover:shadow-[0_0_8px_var(--accent-glow)]"
+        )}
+        onPointerCancel={handleThumbPointerEnd}
+        onPointerDown={handleThumbPointerDown}
+        onPointerMove={handleThumbPointerMove}
+        onPointerUp={handleThumbPointerEnd}
+        style={{
+          height: `${geometry.thumbHeight}px`,
+          top: `${geometry.thumbTop}px`,
+          touchAction: "none"
+        }}
+      />
+    </div>
   );
 };
 

--- a/tests/unit/conversation-scrollbar.test.tsx
+++ b/tests/unit/conversation-scrollbar.test.tsx
@@ -1,0 +1,539 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { act, fireEvent, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { IOS_PWA_CONVERSATION_VIEWPORT_EVENT } from "@/lib/use-ios-pwa";
+
+const stickContextMock = vi.hoisted(() => ({
+  contentRef: { current: null as HTMLElement | null },
+  scrollRef: { current: null as HTMLElement | null }
+}));
+
+vi.mock("use-stick-to-bottom", () => ({
+  StickToBottom: Object.assign(
+    ({ children }: { children?: React.ReactNode }) => React.createElement("div", null, children),
+    { Content: ({ children }: { children?: React.ReactNode }) => React.createElement("div", null, children) }
+  ),
+  useStickToBottomContext: () => stickContextMock
+}));
+
+import { ConversationScrollbar } from "@/components/ai-elements/conversation";
+
+describe("ConversationScrollbar", () => {
+  const originalResizeObserver = globalThis.ResizeObserver;
+  let resizeObserverCallbacks: ResizeObserverCallback[] = [];
+  let scrollMetrics = { scrollTop: 0, scrollHeight: 100, clientHeight: 100 };
+  let trackMetrics = { clientHeight: 256 };
+
+  beforeEach(() => {
+    resizeObserverCallbacks = [];
+    scrollMetrics = { scrollTop: 0, scrollHeight: 100, clientHeight: 100 };
+    trackMetrics = { clientHeight: 256 };
+    Object.defineProperty(window, "PointerEvent", {
+      configurable: true,
+      writable: true,
+      value: class TestPointerEvent extends MouseEvent {
+        readonly pointerId: number;
+        readonly pointerType: string;
+
+        constructor(type: string, init: PointerEventInit = {}) {
+          super(type, init);
+          this.pointerId = init.pointerId ?? 0;
+          this.pointerType = init.pointerType ?? "";
+        }
+      }
+    });
+    const scroller = document.createElement("div");
+    Object.defineProperties(scroller, {
+      scrollTop: {
+        configurable: true,
+        get: () => scrollMetrics.scrollTop,
+        set: (value: number) => {
+          scrollMetrics.scrollTop = Math.max(
+            0,
+            Math.min(value, scrollMetrics.scrollHeight - scrollMetrics.clientHeight)
+          );
+        }
+      },
+      scrollHeight: { configurable: true, get: () => scrollMetrics.scrollHeight },
+      clientHeight: { configurable: true, get: () => scrollMetrics.clientHeight }
+    });
+    stickContextMock.scrollRef.current = scroller;
+    stickContextMock.contentRef.current = document.createElement("div");
+    globalThis.ResizeObserver = class {
+      constructor(callback: ResizeObserverCallback) {
+        resizeObserverCallbacks.push(callback);
+      }
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as typeof ResizeObserver;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    delete (window as { PointerEvent?: unknown }).PointerEvent;
+    globalThis.ResizeObserver = originalResizeObserver;
+  });
+
+  function renderScrollbar() {
+    const view = render(<ConversationScrollbar />);
+    const track = view.container.querySelector("div.absolute.right-0") as HTMLElement;
+    Object.defineProperty(track, "clientHeight", {
+      configurable: true,
+      get: () => trackMetrics.clientHeight
+    });
+    const thumb = view.container.querySelector(
+      '[class*="bg-[var(--accent)]"]'
+    ) as HTMLElement;
+    return { track, thumb };
+  }
+
+  function stubPointerCapture(element: HTMLElement) {
+    Object.assign(element, {
+      hasPointerCapture: vi.fn(() => true),
+      releasePointerCapture: vi.fn(),
+      setPointerCapture: vi.fn()
+    });
+  }
+
+  function stubTrackRect(track: HTMLElement, height = 256) {
+    track.getBoundingClientRect = vi.fn(
+      () =>
+        ({
+          bottom: height,
+          height,
+          left: 0,
+          right: 16,
+          toJSON: () => ({}),
+          top: 0,
+          width: 16,
+          x: 0,
+          y: 0
+        }) as DOMRect
+    );
+  }
+
+  it("stays inert when the content fits the viewport", () => {
+    const { track, thumb } = renderScrollbar();
+
+    expect(track).not.toBeNull();
+    expect(thumb).not.toBeNull();
+    expect(track.className).toContain("opacity-0");
+    expect(track.className).toContain("pointer-events-none");
+    expect(track.className).toContain("touch-none");
+    expect(track.className).toContain("pointer-coarse:w-11");
+    expect(track.className).not.toContain("pointer-coarse:fixed");
+    expect(track.className).not.toContain(["pointer-coarse", "pointer-events-auto"].join(":"));
+    expect(track.className).toContain("-webkit-touch-callout:none");
+    expect(track.className).toContain("select-none");
+    expect(track.className).toContain("-webkit-user-select:none");
+
+    fireEvent.scroll(stickContextMock.scrollRef.current as HTMLElement);
+
+    expect(track.className).toContain("opacity-0");
+    expect(track.className).toContain("pointer-events-none");
+  });
+
+  it("reflects scroll position in the thumb geometry", () => {
+    scrollMetrics = { scrollTop: 192, scrollHeight: 512, clientHeight: 128 };
+    const { track, thumb } = renderScrollbar();
+
+    expect(thumb.style.height).toBe("0px");
+    fireEvent.scroll(stickContextMock.scrollRef.current as HTMLElement);
+
+    expect(thumb.style.height).toBe("64px");
+    expect(thumb.style.top).toBe("96px");
+    expect(track.className).toContain("opacity-100");
+
+    scrollMetrics.scrollHeight = 2048;
+    scrollMetrics.scrollTop = 960;
+    fireEvent.scroll(stickContextMock.scrollRef.current as HTMLElement);
+
+    expect(thumb.style.height).toBe("28px");
+    expect(thumb.style.top).toBe("114px");
+  });
+
+  it("reveals on scroll, auto-hides after idle, and stays visible while dragging", () => {
+    vi.useFakeTimers();
+    scrollMetrics = { scrollTop: 0, scrollHeight: 600, clientHeight: 100 };
+    const { track, thumb } = renderScrollbar();
+
+    expect(track.className).toContain("opacity-0");
+
+    fireEvent.scroll(stickContextMock.scrollRef.current as HTMLElement);
+    expect(track.className).toContain("opacity-100");
+
+    act(() => {
+      vi.advanceTimersByTime(999);
+    });
+    expect(track.className).toContain("opacity-100");
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(track.className).toContain("opacity-0");
+
+    stubPointerCapture(thumb);
+    fireEvent.pointerDown(thumb, { pointerId: 1, clientY: 0 });
+    expect(track.className).toContain("opacity-100");
+    expect(track.className).toContain("select-none");
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(track.className).toContain("opacity-100");
+
+    fireEvent.pointerUp(thumb, { pointerId: 1 });
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(track.className).toContain("opacity-0");
+  });
+
+  it("drags the thumb and scrolls the conversation proportionally", () => {
+    scrollMetrics = { scrollTop: 0, scrollHeight: 600, clientHeight: 100 };
+    const { thumb } = renderScrollbar();
+    stubPointerCapture(thumb);
+
+    fireEvent.pointerDown(thumb, { pointerId: 7, clientY: 0 });
+    expect(scrollMetrics.scrollTop).toBe(0);
+    expect(thumb.setPointerCapture).toHaveBeenCalledWith(7);
+
+    fireEvent.pointerMove(thumb, { pointerId: 7, clientY: 100 });
+    expect(scrollMetrics.scrollTop).toBe(500);
+
+    fireEvent.pointerMove(thumb, { pointerId: 7, clientY: 25 });
+    expect(scrollMetrics.scrollTop).toBe(150);
+
+    fireEvent.pointerUp(thumb, { pointerId: 7 });
+    expect(thumb.releasePointerCapture).toHaveBeenCalledWith(7);
+
+    fireEvent.pointerMove(thumb, { pointerId: 7, clientY: 100 });
+    expect(scrollMetrics.scrollTop).toBe(150);
+  });
+
+  it("centers the viewport on the clicked track position", () => {
+    scrollMetrics = { scrollTop: 0, scrollHeight: 600, clientHeight: 100 };
+    const { track } = renderScrollbar();
+    track.getBoundingClientRect = vi.fn(
+      () =>
+        ({
+          bottom: 240,
+          height: 240,
+          left: 0,
+          right: 16,
+          toJSON: () => ({}),
+          top: 0,
+          width: 16,
+          x: 0,
+          y: 0
+        }) as DOMRect
+    );
+
+    fireEvent.pointerDown(track, { pointerId: 3, clientY: 120 });
+    expect(scrollMetrics.scrollTop).toBe(200);
+
+    fireEvent.pointerDown(track, { pointerId: 4, clientY: 240 });
+    expect(scrollMetrics.scrollTop).toBe(450);
+
+    fireEvent.pointerDown(track, { pointerId: 5, clientY: 0 });
+    expect(scrollMetrics.scrollTop).toBe(0);
+  });
+
+  it("jumps to the released touch position on a quick tap", () => {
+    vi.useFakeTimers();
+    scrollMetrics = { scrollTop: 0, scrollHeight: 512, clientHeight: 128 };
+    const { track, thumb } = renderScrollbar();
+    stubTrackRect(track, 240);
+    fireEvent.scroll(stickContextMock.scrollRef.current as HTMLElement);
+
+    fireEvent.pointerDown(track, { pointerId: 11, pointerType: "touch", clientY: 120 });
+    expect(scrollMetrics.scrollTop).toBe(0);
+    expect(track.className).not.toContain("w-7");
+
+    fireEvent.pointerUp(track, { pointerId: 11, pointerType: "touch", clientY: 120 });
+    expect(scrollMetrics.scrollTop).toBe(128);
+    expect(track.className).not.toContain("w-7");
+    expect(thumb.className).not.toContain("w-3");
+  });
+
+  it("enters scrub mode after a 150ms hold and snaps the thumb under the finger", () => {
+    vi.useFakeTimers();
+    scrollMetrics = { scrollTop: 0, scrollHeight: 512, clientHeight: 128 };
+    const { track, thumb } = renderScrollbar();
+    stubTrackRect(track);
+    fireEvent.scroll(stickContextMock.scrollRef.current as HTMLElement);
+    stubPointerCapture(track);
+
+    fireEvent.pointerDown(track, { pointerId: 12, pointerType: "touch", clientY: 128 });
+    expect(track.className).not.toContain("w-7");
+
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+
+    expect(track.className).toContain("w-7");
+    expect(track.className).toContain("pointer-coarse:w-11");
+    expect(track.className).toContain("select-none");
+    expect(thumb.className).toContain("w-3");
+    expect(track.setPointerCapture).toHaveBeenCalledWith(12);
+    expect(scrollMetrics.scrollTop).toBe(192);
+  });
+
+  it("scrubs absolutely while held, the thumb center tracking the finger", () => {
+    vi.useFakeTimers();
+    scrollMetrics = { scrollTop: 0, scrollHeight: 512, clientHeight: 128 };
+    const { track } = renderScrollbar();
+    stubTrackRect(track);
+    fireEvent.scroll(stickContextMock.scrollRef.current as HTMLElement);
+    stubPointerCapture(track);
+
+    fireEvent.pointerDown(track, { pointerId: 13, pointerType: "touch", clientY: 128 });
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+    expect(scrollMetrics.scrollTop).toBe(192);
+
+    fireEvent.pointerMove(track, { pointerId: 13, pointerType: "touch", clientY: 160 });
+    expect(scrollMetrics.scrollTop).toBe(256);
+
+    fireEvent.pointerMove(track, { pointerId: 13, pointerType: "touch", clientY: 224 });
+    expect(scrollMetrics.scrollTop).toBe(384);
+
+    fireEvent.pointerMove(track, { pointerId: 13, pointerType: "touch", clientY: 32 });
+    expect(scrollMetrics.scrollTop).toBe(0);
+
+    fireEvent.pointerMove(track, { pointerId: 13, pointerType: "touch", clientY: 400 });
+    expect(scrollMetrics.scrollTop).toBe(384);
+  });
+
+  it("exits scrub mode on release and re-hides after idle", () => {
+    vi.useFakeTimers();
+    scrollMetrics = { scrollTop: 0, scrollHeight: 512, clientHeight: 128 };
+    const { track, thumb } = renderScrollbar();
+    stubTrackRect(track);
+    fireEvent.scroll(stickContextMock.scrollRef.current as HTMLElement);
+    stubPointerCapture(track);
+
+    fireEvent.pointerDown(track, { pointerId: 14, pointerType: "touch", clientY: 128 });
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+    expect(track.className).toContain("w-7");
+
+    fireEvent.pointerUp(track, { pointerId: 14, pointerType: "touch", clientY: 128 });
+    expect(track.releasePointerCapture).toHaveBeenCalledWith(14);
+    expect(track.className).not.toContain("w-7");
+    expect(thumb.className).not.toContain("w-3");
+
+    act(() => {
+      vi.advanceTimersByTime(999);
+    });
+    expect(track.className).toContain("opacity-100");
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(track.className).toContain("opacity-0");
+  });
+
+  it("enters scrub mode when the finger drags past the slop radius before the hold delay", () => {
+    vi.useFakeTimers();
+    scrollMetrics = { scrollTop: 0, scrollHeight: 512, clientHeight: 128 };
+    const { track, thumb } = renderScrollbar();
+    stubTrackRect(track);
+    fireEvent.scroll(stickContextMock.scrollRef.current as HTMLElement);
+    stubPointerCapture(track);
+
+    fireEvent.pointerDown(track, { pointerId: 15, pointerType: "touch", clientY: 128 });
+    expect(track.className).not.toContain("w-7");
+
+    fireEvent.pointerMove(track, { pointerId: 15, pointerType: "touch", clientY: 139 });
+
+    expect(track.setPointerCapture).toHaveBeenCalledWith(15);
+    expect(track.className).toContain("w-7");
+    expect(thumb.className).toContain("w-3");
+    expect(scrollMetrics.scrollTop).toBe(214);
+
+    fireEvent.pointerMove(track, { pointerId: 15, pointerType: "touch", clientY: 171 });
+    expect(scrollMetrics.scrollTop).toBe(278);
+
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+    expect(track.className).toContain("w-7");
+
+    fireEvent.pointerUp(track, { pointerId: 15, pointerType: "touch", clientY: 171 });
+    expect(track.releasePointerCapture).toHaveBeenCalledWith(15);
+    expect(track.className).not.toContain("w-7");
+    expect(scrollMetrics.scrollTop).toBe(278);
+  });
+
+  it("keeps the strip always visible and touchable on coarse pointers while hiding it on fine pointers", () => {
+    vi.useFakeTimers();
+    scrollMetrics = { scrollTop: 0, scrollHeight: 600, clientHeight: 100 };
+    const { track } = renderScrollbar();
+
+    expect(track.className).toContain("pointer-fine:opacity-0");
+    expect(track.className).not.toContain("pointer-fine:pointer-events-none");
+    expect(track.className.split(" ")).not.toContain("pointer-events-none");
+
+    fireEvent.scroll(stickContextMock.scrollRef.current as HTMLElement);
+    expect(track.className).toContain("opacity-100");
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(track.className).toContain("pointer-fine:opacity-0");
+    expect(track.className.split(" ")).not.toContain("pointer-events-none");
+  });
+
+  it("reveals on mouse hover, stays visible while hovered, and hides after leaving", () => {
+    vi.useFakeTimers();
+    scrollMetrics = { scrollTop: 0, scrollHeight: 600, clientHeight: 100 };
+    const { track } = renderScrollbar();
+
+    expect(track.className).toContain("pointer-fine:opacity-0");
+
+    fireEvent.pointerOver(track, { pointerType: "mouse" });
+    expect(track.className).toContain("opacity-100");
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(track.className).toContain("opacity-100");
+
+    fireEvent.pointerOut(track, { pointerType: "mouse" });
+    act(() => {
+      vi.advanceTimersByTime(999);
+    });
+    expect(track.className).toContain("opacity-100");
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(track.className).toContain("pointer-fine:opacity-0");
+  });
+
+  it("does not pin visibility from touch pointer enter events", () => {
+    vi.useFakeTimers();
+    scrollMetrics = { scrollTop: 0, scrollHeight: 600, clientHeight: 100 };
+    const { track } = renderScrollbar();
+
+    fireEvent.pointerOver(track, { pointerType: "touch" });
+    expect(track.className).toContain("pointer-fine:opacity-0");
+
+    fireEvent.scroll(stickContextMock.scrollRef.current as HTMLElement);
+    expect(track.className).toContain("opacity-100");
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(track.className).toContain("pointer-fine:opacity-0");
+  });
+
+  it("jumps on a quick tap even when the fade state is idle", () => {
+    scrollMetrics = { scrollTop: 0, scrollHeight: 600, clientHeight: 100 };
+    const { track } = renderScrollbar();
+    stubTrackRect(track, 240);
+
+    expect(track.className).toContain("pointer-fine:opacity-0");
+
+    fireEvent.pointerDown(track, { pointerId: 31, pointerType: "touch", clientY: 120 });
+    expect(track.className).toContain("opacity-100");
+
+    fireEvent.pointerUp(track, { pointerId: 31, pointerType: "touch", clientY: 120 });
+    expect(scrollMetrics.scrollTop).toBe(200);
+
+    fireEvent.pointerDown(track, { pointerId: 32, pointerType: "touch", clientY: 240 });
+    fireEvent.pointerUp(track, { pointerId: 32, pointerType: "touch", clientY: 240 });
+    expect(scrollMetrics.scrollTop).toBe(450);
+  });
+
+  it("exits scrub mode from window-captured pointer events when the track misses them", () => {
+    vi.useFakeTimers();
+    scrollMetrics = { scrollTop: 0, scrollHeight: 512, clientHeight: 128 };
+    const { track } = renderScrollbar();
+    stubTrackRect(track);
+    fireEvent.scroll(stickContextMock.scrollRef.current as HTMLElement);
+    stubPointerCapture(track);
+
+    fireEvent.pointerDown(track, { pointerId: 21, pointerType: "touch", clientY: 128 });
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+    expect(track.className).toContain("w-7");
+
+    act(() => {
+      fireEvent.pointerMove(window, { pointerId: 21, pointerType: "touch", clientY: 224 });
+    });
+    expect(scrollMetrics.scrollTop).toBe(384);
+
+    act(() => {
+      fireEvent.pointerMove(window, { pointerId: 99, pointerType: "touch", clientY: 32 });
+    });
+    expect(scrollMetrics.scrollTop).toBe(384);
+
+    act(() => {
+      fireEvent.pointerUp(window, { pointerId: 21, pointerType: "touch" });
+    });
+    expect(track.className).not.toContain("w-7");
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(track.className).toContain("opacity-0");
+  });
+
+  it("cancels native touch defaults on the strip", () => {
+    const { track } = renderScrollbar();
+
+    const startEvent = new Event("touchstart", { bubbles: true, cancelable: true });
+    track.dispatchEvent(startEvent);
+    expect(startEvent.defaultPrevented).toBe(true);
+
+    const moveEvent = new Event("touchmove", { bubbles: true, cancelable: true });
+    track.dispatchEvent(moveEvent);
+    expect(moveEvent.defaultPrevented).toBe(true);
+  });
+
+  it("re-measures geometry on resize observer, window resize, and iOS viewport events", () => {
+    const { thumb } = renderScrollbar();
+    expect(thumb.style.height).toBe("0px");
+
+    scrollMetrics = { scrollTop: 192, scrollHeight: 512, clientHeight: 128 };
+    act(() => {
+      for (const callback of resizeObserverCallbacks) {
+        callback([], {} as ResizeObserver);
+      }
+    });
+    expect(thumb.style.height).toBe("64px");
+    expect(thumb.style.top).toBe("96px");
+
+    scrollMetrics.scrollTop = 384;
+    act(() => {
+      window.dispatchEvent(new Event("resize"));
+    });
+    expect(thumb.style.top).toBe("192px");
+
+    scrollMetrics.scrollTop = 192;
+    act(() => {
+      window.dispatchEvent(new Event(IOS_PWA_CONVERSATION_VIEWPORT_EVENT));
+    });
+    expect(thumb.style.top).toBe("96px");
+  });
+
+  it("forwards wheel deltas over the strip to the scroller", () => {
+    scrollMetrics = { scrollTop: 0, scrollHeight: 600, clientHeight: 100 };
+    const { track } = renderScrollbar();
+
+    fireEvent.wheel(track, { deltaY: 120 });
+    expect(scrollMetrics.scrollTop).toBe(120);
+
+    fireEvent.wheel(track, { deltaY: -45 });
+    expect(scrollMetrics.scrollTop).toBe(75);
+  });
+});

--- a/tests/unit/pwa-shell-css.test.ts
+++ b/tests/unit/pwa-shell-css.test.ts
@@ -21,6 +21,7 @@ function expectRuleDeclaration(selector: string, declaration: string) {
 
 describe("PWA shell CSS", () => {
   it("locks the iOS PWA document while preserving scroll containment rules", () => {
+    expectRuleDeclaration("html", "overscroll-behavior: none;");
     expectRuleDeclaration("html.ios-pwa", "overflow: hidden;");
     expectRuleDeclaration("html.ios-pwa body", "overflow: hidden;");
     expectRuleDeclaration("body", "overscroll-behavior: none;");


### PR DESCRIPTION
## Problem
The conversation view relied on a hidden native scrollbar, giving no visual scroll indicator and no easy way to jump or scrub through long conversations, especially on touch devices.

## Solution
Added a custom `ConversationScrollbar` component rendered inside the conversation content:

- Proportional thumb with min height, positioned from scroller geometry, updated on scroll, resize, ResizeObserver, and iOS PWA viewport events
- Auto-reveals on scroll/hover, auto-hides after 1s idle, stays visible while dragging/scrubbing/hovering
- Mouse: click track to center viewport, drag thumb to scroll proportionally
- Touch: quick tap jumps, 150ms hold or 10px drag slop enters scrub mode with a wider hit area, thumb tracking the finger via pointer capture (with window-level fallback handlers)
- Wheel deltas over the strip forward to the scroller; native touch defaults and context menu suppressed on the track
- Added `overscroll-behavior: none` on `html` to prevent page bounce

## Testing
- New unit test suite `tests/unit/conversation-scrollbar.test.tsx` covering geometry, reveal/hide timing, drag, tap-to-jump, scrub mode entry/exit, slop drag, pointer-coarse visibility, hover behavior, iOS viewport re-measure, and wheel forwarding
- Updated `tests/unit/pwa-shell-css.test.ts` to assert the new `html` overscroll rule