### PR TITLE
Send x-opencode-session header for OpenCode Go requests

### DIFF
--- a/lib/anthropic.ts
+++ b/lib/anthropic.ts
@@ -2,7 +2,7 @@ import Anthropic from "@anthropic-ai/sdk";
 
 import { getAttachmentDataUrl } from "@/lib/attachments";
 import { supportsVisibleReasoning } from "@/lib/model-capabilities";
-import { getProviderApiBaseUrl, getProviderApiKey, getProviderApiMode } from "@/lib/provider-profile";
+import { getOpenCodeSessionHeaders, getProviderApiBaseUrl, getProviderApiKey, getProviderApiMode } from "@/lib/provider-profile";
 import { normalizeLineBreaks } from "@/lib/text-utils";
 import { estimatePromptTokens } from "@/lib/tokenization";
 import type {
@@ -224,10 +224,11 @@ type AnthropicStreamResult = {
   usage: { inputTokens?: number; outputTokens?: number; reasoningTokens?: number; cacheReadTokens?: number; cacheCreationTokens?: number };
 };
 
-function createAnthropicClient(settings: RuntimeProviderProfile): Anthropic {
+function createAnthropicClient(settings: RuntimeProviderProfile, conversationId?: string): Anthropic {
   return new Anthropic({
     apiKey: getProviderApiKey(settings),
-    baseURL: getProviderApiBaseUrl(settings)
+    baseURL: getProviderApiBaseUrl(settings),
+    defaultHeaders: getOpenCodeSessionHeaders(settings, conversationId)
   });
 }
 
@@ -236,9 +237,10 @@ export async function* streamAnthropicResponse(input: {
   promptMessages: PromptMessage[];
   tools?: ToolDefinition[];
   abortSignal?: AbortSignal;
+  conversationId?: string;
   client?: Anthropic;
 }): AsyncGenerator<ChatStreamEvent, AnthropicStreamResult, void> {
-  const client = input.client ?? createAnthropicClient(input.settings);
+  const client = input.client ?? createAnthropicClient(input.settings, input.conversationId);
   const showThinking = input.settings.reasoningSummaryEnabled;
   const params = buildAnthropicRequest({
     settings: input.settings,
@@ -328,10 +330,11 @@ export async function* streamAnthropicResponse(input: {
 export async function callAnthropicText(input: {
   settings: RuntimeProviderProfile;
   messages: PromptMessage[];
+  conversationId?: string;
   client?: Anthropic;
   abortSignal?: AbortSignal;
 }): Promise<string> {
-  const client = input.client ?? createAnthropicClient(input.settings);
+  const client = input.client ?? createAnthropicClient(input.settings, input.conversationId);
   const params = buildAnthropicRequest({ settings: input.settings, messages: input.messages });
   const request = {
     ...params,

--- a/lib/assistant-runtime.ts
+++ b/lib/assistant-runtime.ts
@@ -257,6 +257,7 @@ async function forceDirectAnswerAfterToolLoop(input: {
   settings: RuntimeProviderProfile;
   promptMessages: PromptMessage[];
   visionMcpServers?: McpServer[];
+  conversationId?: string;
   abortSignal?: AbortSignal;
   enableStreamRetry?: boolean;
   onEvent?: (event: ChatStreamEvent) => void;
@@ -275,6 +276,7 @@ async function forceDirectAnswerAfterToolLoop(input: {
     streamProviderResponse({
       settings: input.settings,
       promptMessages: providerPromptMessages,
+      conversationId: input.conversationId,
       abortSignal: input.abortSignal
     });
   const providerStream =
@@ -513,6 +515,7 @@ export async function resolveAssistantTurn(input: {
         promptMessages: providerPromptMessages,
         tools: tools.length ? tools : undefined,
         abortSignal: input.abortSignal,
+        conversationId: input.conversationId,
         runtimeToolContext: {
           settings: input.settings,
           visionProfile: input.visionProfile,
@@ -642,6 +645,7 @@ export async function resolveAssistantTurn(input: {
         settings: input.settings,
         promptMessages,
         visionMcpServers,
+        conversationId: input.conversationId,
         abortSignal: input.abortSignal,
         enableStreamRetry: input.enableStreamRetry,
         onEvent: input.onEvent,

--- a/lib/image-generation/compile-image-instruction.ts
+++ b/lib/image-generation/compile-image-instruction.ts
@@ -105,6 +105,7 @@ user: ${latestUserRequest}`;
 export async function compileImageInstruction(input: {
   settings: RuntimeProviderProfile;
   promptMessages: PromptMessage[];
+  conversationId?: string;
   callProviderText?: typeof callProviderTextDefault;
   abortSignal?: AbortSignal;
 }): Promise<CompiledImageInstruction> {
@@ -114,6 +115,7 @@ export async function compileImageInstruction(input: {
     settings: input.settings,
     prompt,
     purpose: "image_instruction",
+    conversationId: input.conversationId,
     abortSignal: input.abortSignal
   });
 

--- a/lib/provider-adapters/anthropic.ts
+++ b/lib/provider-adapters/anthropic.ts
@@ -7,7 +7,7 @@ import { withDateContextUserMessage } from "@/lib/provider-message-formatting";
 import { stripThinkingDelimiters } from "@/lib/thinking-delimiter-parsing";
 import type { ChatStreamEvent, ReasoningEffort, RuntimeProviderProfile } from "@/lib/types";
 import Anthropic from "@anthropic-ai/sdk";
-import { getProviderApiBaseUrl, getProviderApiKey } from "@/lib/provider-profile";
+import { getOpenCodeSessionHeaders, getProviderApiBaseUrl, getProviderApiKey } from "@/lib/provider-profile";
 import type {
   ProviderStreamInput,
   ProviderStreamResult,
@@ -29,6 +29,7 @@ export async function callAnthropicAdapterText(input: ProviderTextInput) {
     await callAnthropicText({
       settings,
       messages: withDateContextUserMessage([{ role: "user", content: input.prompt }]),
+      conversationId: input.conversationId,
       abortSignal: input.abortSignal
     })
   );
@@ -39,7 +40,8 @@ export async function callAnthropicAdapterText(input: ProviderTextInput) {
 export async function discoverAnthropicModels(settings: RuntimeProviderProfile) {
   const client = new Anthropic({
     apiKey: getProviderApiKey(settings),
-    baseURL: getProviderApiBaseUrl(settings)
+    baseURL: getProviderApiBaseUrl(settings),
+    defaultHeaders: getOpenCodeSessionHeaders(settings)
   });
   const models = await client.models.list();
   return models.data.map((model) => ({
@@ -57,6 +59,7 @@ export async function* streamAnthropicAdapterResponse(
     settings: input.settings,
     promptMessages: withDateContextUserMessage(input.promptMessages),
     tools: input.tools,
+    conversationId: input.conversationId,
     abortSignal: input.abortSignal
   });
 }

--- a/lib/provider-adapters/openai-compatible.ts
+++ b/lib/provider-adapters/openai-compatible.ts
@@ -155,7 +155,7 @@ export async function callOpenAiCompatibleText(input: ProviderTextInput) {
     : settings;
   const contextualPrompt = withDateContextUserMessage([{ role: "user", content: input.prompt }]);
 
-  const client = createOpenAIClient(profile, getProviderApiKey(profile));
+  const client = createOpenAIClient(profile, getProviderApiKey(profile), input.conversationId);
 
   if (getProviderApiMode(profile) === "responses") {
     const reasoning = buildReasoningConfig(profile);
@@ -222,7 +222,7 @@ export async function* streamOpenAiCompatibleResponse(
   const contextualPromptMessages = withDateContextUserMessage(promptMessages);
   setActiveTokenizer(settings.tokenizerModel ?? "gpt-tokenizer");
 
-  const client = createOpenAIClient(settings, getProviderApiKey(settings));
+  const client = createOpenAIClient(settings, getProviderApiKey(settings), input.conversationId);
   const abortController = new AbortController();
   const signal = input.abortSignal ?? abortController.signal;
   let answer = "";

--- a/lib/provider-adapters/openai-message-formatting.ts
+++ b/lib/provider-adapters/openai-message-formatting.ts
@@ -2,13 +2,14 @@ import OpenAI from "openai";
 
 import { getAttachmentDataUrl } from "@/lib/attachments";
 import { resolveCapabilities } from "@/lib/model-capabilities";
-import { getProviderApiBaseUrl, getProviderApiMode } from "@/lib/provider-profile";
+import { getOpenCodeSessionHeaders, getProviderApiBaseUrl, getProviderApiMode } from "@/lib/provider-profile";
 import type { PromptMessage, ProviderProfile } from "@/lib/types";
 
-export function createOpenAIClient(settings: ProviderProfile, apiKey: string) {
+export function createOpenAIClient(settings: ProviderProfile, apiKey: string, conversationId?: string) {
   return new OpenAI({
     apiKey,
-    baseURL: getProviderApiBaseUrl(settings)
+    baseURL: getProviderApiBaseUrl(settings),
+    defaultHeaders: getOpenCodeSessionHeaders(settings, conversationId)
   });
 }
 

--- a/lib/provider-adapters/types.ts
+++ b/lib/provider-adapters/types.ts
@@ -48,6 +48,7 @@ export type ProviderStreamInput = {
   promptMessages: PromptMessage[];
   tools?: ToolDefinition[];
   abortSignal?: AbortSignal;
+  conversationId?: string;
   runtimeToolContext?: RuntimeToolContext;
 };
 

--- a/lib/provider-catalog.ts
+++ b/lib/provider-catalog.ts
@@ -291,6 +291,10 @@ function normalizeApiBaseUrl(value: string) {
   return value.trim().replace(/\/+$/, "").toLowerCase();
 }
 
+export function isOpenCodeGoApiBaseUrl(apiBaseUrl: string) {
+  return normalizeApiBaseUrl(apiBaseUrl).startsWith("https://opencode.ai/zen/go");
+}
+
 function normalizeModelId(value: string) {
   const normalized = value.trim().toLowerCase();
   return normalized.includes("/")

--- a/lib/provider-profile.ts
+++ b/lib/provider-profile.ts
@@ -1,5 +1,6 @@
 import {
   PROVIDER_CATALOG,
+  isOpenCodeGoApiBaseUrl,
   resolveProviderRequestApiMode,
   type ApiMode,
   type ProviderConnectionMode,
@@ -122,6 +123,14 @@ export function getProviderApiBaseUrl(profile: ProviderProfile) {
   return profile.providerKind === "github_copilot"
     ? ""
     : profile.providerConfig.apiBaseUrl;
+}
+
+export function getOpenCodeSessionHeaders(
+  profile: ProviderProfile,
+  conversationId?: string
+): Record<string, string> | undefined {
+  if (!isOpenCodeGoApiBaseUrl(getProviderApiBaseUrl(profile))) return undefined;
+  return { "x-opencode-session": conversationId ?? profile.id };
 }
 
 export function getProviderApiKey(profile: RuntimeProviderProfile) {

--- a/lib/tool-executors.ts
+++ b/lib/tool-executors.ts
@@ -260,6 +260,7 @@ export async function executeImageGeneration(
     const instruction = await compileImageInstruction({
       settings: context.input.settings,
       promptMessages: context.promptMessages,
+      conversationId,
       abortSignal: context.input.abortSignal
     });
     throwIfAborted(context.input.abortSignal);
@@ -978,6 +979,7 @@ export async function executeAnalyzeImage(
     const providerStream = streamProviderResponse({
       settings: context.input.visionProfile,
       promptMessages,
+      conversationId,
       abortSignal: context.input.abortSignal
     });
 

--- a/lib/web-search-pipeline.ts
+++ b/lib/web-search-pipeline.ts
@@ -271,6 +271,7 @@ export async function planWebSearch(input: {
   userContext?: string;
   forceFanOut: boolean;
   maxQueries: number;
+  conversationId?: string;
   abortSignal?: AbortSignal;
 }): Promise<WebSearchPipelinePlan> {
   if (!input.providerProfile) return { action: "direct" };
@@ -287,6 +288,7 @@ export async function planWebSearch(input: {
           maxQueries: input.maxQueries
         }),
         purpose: "web_search_planning",
+        conversationId: input.conversationId,
         abortSignal: planningSignal
       }),
       planningSignal,
@@ -570,6 +572,7 @@ export async function runWebSearchPipeline(input: {
       userContext: input.userContext,
       forceFanOut: input.mode === "always",
       maxQueries: input.maxQueries,
+      conversationId: input.conversationId,
       abortSignal: input.abortSignal
     });
     const subqueries = plan.action === "fan_out"

--- a/tests/unit/anthropic.test.ts
+++ b/tests/unit/anthropic.test.ts
@@ -1,4 +1,19 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@anthropic-ai/sdk", () => ({
+  default: vi.fn().mockImplementation(() => ({
+    messages: {
+      stream: () => ({
+        async *[Symbol.asyncIterator]() {}
+      }),
+      async create() {
+        return { content: [{ type: "text", text: "ok" }] };
+      }
+    }
+  }))
+}));
+
+import Anthropic from "@anthropic-ai/sdk";
 
 vi.mock("@/lib/attachments", () => ({
   getAttachmentDataUrl: vi.fn(() => "data:image/png;base64,IMGDATA")
@@ -535,5 +550,50 @@ describe("anthropic conversion branch coverage", () => {
     });
 
     expect(text).toBe("");
+  });
+});
+
+describe("OpenCode session header", () => {
+  it("sends x-opencode-session with the conversation id for OpenCode Go streams", async () => {
+    const gen = streamAnthropicResponse({
+      settings: baseSettings({
+        providerConfig: { apiBaseUrl: "https://opencode.ai/zen/go" },
+        providerPresetId: "opencode_go_anthropic"
+      }),
+      promptMessages: [{ role: "user", content: "hi" }],
+      conversationId: "conv_session_3"
+    });
+
+    await gen.next();
+
+    expect(vi.mocked(Anthropic).mock.calls.at(-1)?.[0]).toMatchObject({
+      defaultHeaders: { "x-opencode-session": "conv_session_3" }
+    });
+  });
+
+  it("falls back to the profile id without a conversation", async () => {
+    await callAnthropicText({
+      settings: baseSettings({
+        id: "prov_opencode_anthropic",
+        providerConfig: { apiBaseUrl: "https://opencode.ai/zen/go/" }
+      }),
+      messages: [{ role: "user", content: "hi" }]
+    });
+
+    expect(vi.mocked(Anthropic).mock.calls.at(-1)?.[0]).toMatchObject({
+      defaultHeaders: { "x-opencode-session": "prov_opencode_anthropic" }
+    });
+  });
+
+  it("omits the header for other base urls", async () => {
+    const gen = streamAnthropicResponse({
+      settings: baseSettings(),
+      promptMessages: [{ role: "user", content: "hi" }],
+      conversationId: "conv_session_3"
+    });
+
+    await gen.next();
+
+    expect(vi.mocked(Anthropic).mock.calls.at(-1)?.[0]?.defaultHeaders).toBeUndefined();
   });
 });

--- a/tests/unit/provider.test.ts
+++ b/tests/unit/provider.test.ts
@@ -1,3 +1,4 @@
+import OpenAI from "openai";
 import type { ChatStreamEvent, RuntimeProviderProfile } from "@/lib/types";
 import { createRuntimeProviderProfile } from "@/tests/provider-fixtures";
 
@@ -1090,6 +1091,93 @@ describe("provider integration", () => {
 
     expect(chatCreate).toHaveBeenCalledOnce();
     expect(responsesCreate).not.toHaveBeenCalled();
+  });
+
+  it("sends the OpenCode session header with the conversation id for OpenCode Go streams", async () => {
+    chatCreate.mockResolvedValue(
+      createAsyncStream([{ choices: [{ delta: { content: "done" } }] }])
+    );
+
+    const { streamProviderResponse } = await import("@/lib/provider");
+    const stream = streamProviderResponse({
+      settings: createSettings({
+        apiBaseUrl: "https://opencode.ai/zen/go/v1",
+        apiMode: "chat_completions",
+        model: "kimi-k2.6",
+        providerPresetId: "opencode_go"
+      }),
+      promptMessages: [{ role: "user", content: "Hello" }],
+      conversationId: "conv_session_1"
+    });
+
+    await stream.next();
+
+    expect(vi.mocked(OpenAI).mock.calls.at(-1)?.[0]).toMatchObject({
+      defaultHeaders: { "x-opencode-session": "conv_session_1" }
+    });
+  });
+
+  it("passes the conversation id through OpenCode Go text requests", async () => {
+    chatCreate.mockResolvedValue({ choices: [{ message: { content: "ok" } }] });
+
+    const { callProviderText } = await import("@/lib/provider");
+    await callProviderText({
+      settings: createSettings({
+        apiBaseUrl: "https://opencode.ai/zen/go/v1",
+        apiMode: "chat_completions",
+        model: "kimi-k2.6",
+        providerPresetId: "opencode_go"
+      }),
+      prompt: "Give this conversation a title",
+      purpose: "title",
+      conversationId: "conv_session_2"
+    });
+
+    expect(vi.mocked(OpenAI).mock.calls.at(-1)?.[0]).toMatchObject({
+      defaultHeaders: { "x-opencode-session": "conv_session_2" }
+    });
+  });
+
+  it("falls back to the profile id for the OpenCode session header without a conversation", async () => {
+    chatCreate.mockResolvedValue({ choices: [{ message: { content: "ok" } }] });
+
+    const { callProviderText } = await import("@/lib/provider");
+    await callProviderText({
+      settings: createSettings({
+        id: "prov_opencode_1",
+        apiBaseUrl: "https://opencode.ai/zen/go/v1/",
+        apiMode: "chat_completions",
+        model: "kimi-k2.6",
+        providerPresetId: "opencode_go"
+      }),
+      prompt: "Reply with connected",
+      purpose: "test"
+    });
+
+    expect(vi.mocked(OpenAI).mock.calls.at(-1)?.[0]).toMatchObject({
+      defaultHeaders: { "x-opencode-session": "prov_opencode_1" }
+    });
+  });
+
+  it("omits the OpenCode session header for other providers", async () => {
+    chatCreate.mockResolvedValue(
+      createAsyncStream([{ choices: [{ delta: { content: "done" } }] }])
+    );
+
+    const { streamProviderResponse } = await import("@/lib/provider");
+    const stream = streamProviderResponse({
+      settings: createSettings({
+        apiBaseUrl: "https://api.example.com/v1",
+        apiMode: "chat_completions",
+        model: "some-model"
+      }),
+      promptMessages: [{ role: "user", content: "Hello" }],
+      conversationId: "conv_session_1"
+    });
+
+    await stream.next();
+
+    expect(vi.mocked(OpenAI).mock.calls.at(-1)?.[0]?.defaultHeaders).toBeUndefined();
   });
 
   it("serializes tool outputs and assistant tool calls for responses mode streams", async () => {


### PR DESCRIPTION
## Problem
OpenCode Go endpoints expect an `x-opencode-session` header so requests in the same conversation share a session, but our Anthropic and OpenAI-compatible clients never sent it.

## Solution
In plain terms: whenever we talk to an OpenCode Go API, we now attach a sticky name tag to every request so the server knows which conversation it belongs to.

- Added `isOpenCodeGoApiBaseUrl` to detect OpenCode Go base URLs and `getOpenCodeSessionHeaders` in `lib/provider-profile.ts`, which returns `{ "x-opencode-session": conversationId ?? profile.id }` only for OpenCode Go.
- Threaded an optional `conversationId` through the request pipeline (`assistant-runtime`, provider adapters, tool executors, web search pipeline, image instruction compilation) and applied the header as `defaultHeaders` on both the Anthropic and OpenAI client constructors (including model discovery).

## Testing
- Added unit tests in `tests/unit/anthropic.test.ts` and `tests/unit/provider.test.ts` covering: header sent with the conversation id, fallback to the profile id when no conversation exists, and header omitted for non-OpenCode base URLs, for both streaming and text requests.