### PR TITLE
Add bot workspace skill management UI and API

### DIFF
--- a/app/api/bots/[botId]/skills/[skillId]/route.ts
+++ b/app/api/bots/[botId]/skills/[skillId]/route.ts
@@ -1,0 +1,88 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { requireUser } from "@/lib/auth";
+import { getBot } from "@/lib/bots";
+import {
+  deleteBotWorkspaceSkill,
+  getBotWorkspaceSkill,
+  parseBotWorkspaceSkillId,
+  saveBotWorkspaceSkill
+} from "@/lib/bot-workspace-skills";
+import { parseSkillContentMetadata, stripSkillFrontmatter } from "@/lib/skill-metadata";
+import { badRequest, ok, parseRouteParams } from "@/lib/http";
+
+const paramsSchema = z.object({
+  botId: z.string().min(1),
+  skillId: z.string().min(1)
+});
+
+const updateSchema = z.object({
+  name: z.string().trim().min(1).optional(),
+  description: z.string().trim().min(1).optional(),
+  instructions: z.string().trim().min(1).optional()
+});
+
+export async function PATCH(
+  request: Request,
+  context: { params: Promise<{ botId: string; skillId: string }> }
+) {
+  const user = await requireUser();
+  const params = await parseRouteParams(context, paramsSchema, "skill id");
+  if (params instanceof NextResponse) return params;
+
+  const bot = getBot(params.botId, user.id);
+  if (!bot) {
+    return badRequest("Bot not found", 404);
+  }
+
+  if (!parseBotWorkspaceSkillId(bot, params.skillId)) {
+    return badRequest("Skill not found", 404);
+  }
+
+  const existing = getBotWorkspaceSkill(bot, params.skillId);
+  if (!existing) {
+    return badRequest("Skill not found", 404);
+  }
+
+  const body = updateSchema.safeParse(await request.json());
+  if (!body.success) {
+    return badRequest("Invalid skill data");
+  }
+
+  const metadata = parseSkillContentMetadata(existing.content);
+  const result = saveBotWorkspaceSkill(
+    bot,
+    {
+      name: body.data.name ?? metadata.name ?? existing.name,
+      description: body.data.description ?? metadata.description ?? existing.description,
+      instructions: body.data.instructions ?? stripSkillFrontmatter(existing.content).trim()
+    },
+    params.skillId
+  );
+  if ("error" in result) {
+    return badRequest(result.error);
+  }
+
+  return ok({ skill: result.skill });
+}
+
+export async function DELETE(
+  _request: Request,
+  context: { params: Promise<{ botId: string; skillId: string }> }
+) {
+  const user = await requireUser();
+  const params = await parseRouteParams(context, paramsSchema, "skill id");
+  if (params instanceof NextResponse) return params;
+
+  const bot = getBot(params.botId, user.id);
+  if (!bot) {
+    return badRequest("Bot not found", 404);
+  }
+
+  if (!deleteBotWorkspaceSkill(bot, params.skillId)) {
+    return badRequest("Skill not found", 404);
+  }
+
+  return ok({ success: true });
+}

--- a/app/api/bots/[botId]/skills/route.ts
+++ b/app/api/bots/[botId]/skills/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { requireUser } from "@/lib/auth";
+import { getBot } from "@/lib/bots";
+import { listBotWorkspaceSkills, saveBotWorkspaceSkill } from "@/lib/bot-workspace-skills";
+import { badRequest, ok, parseRouteParams } from "@/lib/http";
+
+const paramsSchema = z.object({
+  botId: z.string().min(1)
+});
+
+const createSchema = z.object({
+  name: z.string().trim().min(1),
+  description: z.string().trim().min(1),
+  instructions: z.string().trim().min(1)
+});
+
+export async function GET(
+  _request: Request,
+  context: { params: Promise<{ botId: string }> }
+) {
+  const user = await requireUser();
+  const params = await parseRouteParams(context, paramsSchema, "bot id");
+  if (params instanceof NextResponse) return params;
+
+  const bot = getBot(params.botId, user.id);
+  if (!bot) {
+    return badRequest("Bot not found", 404);
+  }
+
+  return ok({ skills: listBotWorkspaceSkills(bot) });
+}
+
+export async function POST(
+  request: Request,
+  context: { params: Promise<{ botId: string }> }
+) {
+  const user = await requireUser();
+  const params = await parseRouteParams(context, paramsSchema, "bot id");
+  if (params instanceof NextResponse) return params;
+
+  const bot = getBot(params.botId, user.id);
+  if (!bot) {
+    return badRequest("Bot not found", 404);
+  }
+
+  const body = createSchema.safeParse(await request.json());
+  if (!body.success) {
+    return badRequest("Invalid skill data");
+  }
+
+  const result = saveBotWorkspaceSkill(bot, body.data);
+  if ("error" in result) {
+    return badRequest(result.error);
+  }
+
+  return ok({ skill: result.skill }, { status: 201 });
+}

--- a/components/agents/bot-detail-view.tsx
+++ b/components/agents/bot-detail-view.tsx
@@ -21,13 +21,14 @@ import type { BotWorkspaceNode } from "@/lib/bot-sandbox";
 import { BotAvatar } from "@/components/agents/bot-avatar";
 import { BotStatusChip } from "@/components/agents/bot-status";
 import { BotFormModal } from "@/components/agents/bot-form-modal";
+import { BotSkillModal } from "@/components/agents/bot-skill-modal";
 import { ChatView } from "@/components/chat-view";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/settings/badge";
 import { addGlobalWsListener } from "@/lib/ws-client";
 import type { ConversationViewPayload } from "@/lib/conversation-view";
-import type { Automation, BotSummary, UserMemory } from "@/lib/types";
+import type { Automation, BotSummary, Skill, UserMemory } from "@/lib/types";
 
 function scheduleSummary(automation: Automation) {
   if (automation.scheduleKind === "interval" && automation.intervalMinutes) {
@@ -183,6 +184,11 @@ export function BotDetailView({
   const [botMemories, setBotMemories] = useState<UserMemory[] | null>(null);
   const [botMemoriesError, setBotMemoriesError] = useState<string | null>(null);
   const [memoryDeleteTarget, setMemoryDeleteTarget] = useState<UserMemory | null>(null);
+  const [botSkills, setBotSkills] = useState<Skill[] | null>(null);
+  const [botSkillsError, setBotSkillsError] = useState<string | null>(null);
+  const [skillEditTarget, setSkillEditTarget] = useState<Skill | null>(null);
+  const [isSkillModalOpen, setIsSkillModalOpen] = useState(false);
+  const [skillDeleteTarget, setSkillDeleteTarget] = useState<Skill | null>(null);
   const resetNoticeHandle = useRef<number | null>(null);
   const refreshTimerRef = useRef<number | null>(null);
 
@@ -231,6 +237,21 @@ export function BotDetailView({
     }
   }, [initialBot.id]);
 
+  const loadSkills = useCallback(async () => {
+    try {
+      const response = await fetch(`/api/bots/${initialBot.id}/skills`);
+      if (!response.ok) {
+        setBotSkillsError("Unable to load skills");
+        return;
+      }
+      const payload = (await response.json()) as { skills?: Skill[] };
+      setBotSkills(Array.isArray(payload.skills) ? payload.skills : []);
+      setBotSkillsError(null);
+    } catch {
+      setBotSkillsError("Unable to load skills");
+    }
+  }, [initialBot.id]);
+
   useEffect(() => {
     setBot(initialBot);
   }, [initialBot]);
@@ -243,6 +264,7 @@ export function BotDetailView({
   useEffect(() => {
     void loadWorkspace();
     void loadMemories();
+    void loadSkills();
     const noticeHandle = resetNoticeHandle;
     const refreshHandle = refreshTimerRef;
     return () => {
@@ -253,7 +275,7 @@ export function BotDetailView({
         window.clearTimeout(refreshHandle.current);
       }
     };
-  }, [loadMemories, loadWorkspace]);
+  }, [loadMemories, loadSkills, loadWorkspace]);
 
   useEffect(() => {
     return addGlobalWsListener((msg) => {
@@ -272,10 +294,11 @@ export function BotDetailView({
         refreshTimerRef.current = window.setTimeout(() => {
           refreshTimerRef.current = null;
           void refreshBot();
+          void loadSkills();
         }, 250);
       }
     });
-  }, [initialBot.id, refreshBot, router]);
+  }, [initialBot.id, loadSkills, refreshBot, router]);
 
   async function handleEdit(values: {
     name: string;
@@ -353,6 +376,28 @@ export function BotDetailView({
       await loadMemories();
     } catch {
       setBotMemoriesError("Could not delete memory");
+    }
+  }
+
+  async function handleSkillDelete() {
+    const target = skillDeleteTarget;
+    setSkillDeleteTarget(null);
+    if (!target) {
+      return;
+    }
+
+    try {
+      const response = await fetch(
+        `/api/bots/${bot.id}/skills/${encodeURIComponent(target.id)}`,
+        { method: "DELETE" }
+      );
+      if (!response.ok) {
+        setBotSkillsError("Could not delete skill");
+        return;
+      }
+      await loadSkills();
+    } catch {
+      setBotSkillsError("Could not delete skill");
     }
   }
 
@@ -479,6 +524,69 @@ export function BotDetailView({
                     depth={0}
                   />
                 </div>
+              )}
+            </div>
+          </PanelSection>
+
+          <PanelSection
+            title="Skills"
+            action={
+              <button
+                type="button"
+                onClick={() => {
+                  setSkillEditTarget(null);
+                  setIsSkillModalOpen(true);
+                }}
+                className="shrink-0 rounded-lg border border-white/12 bg-white/[0.03] px-2.5 py-1.5 text-[11px] font-medium text-[#cbd5e1] transition-colors hover:border-white/20 hover:bg-white/[0.05] hover:text-white"
+              >
+                Add skill
+              </button>
+            }
+          >
+            <p className="text-xs leading-5 text-[var(--muted)]">
+              Skills this bot keeps in its workspace. It can save skills itself, and you can add or edit them here.
+            </p>
+            <div className="mt-3">
+              {botSkillsError ? (
+                <div className="text-xs text-red-200">{botSkillsError}</div>
+              ) : botSkills === null ? (
+                <div className="text-xs text-[var(--muted)]">Loading skills…</div>
+              ) : botSkills.length === 0 ? (
+                <p className="text-xs text-[var(--muted)]">
+                  No skills yet. This bot saves skills it creates here, and you can add your own.
+                </p>
+              ) : (
+                <ul className="divide-y divide-white/4 rounded-xl border border-white/6 bg-white/[0.02]">
+                  {botSkills.map((skill) => (
+                    <li key={skill.id} className="flex items-start justify-between gap-3 px-3 py-2">
+                      <div className="min-w-0 flex-1">
+                        <span className="block truncate text-xs font-medium text-[#f4f4f5]">{skill.name}</span>
+                        <span className="mt-0.5 block truncate text-[11px] text-[var(--muted)]">{skill.description}</span>
+                      </div>
+                      <span className="flex shrink-0 items-center gap-1">
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setSkillEditTarget(skill);
+                            setIsSkillModalOpen(true);
+                          }}
+                          aria-label={`Edit skill ${skill.name}`}
+                          className="inline-flex h-6 w-6 items-center justify-center rounded-md text-[#52525b] transition-colors hover:bg-white/[0.06] hover:text-[#f4f4f5]"
+                        >
+                          <Pencil className="h-3 w-3" aria-hidden="true" />
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => setSkillDeleteTarget(skill)}
+                          aria-label={`Delete skill ${skill.name}`}
+                          className="inline-flex h-6 w-6 items-center justify-center rounded-md text-[#52525b] transition-colors hover:bg-red-500/10 hover:text-red-300"
+                        >
+                          <Trash2 className="h-3 w-3" aria-hidden="true" />
+                        </button>
+                      </span>
+                    </li>
+                  ))}
+                </ul>
               )}
             </div>
           </PanelSection>
@@ -642,6 +750,30 @@ export function BotDetailView({
           </>
         }
         onConfirm={handleMemoryDelete}
+      />
+
+      <BotSkillModal
+        open={isSkillModalOpen}
+        onOpenChange={setIsSkillModalOpen}
+        botId={bot.id}
+        skill={skillEditTarget}
+        onSaved={loadSkills}
+      />
+
+      <ConfirmDialog
+        open={skillDeleteTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setSkillDeleteTarget(null);
+          }
+        }}
+        title="Delete skill?"
+        description={
+          <>
+            <strong className="font-medium text-[var(--text)]">{skillDeleteTarget?.name}</strong> will be removed from this bot&apos;s workspace. This action cannot be undone.
+          </>
+        }
+        onConfirm={handleSkillDelete}
       />
 
       <ConfirmDialog

--- a/components/agents/bot-skill-modal.tsx
+++ b/components/agents/bot-skill-modal.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Sparkles } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { DialogShell } from "@/components/ui/dialog-shell";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { fieldLabel } from "@/lib/settings-styles";
+import { parseSkillContentMetadata, stripSkillFrontmatter } from "@/lib/skill-metadata";
+import type { Skill } from "@/lib/types";
+
+type SkillFormValues = {
+  name: string;
+  description: string;
+  instructions: string;
+};
+
+function valuesFromSkill(skill: Skill | null): SkillFormValues {
+  if (!skill) {
+    return {
+      name: "",
+      description: "",
+      instructions: ""
+    };
+  }
+
+  const metadata = parseSkillContentMetadata(skill.content);
+  return {
+    name: metadata.name ?? skill.name,
+    description: metadata.description ?? skill.description,
+    instructions: stripSkillFrontmatter(skill.content).trim()
+  };
+}
+
+export function BotSkillModal({
+  open,
+  onOpenChange,
+  botId,
+  skill = null,
+  onSaved
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  botId: string;
+  skill?: Skill | null;
+  onSaved: () => void;
+}) {
+  const [values, setValues] = useState<SkillFormValues>(() => valuesFromSkill(skill));
+  const [error, setError] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setValues(valuesFromSkill(skill));
+      setError(null);
+      setIsSaving(false);
+    }
+  }, [open, skill]);
+
+  function update<K extends keyof SkillFormValues>(key: K, value: SkillFormValues[K]) {
+    setValues((current) => ({ ...current, [key]: value }));
+  }
+
+  async function handleSubmit() {
+    const name = values.name.trim();
+    const description = values.description.trim();
+    const instructions = values.instructions.trim();
+
+    if (!name || !description || !instructions) {
+      setError("Name, description, and instructions are all required");
+      return;
+    }
+
+    setIsSaving(true);
+    setError(null);
+
+    try {
+      const response = await fetch(
+        skill ? `/api/bots/${botId}/skills/${skill.id}` : `/api/bots/${botId}/skills`,
+        {
+          method: skill ? "PATCH" : "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name, description, instructions })
+        }
+      );
+
+      if (!response.ok) {
+        const failure = (await response.json().catch(() => null)) as { error?: string } | null;
+        setError(failure?.error ?? "Unable to save skill");
+        return;
+      }
+
+      onOpenChange(false);
+      onSaved();
+    } catch {
+      setError("Unable to save skill");
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  return (
+    <DialogShell
+      open={open}
+      onOpenChange={onOpenChange}
+      title={skill ? "Edit skill" : "Add skill"}
+      description="Skills live in this bot's workspace as SKILL.md files."
+      size="lg"
+      icon={
+        <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-[10px] border border-[var(--accent)]/25 bg-[var(--accent)]/10">
+          <Sparkles className="h-[18px] w-[18px] text-[var(--accent)]" />
+        </div>
+      }
+      footer={
+        <>
+          <Button
+            type="button"
+            variant="ghost"
+            autoFocus
+            className="px-4 py-2 text-xs"
+            onClick={() => onOpenChange(false)}
+            disabled={isSaving}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            className="px-4 py-2 text-xs"
+            onClick={() => void handleSubmit()}
+            disabled={isSaving}
+          >
+            {isSaving ? "Saving…" : "Save"}
+          </Button>
+        </>
+      }
+    >
+      <div className="space-y-4">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <div>
+            <label className={fieldLabel}>Name</label>
+            <Input
+              aria-label="Skill name"
+              value={values.name}
+              onChange={(event) => update("name", event.target.value)}
+              placeholder="Web research"
+              maxLength={100}
+            />
+          </div>
+          <div>
+            <label className={fieldLabel}>Description</label>
+            <Input
+              aria-label="Skill description"
+              value={values.description}
+              onChange={(event) => update("description", event.target.value)}
+              placeholder="What this skill does"
+              maxLength={200}
+            />
+          </div>
+        </div>
+        <div>
+          <label className={fieldLabel}>Instructions</label>
+          <Textarea
+            aria-label="Skill instructions"
+            value={values.instructions}
+            onChange={(event) => update("instructions", event.target.value)}
+            placeholder="Step-by-step instructions for the bot to follow when using this skill."
+            rows={12}
+          />
+        </div>
+        {error ? <p className="text-xs text-red-300">{error}</p> : null}
+      </div>
+    </DialogShell>
+  );
+}

--- a/lib/bot-workspace-skills.ts
+++ b/lib/bot-workspace-skills.ts
@@ -1,4 +1,4 @@
-import { readdirSync, readFileSync, statSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { getBotWorkspaceDir } from "@/lib/bot-sandbox";
 import { parseSkillContentMetadata } from "@/lib/skill-metadata";
@@ -9,8 +9,18 @@ import type { Bot, Skill } from "@/lib/types";
 export const BOT_WORKSPACE_SKILL_ID_PREFIX = "botws-";
 
 const MAX_BOT_WORKSPACE_SKILLS = 50;
-const MAX_SKILL_FILE_BYTES = 200 * 1024;
+export const MAX_SKILL_FILE_BYTES = 200 * 1024;
 const SKILL_FILE_NAME = "SKILL.md";
+const MAX_SKILL_NAME_CHARS = 100;
+const FOLDER_SLUG_PATTERN = /^[a-z0-9-]{1,64}$/;
+
+export type BotWorkspaceSkillInput = {
+  name: string;
+  description: string;
+  instructions: string;
+};
+
+export type BotWorkspaceSkillSaveResult = { skill: Skill } | { error: string };
 
 export function getBotSkillsDir(bot: Pick<Bot, "id" | "userId">) {
   return join(getBotWorkspaceDir(bot), "skills");
@@ -34,6 +44,140 @@ export function buildBotWorkspaceSkillId(botId: string, folderSlug: string) {
   return `${BOT_WORKSPACE_SKILL_ID_PREFIX}${sanitizedBotId}-${folderSlug}`;
 }
 
+export function parseBotWorkspaceSkillId(bot: Pick<Bot, "id">, skillId: string) {
+  const sanitizedBotId = bot.id.replace(/[^a-zA-Z0-9_-]+/g, "-") || "bot";
+  const prefix = `${BOT_WORKSPACE_SKILL_ID_PREFIX}${sanitizedBotId}-`;
+  if (!skillId.startsWith(prefix)) {
+    return null;
+  }
+  const folderSlug = skillId.slice(prefix.length);
+  return FOLDER_SLUG_PATTERN.test(folderSlug) ? folderSlug : null;
+}
+
+export function buildSkillMarkdown(name: string, description: string, instructions: string) {
+  return `---\nname: ${name}\ndescription: ${description}\n---\n\n${instructions}\n`;
+}
+
+function normalizeSingleLine(value: string) {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+export function saveBotWorkspaceSkill(
+  bot: Pick<Bot, "id" | "userId">,
+  input: BotWorkspaceSkillInput,
+  previousSkillId?: string
+): BotWorkspaceSkillSaveResult {
+  const name = normalizeSingleLine(input.name);
+  const description = normalizeSingleLine(input.description);
+  const instructions = input.instructions.trim();
+
+  if (!name) {
+    return { error: "A skill name is required." };
+  }
+  if (name.length > MAX_SKILL_NAME_CHARS) {
+    return { error: `Skill names must be ${MAX_SKILL_NAME_CHARS} characters or fewer.` };
+  }
+  if (!description) {
+    return { error: "A skill description is required." };
+  }
+  if (!instructions) {
+    return { error: "Skill instructions are required." };
+  }
+
+  const slug = slugifySkillFolderName(name);
+  if (!slug) {
+    return { error: "Cannot derive a valid skill folder name from this name. Use letters, digits, or hyphens." };
+  }
+
+  const content = buildSkillMarkdown(name, description, instructions);
+  if (Buffer.byteLength(content, "utf8") > MAX_SKILL_FILE_BYTES) {
+    return { error: "Skill instructions are too large. Keep the skill under 200 KB." };
+  }
+
+  const skillsDir = getBotSkillsDir(bot);
+  const previousFolderSlug = previousSkillId ? parseBotWorkspaceSkillId(bot, previousSkillId) : null;
+  const skillDir = join(skillsDir, slug);
+  const skillFilePath = join(skillDir, SKILL_FILE_NAME);
+
+  if (previousFolderSlug !== slug && existsSync(skillFilePath)) {
+    return { error: "A skill with this name already exists." };
+  }
+
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(skillFilePath, content, "utf8");
+
+  if (previousFolderSlug && previousFolderSlug !== slug) {
+    rmSync(join(skillsDir, previousFolderSlug), { recursive: true, force: true });
+  }
+
+  const timestamp = statSync(skillFilePath).mtime.toISOString();
+  return {
+    skill: {
+      id: buildBotWorkspaceSkillId(bot.id, slug),
+      name,
+      description,
+      content,
+      enabled: true,
+      createdAt: timestamp,
+      updatedAt: timestamp
+    }
+  };
+}
+
+export function deleteBotWorkspaceSkill(bot: Pick<Bot, "id" | "userId">, skillId: string) {
+  const folderSlug = parseBotWorkspaceSkillId(bot, skillId);
+  if (!folderSlug) {
+    return false;
+  }
+
+  const skillDir = join(getBotSkillsDir(bot), folderSlug);
+  const existed = existsSync(join(skillDir, SKILL_FILE_NAME));
+  rmSync(skillDir, { recursive: true, force: true });
+  return existed;
+}
+
+function readSkillFolder(skillsDir: string, botId: string, folderSlug: string): Skill | null {
+  const skillFilePath = join(skillsDir, folderSlug, SKILL_FILE_NAME);
+  let fileStats: ReturnType<typeof statSync>;
+  try {
+    fileStats = statSync(skillFilePath);
+  } catch {
+    return null;
+  }
+
+  if (!fileStats.isFile() || fileStats.size > MAX_SKILL_FILE_BYTES) {
+    return null;
+  }
+
+  let content: string;
+  try {
+    content = readFileSync(skillFilePath, "utf8");
+  } catch {
+    return null;
+  }
+
+  const metadata = parseSkillContentMetadata(content);
+  const timestamp = fileStats.mtime.toISOString();
+
+  return {
+    id: buildBotWorkspaceSkillId(botId, folderSlug),
+    name: metadata.name?.trim() || folderSlug,
+    description: deriveDescription(content),
+    content,
+    enabled: true,
+    createdAt: timestamp,
+    updatedAt: timestamp
+  };
+}
+
+export function getBotWorkspaceSkill(bot: Pick<Bot, "id" | "userId">, skillId: string) {
+  const folderSlug = parseBotWorkspaceSkillId(bot, skillId);
+  if (!folderSlug) {
+    return null;
+  }
+  return readSkillFolder(getBotSkillsDir(bot), bot.id, folderSlug);
+}
+
 export function listBotWorkspaceSkills(bot: Pick<Bot, "id" | "userId">): Skill[] {
   const skillsDir = getBotSkillsDir(bot);
 
@@ -49,37 +193,10 @@ export function listBotWorkspaceSkills(bot: Pick<Bot, "id" | "userId">): Skill[]
   for (const entry of entries.sort()) {
     if (skills.length >= MAX_BOT_WORKSPACE_SKILLS) break;
 
-    const skillFilePath = join(skillsDir, entry, SKILL_FILE_NAME);
-    let fileStats: ReturnType<typeof statSync>;
-    try {
-      fileStats = statSync(skillFilePath);
-    } catch {
-      continue;
+    const skill = readSkillFolder(skillsDir, bot.id, entry);
+    if (skill) {
+      skills.push(skill);
     }
-
-    if (!fileStats.isFile() || fileStats.size > MAX_SKILL_FILE_BYTES) {
-      continue;
-    }
-
-    let content: string;
-    try {
-      content = readFileSync(skillFilePath, "utf8");
-    } catch {
-      continue;
-    }
-
-    const metadata = parseSkillContentMetadata(content);
-    const timestamp = fileStats.mtime.toISOString();
-
-    skills.push({
-      id: buildBotWorkspaceSkillId(bot.id, entry),
-      name: metadata.name?.trim() || entry,
-      description: deriveDescription(content),
-      content,
-      enabled: true,
-      createdAt: timestamp,
-      updatedAt: timestamp
-    });
   }
 
   return skills;

--- a/lib/skill-metadata.ts
+++ b/lib/skill-metadata.ts
@@ -33,6 +33,16 @@ function normalizePrefixes(prefixes: string[]) {
   return [...new Set(prefixes.map((prefix) => prefix.trim()).filter(Boolean))];
 }
 
+export function stripSkillFrontmatter(content: string): string {
+  const match = content.match(/^---\s*\n([\s\S]*?)\n---\s*(?:\n|$)/);
+
+  if (!match) {
+    return content;
+  }
+
+  return content.slice(match[0].length);
+}
+
 export function parseSkillContentMetadata(content: string): SkillContentMetadata {
   const match = content.match(/^---\s*\n([\s\S]*?)\n---\s*(?:\n|$)/);
 

--- a/lib/tool-executors.ts
+++ b/lib/tool-executors.ts
@@ -29,7 +29,7 @@ import {
 } from "@/lib/screenshot-artifact-capabilities";
 import { getLatestUserPromptContent } from "./prompt-analysis";
 import { getSkillResolvedDescription, getSkillResolvedName } from "./skill-runtime";
-import { buildBotWorkspaceSkillId, getBotSkillsDir, listBotWorkspaceSkills, slugifySkillFolderName } from "./bot-workspace-skills";
+import { buildBotWorkspaceSkillId, buildSkillMarkdown, getBotSkillsDir, listBotWorkspaceSkills, slugifySkillFolderName } from "./bot-workspace-skills";
 import { nowIso } from "@/lib/utils";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
@@ -695,7 +695,7 @@ export async function executeSaveSkill(
 
   const skillDir = join(getBotSkillsDir(bot), slug);
   const skillFilePath = join(skillDir, "SKILL.md");
-  const content = `---\nname: ${name}\ndescription: ${description}\n---\n\n${instructions}\n`;
+  const content = buildSkillMarkdown(name, description, instructions);
 
   throwIfAborted(context.input.abortSignal);
   const handle = await context.input.onActionStart?.({

--- a/tests/e2e/bots.spec.ts
+++ b/tests/e2e/bots.spec.ts
@@ -30,7 +30,7 @@ test("agents roster shows the chief and supports creating a bot", async ({ page 
 
   await page.getByRole("button", { name: "Create bot" }).click();
 
-  await expect(page).toHaveURL(/\/agents\/bot_/, { timeout: 15_000 });
+  await expect(page).toHaveURL(/\/agents\/bot/, { timeout: 15_000 });
   await expect(page.getByText("E2E Scout").first()).toBeVisible({ timeout: 10_000 });
   await expect(page.getByText("E2E lookouts").first()).toBeVisible({ timeout: 10_000 });
 
@@ -46,11 +46,58 @@ test("bot detail page exposes sandbox actions and edit", async ({ page }) => {
 
   const chiefRow = page.getByRole("link", { name: /Chief of Staff/ }).first();
   await chiefRow.click();
-  await expect(page).toHaveURL(/\/agents\/bot_/, { timeout: 15_000 });
+  await expect(page).toHaveURL(/\/agents\/bot/, { timeout: 15_000 });
   await expect(page.getByText("Coordinates your team of bots").first()).toBeVisible({
     timeout: 10_000
   });
 
   await expect(page.getByRole("button", { name: "Edit" })).toBeVisible({ timeout: 10_000 });
-  await expect(page.getByText("Sandbox").first()).toBeVisible({ timeout: 10_000 });
+  await page.getByRole("button", { name: "Details" }).click();
+  await expect(page.getByText("Workspace").first()).toBeVisible({ timeout: 10_000 });
+});
+
+test("bot detail manages workspace skills from the details panel", async ({ page }) => {
+  await signIn(page);
+
+  await page.goto("/agents");
+  await expect(page.getByText("Chief of Staff").first()).toBeVisible({ timeout: 15_000 });
+
+  const newBotButton = page.getByRole("button", { name: "New bot" });
+  await expect(newBotButton).toBeVisible({ timeout: 10_000 });
+  await newBotButton.click();
+
+  await page.getByLabel("Bot name").fill("E2E Skill Keeper");
+  await page.getByLabel("Bot description").fill("Created by the skills e2e test.");
+  await page.getByRole("button", { name: "Create bot" }).click();
+  await expect(page).toHaveURL(/\/agents\/bot/, { timeout: 15_000 });
+
+  await page.getByRole("button", { name: "Details" }).click();
+  const skillsSection = page.locator("section", { has: page.getByText("Skills", { exact: true }) }).first();
+  await expect(skillsSection.getByText("No skills yet.")).toBeVisible({ timeout: 10_000 });
+
+  await skillsSection.getByRole("button", { name: "Add skill" }).click();
+  const createDialog = page.getByRole("dialog", { name: "Add skill" });
+  await createDialog.getByLabel("Skill name").fill("Meeting notes");
+  await createDialog.getByLabel("Skill description").fill("Summarize meetings.");
+  await createDialog.getByLabel("Skill instructions").fill("Capture action items and owners.");
+  await createDialog.getByRole("button", { name: "Save" }).click();
+
+  await expect(skillsSection.getByText("Meeting notes")).toBeVisible({ timeout: 10_000 });
+  await expect(skillsSection.getByText("Summarize meetings.")).toBeVisible({ timeout: 10_000 });
+
+  await skillsSection.getByRole("button", { name: "Edit skill Meeting notes" }).click();
+  const editDialog = page.getByRole("dialog", { name: "Edit skill" });
+  await expect(editDialog.getByLabel("Skill name")).toHaveValue("Meeting notes");
+  await expect(editDialog.getByLabel("Skill instructions")).toHaveValue("Capture action items and owners.");
+  await editDialog.getByLabel("Skill name").fill("Deep research");
+  await editDialog.getByRole("button", { name: "Save" }).click();
+
+  await expect(skillsSection.getByText("Deep research")).toBeVisible({ timeout: 10_000 });
+  await expect(skillsSection.getByText("Meeting notes")).toHaveCount(0);
+
+  await skillsSection.getByRole("button", { name: "Delete skill Deep research" }).click();
+  const deleteDialog = page.getByRole("dialog", { name: "Delete skill?" });
+  await deleteDialog.getByRole("button", { name: "Delete" }).click();
+
+  await expect(skillsSection.getByText("No skills yet.")).toBeVisible({ timeout: 10_000 });
 });

--- a/tests/unit/bot-detail-skills.test.tsx
+++ b/tests/unit/bot-detail-skills.test.tsx
@@ -1,0 +1,369 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+
+import { BotDetailView } from "@/components/agents/bot-detail-view";
+import type { ConversationViewPayload } from "@/lib/conversation-view";
+import type { BotSummary, Skill } from "@/lib/types";
+
+const routerMocks = vi.hoisted(() => ({
+  push: vi.fn()
+}));
+
+const wsMocks = vi.hoisted(() => ({
+  listener: null as ((msg: { type: string; run?: { botId: string } }) => void) | null
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: routerMocks.push,
+    refresh: vi.fn()
+  })
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  )
+}));
+
+vi.mock("@/lib/ws-client", () => ({
+  addGlobalWsListener: (listener: (msg: { type: string; run?: { botId: string } }) => void) => {
+    wsMocks.listener = listener;
+    return () => undefined;
+  }
+}));
+
+vi.mock("@/components/chat-view", () => ({
+  ChatView: () => <div data-testid="chat-view" />
+}));
+
+vi.mock("@/components/agents/bot-form-modal", () => ({
+  BotFormModal: () => null
+}));
+
+function renderWithPanelOpen(ui: React.ReactElement) {
+  render(ui);
+  const toggle = screen.getAllByRole("button").find((button) =>
+    button.textContent?.includes("Details")
+  );
+  fireEvent.click(toggle!);
+}
+
+function buildBot(overrides: Partial<BotSummary> = {}): BotSummary {
+  return {
+    id: "bot_1",
+    name: "Research Bot",
+    title: "Digs into topics",
+    description: "Researches topics for the team.",
+    avatarSeed: "seed_research",
+    isChief: false,
+    homeConversationId: "conv_1",
+    status: "idle",
+    waitingForInput: false,
+    lastRunAt: null,
+    createdAt: "2026-04-10T12:00:00.000Z",
+    updatedAt: "2026-04-10T12:00:00.000Z",
+    ...overrides
+  };
+}
+
+function buildSkill(overrides: Partial<Skill> = {}): Skill {
+  return {
+    id: "botws-bot_1-web-research",
+    name: "Web research",
+    description: "Research a topic across sources.",
+    content:
+      "---\nname: Web research\ndescription: Research a topic across sources.\n---\n\nSearch broadly, then summarize.",
+    enabled: true,
+    createdAt: "2026-04-10T12:00:00.000Z",
+    updatedAt: "2026-04-10T12:00:00.000Z",
+    ...overrides
+  };
+}
+
+function mockSkillEndpoints(skills: Skill[], options: { failList?: boolean } = {}) {
+  const current = [...skills];
+  const calls: Array<{ method: string; url: string; body?: unknown }> = [];
+  const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const method = init?.method ?? "GET";
+    calls.push({ method, url, body: init?.body ? JSON.parse(String(init.body)) : undefined });
+
+    if (url === "/api/bots/bot_1/skills" && method === "GET") {
+      if (options.failList) {
+        return { ok: false, json: async () => ({ error: "nope" }) } as Response;
+      }
+      return { ok: true, json: async () => ({ skills: current }) } as Response;
+    }
+
+    if (url === "/api/bots/bot_1/skills" && method === "POST") {
+      const body = JSON.parse(String(init?.body)) as {
+        name: string;
+        description: string;
+        instructions: string;
+      };
+      const created = buildSkill({
+        id: `botws-bot_1-${body.name.toLowerCase().replace(/\s+/g, "-")}`,
+        name: body.name,
+        description: body.description,
+        content: `---\nname: ${body.name}\ndescription: ${body.description}\n---\n\n${body.instructions}`
+      });
+      current.push(created);
+      return { ok: true, status: 201, json: async () => ({ skill: created }) } as Response;
+    }
+
+    if (url.startsWith("/api/bots/bot_1/skills/") && method === "PATCH") {
+      const id = url.split("/").pop()!;
+      const body = JSON.parse(String(init?.body)) as Record<string, string>;
+      const index = current.findIndex((skill) => skill.id === id);
+      if (index >= 0) {
+        current[index] = { ...current[index], ...body };
+      }
+      return { ok: true, json: async () => ({ skill: current[index] }) } as Response;
+    }
+
+    if (url.startsWith("/api/bots/bot_1/skills/") && method === "DELETE") {
+      const id = url.split("/").pop()!;
+      const index = current.findIndex((skill) => skill.id === id);
+      if (index >= 0) {
+        current.splice(index, 1);
+      }
+      return { ok: true, json: async () => ({ success: true }) } as Response;
+    }
+
+    if (url === "/api/bots/bot_1/memories" && method === "GET") {
+      return { ok: true, json: async () => ({ memories: [] }) } as Response;
+    }
+
+    if (url === "/api/bots/bot_1/workspace" && method === "GET") {
+      return {
+        ok: true,
+        json: async () => ({
+          tree: { name: "bot_1", path: "", isDirectory: true, byteSize: 0, children: [] }
+        })
+      } as Response;
+    }
+
+    throw new Error(`Unhandled fetch: ${method} ${url}`);
+  }) as unknown as typeof fetch;
+  global.fetch = fetchMock;
+  return { fetchMock, calls };
+}
+
+function renderView(bot: BotSummary = buildBot()) {
+  renderWithPanelOpen(
+    React.createElement(BotDetailView, {
+      bot,
+      systemPrompt: "You are a research bot.",
+      conversationPayload: {} as ConversationViewPayload,
+      routines: []
+    })
+  );
+}
+
+describe("bot detail skills", () => {
+  it("lists the bot's workspace skills from the API", async () => {
+    mockSkillEndpoints([
+      buildSkill(),
+      buildSkill({
+        id: "botws-bot_1-pdf-extraction",
+        name: "PDF extraction",
+        description: "Pull text out of PDF files.",
+        content: "---\nname: PDF extraction\ndescription: Pull text out of PDF files.\n---\n\nUse pdftotext."
+      })
+    ]);
+
+    renderView();
+
+    expect(await screen.findByText("Web research")).toBeInTheDocument();
+    expect(screen.getByText("PDF extraction")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Add skill" })).toBeInTheDocument();
+  });
+
+  it("shows the empty state when the bot has no skills", async () => {
+    mockSkillEndpoints([]);
+
+    renderView();
+
+    expect(
+      await screen.findByText("No skills yet. This bot saves skills it creates here, and you can add your own.")
+    ).toBeInTheDocument();
+  });
+
+  it("shows a load error when listing skills fails", async () => {
+    mockSkillEndpoints([], { failList: true });
+
+    renderView();
+
+    expect(await screen.findByText("Unable to load skills")).toBeInTheDocument();
+  });
+
+  it("edits a skill through the modal and refetches", async () => {
+    const { calls } = mockSkillEndpoints([buildSkill()]);
+
+    renderView();
+
+    expect(await screen.findByText("Web research")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Edit skill Web research" }));
+
+    const dialog = await screen.findByRole("dialog", { name: "Edit skill" });
+    const nameInput = within(dialog).getByLabelText("Skill name");
+    expect(nameInput).toHaveValue("Web research");
+    expect(within(dialog).getByLabelText("Skill description")).toHaveValue(
+      "Research a topic across sources."
+    );
+    expect(within(dialog).getByLabelText("Skill instructions")).toHaveValue(
+      "Search broadly, then summarize."
+    );
+
+    fireEvent.change(nameInput, { target: { value: "Deep research" } });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(calls).toContainEqual({
+        method: "PATCH",
+        url: "/api/bots/bot_1/skills/botws-bot_1-web-research",
+        body: {
+          name: "Deep research",
+          description: "Research a topic across sources.",
+          instructions: "Search broadly, then summarize."
+        }
+      });
+    });
+    expect(await screen.findByText("Deep research")).toBeInTheDocument();
+  });
+
+  it("creates a skill through the modal and validates required fields", async () => {
+    const { fetchMock, calls } = mockSkillEndpoints([]);
+
+    renderView();
+
+    expect(await screen.findByText("No skills yet. This bot saves skills it creates here, and you can add your own.")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Add skill" }));
+
+    const dialog = await screen.findByRole("dialog", { name: "Add skill" });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Save" }));
+
+    expect(
+      await within(dialog).findByText("Name, description, and instructions are all required")
+    ).toBeInTheDocument();
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      "/api/bots/bot_1/skills",
+      expect.objectContaining({ method: "POST" })
+    );
+
+    fireEvent.change(within(dialog).getByLabelText("Skill name"), { target: { value: "Meeting notes" } });
+    fireEvent.change(within(dialog).getByLabelText("Skill description"), {
+      target: { value: "Summarize meetings." }
+    });
+    fireEvent.change(within(dialog).getByLabelText("Skill instructions"), {
+      target: { value: "Capture action items." }
+    });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/bots/bot_1/skills",
+        expect.objectContaining({ method: "POST" })
+      );
+    });
+    expect(calls.filter((call) => call.method === "POST")).toHaveLength(1);
+    expect(calls.find((call) => call.method === "POST")?.body).toEqual({
+      name: "Meeting notes",
+      description: "Summarize meetings.",
+      instructions: "Capture action items."
+    });
+    expect(await screen.findByText("Meeting notes")).toBeInTheDocument();
+  });
+
+  it("surfaces API errors inside the modal", async () => {
+    global.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url === "/api/bots/bot_1/skills" && (init?.method ?? "GET") === "GET") {
+        return { ok: true, json: async () => ({ skills: [] }) } as Response;
+      }
+      if (url === "/api/bots/bot_1/memories") {
+        return { ok: true, json: async () => ({ memories: [] }) } as Response;
+      }
+      if (url === "/api/bots/bot_1/workspace") {
+        return {
+          ok: true,
+          json: async () => ({ tree: { name: "bot_1", path: "", isDirectory: true, byteSize: 0, children: [] } })
+        } as Response;
+      }
+      return {
+        ok: false,
+        status: 400,
+        json: async () => ({ error: "A skill with this name already exists." })
+      } as Response;
+    }) as unknown as typeof fetch;
+
+    renderView();
+    await screen.findByText("No skills yet. This bot saves skills it creates here, and you can add your own.");
+    fireEvent.click(screen.getByRole("button", { name: "Add skill" }));
+
+    const dialog = await screen.findByRole("dialog", { name: "Add skill" });
+    fireEvent.change(within(dialog).getByLabelText("Skill name"), { target: { value: "Dup" } });
+    fireEvent.change(within(dialog).getByLabelText("Skill description"), {
+      target: { value: "d" }
+    });
+    fireEvent.change(within(dialog).getByLabelText("Skill instructions"), {
+      target: { value: "i" }
+    });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Save" }));
+
+    expect(
+      await within(dialog).findByText("A skill with this name already exists.")
+    ).toBeInTheDocument();
+  });
+
+  it("deletes a skill through the confirm dialog and refetches", async () => {
+    const { fetchMock } = mockSkillEndpoints([buildSkill()]);
+
+    renderView();
+
+    expect(await screen.findByText("Web research")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Delete skill Web research" }));
+
+    const dialog = await screen.findByRole("dialog", { name: "Delete skill?" });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/bots/bot_1/skills/botws-bot_1-web-research",
+        expect.objectContaining({ method: "DELETE" })
+      );
+    });
+    await waitFor(() => {
+      expect(screen.queryByText("Web research")).not.toBeInTheDocument();
+    });
+  });
+
+  it("refetches skills after a bot run updates", async () => {
+    const { calls } = mockSkillEndpoints([]);
+
+    renderView();
+    await screen.findByText("No skills yet. This bot saves skills it creates here, and you can add your own.");
+
+    const listCalls = () =>
+      calls.filter((call) => call.url === "/api/bots/bot_1/skills" && call.method === "GET");
+    expect(listCalls()).toHaveLength(1);
+
+    wsMocks.listener?.({ type: "bot_run_updated", run: { botId: "bot_1" } });
+
+    await waitFor(
+      () => {
+        expect(listCalls().length).toBeGreaterThanOrEqual(2);
+      },
+      { timeout: 2000 }
+    );
+  });
+});

--- a/tests/unit/bot-skills-routes.test.ts
+++ b/tests/unit/bot-skills-routes.test.ts
@@ -1,0 +1,215 @@
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createBot } from "@/lib/bots";
+import { getBotSkillsDir, listBotWorkspaceSkills } from "@/lib/bot-workspace-skills";
+import { createLocalUser } from "@/lib/users";
+import type { Bot } from "@/lib/types";
+
+const { requireUserMock } = vi.hoisted(() => ({
+  requireUserMock: vi.fn()
+}));
+
+vi.mock("@/lib/auth", () => ({
+  requireUser: requireUserMock
+}));
+
+function buildBotContext(botId: string): { params: Promise<{ botId: string }> } {
+  return { params: Promise.resolve({ botId }) };
+}
+
+function buildSkillContext(
+  botId: string,
+  skillId: string
+): { params: Promise<{ botId: string; skillId: string }> } {
+  return { params: Promise.resolve({ botId, skillId }) };
+}
+
+function seedWorkspaceSkill(bot: Pick<Bot, "id" | "userId">, folder: string, content: string) {
+  const skillDir = join(getBotSkillsDir(bot), folder);
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(join(skillDir, "SKILL.md"), content, "utf8");
+}
+
+async function createUserWithBot(username: string) {
+  const user = await createLocalUser({ username, password: "password-123", role: "user" as const });
+  const bot = createBot({ name: `${username} bot` }, user.id);
+  return { user, bot };
+}
+
+describe("bot skills routes", () => {
+  beforeEach(() => {
+    requireUserMock.mockReset();
+  });
+
+  it("lists the bot's workspace skills for the owner", async () => {
+    const { user, bot } = await createUserWithBot("skillsowner");
+    requireUserMock.mockResolvedValue(user);
+    seedWorkspaceSkill(
+      bot,
+      "pdf-extraction",
+      "---\nname: PDF Extraction\ndescription: Pull text from PDFs.\n---\n\nRun pdftotext."
+    );
+
+    const { GET } = await import("@/app/api/bots/[botId]/skills/route");
+    const response = await GET(new Request("http://localhost/"), buildBotContext(bot.id));
+    const payload = (await response.json()) as { skills?: Array<{ name: string }> };
+
+    expect(response.status).toBe(200);
+    expect(payload.skills?.map((skill) => skill.name)).toEqual(["PDF Extraction"]);
+  });
+
+  it("hides skills from other users and unknown bots", async () => {
+    const { user } = await createUserWithBot("skillsstranger");
+    const { bot } = await createUserWithBot("skillshidden");
+    requireUserMock.mockResolvedValue(user);
+
+    const { GET } = await import("@/app/api/bots/[botId]/skills/route");
+    const notOwner = await GET(new Request("http://localhost/"), buildBotContext(bot.id));
+    const missing = await GET(new Request("http://localhost/"), buildBotContext("bot_missing"));
+
+    expect(notOwner.status).toBe(404);
+    expect(missing.status).toBe(404);
+  });
+
+  it("creates a skill from name, description, and instructions", async () => {
+    const { user, bot } = await createUserWithBot("skillscreator");
+    requireUserMock.mockResolvedValue(user);
+
+    const { POST } = await import("@/app/api/bots/[botId]/skills/route");
+    const response = await POST(
+      new Request("http://localhost/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          name: "Meeting Notes",
+          description: "Summarize meetings.",
+          instructions: "Capture action items."
+        })
+      }),
+      buildBotContext(bot.id)
+    );
+    const payload = (await response.json()) as { skill?: { id: string; content: string } };
+
+    expect(response.status).toBe(201);
+    expect(payload.skill?.content).toBe(
+      "---\nname: Meeting Notes\ndescription: Summarize meetings.\n---\n\nCapture action items.\n"
+    );
+    expect(existsSync(join(getBotSkillsDir(bot), "meeting-notes", "SKILL.md"))).toBe(true);
+  });
+
+  it("rejects invalid create payloads and name collisions", async () => {
+    const { user, bot } = await createUserWithBot("skillsinvalid");
+    requireUserMock.mockResolvedValue(user);
+    seedWorkspaceSkill(bot, "taken", "Existing");
+
+    const { POST } = await import("@/app/api/bots/[botId]/skills/route");
+    const invalid = await POST(
+      new Request("http://localhost/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: "Only Name" })
+      }),
+      buildBotContext(bot.id)
+    );
+    const collision = await POST(
+      new Request("http://localhost/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: "Taken", description: "d", instructions: "i" })
+      }),
+      buildBotContext(bot.id)
+    );
+
+    expect(invalid.status).toBe(400);
+    expect(collision.status).toBe(400);
+    expect(((await collision.json()) as { error: string }).error).toContain("already exists");
+  });
+
+  it("patches fields, merges with existing content, and renames folders on name change", async () => {
+    const { user, bot } = await createUserWithBot("skillspatcher");
+    requireUserMock.mockResolvedValue(user);
+    seedWorkspaceSkill(
+      bot,
+      "old-name",
+      "---\nname: Old Name\ndescription: Old description.\n---\n\nOld instructions."
+    );
+
+    const { PATCH } = await import("@/app/api/bots/[botId]/skills/[skillId]/route");
+    const skillId = `botws-${bot.id}-old-name`;
+    const partial = await PATCH(
+      new Request("http://localhost/", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ description: "New description." })
+      }),
+      buildSkillContext(bot.id, skillId)
+    );
+
+    expect(partial.status).toBe(200);
+    const partialPayload = (await partial.json()) as { skill?: { content: string } };
+    expect(partialPayload.skill?.content).toBe(
+      "---\nname: Old Name\ndescription: New description.\n---\n\nOld instructions.\n"
+    );
+
+    const renamed = await PATCH(
+      new Request("http://localhost/", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: "New Name" })
+      }),
+      buildSkillContext(bot.id, skillId)
+    );
+
+    expect(renamed.status).toBe(200);
+    const renamedPayload = (await renamed.json()) as { skill?: { id: string } };
+    expect(renamedPayload.skill?.id).toBe(`botws-${bot.id}-new-name`);
+    expect(existsSync(join(getBotSkillsDir(bot), "old-name"))).toBe(false);
+    expect(listBotWorkspaceSkills(bot).map((skill) => skill.name)).toEqual(["New Name"]);
+  });
+
+  it("returns 404 for unknown or malformed skill ids", async () => {
+    const { user, bot } = await createUserWithBot("skillsmissing");
+    requireUserMock.mockResolvedValue(user);
+
+    const { PATCH, DELETE } = await import("@/app/api/bots/[botId]/skills/[skillId]/route");
+    const unknown = await PATCH(
+      new Request("http://localhost/", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: "Whatever" })
+      }),
+      buildSkillContext(bot.id, `botws-${bot.id}-ghost`)
+    );
+    const malformed = await DELETE(
+      new Request("http://localhost/", { method: "DELETE" }),
+      buildSkillContext(bot.id, "../escape")
+    );
+
+    expect(unknown.status).toBe(404);
+    expect(malformed.status).toBe(404);
+  });
+
+  it("deletes a skill folder", async () => {
+    const { user, bot } = await createUserWithBot("skillsdeleter");
+    requireUserMock.mockResolvedValue(user);
+    seedWorkspaceSkill(bot, "doomed", "Body");
+
+    const { DELETE } = await import("@/app/api/bots/[botId]/skills/[skillId]/route");
+    const response = await DELETE(
+      new Request("http://localhost/", { method: "DELETE" }),
+      buildSkillContext(bot.id, `botws-${bot.id}-doomed`)
+    );
+    const second = await DELETE(
+      new Request("http://localhost/", { method: "DELETE" }),
+      buildSkillContext(bot.id, `botws-${bot.id}-doomed`)
+    );
+
+    expect(response.status).toBe(200);
+    expect(((await response.json()) as { success: boolean }).success).toBe(true);
+    expect(existsSync(join(getBotSkillsDir(bot), "doomed"))).toBe(false);
+    expect(second.status).toBe(404);
+  });
+});

--- a/tests/unit/bot-workspace-skills.test.ts
+++ b/tests/unit/bot-workspace-skills.test.ts
@@ -1,14 +1,20 @@
-import { mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
 import {
+  MAX_SKILL_FILE_BYTES,
   buildBotWorkspaceSkillId,
+  buildSkillMarkdown,
+  deleteBotWorkspaceSkill,
   getBotSkillsDir,
+  getBotWorkspaceSkill,
   isBotWorkspaceSkillId,
   listBotWorkspaceSkills,
   mergeSkillsWithWorkspace,
+  parseBotWorkspaceSkillId,
+  saveBotWorkspaceSkill,
   slugifySkillFolderName
 } from "@/lib/bot-workspace-skills";
 import type { Skill } from "@/lib/types";
@@ -92,6 +98,158 @@ describe("bot-workspace-skills", () => {
     expect(slugifySkillFolderName("  --Leading and trailing--  ")).toBe("leading-and-trailing");
     expect(slugifySkillFolderName("!!!")).toBe("");
     expect(slugifySkillFolderName(`a`.repeat(100))).toHaveLength(64);
+  });
+
+  describe("buildSkillMarkdown", () => {
+    it("wraps name and description in frontmatter above the instructions", () => {
+      expect(buildSkillMarkdown("PDF Extraction", "Pull text from PDFs.", "Run pdftotext first.")).toBe(
+        "---\nname: PDF Extraction\ndescription: Pull text from PDFs.\n---\n\nRun pdftotext first.\n"
+      );
+    });
+  });
+
+  describe("parseBotWorkspaceSkillId", () => {
+    it("returns the folder slug for ids built for this bot", () => {
+      const skillId = buildBotWorkspaceSkillId(bot.id, "pdf-extraction");
+      expect(parseBotWorkspaceSkillId(bot, skillId)).toBe("pdf-extraction");
+    });
+
+    it("rejects ids from another bot", () => {
+      const otherBotId = buildBotWorkspaceSkillId("bot_other", "pdf-extraction");
+      expect(parseBotWorkspaceSkillId(bot, otherBotId)).toBeNull();
+    });
+
+    it("rejects traversal and malformed folder slugs", () => {
+      const sanitizedBotId = bot.id.replace(/[^a-zA-Z0-9_-]+/g, "-");
+      expect(parseBotWorkspaceSkillId(bot, `botws-${sanitizedBotId}-..`)).toBeNull();
+      expect(parseBotWorkspaceSkillId(bot, `botws-${sanitizedBotId}-../escape`)).toBeNull();
+      expect(parseBotWorkspaceSkillId(bot, `botws-${sanitizedBotId}-/etc/passwd`)).toBeNull();
+      expect(parseBotWorkspaceSkillId(bot, `botws-${sanitizedBotId}-Uppercase`)).toBeNull();
+      expect(parseBotWorkspaceSkillId(bot, `botws-${sanitizedBotId}-`)).toBeNull();
+      expect(parseBotWorkspaceSkillId(bot, "skill_db_1")).toBeNull();
+    });
+  });
+
+  describe("saveBotWorkspaceSkill", () => {
+    it("creates the canonical SKILL.md folder and returns the skill", () => {
+      const result = saveBotWorkspaceSkill(bot, {
+        name: "Meeting Notes",
+        description: "Summarize meetings.",
+        instructions: "Capture action items."
+      });
+
+      expect("error" in result && result.error).toBeFalsy();
+      if (!("skill" in result)) throw new Error("expected skill");
+      expect(result.skill.id).toBe(buildBotWorkspaceSkillId(bot.id, "meeting-notes"));
+      expect(result.skill.name).toBe("Meeting Notes");
+      expect(result.skill.description).toBe("Summarize meetings.");
+      expect(result.skill.enabled).toBe(true);
+
+      const written = readFileSync(join(getBotSkillsDir(bot), "meeting-notes", "SKILL.md"), "utf8");
+      expect(written).toBe(buildSkillMarkdown("Meeting Notes", "Summarize meetings.", "Capture action items."));
+      expect(getBotWorkspaceSkill(bot, result.skill.id)?.content).toBe(written);
+    });
+
+    it("collapses whitespace in name and description", () => {
+      const result = saveBotWorkspaceSkill(bot, {
+        name: "  Whitespace   Heavy  ",
+        description: "  A   description.  ",
+        instructions: "Body"
+      });
+
+      if (!("skill" in result)) throw new Error("expected skill");
+      expect(result.skill.name).toBe("Whitespace Heavy");
+      expect(result.skill.description).toBe("A description.");
+    });
+
+    it("rejects missing fields, long names, unusable slugs, and oversized content", () => {
+      expect(saveBotWorkspaceSkill(bot, { name: "", description: "d", instructions: "i" })).toMatchObject({
+        error: expect.any(String)
+      });
+      expect(saveBotWorkspaceSkill(bot, { name: "n", description: "", instructions: "i" })).toMatchObject({
+        error: expect.any(String)
+      });
+      expect(saveBotWorkspaceSkill(bot, { name: "n", description: "d", instructions: "  " })).toMatchObject({
+        error: expect.any(String)
+      });
+      expect(
+        saveBotWorkspaceSkill(bot, { name: "x".repeat(101), description: "d", instructions: "i" })
+      ).toMatchObject({ error: expect.any(String) });
+      expect(
+        saveBotWorkspaceSkill(bot, { name: "!!!", description: "d", instructions: "i" })
+      ).toMatchObject({ error: expect.any(String) });
+      expect(
+        saveBotWorkspaceSkill(bot, {
+          name: "Huge",
+          description: "d",
+          instructions: "x".repeat(MAX_SKILL_FILE_BYTES)
+        })
+      ).toMatchObject({ error: expect.any(String) });
+    });
+
+    it("rejects creates that collide with an existing skill folder", () => {
+      writeWorkspaceSkill("collision-target", "Existing body");
+
+      const result = saveBotWorkspaceSkill(bot, {
+        name: "Collision Target",
+        description: "d",
+        instructions: "i"
+      });
+
+      expect(result).toMatchObject({ error: expect.stringContaining("already exists") });
+      expect(readFileSync(join(getBotSkillsDir(bot), "collision-target", "SKILL.md"), "utf8")).toBe(
+        "Existing body"
+      );
+    });
+
+    it("renames the folder when the name changes and rejects taken target slugs", () => {
+      const created = saveBotWorkspaceSkill(bot, {
+        name: "Rename Me",
+        description: "d",
+        instructions: "i"
+      });
+      if (!("skill" in created)) throw new Error("expected skill");
+
+      writeWorkspaceSkill("taken-folder", "Other skill");
+
+      const blocked = saveBotWorkspaceSkill(
+        bot,
+        { name: "Taken Folder", description: "d", instructions: "i" },
+        created.skill.id
+      );
+      expect(blocked).toMatchObject({ error: expect.stringContaining("already exists") });
+
+      const renamed = saveBotWorkspaceSkill(
+        bot,
+        { name: "Renamed Skill", description: "d", instructions: "new body" },
+        created.skill.id
+      );
+      if (!("skill" in renamed)) throw new Error("expected skill");
+
+      expect(renamed.skill.id).toBe(buildBotWorkspaceSkillId(bot.id, "renamed-skill"));
+      expect(existsSync(join(getBotSkillsDir(bot), "rename-me"))).toBe(false);
+      expect(readFileSync(join(getBotSkillsDir(bot), "renamed-skill", "SKILL.md"), "utf8")).toContain("new body");
+    });
+  });
+
+  describe("deleteBotWorkspaceSkill", () => {
+    it("removes the skill folder and reports whether it existed", () => {
+      const created = saveBotWorkspaceSkill(bot, {
+        name: "Delete Me",
+        description: "d",
+        instructions: "i"
+      });
+      if (!("skill" in created)) throw new Error("expected skill");
+
+      expect(deleteBotWorkspaceSkill(bot, created.skill.id)).toBe(true);
+      expect(existsSync(join(getBotSkillsDir(bot), "delete-me"))).toBe(false);
+      expect(deleteBotWorkspaceSkill(bot, created.skill.id)).toBe(false);
+    });
+
+    it("ignores invalid ids without touching the skills dir", () => {
+      expect(deleteBotWorkspaceSkill(bot, "../escape")).toBe(false);
+      expect(deleteBotWorkspaceSkill(bot, "skill_db_1")).toBe(false);
+    });
   });
 
   describe("mergeSkillsWithWorkspace", () => {


### PR DESCRIPTION
## Problem
Bots can save skills as SKILL.md files in their workspace, but there was no way for users to see, add, edit, or delete those skills from the bot detail page.

## Solution
In plain terms: the bot's detail page now has a "Skills" section where you can view, create, edit, and delete the skills a bot keeps in its workspace, backed by new API routes that safely read and write the SKILL.md files on disk.

Details:
- New API routes `GET/POST /api/bots/[botId]/skills` and `PATCH/DELETE /api/bots/[botId]/skills/[skillId]`, scoped to the bot owner with 404s for unknown bots, unknown/malformed skill ids, and path-traversal slugs.
- `lib/bot-workspace-skills.ts` gains `saveBotWorkspaceSkill`, `deleteBotWorkspaceSkill`, `getBotWorkspaceSkill`, `parseBotWorkspaceSkillId`, and `buildSkillMarkdown`, with validation (name length, slug safety, 200 KB size cap, duplicate-folder rejection) and folder renaming when a skill's name changes.
- `BotSkillModal` handles create/edit with required-field validation and surfaces API errors; `BotDetailView` adds a Skills panel with edit/delete actions, empty and error states, and refetches after bot runs.
- `stripSkillFrontmatter` added to `lib/skill-metadata.ts` to recover instructions from existing content; `tool-executors.ts` now uses shared `buildSkillMarkdown`.

## Testing
- New unit tests: `tests/unit/bot-skills-routes.test.ts` (route auth, validation, patch/rename/delete), `tests/unit/bot-detail-skills.test.tsx` (UI list/create/edit/delete/error/refetch), and extended `tests/unit/bot-workspace-skills.test.ts` (save/delete/id parsing, traversal rejection).
- New e2e test in `tests/e2e/bots.spec.ts` covering the full add → edit → delete skill flow.