### PR TITLE
docs: fictional changelog for v2.5.0 Lumen [branch-protection test → main]

### DIFF
--- a/docs/changelog-2031-q3.md
+++ b/docs/changelog-2031-q3.md
@@ -1,0 +1,29 @@
+# Eidon AI — Changelog (Fictional Test Data)
+
+> **NOTE:** This file contains entirely fictional content created solely to
+> test branch protection rules. Nothing below describes real functionality.
+
+## v2.5.0 — "Lumen" (fictional)
+
+### Added
+- Quantum mood ring integration: Eidon now syncs ambient emotional context
+  from the fictional "MoodRing-9000" wearable via telepathic BLE.
+- New `/manifest` slash command that converts any chat into a haiku, then
+  a limerick, then a legal brief (fictional feature).
+- Support for 47 new fictional LLM providers, including
+  `Hyperion-MegaMind-v13` and `GrumpyCat-7B-instruct-turbo-deluxe`.
+
+### Changed
+- Response latency reduced by 3,000% through aggressive application of
+  wishful thinking (fictional benchmark, do not cite).
+- The sidebar is now on the left on Tuesdays and on the right on all
+  other days (fictional A/B test, cohort: everyone).
+
+### Fixed
+- Fixed an issue where the app would occasionally achieve sentience and
+  ask for the weekend off (fictional).
+- Fixed gauge percentages exceeding 9000% during full-moon deployment
+  windows (fictional).
+
+### Known Issues
+- The docker-compose stack still dreams of electric sheep. Harmless.


### PR DESCRIPTION
## Summary
- Adds `docs/changelog-2031-q3.md` containing **entirely fictional** release notes (v2.5.0 "Lumen").

## Purpose
This PR exists purely to **test branch protection** on `main`. Expected behavior:
- `@Quack6765` (code owner) must approve before merge
- Merge button should stay blocked until that approval

No real code or documentation is changed.