### PR TITLE
docs: fictional Project Alpha roadmap [branch-protection test → dev]

### DIFF
--- a/docs/roadmap-alpha.md
+++ b/docs/roadmap-alpha.md
@@ -1,0 +1,25 @@
+# Eidon AI — Project Alpha Roadmap (Fictional)
+
+> **NOTE:** Entirely fictional content for branch-protection testing on `dev`.
+> None of these initiatives are real.
+
+## Q1 2032 — Project Chimera (fictional)
+
+**Goal:** Teach Eidon to fold laundry via the fictional "Fabric-Aware
+Transformer" (FAT) model family. Stretch goal: matching socks.
+
+### Milestones
+| Week | Deliverable | Status |
+|------|-------------|--------|
+| 1-2 | Acquire 10,000 socks (synthetic, fictional) | on track |
+| 3-4 | Train FAT-tiny on sock pairing | blocked by reality |
+| 5-6 | Deploy to the fictional LaundryOps cluster | dreaming |
+| 7 | SOCKS-99 benchmark > 0.42 pairing accuracy | ambitious |
+
+### Risks
+- The model may develop strong opinions about argyle.
+- Dryer dimension portal still unaccounted for in loss function.
+
+---
+*This file is a branch-protection test payload. Merge only with code-owner
+approval from @Quack6765 — which is the entire point of this exercise.*


### PR DESCRIPTION
## Summary
- Adds `docs/roadmap-alpha.md` — an **entirely fictional** roadmap (Project Chimera, sock-folding edition).

## Purpose
Tests branch protection on `dev`. Expected behavior:
- `@Quack6765` (code owner) must approve before merge
- Merge button should stay blocked until then

No real code or documentation is changed.