### PR TITLE
Only reveal conversation scrollbar for user-initiated scrolling

### DIFF
--- a/components/ai-elements/conversation.tsx
+++ b/components/ai-elements/conversation.tsx
@@ -164,6 +164,26 @@ const SCROLLBAR_THUMB_MIN_HEIGHT_PX = 28;
 const SCROLLBAR_HIDE_DELAY_MS = 1000;
 const SCROLLBAR_HOLD_DELAY_MS = 150;
 const SCROLLBAR_TOUCH_SLOP_PX = 10;
+const SCROLLBAR_USER_SCROLL_INTENT_MS = 150;
+
+const SCROLL_INTENT_KEYS = new Set([
+  "ArrowUp",
+  "ArrowDown",
+  "ArrowLeft",
+  "ArrowRight",
+  "PageUp",
+  "PageDown",
+  "Home",
+  "End",
+  " "
+]);
+
+const isEditableEventTarget = (target: EventTarget | null): boolean =>
+  target instanceof HTMLElement &&
+  (target.isContentEditable ||
+    target.tagName === "INPUT" ||
+    target.tagName === "TEXTAREA" ||
+    target.tagName === "SELECT");
 
 const isTouchPointerType = (pointerType: string): boolean =>
   pointerType === "touch" || pointerType === "pen";
@@ -184,6 +204,7 @@ export const ConversationScrollbar = ({
     scrubbing: boolean;
     startY: number;
   } | null>(null);
+  const userScrollAtRef = useRef(Number.NEGATIVE_INFINITY);
   const [dragging, setDragging] = useState(false);
   const [scrubbing, setScrubbing] = useState(false);
   const [isVisible, setIsVisible] = useState(false);
@@ -218,6 +239,10 @@ export const ConversationScrollbar = ({
     );
   }, [scrollRef]);
 
+  const noteUserScroll = useCallback(() => {
+    userScrollAtRef.current = performance.now();
+  }, []);
+
   const reveal = useCallback(() => {
     if (hideTimerRef.current !== null) {
       window.clearTimeout(hideTimerRef.current);
@@ -241,13 +266,27 @@ export const ConversationScrollbar = ({
     const contentElement = contentRef.current;
     if (!scrollElement || !contentElement) return;
 
+    const isUserInitiatedScroll = () =>
+      performance.now() - userScrollAtRef.current <= SCROLLBAR_USER_SCROLL_INTENT_MS;
+
     const handleScroll = () => {
       updateGeometry();
-      reveal();
+      if (isUserInitiatedScroll()) reveal();
+    };
+
+    const handleUserWheel = () => noteUserScroll();
+    const handleUserTouchMove = () => noteUserScroll();
+    const handleUserKeyDown = (event: KeyboardEvent) => {
+      if (!SCROLL_INTENT_KEYS.has(event.key)) return;
+      if (isEditableEventTarget(event.target)) return;
+      noteUserScroll();
     };
 
     updateGeometry();
     scrollElement.addEventListener("scroll", handleScroll, { passive: true });
+    scrollElement.addEventListener("wheel", handleUserWheel, { passive: true });
+    scrollElement.addEventListener("touchmove", handleUserTouchMove, { passive: true });
+    scrollElement.addEventListener("keydown", handleUserKeyDown);
     window.addEventListener("resize", updateGeometry);
     window.addEventListener(IOS_PWA_CONVERSATION_VIEWPORT_EVENT, updateGeometry);
     const observer = typeof ResizeObserver === "undefined" ? null : new ResizeObserver(updateGeometry);
@@ -256,12 +295,15 @@ export const ConversationScrollbar = ({
     return () => {
       observer?.disconnect();
       scrollElement.removeEventListener("scroll", handleScroll);
+      scrollElement.removeEventListener("wheel", handleUserWheel);
+      scrollElement.removeEventListener("touchmove", handleUserTouchMove);
+      scrollElement.removeEventListener("keydown", handleUserKeyDown);
       window.removeEventListener("resize", updateGeometry);
       window.removeEventListener(IOS_PWA_CONVERSATION_VIEWPORT_EVENT, updateGeometry);
       if (hideTimerRef.current !== null) window.clearTimeout(hideTimerRef.current);
       if (holdTimerRef.current !== null) window.clearTimeout(holdTimerRef.current);
     };
-  }, [contentRef, scrollRef, reveal, updateGeometry]);
+  }, [contentRef, scrollRef, reveal, updateGeometry, noteUserScroll]);
 
   const clearHoldTimer = () => {
     if (holdTimerRef.current !== null) {
@@ -388,6 +430,7 @@ export const ConversationScrollbar = ({
       }, SCROLLBAR_HOLD_DELAY_MS);
       return;
     }
+    noteUserScroll();
     jumpToCenter(event.clientY);
   };
 
@@ -445,7 +488,9 @@ export const ConversationScrollbar = ({
 
   const handleWheel = (event: React.WheelEvent<HTMLDivElement>) => {
     const scroller = scrollRef.current;
-    if (scroller) scroller.scrollTop += event.deltaY;
+    if (!scroller) return;
+    noteUserScroll();
+    scroller.scrollTop += event.deltaY;
   };
 
   const scrubHandlersRef = useRef({

--- a/tests/unit/conversation-scrollbar.test.tsx
+++ b/tests/unit/conversation-scrollbar.test.tsx
@@ -142,7 +142,9 @@ describe("ConversationScrollbar", () => {
     const { track, thumb } = renderScrollbar();
 
     expect(thumb.style.height).toBe("0px");
-    fireEvent.scroll(stickContextMock.scrollRef.current as HTMLElement);
+    const scroller = stickContextMock.scrollRef.current as HTMLElement;
+    fireEvent.wheel(scroller, { deltaY: 24 });
+    fireEvent.scroll(scroller);
 
     expect(thumb.style.height).toBe("64px");
     expect(thumb.style.top).toBe("96px");
@@ -156,14 +158,19 @@ describe("ConversationScrollbar", () => {
     expect(thumb.style.top).toBe("114px");
   });
 
-  it("reveals on scroll, auto-hides after idle, and stays visible while dragging", () => {
+  it("reveals on user scroll, auto-hides after idle, and stays visible while dragging", () => {
     vi.useFakeTimers();
     scrollMetrics = { scrollTop: 0, scrollHeight: 600, clientHeight: 100 };
     const { track, thumb } = renderScrollbar();
+    const scroller = stickContextMock.scrollRef.current as HTMLElement;
 
     expect(track.className).toContain("opacity-0");
 
-    fireEvent.scroll(stickContextMock.scrollRef.current as HTMLElement);
+    fireEvent.scroll(scroller);
+    expect(track.className).toContain("pointer-fine:opacity-0");
+
+    fireEvent.wheel(scroller, { deltaY: 24 });
+    fireEvent.scroll(scroller);
     expect(track.className).toContain("opacity-100");
 
     act(() => {
@@ -376,12 +383,14 @@ describe("ConversationScrollbar", () => {
     vi.useFakeTimers();
     scrollMetrics = { scrollTop: 0, scrollHeight: 600, clientHeight: 100 };
     const { track } = renderScrollbar();
+    const scroller = stickContextMock.scrollRef.current as HTMLElement;
 
     expect(track.className).toContain("pointer-fine:opacity-0");
     expect(track.className).not.toContain("pointer-fine:pointer-events-none");
     expect(track.className.split(" ")).not.toContain("pointer-events-none");
 
-    fireEvent.scroll(stickContextMock.scrollRef.current as HTMLElement);
+    fireEvent.wheel(scroller, { deltaY: 24 });
+    fireEvent.scroll(scroller);
     expect(track.className).toContain("opacity-100");
 
     act(() => {
@@ -422,11 +431,13 @@ describe("ConversationScrollbar", () => {
     vi.useFakeTimers();
     scrollMetrics = { scrollTop: 0, scrollHeight: 600, clientHeight: 100 };
     const { track } = renderScrollbar();
+    const scroller = stickContextMock.scrollRef.current as HTMLElement;
 
     fireEvent.pointerOver(track, { pointerType: "touch" });
     expect(track.className).toContain("pointer-fine:opacity-0");
 
-    fireEvent.scroll(stickContextMock.scrollRef.current as HTMLElement);
+    fireEvent.wheel(scroller, { deltaY: 24 });
+    fireEvent.scroll(scroller);
     expect(track.className).toContain("opacity-100");
 
     act(() => {
@@ -486,6 +497,83 @@ describe("ConversationScrollbar", () => {
       vi.advanceTimersByTime(2000);
     });
     expect(track.className).toContain("opacity-0");
+  });
+
+  it("stays hidden while tokens stream and only stick-to-bottom auto-scrolls fire", () => {
+    vi.useFakeTimers();
+    scrollMetrics = { scrollTop: 0, scrollHeight: 600, clientHeight: 100 };
+    const { track, thumb } = renderScrollbar();
+    const scroller = stickContextMock.scrollRef.current as HTMLElement;
+
+    for (let tick = 1; tick <= 5; tick += 1) {
+      scrollMetrics.scrollTop = tick * 12;
+      fireEvent.scroll(scroller);
+      act(() => {
+        vi.advanceTimersByTime(250);
+      });
+    }
+
+    expect(track.className).not.toContain("opacity-100");
+    expect(track.className).toContain("pointer-fine:opacity-0");
+    const expectedThumbHeight = Math.max(28, (100 / 600) * 256);
+    expect(thumb.style.height).toBe(`${expectedThumbHeight}px`);
+    expect(parseFloat(thumb.style.top)).toBeCloseTo((60 / 500) * (256 - expectedThumbHeight));
+  });
+
+  it("reveals on user wheel scrolling and stays hidden for later programmatic scrolls", () => {
+    vi.useFakeTimers();
+    scrollMetrics = { scrollTop: 0, scrollHeight: 600, clientHeight: 100 };
+    const { track } = renderScrollbar();
+    const scroller = stickContextMock.scrollRef.current as HTMLElement;
+
+    fireEvent.wheel(scroller, { deltaY: 40 });
+    fireEvent.scroll(scroller);
+    expect(track.className).toContain("opacity-100");
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(track.className).toContain("pointer-fine:opacity-0");
+
+    scrollMetrics.scrollTop = 300;
+    fireEvent.scroll(scroller);
+    expect(track.className).not.toContain("opacity-100");
+  });
+
+  it("reveals on touch scrolling", () => {
+    scrollMetrics = { scrollTop: 0, scrollHeight: 600, clientHeight: 100 };
+    const { track } = renderScrollbar();
+    const scroller = stickContextMock.scrollRef.current as HTMLElement;
+
+    fireEvent.touchMove(scroller);
+    fireEvent.scroll(scroller);
+    expect(track.className).toContain("opacity-100");
+  });
+
+  it("reveals on keyboard scrolling but ignores keys typed inside editable targets", () => {
+    scrollMetrics = { scrollTop: 0, scrollHeight: 600, clientHeight: 100 };
+    const { track } = renderScrollbar();
+    const scroller = stickContextMock.scrollRef.current as HTMLElement;
+    const editor = document.createElement("textarea");
+    scroller.append(editor);
+
+    fireEvent.keyDown(editor, { key: "ArrowDown" });
+    fireEvent.scroll(scroller);
+    expect(track.className).not.toContain("opacity-100");
+
+    fireEvent.keyDown(scroller, { key: "PageDown" });
+    fireEvent.scroll(scroller);
+    expect(track.className).toContain("opacity-100");
+  });
+
+  it("reveals the strip when forwarding wheel deltas over it", () => {
+    vi.useFakeTimers();
+    scrollMetrics = { scrollTop: 0, scrollHeight: 600, clientHeight: 100 };
+    const { track } = renderScrollbar();
+
+    fireEvent.wheel(track, { deltaY: 120 });
+    fireEvent.scroll(stickContextMock.scrollRef.current as HTMLElement);
+    expect(track.className).toContain("opacity-100");
   });
 
   it("cancels native touch defaults on the strip", () => {


### PR DESCRIPTION
## Problem

The conversation scrollbar popped up whenever the chat scrolled for any reason — including automatic scrolling while new tokens streamed in. That made a scrollbar flash on screen even when the user never touched anything.

## Solution

Think of it like a light switch tied to your hand instead of the room: the scrollbar now only lights up when the user actually scrolls. We track "user intent" by listening for wheel, touch, and keyboard scrolling (arrow keys, PageUp/PageDown, Home/End, space) and ignoring keys typed inside inputs or textareas. Programmatic scrolls (like streaming auto-scroll) still update the thumb geometry, but keep the scrollbar hidden.

- Added a 150ms user-scroll intent window (`SCROLLBAR_USER_SCROLL_INTENT`) so a scroll event only reveals the scrollbar if it closely follows user input
- Added `wheel`, `touchmove`, and `keydown` listeners on the scroll container, with an `isEditableEventTarget` guard
- Noted user intent in track pointer-down and wheel-forwarding handlers
- Updated unit tests and added new cases covering: staying hidden during streaming auto-scrolls, wheel vs. programmatic scroll, touch scroll, keyboard scroll with editable-target exclusion, and wheel forwarding over the strip

## Testing

Covered by unit tests in `tests/unit/conversation-scrollbar.test.tsx`.