### PR TITLE
Sync CODEOWNERS into dev

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owner for everything in the repository
+* @Quack6765


### PR DESCRIPTION
Brings the CODEOWNERS file (@Quack6765 owns all files) from main into dev so both protected branches carry it.