### PR TITLE
Document mobile contract duties and iOS spec regeneration in agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,35 +14,22 @@
   PID: 12345
   ```
 
-### Mobile API contract and the iOS client spec
+### Mobile API contract and native clients
 
 `contracts/mobile-api-v1.openapi.json` (and
-`contracts/mobile-api-v1.websocket.schema.json`) define the mobile API that the
-native iOS client (`Quack6765/Eidon-AI-IOS`, sibling checkout at
-`/Users/charles/Documents/Github/Eidon-AI-IOS`) is built against. The contract
-is the source of truth; the iOS app derives its generated client from it.
+`contracts/mobile-api-v1.websocket.schema.json`) define the mobile API that
+native clients are built against. The contract is the source of truth; clients
+derive their generated API layers from it — they never hand-edit their side.
 
-**After any change to the API surface** — new or modified routes, request/response
-schemas, enums, or the WebSocket event set — always:
+**After any change to the API surface** — new or modified routes,
+request/response schemas, enums, or the WebSocket event set — always:
 
 1. Update `contracts/mobile-api-v1.openapi.json` in the same PR (and the
    gateway route table in `app/api/v1/[...path]/route.ts` when mounting new
    shared handlers). Update `tests/unit/mobile-contracts.test.ts` and
    `tests/unit/mobile-routes.test.ts` expectations (documented operation and
    request-body counts) so the contract stays verified.
-2. Regenerate the iOS client spec — never hand-edit it. From the iOS repo, run
-   the prepare script once per artifact, sourcing the contract from this repo
-   at the ref the iOS work targets (a release tag for release parity,
-   `origin/dev` for dev parity; the Orca worktree `openapi-spec-sync` is a
-   stable `origin/dev` source):
-   ```
-   swift Scripts/prepare-openapi-contract.swift <this-repo>/contracts/mobile-api-v1.openapi.json Eidon/openapi.yaml
-   swift Scripts/prepare-openapi-contract.swift <this-repo>/contracts/mobile-api-v1.openapi.json Eidon/OpenAPI/mobile-api-v1.openapi.json
-   ```
-   `Eidon/openapi.yaml` is the build input for swift-openapi-generator — a stale
-   one makes the iOS app decode against an old schema and fail at runtime with
-   `DecodingError`, so regenerating both artifacts is mandatory, not optional.
-3. Coordinate the follow-through: the regenerated spec plus a decoding test for
-   the new/changed shape belong in the iOS repo, committed together with the
-   consuming client code. If you only changed the web side, flag the iOS
-   regeneration explicitly in the PR description so it is not forgotten.
+2. Note in the PR description that native clients must regenerate their
+   derived specs from the updated contract. A stale generated client compiles
+   cleanly and fails only at runtime with decoding errors, so this
+   regeneration step must be called out explicitly — never assumed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,3 +13,36 @@
   http://localhost:3127
   PID: 12345
   ```
+
+### Mobile API contract and the iOS client spec
+
+`contracts/mobile-api-v1.openapi.json` (and
+`contracts/mobile-api-v1.websocket.schema.json`) define the mobile API that the
+native iOS client (`Quack6765/Eidon-AI-IOS`, sibling checkout at
+`/Users/charles/Documents/Github/Eidon-AI-IOS`) is built against. The contract
+is the source of truth; the iOS app derives its generated client from it.
+
+**After any change to the API surface** — new or modified routes, request/response
+schemas, enums, or the WebSocket event set — always:
+
+1. Update `contracts/mobile-api-v1.openapi.json` in the same PR (and the
+   gateway route table in `app/api/v1/[...path]/route.ts` when mounting new
+   shared handlers). Update `tests/unit/mobile-contracts.test.ts` and
+   `tests/unit/mobile-routes.test.ts` expectations (documented operation and
+   request-body counts) so the contract stays verified.
+2. Regenerate the iOS client spec — never hand-edit it. From the iOS repo, run
+   the prepare script once per artifact, sourcing the contract from this repo
+   at the ref the iOS work targets (a release tag for release parity,
+   `origin/dev` for dev parity; the Orca worktree `openapi-spec-sync` is a
+   stable `origin/dev` source):
+   ```
+   swift Scripts/prepare-openapi-contract.swift <this-repo>/contracts/mobile-api-v1.openapi.json Eidon/openapi.yaml
+   swift Scripts/prepare-openapi-contract.swift <this-repo>/contracts/mobile-api-v1.openapi.json Eidon/OpenAPI/mobile-api-v1.openapi.json
+   ```
+   `Eidon/openapi.yaml` is the build input for swift-openapi-generator — a stale
+   one makes the iOS app decode against an old schema and fail at runtime with
+   `DecodingError`, so regenerating both artifacts is mandatory, not optional.
+3. Coordinate the follow-through: the regenerated spec plus a decoding test for
+   the new/changed shape belong in the iOS repo, committed together with the
+   consuming client code. If you only changed the web side, flag the iOS
+   regeneration explicitly in the PR description so it is not forgotten.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,35 +14,22 @@
   PID: 12345
   ```
 
-### Mobile API contract and the iOS client spec
+### Mobile API contract and native clients
 
 `contracts/mobile-api-v1.openapi.json` (and
-`contracts/mobile-api-v1.websocket.schema.json`) define the mobile API that the
-native iOS client (`Quack6765/Eidon-AI-IOS`, sibling checkout at
-`/Users/charles/Documents/Github/Eidon-AI-IOS`) is built against. The contract
-is the source of truth; the iOS app derives its generated client from it.
+`contracts/mobile-api-v1.websocket.schema.json`) define the mobile API that
+native clients are built against. The contract is the source of truth; clients
+derive their generated API layers from it — they never hand-edit their side.
 
-**After any change to the API surface** — new or modified routes, request/response
-schemas, enums, or the WebSocket event set — always:
+**After any change to the API surface** — new or modified routes,
+request/response schemas, enums, or the WebSocket event set — always:
 
 1. Update `contracts/mobile-api-v1.openapi.json` in the same PR (and the
    gateway route table in `app/api/v1/[...path]/route.ts` when mounting new
    shared handlers). Update `tests/unit/mobile-contracts.test.ts` and
    `tests/unit/mobile-routes.test.ts` expectations (documented operation and
    request-body counts) so the contract stays verified.
-2. Regenerate the iOS client spec — never hand-edit it. From the iOS repo, run
-   the prepare script once per artifact, sourcing the contract from this repo
-   at the ref the iOS work targets (a release tag for release parity,
-   `origin/dev` for dev parity; the Orca worktree `openapi-spec-sync` is a
-   stable `origin/dev` source):
-   ```
-   swift Scripts/prepare-openapi-contract.swift <this-repo>/contracts/mobile-api-v1.openapi.json Eidon/openapi.yaml
-   swift Scripts/prepare-openapi-contract.swift <this-repo>/contracts/mobile-api-v1.openapi.json Eidon/OpenAPI/mobile-api-v1.openapi.json
-   ```
-   `Eidon/openapi.yaml` is the build input for swift-openapi-generator — a stale
-   one makes the iOS app decode against an old schema and fail at runtime with
-   `DecodingError`, so regenerating both artifacts is mandatory, not optional.
-3. Coordinate the follow-through: the regenerated spec plus a decoding test for
-   the new/changed shape belong in the iOS repo, committed together with the
-   consuming client code. If you only changed the web side, flag the iOS
-   regeneration explicitly in the PR description so it is not forgotten.
+2. Note in the PR description that native clients must regenerate their
+   derived specs from the updated contract. A stale generated client compiles
+   cleanly and fails only at runtime with decoding errors, so this
+   regeneration step must be called out explicitly — never assumed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,3 +13,36 @@
   http://localhost:3127
   PID: 12345
   ```
+
+### Mobile API contract and the iOS client spec
+
+`contracts/mobile-api-v1.openapi.json` (and
+`contracts/mobile-api-v1.websocket.schema.json`) define the mobile API that the
+native iOS client (`Quack6765/Eidon-AI-IOS`, sibling checkout at
+`/Users/charles/Documents/Github/Eidon-AI-IOS`) is built against. The contract
+is the source of truth; the iOS app derives its generated client from it.
+
+**After any change to the API surface** — new or modified routes, request/response
+schemas, enums, or the WebSocket event set — always:
+
+1. Update `contracts/mobile-api-v1.openapi.json` in the same PR (and the
+   gateway route table in `app/api/v1/[...path]/route.ts` when mounting new
+   shared handlers). Update `tests/unit/mobile-contracts.test.ts` and
+   `tests/unit/mobile-routes.test.ts` expectations (documented operation and
+   request-body counts) so the contract stays verified.
+2. Regenerate the iOS client spec — never hand-edit it. From the iOS repo, run
+   the prepare script once per artifact, sourcing the contract from this repo
+   at the ref the iOS work targets (a release tag for release parity,
+   `origin/dev` for dev parity; the Orca worktree `openapi-spec-sync` is a
+   stable `origin/dev` source):
+   ```
+   swift Scripts/prepare-openapi-contract.swift <this-repo>/contracts/mobile-api-v1.openapi.json Eidon/openapi.yaml
+   swift Scripts/prepare-openapi-contract.swift <this-repo>/contracts/mobile-api-v1.openapi.json Eidon/OpenAPI/mobile-api-v1.openapi.json
+   ```
+   `Eidon/openapi.yaml` is the build input for swift-openapi-generator — a stale
+   one makes the iOS app decode against an old schema and fail at runtime with
+   `DecodingError`, so regenerating both artifacts is mandatory, not optional.
+3. Coordinate the follow-through: the regenerated spec plus a decoding test for
+   the new/changed shape belong in the iOS repo, committed together with the
+   consuming client code. If you only changed the web side, flag the iOS
+   regeneration explicitly in the PR description so it is not forgotten.


### PR DESCRIPTION
## Problem

Agents working in this repo could change the mobile API surface (routes, schemas, enums, WS events) without updating `contracts/mobile-api-v1.openapi.json`, and native clients' generated specs were never flagged for regeneration — a stale generated layer compiles cleanly and only fails at runtime with decoding errors.

## Solution

Adds a "Mobile API contract and native clients" section to AGENTS.md and CLAUDE.md:

- The contract is the source of truth for native clients; any API-surface change must update the contract in the same PR (plus the v1 gateway route table and the contract-count test expectations).
- The PR description must explicitly call out that native clients need to regenerate their derived specs from the updated contract.

Deliberately worded without naming or linking any client repository — the instructions stay accurate for any current or future consumer of the contract.

## Testing

Docs-only change.
