### PR TITLE
Skip provider and MCP onboarding steps when already configured

### DIFF
--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -2,6 +2,7 @@ import { redirect } from "next/navigation";
 
 import { OnboardingFlow } from "@/components/onboarding/onboarding-flow";
 import { requireUser } from "@/lib/auth";
+import { hasMcpServers } from "@/lib/mcp-servers";
 import { getSanitizedSettings } from "@/lib/settings";
 
 export const dynamic = "force-dynamic";
@@ -13,10 +14,17 @@ export default async function OnboardingPage() {
     redirect("/");
   }
 
+  const hasProviderConfigured = settings.providerProfiles.some(
+    (profile) => profile.connection.status === "connected"
+  );
+  const hasMcpServerConfigured = hasMcpServers();
+
   return (
     <main className="min-h-dvh bg-[var(--background)]">
       <OnboardingFlow
         role={user.role}
+        hasProviderConfigured={hasProviderConfigured}
+        hasMcpServerConfigured={hasMcpServerConfigured}
         settings={{
           defaultView: settings.defaultView,
           toolCallDisplay: settings.toolCallDisplay,

--- a/components/onboarding/onboarding-flow.tsx
+++ b/components/onboarding/onboarding-flow.tsx
@@ -51,16 +51,23 @@ async function readError(response: Response, fallback: string) {
 
 export function OnboardingFlow({
   role,
-  settings
+  settings,
+  hasProviderConfigured = false,
+  hasMcpServerConfigured = false
 }: {
   role: UserRole;
   settings: OnboardingSettings;
+  hasProviderConfigured?: boolean;
+  hasMcpServerConfigured?: boolean;
 }) {
   const router = useRouter();
   const toast = useToastState();
   const { showToast } = toast;
 
-  const steps = useMemo(() => getOnboardingSteps(role), [role]);
+  const steps = useMemo(
+    () => getOnboardingSteps(role, { hasProviderConfigured, hasMcpServerConfigured }),
+    [role, hasProviderConfigured, hasMcpServerConfigured]
+  );
   const [stepIndex, setStepIndex] = useState(0);
   const step = steps[stepIndex];
   const progress = getOnboardingProgress(steps, step);

--- a/lib/mcp-servers.ts
+++ b/lib/mcp-servers.ts
@@ -91,6 +91,13 @@ export function listSanitizedMcpServers() {
 
 const SELECT_COLUMNS = `id, name, slug, url, headers, transport, command, args, env, enabled, is_vision_mcp, created_at, updated_at`;
 
+export function hasMcpServers() {
+  const row = getDb()
+    .prepare("SELECT COUNT(*) AS count FROM mcp_servers")
+    .get() as { count: number };
+  return row.count > 0;
+}
+
 export function listMcpServers() {
   const rows = getDb()
     .prepare(

--- a/lib/onboarding.ts
+++ b/lib/onboarding.ts
@@ -28,9 +28,21 @@ export type OnboardingStep = (typeof ONBOARDING_STEPS)[number];
 /** Provider and MCP configuration are admin-only, so non-admins get a shorter flow. */
 const ADMIN_ONLY_STEPS: ReadonlySet<OnboardingStep> = new Set(["provider", "mcp-server"]);
 
-export function getOnboardingSteps(role: UserRole): OnboardingStep[] {
-  if (role === "admin") return [...ONBOARDING_STEPS];
-  return ONBOARDING_STEPS.filter((step) => !ADMIN_ONLY_STEPS.has(step));
+export type OnboardingStepContext = {
+  hasProviderConfigured?: boolean;
+  hasMcpServerConfigured?: boolean;
+};
+
+export function getOnboardingSteps(
+  role: UserRole,
+  context: OnboardingStepContext = {}
+): OnboardingStep[] {
+  return ONBOARDING_STEPS.filter((step) => {
+    if (ADMIN_ONLY_STEPS.has(step) && role !== "admin") return false;
+    if (step === "provider" && context.hasProviderConfigured) return false;
+    if (step === "mcp-server" && context.hasMcpServerConfigured) return false;
+    return true;
+  });
 }
 
 /**

--- a/tests/unit/onboarding-flow.test.tsx
+++ b/tests/unit/onboarding-flow.test.tsx
@@ -43,9 +43,17 @@ function makeSettings(): OnboardingSettings {
   };
 }
 
-function renderFlow(role: UserRole = "admin") {
+function renderFlow(
+  role: UserRole = "admin",
+  options: { hasProviderConfigured?: boolean; hasMcpServerConfigured?: boolean } = {}
+) {
   return render(
-    React.createElement(OnboardingFlow, { role, settings: makeSettings() })
+    React.createElement(OnboardingFlow, {
+      role,
+      settings: makeSettings(),
+      hasProviderConfigured: options.hasProviderConfigured ?? false,
+      hasMcpServerConfigured: options.hasMcpServerConfigured ?? false
+    })
   );
 }
 
@@ -90,6 +98,36 @@ describe("onboarding flow", () => {
     // Never offered the provider or MCP steps.
     expect(screen.queryByText("Connect a model provider")).toBeNull();
     expect(screen.queryByText("Add an MCP server")).toBeNull();
+  });
+
+  it("skips the provider step for an admin who already has a provider", async () => {
+    renderFlow("admin", { hasProviderConfigured: true });
+    startFlow();
+    expect(screen.getByText("Step 1 of 3")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    await waitFor(() => expect(screen.getByText("Step 2 of 3")).toBeTruthy());
+    expect(screen.getByText("How should tool calls look?")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    await waitFor(() => expect(screen.getByText("Add an MCP server")).toBeTruthy());
+    expect(screen.queryByText("Connect a model provider")).toBeNull();
+  });
+
+  it("goes straight through the preference steps when everything is configured", async () => {
+    renderFlow("admin", { hasProviderConfigured: true, hasMcpServerConfigured: true });
+    startFlow();
+    expect(screen.getByText("Step 1 of 2")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    await waitFor(() => expect(screen.getByText("Step 2 of 2")).toBeTruthy());
+
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    await waitFor(() => expect(screen.getByText("You're set up")).toBeTruthy());
+    expect(screen.queryByText("Connect a model provider")).toBeNull();
+    expect(screen.queryByText("Add an MCP server")).toBeNull();
+    expect(screen.getByText("Opening into Chat")).toBeTruthy();
+    expect(screen.getByText("Tool activity shown as pills")).toBeTruthy();
   });
 
   it("saves the chosen default view when advancing", async () => {

--- a/tests/unit/onboarding.test.ts
+++ b/tests/unit/onboarding.test.ts
@@ -66,6 +66,35 @@ describe("onboarding steps", () => {
     expect(getOnboardingProgress(steps, "default-view")).toEqual({ current: 1, total: 2 });
     expect(getOnboardingProgress(steps, "tool-display")).toEqual({ current: 2, total: 2 });
   });
+
+  it("skips the provider step when a provider is already configured", () => {
+    const steps = getOnboardingSteps("admin", { hasProviderConfigured: true });
+    expect(steps).toEqual(["welcome", "default-view", "tool-display", "mcp-server", "done"]);
+  });
+
+  it("skips the MCP step when an MCP server already exists", () => {
+    const steps = getOnboardingSteps("admin", { hasMcpServerConfigured: true });
+    expect(steps).toEqual(["welcome", "default-view", "tool-display", "provider", "done"]);
+  });
+
+  it("skips both admin setup steps when both are configured", () => {
+    const steps = getOnboardingSteps("admin", {
+      hasProviderConfigured: true,
+      hasMcpServerConfigured: true
+    });
+    expect(steps).toEqual(["welcome", "default-view", "tool-display", "done"]);
+  });
+
+  it("recomputes progress totals over skipped steps", () => {
+    const providerSkipped = getOnboardingSteps("admin", { hasProviderConfigured: true });
+    expect(getOnboardingProgress(providerSkipped, "tool-display")).toEqual({ current: 2, total: 3 });
+
+    const bothSkipped = getOnboardingSteps("admin", {
+      hasProviderConfigured: true,
+      hasMcpServerConfigured: true
+    });
+    expect(getOnboardingProgress(bothSkipped, "tool-display")).toEqual({ current: 2, total: 2 });
+  });
 });
 
 describe("buildProviderCatalogPayload", () => {


### PR DESCRIPTION
## Problem
Admins had to redo the "Connect a model provider" and "Add an MCP server" onboarding steps even when a provider was already connected or an MCP server already existed.

## Solution
In simple terms: if you already set something up, the wizard no longer asks you to set it up again.

- `getOnboardingSteps` now accepts an `OnboardingStepContext` (`hasProviderConfigured`, `hasMcpServerConfigured`) and filters out the `provider` / `mcp-server` steps when they are already configured (admins only).
- The onboarding page checks for a connected provider profile and a new `hasMcpServers()` helper (count query on `mcp_servers`) and passes the flags into `OnboardingFlow`.
- Step progress totals recompute correctly over skipped steps.

## Testing
- Unit tests for step filtering (provider skipped, MCP skipped, both skipped) and progress totals.
- Flow tests verify an admin with everything configured goes straight through the preference steps to done.